### PR TITLE
feat(web): refresh login card heading to value-prop copy

### DIFF
--- a/apps/web/src/routes/login/auth-card.tsx
+++ b/apps/web/src/routes/login/auth-card.tsx
@@ -39,11 +39,11 @@ export function LoginAuthCard({
   step,
 }: LoginAuthCardProps): ReactElement {
   const isOtpStep = step === "otp";
-  const heading = step === "otp" ? "Check your email" : "Continue to Mosoo";
+  const heading = step === "otp" ? "Check your email" : "Start building in 30 seconds";
   const subheading =
     step === "otp"
       ? "Enter the verification code we just sent you."
-      : "Use Google or an email code. No password required.";
+      : "No credit card required. Free to start.";
 
   return (
     <div className="flex flex-1 items-center justify-center px-6 pb-16">


### PR DESCRIPTION
## Summary

- Replace the non-OTP heading/subheading on the landing sign-in card (`apps/web/src/routes/login/auth-card.tsx`) with the value-led copy from the YEF-664 reference: **"Start building in 30 seconds"** / **"No credit card required. Free to start."**.
- OTP step copy is untouched.

## Why

- Issue YEF-664 asks the landing sign-in card to mirror the "30 秒内开始创建" layout from the attached reference, surfacing the time-to-value proposition before users hit the Google / email buttons.

## Verification

- Commands: N/A — pure string-literal swap inside an already-rendered component.
- Manual steps: not run locally — the monorepo dev server needs a longer setup than this turn allowed; ship-fast was requested in the issue thread. Will rely on CI + PR preview for visual confirmation. Happy to attach a before/after screenshot on request.

## Risk And Blast Radius

- Affected packages: `@mosoo/web` only.
- Affected user flows or APIs: landing sign-in card non-OTP step. OTP step, Google/email buttons, error rendering, and disclaimer line are all unchanged.
- Rollback: revert this single commit (2 lines).

## Evidence

- UI/UX: copy diff is the only visible change — heading + subheading text on the non-OTP step. No layout/spacing/component changes.
- Reference (from issue YEF-664): "Start building in 30 seconds" + "No credit card required. Free to start." stacked above the auth buttons.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Confirm the copy fits the brand voice for the landing entry point; we can iterate on wording without touching layout if needed.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `feat`
- [x] Subject starts lowercase; no `!`
- [x] Branch follows agent convention
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: will sign if prompted
- [x] Self-assigned (agent author)
- [x] Diff scoped; no unrelated cleanup
- [ ] UI/UX screenshots: not attached this turn — change is a 2-line copy swap; can add a before/after on request
- [x] No generated files touched

## Generated Files, Schema, And Lockfile

- N/A — no touched generated artifacts.
- GraphQL codegen: N/A
- DB baseline: N/A
- Lockfile: N/A
- Confirm no hand-edits to generated paths: confirmed