### PR TITLE
docs(spec): define app service boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ For implementation language and V1 boundaries, read [SPEC.md](./docs/SPEC.md) be
 ## Current Product Lock
 
 - The primary loop is `PRD.md + @mosoo` -> create or select an App -> provision Agents and app-local resources -> expose an Agent through API or channel when needed -> export the App as `Skill.md`.
-- Project is the canonical engineering noun. App is the user-facing console noun. Avoid introducing parallel nouns such as Workspace, Team, Application, or Agent Service for this boundary.
+- Project is the canonical engineering noun. App is the user-facing console noun. Avoid introducing parallel boundary nouns such as Workspace, Team, Application, Service App, or Product.
 - Agents, Threads / Sessions, Spaces, Environments, Skills, MCP servers, Provider keys, Channels, Agent exposure state, export, and app-scoped cost belong to the Project/App boundary first.
-- App is not a Web shell, GitHub repository, App runtime, or App-level API endpoint in V1. Agent owns runtime, API endpoint exposure, and channel delivery.
+- App is not a Web shell, GitHub repository, App runtime, App-level API endpoint, or generic Service container in V1. Do not add a unified `services` table or polymorphic `service.kind`.
+- Agents own runtime, API endpoint exposure, and channel delivery.
 - The console should create a default App during onboarding. If an Organization has one App, route directly into that App; the App list only becomes prominent when there is a second App.
 
 ## What Is Mosoo
@@ -53,7 +54,7 @@ The current roadmap centers on these goals:
 - **OPC / personal developers first**: polish the full loop for creating, exposing, running, debugging, and exporting one Agent App as an individual developer.
 - **Cloudflare-native runtime**: continue converging the architecture around Workers, Durable Objects, D1, R2, and related platform capabilities.
 - **Complete open-source community path**: prioritize the core capabilities required for a self-hostable, modifiable, extensible community edition.
-- **Project/App resource boundary**: move Agent, Thread / Session, Space, Environment, Skill, MCP, Provider Credential, Channel, Agent exposure state, export, and app-scoped Cost under one boundary.
+- **Project/App resource boundary**: move Agent, Thread / Session, Space, Environment, Skill, MCP, Provider Credential, Channel, Agent exposure state, export, and app-scoped Cost under one boundary without adding a generic Service entity.
 - **Enterprise capability expansion**: after personal and OPC scenarios work end to end, add team collaboration, permissions, cost governance, version control, and runtime governance.
 
 For the current status snapshot — what is **Planned**, **In Development**, and **Done** — see [roadmap.md](./roadmap.md).

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -14,15 +14,20 @@ If this document conflicts with older PRDs, follow this document first, then
 
 1. App is the user-facing product boundary.
 2. Project is the engineering name for the same boundary.
-3. App is an Agent capability package, not a Web deployment unit.
+3. App is an Agent and resource package, not a Web deployment unit.
 4. Organization is only the account, billing, tenant, and future-governance shell.
-5. App has no runtime. Runtime belongs to Agents.
-6. Agent is the App-local execution and delivery unit.
-7. Thread is the product name for an Agent Session in V1.
-8. App resources are shared at App scope; Agents bind the resources they need.
-9. V1 optimizes for delivery and reuse, not administration.
-10. Owner-only access is the default for V1.
-11. Future governance must not block the single-owner App loop.
+5. App owns concrete App-local concepts directly; V1 does not introduce a generic
+   Service entity.
+6. App has no runtime. Runtime belongs to Agents or future explicitly named runtime
+   resources.
+7. Agent is the App-local unit that owns Agent runtime and delivery.
+8. Thread is the product name for an Agent Session in V1.
+9. App resources are shared at App scope; Agents bind the resources they need.
+10. Common one-Agent, one-Channel shapes should come from Project Templates, not from a
+    required App or Agent type decision.
+11. V1 optimizes for delivery and reuse, not administration.
+12. Owner-only access is the default for V1.
+13. Future governance must not block the single-owner App loop.
 
 ## Core Concepts
 
@@ -72,9 +77,11 @@ An App:
 
 - Is what the user creates, opens, configures, monitors, and exports.
 - Is a boundary for a real-world Agent application.
-- Organizes one or more Agents.
+- Organizes one or more App-local Agents.
 - Owns shared resources used by those Agents.
-- Aggregates Threads, usage, health, logs, and expose state through its Agents.
+- Aggregates Threads, usage, health, logs, and expose state through its Agents and
+  resources.
+- Can be created blank or from a Project Template that provisions a concrete resource set.
 - Can be packaged into one `Skill.md` for coding-agent reuse.
 - Is the default console entry after onboarding when the Organization has one App.
 
@@ -100,6 +107,38 @@ An Agent:
 entity, table, service layer, or product container.
 
 An App can contain many Agents, but one Agent per App is expected to be common.
+
+### Generic Service Entity
+
+V1 does not have a generic Service domain entity.
+
+Rules:
+
+- Do not add a unified `services` table.
+- Do not model App resources through a polymorphic `service.kind`.
+- Do not create generic Service CRUD as the primary API for Agents, Channels, Storage,
+  Environments, Skills, MCP servers, or Provider credentials.
+- Console copy may group concrete resources under "Services" or "Resources" for scanning,
+  but that grouping must not become a database, API, permission, or lifecycle boundary.
+- If a future resource shares a deployment/runtime lifecycle, such as Web/API runtime,
+  database service, scheduled job, or worker process, model it with an explicit noun and
+  add a dedicated contract for its lifecycle.
+- API-layer names such as File Service or Environment Service are implementation modules
+  and do not imply a generic App Service entity.
+
+### Project Template
+
+A Project Template is a reusable App blueprint.
+
+A Project Template:
+
+- Creates a Project/App plus one or more preconfigured concrete resources.
+- Can represent common shapes such as one Pet Agent bound to one Channel.
+- Can represent larger shapes such as multiple Agents plus Storage, MCP, Provider, and
+  Channel resources.
+- Selects defaults and wiring, but does not create `app.type` or `project.type` as runtime
+  drivers.
+- Is the preferred path for simple chatbot-style Apps and other repeatable resource graphs.
 
 ### Thread
 
@@ -278,6 +317,7 @@ Account
         +-- MCP Servers
         +-- Provider Credentials
         +-- Channels
+        +-- Gateways / exposure surfaces
         +-- Operations
         |   +-- usage
         |   +-- health
@@ -290,11 +330,12 @@ Rules:
 
 - Organization owns Projects, not App resources directly.
 - Project and App are the same boundary with different names for different audiences.
-- App owns organization, resource, export, and operations scope.
+- App owns business resources, export, and operations scope.
 - App has no runtime.
-- Agent owns runtime, endpoint exposure, channel delivery, and V1 Threads/Sessions.
+- Agents own Agent runtime, endpoint exposure, channel delivery, and Threads/Sessions in V1.
 - Thread is a product name for Agent Session in V1.
 - Usage has Project/App as the business dimension and Organization as the billing rollup.
+- V1 has no unified `services` table or generic Service lifecycle.
 
 ## V1 Goals
 
@@ -303,7 +344,9 @@ V1 must support:
 - A personal developer signs in.
 - The system creates or selects the developer's Organization shell.
 - The system creates a default App.
-- The user can create or configure one or more Agents inside the App.
+- The user can start from a blank App or a Project Template.
+- The user can create or configure one or more concrete App resources.
+- The user can create or configure one or more Agents when the App needs runtime.
 - The Agent can reference an Environment.
 - The Agent can use App-local Provider credentials.
 - The Agent can bind App-local Storage, Skills, MCP servers, and Channels when configured.
@@ -311,7 +354,8 @@ V1 must support:
 - The user can expose an Agent through an API endpoint.
 - The system can map channel external threads to Agent Sessions when Channel delivery is
   configured.
-- The user can inspect App-scoped Threads, usage, health, logs, and Agent expose state.
+- The user can inspect App-scoped Agents, resources, Threads, usage, health, logs, and
+  Agent expose state.
 - The user can export the App as one `Skill.md`.
 
 ## Non Goals
@@ -340,6 +384,10 @@ V1 must not include:
 - Cross-member cost reporting.
 - Audit logs.
 - `app.type` or `project.type` as runtime, access, or ownership drivers.
+- A required single Agent type picker as the App creation path.
+- Persistence-layer limits driven by App type or Agent type.
+- Generic `services` table, polymorphic `service.kind`, or generic Service CRUD.
+- Multi-resource graphs as the default burden for simple Apps.
 - Generic Interface entity.
 - App runtime.
 - App router runtime.
@@ -366,21 +414,25 @@ V1 must not include:
 
 ### Create App
 
-1. User chooses New App.
+1. User chooses New App, or chooses a Project Template.
 2. System creates a Project.
 3. Console displays it as an App.
 4. System creates or assigns default App-local resource sets for Agents, Storage,
-   Environments, Skills, MCP servers, Provider credentials, Channels, operations, and export.
-5. System does not create Web shell, GitHub repository, App runtime, App API endpoint, or
+   Environments, Skills, MCP servers, Provider credentials, Channels, operations, and
+   export.
+5. If a Project Template is selected, system provisions the template's concrete resource
+   graph, such as one Pet Agent bound to one Channel.
+6. System does not create Web shell, GitHub repository, App runtime, App API endpoint, or
    database tables as a consequence of App creation.
 
-### Configure Agent
+### Configure App Resources
 
-1. User creates or edits an Agent inside an App.
-2. Agent chooses runtime kind, model/provider, prompt/config, Environment, and optional
-   resource bindings.
-3. System validates required Provider credentials and Environment readiness.
-4. Agent remains the runtime and delivery unit.
+1. User creates or edits a concrete resource inside an App.
+2. The resource type determines which configuration is relevant.
+3. Agents choose runtime kind, model/provider, prompt/config, Environment, and
+   optional resource bindings.
+4. System validates required Provider credentials and Environment readiness for Agents.
+5. Non-runtime resources do not gain runtime because they are listed beside Agents.
 
 ### Run Thread
 
@@ -420,8 +472,9 @@ V1 must not include:
 1. Runtime emits normalized model usage.
 2. Cost service writes usage events with Project/App as the primary business dimension.
 3. Organization is retained as a billing rollup.
-4. App views show Agent list, Thread history, expose state, spend, request count,
-   token/cache usage, model breakdown, recent runs, logs, health, and unpriced usage count.
+4. App views show Agent detail, resource lists, Thread history, expose state, spend, request
+   count, token/cache usage, model breakdown, recent runs, logs, health, and unpriced usage
+   count.
 5. V1 does not show member drilldown.
 
 ## Access Rules
@@ -441,13 +494,14 @@ Apps
 +-- App
     +-- Overview
     +-- Agents
+    +-- Resources
+    |   +-- Channels / Gateways
+    |   +-- Storage / Spaces
+    |   +-- Environments
+    |   +-- Skills
+    |   +-- MCP
+    |   +-- Providers
     +-- Threads
-    +-- Storage
-    +-- Environments
-    +-- Skills
-    +-- MCP
-    +-- Providers
-    +-- Channels
     +-- Usage
     +-- Logs
     +-- Export
@@ -458,8 +512,13 @@ Rules:
 
 - A one-App Organization routes directly to App Overview.
 - Apps list exists for creating or switching Apps, not as a blocking first screen.
+- Project Templates can create a simple one-Agent, one-Channel App without teaching the user
+  the full resource graph first.
 - Members does not appear in V1 navigation.
 - Organization settings stay thin.
+- Agents is where users inspect App-local runtime/delivery units.
+- Resources is where users inspect Channels, Storage, Environments, Skills, MCP servers,
+  Providers, and Gateways.
 - Agent detail is where runtime, endpoint exposure, channel delivery, and Thread creation
   happen.
 - WebUI Thread views operate Mosoo Sessions; they are not a user-published Web App surface.
@@ -469,11 +528,17 @@ Rules:
 - When older docs say Organization-owned resource, read it as Project/App-owned unless it is
   explicitly about billing or future governance.
 - When older docs say Workspace or Team, do not introduce those nouns.
-- When older docs say Agent Service, read it as Agent.
+- When older docs say Agent Service, read it as the existing Agent identity, not as a second
+  Agent table or a separate App boundary.
+- When older docs introduce a generic App-local Service capability/resource entity, treat that
+  as historical wording. New work should model concrete resources directly.
 - When older docs say Publish App, App API, Web shell, or public preview URL, treat it as
   old Web-app-first wording unless a later spec reopens the decision.
 - When older docs say App owns delivery surface, read it as App aggregates Agent exposure and
   operations; Agent owns endpoint and channel delivery in V1.
+- When older docs ask users to choose one Agent type as the creation path, prefer a Project
+  Template or an Agent setting, depending on whether the choice describes an App shape or a
+  runtime behavior.
 - When older docs mention member, coworker, shared with me, everyone in organization,
   Owner/Admin/Member, invitation, or access request, treat it as future governance.
 - Do not delete compatibility tables until Project/App ownership and owner access replace
@@ -483,18 +548,20 @@ Rules:
 
 1. Add Project/App ID, contract, database table, GraphQL surface, and default provisioning.
 2. Add Project owner access helpers and keep Organization membership only as a migration bridge.
-3. Move Agent creation, reads, updates, and readiness under Project/App.
-4. Keep Thread as Agent Session in V1; add Project/App inheritance through Agent and App-level
-   aggregation.
+3. Move Agent creation, reads, updates, and readiness under Project/App without introducing a
+   generic Service table.
+4. Keep Thread as Agent Session in V1; add Project/App inheritance through Agent and
+   App-level aggregation.
 5. Move Environment defaults and Provider credentials under Project/App.
 6. Move MCP servers, Skills, Storage/Spaces, and Channels under Project/App resource ownership.
 7. Keep Agent API endpoint exposure and Channel delivery on Agent.
-8. Add App usage, health, logs, and Organization billing rollup.
-9. Make App Overview the console root.
-10. Add App export to one `Skill.md`.
-11. Remove or hide public Members, RBAC, invitations, access requests, resource-sharing,
+8. Add Project Templates for common simple shapes such as Pet Agent plus Channel.
+9. Add App usage, health, logs, and Organization billing rollup.
+10. Make App Overview the console root.
+11. Add App export to one `Skill.md`.
+12. Remove or hide public Members, RBAC, invitations, access requests, resource-sharing,
     App-publish, preview-URL, and Web-shell surfaces from the V1 path.
-12. Remove internal services, contracts, tests, and database tables for old governance after
+13. Remove internal services, contracts, tests, and database tables for old governance after
     no runtime path depends on them.
 
 ## Acceptance Checklist
@@ -504,6 +571,10 @@ An implementation is aligned with this Spec when:
 - A new user reaches a default App without seeing team or member flows.
 - App Overview is the first screen for a one-App Organization.
 - Creating an Agent requires an App context.
+- Creating concrete resources requires an App context.
+- There is no generic `services` table, `service.kind`, or generic Service CRUD.
+- A simple one-Agent, one-Channel App can be created from a Project Template instead of a
+  required App or Agent type picker.
 - App creation does not create Web shell, GitHub repository, App runtime, App API endpoint, or
   database tables.
 - Thread creation targets one Agent and creates a Session.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,9 +2,9 @@
 
 ## 1. Vision And Principles
 
-This project provides a deliberately simple web experience for orchestrating heterogeneous Agents, including CLI tools and SDK-based runtimes.
+This project provides a deliberately simple web experience for orchestrating App-local Agents and concrete resources backed by CLI tools and SDK-based runtimes.
 
-The current priority is OPCs, personal developers, and small self-hosted deployments. A user should be able to bring `PRD.md`, invoke `@mosoo`, and get a running Agent App in their own Cloudflare account with low operational overhead. In the current construction phase, assume one human owns one Organization: Organization is the account / billing / tenant shell, Project is the code and data boundary, and App is the console noun. Team collaboration, enterprise governance, cost management, and stronger compliance controls are extension paths for the same architecture, not default complexity for the current community edition.
+The current priority is OPCs, personal developers, and small self-hosted deployments. A user should be able to bring `PRD.md`, invoke `@mosoo`, and get a running Agent App in their own Cloudflare account with low operational overhead. In the current construction phase, assume one human owns one Organization: Organization is the account / billing / tenant shell, Project is the code and data boundary, and App is the console noun. Project/App owns concrete resources directly; it does not introduce a generic Service entity, `services` table, or polymorphic `service.kind`. Team collaboration, enterprise governance, cost management, and stronger compliance controls are extension paths for the same architecture, not default complexity for the current community edition.
 
 To support lightweight deployment, fast iteration, and future governance expansion, the architecture embraces Serverless and edge computing and follows these baseline principles:
 
@@ -45,7 +45,7 @@ graph TD
 
         Identity[Identity & Access Service<br/>Org / Account / Membership]
         Auth[Auth Service]
-        Project[Project / App Service<br/>Delivery Boundary]
+        Project[Project / App Domain<br/>Resource Boundary]
         Session[Session Service / Event Bus<br/>Durable Objects]
         Vault[Credential / Secret Vault Service]
         File[File Service<br/>Space Control & Snapshots]
@@ -60,7 +60,7 @@ graph TD
 
         Ingress --> |GraphQL Resolver / In-Process Calls| Identity & Auth & Project & Vault & File & Env & Agent_Plane & Cost
         Ingress --> |WS Upgrade Handoff| Session
-        Project --> |Owns App-local resources| Agent_Plane & Vault & File & Env & Cost
+        Project --> |Owns App-local Agents / resources| Agent_Plane & Vault & File & Env & Cost
         File & Agent_Plane --> |Push Events / Session RPC| Session
         Env --> |Resolve frozen EnvironmentRevision| Runtime
         Agent_Plane --> |Usage / Runtime Metrics| Cost
@@ -117,20 +117,22 @@ The Web layer provides the interactive client experience.
 
 The API layer contains business logic, state management, and Agent scheduling. It is the system control plane.
 
-Except for runtime boundaries such as Session Durable Objects and Sandbox instances, the `* Service` terms below refer to domain modules inside the same API Worker codebase, not independently deployed microservices.
+Except for runtime boundaries such as Session Durable Objects and Sandbox instances, the API-layer `* Service` terms below refer to domain modules inside the same API Worker codebase, not independently deployed microservices. Product-level App resources are concrete nouns such as Agent, Channel, Space, Environment, Skill, MCP server, and Provider credential. V1 does not add a generic Service entity, `services` table, or polymorphic `service.kind`.
 
 1. **API / WS Gateway**
    - Stateless Workers provide the shared HTTP and WebSocket ingress layer. They handle authentication, routing, GraphQL queries and mutations, and WebSocket handshakes.
    - WebSocket requests always enter the Worker first. The Worker resolves the Session key and Organization context, then hands the upgraded connection to the corresponding Session Durable Object.
 
-2. **Project / App Service**
-   Project / App Service owns the business, resource, operations, and export boundary for the current pivot. Project is the canonical engineering noun; App is the console noun. A Project belongs to an Organization and is owned by the Organization owner during the single-owner phase. App has no runtime; Agent owns runtime, API endpoint exposure, and channel delivery.
+2. **Project / App Domain**
+   Project / App Domain owns the business, resource, operations, and export boundary for the current pivot. Project is the canonical engineering noun; App is the console noun. A Project belongs to an Organization and is owned by the Organization owner during the single-owner phase. App has no runtime; in V1, Agents own Agent runtime, API endpoint exposure, channel delivery, and Threads / Sessions.
    - **Default App provisioning**: Onboarding / Organization provisioning creates a default Project/App. If the Organization has exactly one App, the console routes directly into that App instead of forcing an App picker.
-   - **Resource ownership**: Agents, Threads / Sessions, Spaces, Environments, Skills, MCP servers, Provider credentials, Channels, Agent exposure state, App export, app health, logs, and app-scoped cost are Project-owned resources. Organization rollups remain for billing and future governance.
+   - **Agent and resource ownership**: Agents, Threads / Sessions, Spaces, Environments, Skills, MCP servers, Provider credentials, Channels, Agent exposure state, App export, app health, logs, and app-scoped cost are Project-owned first. Organization rollups remain for billing and future governance.
+   - **No generic Service entity**: Do not add a unified `services` table, polymorphic `service.kind`, or generic Service CRUD for concrete App resources. If a future Web/API runtime, database service, worker process, or scheduled job is needed, model it with an explicit noun and lifecycle.
+   - **Project Templates**: Common one-Agent, one-Channel Apps should be created from Project Templates that provision a resource graph, not from a required global App type or single Agent type picker.
    - **Access boundary**: Project access maps to the single Organization owner for this phase. Project members, Project roles, ownership transfer, and org-wide shared resources are future extensions, not prerequisites for the first cut.
 
 3. **Agent Plane**
-   The Agent Plane unifies configuration management, lightweight system assistance, and runtime scheduling. The public data entity is the bare `Agent`. Historical terms such as `AgentService` and `PublishedAgent` have been collapsed into `Agent`, and the module name `Agent Plane` avoids a naming collision with the entity itself.
+   The Agent Plane unifies configuration management, lightweight system assistance, and runtime scheduling. The public runtime-backed unit is `Agent`, backed by the existing `Agent` data identity. Historical table or class names such as `AgentService` and `PublishedAgent` have been collapsed into `Agent`; the product noun Agent Service must not be reintroduced as a second Agent table.
    - **Profile management**: Agent definitions are stored under Project in D1 and support CRUD plus import/export flows. The Profile manages Skill availability, MCP bindings, Runtime references, and Provider references for an App-local Agent. Runtime plaintext credentials are not stored in the Profile. New flows resolve them through Credential / Vault by `(execution_actor, project, provider)`, with `(execution_actor, organization, provider)` kept only as migration fallback. In the Runtime Session Kernel, the execution actor is the Agent owner; the caller is used only for ingress context and permission response attribution.
    - **System Agent**: This path helps users create and edit Agent configuration, generate system prompts, choose models and tools, and validate configuration completeness. It uses lightweight LLM calls, does not start a Sandbox, does not launch an Agent Driver or Agent Process, and does not use Skills for dynamic expansion. It is made from model, system prompt, and controlled tool schemas, with Cloudflare Agents SDK used only as a thin session/state/RPC wrapper.
    - **Runtime**: The Runtime validates execution rights and orchestrates Cloudflare Sandbox instances. It does not wait for an in-sandbox Driver to call back to a public endpoint. Instead, it uses Sandbox SDK `wsConnect()` to reach the Driver's local WebSocket / JSON-RPC interface inside the container. It also applies Agent `kind` to choose Pet Sandbox or Cattle Session Sandbox behavior, restores platform conversation history, mounts authorized Spaces, manages Sandbox Backup/Restore and destruction policy, and consumes `sandbox.watch()` file events on the Worker side.

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -9,11 +9,11 @@ Product contracts and the standards used to write them.
 ## Current direction
 
 - [Mosoo Spec](../SPEC.md): canonical V1 nouns, relationships, non-goals, behavior, and implementation order.
-- [Project / App Boundary](./project-app-boundary.md): active construction lock for the current pivot. Read this before implementing data model, IA, resource ownership, access, or deployment changes.
+- [Project / App Boundary](./project-app-boundary.md): active construction lock for the current pivot. Read this before implementing data model, IA, Agent ownership, resource ownership, access, or deployment changes.
 
 ## PRDs
 
-Implementation contracts and shipped product behavior. Each PRD is the high-readability product specification for a capability. When older PRDs mention Organization-owned business assets, members, Admin reach-through, Workspace, or Agent-first service identity, apply the Project/App Boundary drift rules first.
+Implementation contracts and shipped product behavior. Each PRD is the high-readability product specification for a capability. When older PRDs mention Organization-owned business assets, members, Admin reach-through, Workspace, Agent-first service identity, or a required single Agent type picker, apply the Project/App Boundary drift rules first.
 
 ### Agents & packaging
 

--- a/docs/prd/project-app-boundary.md
+++ b/docs/prd/project-app-boundary.md
@@ -11,7 +11,7 @@ The near-term Mosoo wedge is no longer an Agent-first console. The product loop 
 1. A personal developer brings `PRD.md`.
 2. They invoke `@mosoo`.
 3. Mosoo creates or selects a Project, shown as an App in console copy.
-4. Mosoo provisions Agents and app-local resources.
+4. Mosoo provisions App-local Agents and concrete resources.
 5. Mosoo exposes an Agent through API or channel when needed.
 6. Mosoo can export the App as one `Skill.md` for coding-agent reuse.
 
@@ -21,7 +21,14 @@ The current phase deliberately assumes one human owns one Organization. Organiza
 
 - **Project** is the canonical engineering noun for code, database schema, API contracts, architecture, tests, and migrations.
 - **App** is the user-facing console noun. Users should feel they are operating an App, not a database entity.
-- Do not introduce parallel nouns such as Workspace, Team, Application, Agent Service, Service App, or Product unless a later PRD explicitly reopens the naming decision. "Agent Service" is discussion language for Agent, not a new entity.
+- **Agent** is the App-local runtime and delivery unit backed by the existing Agent identity.
+  Do not introduce a second Agent Service table, App boundary, or deployment topology.
+- **Resources** are concrete App-owned nouns such as Channels, Spaces, Environments, Skills,
+  MCP servers, Provider credentials, and future explicit runtime or database resources.
+- **Service** is not a V1 domain entity. Do not add a unified `services` table,
+  polymorphic `service.kind`, or generic Service CRUD for App resources.
+- Do not introduce parallel boundary nouns such as Workspace, Team, Application, Service App,
+  or Product unless a later PRD explicitly reopens the naming decision.
 - Existing Agent-first routes and docs are migration context, not the desired final IA.
 
 ## Ownership Model
@@ -49,7 +56,9 @@ The following resources should belong to Project/App before they belong to a bro
 - Agent exposure state, app health, logs, and App export.
 - App-scoped usage and cost, with Organization rollups preserved for billing and future admin views.
 
-Project/App does not own a V1 Web shell, App runtime, App-level API endpoint, or public preview URL. Agent owns runtime, API endpoint exposure, and channel delivery.
+Project/App does not own a V1 Web shell, App runtime, App-level API endpoint, or public preview URL. In V1, Agents own Agent runtime, API endpoint exposure, channel delivery, and Threads / Sessions. If a future Web/API runtime, database service, worker process, or scheduled job is needed, it should be modeled with an explicit noun and lifecycle rather than through a generic Service table.
+
+Project Templates can provision repeatable resource graphs, such as one Pet Agent bound to one Channel. Templates are how simple chatbot-style Apps avoid a required App type or Agent type decision while still getting a complete starting shape.
 
 Organization remains responsible for account identity, ownership, billing aggregation, and future governance. It must not be used as the default bucket for business resources in new Project/App work.
 
@@ -58,22 +67,25 @@ Organization remains responsible for account identity, ownership, billing aggreg
 The console has two layers:
 
 - **Organization layer**: Apps, Usage / Billing rollups, and thin Organization settings.
-- **App layer**: Overview, Threads, Agents, Spaces, Environments, Skills, MCP servers, Providers, Channels, Usage, Logs, Export, and App settings.
+- **App layer**: Overview, Agents, Resources, Threads, Usage, Logs, Export, and App settings.
+  The Resources view groups Channels / Gateways, Spaces, Environments, Skills, MCP servers,
+  and Providers.
 
 Onboarding should create a default App. If an Organization has exactly one App, login should route directly to that App. The Apps list exists for creating or switching between multiple Apps and should not block the one-App OPC path.
 
 ## Construction Order
 
 1. Add the Project data model, shared contracts, GraphQL surface, and default Project creation during onboarding / Organization provisioning.
-2. Move Agent creation and Agent reads under Project. Threads / Sessions should inherit Project from Agent rather than introducing an independent picker.
-3. Move Environment and Provider defaults to Project scope, with Organization fallback only as a migration bridge.
-4. Move MCP, Skills, and Spaces under Project/App resource ownership. Preserve existing resource semantics, but change the owning boundary first.
-5. Add Project-scoped usage / cost while preserving Organization rollups for billing and future governance.
-6. Move Channels under Project/App resource ownership while keeping Agent channel delivery on Agent.
-7. Keep API endpoint exposure on Agent. Do not add Publish App, App runtime, or App-level API endpoint.
-8. Make the console root an App Overview. Keep the single-App direct-entry behavior before expanding multi-App management.
-9. Add App export to one `Skill.md`.
-10. Only after the above is real, reopen Project members, org-wide shared resources, role matrices, ownership transfer, and enterprise governance.
+2. Move Agent creation and Agent reads under Project without introducing a generic Service entity. Threads / Sessions should inherit Project from Agent rather than introducing an independent picker.
+3. Move concrete resources under Project/App ownership directly; do not route them through a unified `services` table.
+4. Move Environment and Provider defaults to Project scope, with Organization fallback only as a migration bridge.
+5. Move MCP, Skills, Spaces, and Channels under Project/App resource ownership. Preserve existing resource semantics, but change the owning boundary first.
+6. Add Project Templates for common simple shapes such as Pet Agent plus Channel.
+7. Add Project-scoped usage / cost while preserving Organization rollups for billing and future governance.
+8. Keep API endpoint exposure on Agent. Do not add Publish App, App runtime, or App-level API endpoint.
+9. Make the console root an App Overview. Keep the single-App direct-entry behavior before expanding multi-App management.
+10. Add App export to one `Skill.md`.
+11. Only after the above is real, reopen Project members, org-wide shared resources, role matrices, ownership transfer, and enterprise governance.
 
 ## Out Of Scope For This Phase
 
@@ -82,14 +94,22 @@ Onboarding should create a default App. If an Organization has exactly one App, 
 - Multi-user ownership transfer or asset takeover.
 - Enterprise domain discovery expansion, SAML / SCIM, or rich member lifecycle administration.
 - Publish App, App runtime, App-level API endpoint, Web shell, or public preview URL as V1 commitments.
-- App type / Project type or generic Interface entity.
+- App type / Project type, a required single Agent type picker as the App creation path,
+  persistence-layer limits driven by App type or Agent type, or generic Interface entity.
+- Generic `services` table, polymorphic `service.kind`, or generic Service CRUD for concrete
+  App resources.
+- Multi-resource graphs as the default burden for simple Apps.
 - Reworking Agent Builder as the primary experience before Project ownership and default App creation exist.
 
 ## Drift Rules
 
 - If a PRD says Organization-owned for a business resource listed above, read it as historical unless it explicitly says it is describing a future governance layer.
 - If a PRD says member, coworker, shared with me, everyone in organization, Owner / Admin / Member, or access request, treat that text as future multi-member governance unless the current implementation already depends on it.
-- If a PRD says Agent Service, read it as Agent.
-- If a PRD says Agent is the stable service identity, read it as the Agent owning runtime and exposure while App aggregates Agent operations.
+- If a PRD says Agent Service, read it as the existing Agent identity, not as a second Agent
+  table or a separate App boundary.
+- If a PRD says Service is the App-local capability/resource unit, treat that as historical
+  wording; new work should model concrete resources directly.
+- If a PRD says Agent is the stable service identity, read it as Agent owning runtime and exposure while App aggregates Agent operations.
+- If a PRD asks users to choose one Agent type as the creation path, prefer a Project Template or an Agent setting, depending on whether the choice describes an App shape or a runtime behavior.
 - If a PRD says Publish App, App API, Web shell, or public preview URL, treat it as old Web-app-first wording unless a later spec reopens the decision.
 - If implementation work needs a new noun or access boundary, update this document, README, architecture, and the PRD index before changing code.


### PR DESCRIPTION
## Summary

- Define App-local Service as the Project/App capability and resource unit.
- Reframe Agent as an Agent Service backed by the existing Agent identity, without introducing a second Agent table or App runtime.
- Add Project Templates as the path for simple one-Agent, one-Channel Apps and reject required App/Agent type pickers or type-driven persistence limits.
- Sync README, SPEC, architecture, PRD index, and Project/App Boundary PRD.

## Verification

- `bash ./init.sh development`
- `just fmt-check-path README.md`
- `just fmt-check-path docs/SPEC.md`
- `just fmt-check-path docs/prd/project-app-boundary.md`
- `just fmt-check-path docs/prd/README.md`
- `just fmt-check-path docs/architecture.md`
- `just check`
- `just commit-check`

Generated files: none.
GraphQL codegen: checked via `just check`; no generated output committed.
DB baseline/migrations: not changed.