### PR TITLE
chore(github): prepare contribution workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,105 @@
+name: Bug report
+description: Report reproducible behavior that is broken or unexpected.
+title: "fix(scope): "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please keep the report focused on one problem.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Choose the closest affected area.
+      options:
+        - Web app
+        - API
+        - Agent Driver
+        - Runtime
+        - Database
+        - GraphQL
+        - Documentation
+        - Developer tooling
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken?
+      placeholder: Describe the problem in a few sentences.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest reproducible sequence you know.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Add screenshots, logs, recordings, request IDs, or relevant output. Redact secrets.
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Share the environment if relevant.
+      placeholder: |
+        Browser:
+        OS:
+        Mosoo version or commit:
+        Local or production:
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Contribution
+      description: Are you willing to help with a fix?
+      options:
+        - I can submit a PR
+        - I can test a fix
+        - I can provide more details
+        - Not right now
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues before opening this report.
+          required: true
+        - label: I included a reproducible path or explained why I cannot reproduce it locally.
+          required: true
+        - label: I removed or redacted secrets from logs, screenshots, and config.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,81 @@
+name: Feature request
+description: Propose a product or developer experience improvement.
+title: "feat(scope): "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an improvement. Please focus on the user problem first, then the solution.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Choose the closest affected area.
+      options:
+        - Web app
+        - API
+        - Agent Driver
+        - Runtime
+        - Database
+        - GraphQL
+        - Documentation
+        - Developer tooling
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user or maintainer problem should this solve?
+      placeholder: Describe the current pain point and who experiences it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What change do you suggest?
+      placeholder: Keep the proposal as small and concrete as possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What alternatives or workarounds did you consider?
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility and migration
+      description: Note any expected API, data, configuration, deployment, or user workflow impact.
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Contribution
+      description: Are you willing to help implement or validate this?
+      options:
+        - I can submit a PR
+        - I can test an implementation
+        - I can provide product feedback
+        - Not right now
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues before opening this request.
+          required: true
+        - label: I described the problem before the proposed solution.
+          required: true
+        - label: I kept this request focused on one improvement.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,48 +1,60 @@
-Skip inapplicable sections. Fill Summary, Why, Verification, and Required Checks.
+Skip inapplicable sections. Fill Summary, Why, Verification, and Required Checks. External contributors may mark repository-maintainer-only items as N/A.
+
+First-time human contributors may be asked by CLA Assistant to sign `CLA.md`. If prompted, reply in the PR conversation with exactly: `I have read the CLA Document and I hereby sign the CLA`. Do not paste the signature into this PR description.
 
 ## Summary
+
 -
 
 ## Why
+
 -
 
 ## Verification
-- Commands (`vp run check`, focused `bun test`, `vp run graphql:codegen`, etc.):
+
+- Commands (`just check`, `just test-file <path>`, `just graphql-codegen`, etc.):
 - Manual steps:
 
 ## Risk And Blast Radius
+
 - Affected packages:
 - Affected user flows or APIs:
 - Rollback:
 
 ## Evidence
-- UI/UX: before/after screenshots for visible changes. Local login via `@mosoo.ai` development backdoor at `http://localhost:5173`.
+
+- UI/UX: before/after screenshots for visible changes. Local login via the `@mosoo.ai` development login channel at `http://localhost:5173`.
 - API or behavior:
 - Logs, recordings, or test output:
 
 ## Compatibility
+
 - Public contract changes:
 - Env or config changes:
 - Deployment or migration:
 
 ## Reviewer Focus
+
 - Closest review areas:
 - Known trade-offs:
 
 ## Required Checks
+
 - [ ] PR title: `type(scope): subject` (e.g. `fix(fmt): restore pre-commit checks`)
 - [ ] Type: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`, `build`, `ci`, `style`, or `revert`
 - [ ] Subject starts lowercase; `!` only for intentional breaking changes (e.g. `feat(api)!: remove legacy session field`)
-- [ ] Branch: `type/scope-subject` (e.g. `chore/contributing-guide`, `fix/auth-local-backdoor`)
+- [ ] Branch follows `type/scope-subject` when maintained in this repository; fork branch names may vary
 - [ ] Commits: `type(scope): subject`, English only
-- [ ] Self-assigned
+- [ ] CLA: if prompted by CLA Assistant, every human contributor has signed by posting the exact required PR comment
+- [ ] Self-assigned, or maintainer assigned for external contributors
 - [ ] Diff scoped; no unrelated cleanup
 - [ ] UI/UX: screenshots in Evidence, or N/A
 - [ ] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited
 
 ## Generated Files, Schema, And Lockfile
+
 - N/A, or list touched artifacts:
-- GraphQL codegen (`vp run graphql:codegen`):
-- DB baseline (`vp run db:regen`):
+- GraphQL codegen (`just graphql-codegen`):
+- DB baseline (`just db-regen`):
 - Lockfile (`bun.lock`):
 - Confirm no hand-edits to generated paths (`schema.generated.graphql`, `apps/web/src/gql/**`, `pkgs/db/drizzle/**`):

--- a/.github/workflows/pr-commits-lint.yml
+++ b/.github/workflows/pr-commits-lint.yml
@@ -22,10 +22,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version-file: package.json
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+          bun-version: canary
 
       - name: Validate commit messages and authors
-        run: vp exec bun scripts/validate-commit-range.ts ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}
+        run: bun scripts/validate-commit-range.ts ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary

- Add GitHub issue forms for bug reports and feature requests.
- Keep blank issues enabled for early external open-source feedback.
- Update the PR template for external contributors, CLA signing guidance, and human-facing `just` command examples.
- Simplify PR commit lint to run the zero-install commit policy script directly with Bun canary.

## Why

- Mosoo is moving toward external open-source contributions, so GitHub issue and PR entry points need to guide contributors without assuming maintainer-only permissions.
- The PR template previously exposed `vp` and direct `bun test` commands even though `CONTRIBUTING.md` says human-facing repository operations should use `just`.
- `oven-sh/setup-bun@v2` treated `packageManager: bun@1.4.0-canary.1` as an exact GitHub release tag, but `bun-v1.4.0-canary.1` does not exist, causing PR commit lint setup to fail with 404.
- The commit policy script only depends on Bun and Git, so PR commit lint should not run `bun install`, initialize submodules, or call `vp`.

## Verification

- Commands:
  - `python3 /Users/x/.agents/skills/codex-review/scripts/run_codex_review.py --uncommitted`: no blocking findings
  - `git diff --check -- .github/PULL_REQUEST_TEMPLATE.md .github/ISSUE_TEMPLATE`: passed
  - `ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.yml"].sort.each { |path| YAML.load_file(path); puts path }'`: passed
  - `just fmt-check-path .github`: passed
  - commit hook `just tc`: passed
  - pre-push hook `just tc`, `check yaml`, and `validate push commits`: passed
  - `curl -I -L https://github.com/oven-sh/bun/releases/download/bun-v1.4.0-canary.1/bun-linux-x64.zip`: confirmed 404
  - `gh api repos/oven-sh/bun/releases/tags/bun-v1.4.0-canary.1`: confirmed 404
  - `bun scripts/validate-commit-range.ts 202881de752602a91b94ebabe30843b7a90d5c47 HEAD`: passed
- Manual steps:
  - Not run; issue forms should be visually smoke-tested in GitHub after the PR opens.

## Risk And Blast Radius

- Affected packages:
  - N/A; `.github` templates only.
- Affected user flows or APIs:
  - GitHub issue creation, PR authoring, and PR commit lint CI setup.
- Rollback:
  - Revert this commit to restore the previous PR template and remove issue forms.

## Evidence

- UI/UX:
  - N/A for product UI. GitHub issue forms should be checked in the GitHub new issue flow.
- API or behavior:
  - N/A.
- Logs, recordings, or test output:
  - Local command and hook results listed in Verification.

## Compatibility

- Public contract changes:
  - None.
- Env or config changes:
  - None.
- Deployment or migration:
  - None.

## Reviewer Focus

- Closest review areas:
  - Issue form required fields, blank issue behavior, PR template guidance for external contributors, and zero-install commit lint behavior.
- Known trade-offs:
  - Blank issues remain enabled to avoid forcing early external contributors into only bug or feature forms.

## Required Checks

- [x] PR title: `type(scope): subject` (e.g. `fix(fmt): restore pre-commit checks`)
- [x] Type: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`, `build`, `ci`, `style`, or `revert`
- [x] Subject starts lowercase; `!` only for intentional breaking changes (e.g. `feat(api)!: remove legacy session field`)
- [x] Branch follows `type/scope-subject` when maintained in this repository; fork branch names may vary
- [x] Commits: `type(scope): subject`, English only
- [x] CLA: if prompted by CLA Assistant, every human contributor has signed by posting the exact required PR comment
- [x] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence, or N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A, or list touched artifacts:
  - N/A.
- GraphQL codegen (`just graphql-codegen`):
  - N/A.
- DB baseline (`just db-regen`):
  - N/A.
- Lockfile (`bun.lock`):
  - N/A.
- Confirm no hand-edits to generated paths (`schema.generated.graphql`, `apps/web/src/gql/**`, `pkgs/db/drizzle/**`):
  - Confirmed; no generated paths touched.
