### PR TITLE
docs(prd): garden project/app pivot drift in agent-manifest and api surface

### DIFF
--- a/docs/prd/agent-manifest.md
+++ b/docs/prd/agent-manifest.md
@@ -30,7 +30,7 @@ It is **not** a "super `agent.yaml`" that unifies the vendor configuration files
 The core points it solves are:
 
 1. **Consumable by downstream tools** — whether it is our own Agent Builder, other automation tools, or future third-party platforms, all of them can read the same Manifest to understand "who this Agent is and what it needs."
-2. **Making `.agent` files easy to distribute** — a `.zip` that contains `manifest.json` plus asset files (skills / environment definition / etc.) can be attached to a GitHub, Notion, or Slack file and handed to a colleague, and can also be imported into any Mosoo workspace or organization.
+2. **Making `.agent` files easy to distribute** — a `.zip` that contains `manifest.json` plus asset files (skills / environment definition / etc.) can be attached to a GitHub, Notion, or Slack file and handed to a colleague, and can also be imported into any Mosoo organization.
 3. **Declarative** — the user expresses "what I want," and the platform renders it into something a concrete runtime can run. The user does **not** write startup commands, does not maintain a vendor `.toml`, and does not toggle dozens of advanced switches in a UI form.
 
 ---

--- a/docs/prd/published-agent-api-surface.md
+++ b/docs/prd/published-agent-api-surface.md
@@ -4,7 +4,7 @@
 >
 > This document is aligned with the 2026-05-28 Thread-first public API lock.
 >
-> **Current Project/App boundary note**: Public API calls still enter an Agent service, but the delivery surface should be owned by Project/App. App routes, tokens, docs, usage attribution, and preview URLs should be designed App-first, with the Agent as the App-local service/runtime target. See [Project / App Boundary](./project-app-boundary.md).
+> **Current Project/App boundary note**: Public API calls still enter an Agent service, but the delivery surface should be owned by Project/App. App routes, tokens, docs, and usage attribution should be designed App-first, with the Agent as the App-local service/runtime target. Public preview URLs are not a V1 App commitment (see `docs/SPEC.md` § Non Goals and [Project / App Boundary](./project-app-boundary.md) § Out Of Scope For This Phase) — do not design around them in this phase. See [Project / App Boundary](./project-app-boundary.md).
 
 ---
 


### PR DESCRIPTION
## Summary

- Drop the reintroduced `Workspace` noun from `agent-manifest.md`'s `.agent` distribution copy so it no longer conflicts with the Identity & Access pivot that scrubbed Workspace out of product nouns.
- Tighten the `published-agent-api-surface.md` Project/App boundary note to remove "preview URLs" from the App-first design list, and call out the V1 non-goal inline so readers don't design App preview URLs into the public API surface this phase.

## Why

The last 24 hours of doc commits (`fdb19d81`, `40ca2a6d`, `9f094e20`, `8f94b4a8`, `ce246498`) locked the Project/App pivot, the V1 SPEC, and the doc layout. Two leftover drifts contradict the new locks:

1. `docs/prd/agent-manifest.md` §"Breaking it down" still said `.agent` files can be imported into "any Mosoo workspace or organization" — reintroducing the Workspace noun that `docs/prd/identity-access.md` §1 says was scrubbed completely from code, UI, and docs, and that `docs/SPEC.md` Migration Rules and `docs/prd/project-app-boundary.md` Naming Lock both forbid reintroducing.
2. `docs/prd/published-agent-api-surface.md` boundary note (added in `40ca2a6d`) instructs designers to treat "App routes, tokens, docs, usage attribution, and preview URLs" as App-first, but the V1 SPEC lock that landed in `9f094e20` listed "Public preview URL as an App commitment" under Non Goals (`docs/SPEC.md` §"Non Goals" and `docs/prd/project-app-boundary.md` §"Out Of Scope For This Phase"). Without this fix, a reader following the PRD banner would start designing App preview URLs that the V1 spec rejects.

Code already matches the V1 spec — no `workspace` entity exists in `pkgs/db/src/schema/**`, no public App preview URL surface in `apps/api/src/modules/public-api/**`. The fixes are doc-only; no contract, schema, or runtime behavior changes.

Other recent drift was already self-noted by upstream commits (deprecation banners on `agent-runtime-logs.md` / `agent-file-browser.md`, the `agent-type.md` creation-flow banner corrected in `ce246498`, the `session-files.md` Files Panel banner), so no further edits in this PR.

## Verification

- Commands: `git diff` review of the two edits; grep for residual `Workspace` reintroductions (`grep -n "workspace or organization" docs/`) returns empty after the fix; grep for `preview URL` non-goal sources (`grep -n "preview URL" docs/`) confirms the SPEC + boundary still hold the canonical non-goal text.
- Manual steps: re-read both PRD top-of-file banners end-to-end to confirm tone matches surrounding `Current Project/App boundary note` callouts.

## Risk And Blast Radius

- Affected packages: `docs/prd/agent-manifest.md`, `docs/prd/published-agent-api-surface.md`.
- Affected user flows or APIs: none — doc-only.
- Rollback: `git revert` either commit independently; no follow-up needed.

## Evidence

- UI/UX: N/A (doc-only change).
- API or behavior: no change.
- Logs, recordings, or test output: N/A.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: `docs/prd/agent-manifest.md` §"Breaking it down" item 2; `docs/prd/published-agent-api-surface.md` top-of-file `Current Project/App boundary note`.
- Known trade-offs: the published-agent-api banner now spells out the non-goal twice (once inline, once via the boundary-PRD link), but the explicit Non Goals callout is intentional so the reader cannot follow only the banner and miss the SPEC rule.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `docs`
- [x] Subject starts lowercase; no `!`
- [x] Branch follows `agent/<owner>/<short-id>` per assignment naming
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: will sign in PR conversation if prompted
- [x] Self-assigned
- [x] Diff scoped; no unrelated cleanup