### PR TITLE
feat(app-boundary): remove app agent organization payload

### DIFF
--- a/apps/api/src/adapters/graphql/schema.generated.graphql
+++ b/apps/api/src/adapters/graphql/schema.generated.graphql
@@ -551,7 +551,6 @@ type App {
   defaultEnvironmentId: ULID
   id: ULID!
   name: String!
-  organizationId: ULID!
   ownerAccountId: ULID!
   slug: String!
 }

--- a/apps/api/src/adapters/graphql/schema/app-schema.ts
+++ b/apps/api/src/adapters/graphql/schema/app-schema.ts
@@ -4,7 +4,6 @@ export const appSchema = /* GraphQL */ `
     defaultEnvironmentId: ULID
     id: ULID!
     name: String!
-    organizationId: ULID!
     ownerAccountId: ULID!
     slug: String!
   }

--- a/apps/api/src/modules/agents/application/agent-repository.ts
+++ b/apps/api/src/modules/agents/application/agent-repository.ts
@@ -12,7 +12,6 @@ import type {
   AgentDeploymentVersionId,
   AgentId,
   EnvironmentId,
-  OrganizationId,
   AppId,
   SkillId,
 } from "@mosoo/id";
@@ -26,7 +25,6 @@ import {
   readAgentId,
   readEnvironmentId,
   readMcpServerId,
-  readOrganizationId,
   readAppId,
 } from "./agent-platform-ids";
 import { normalizeAgentSkillIds } from "./agent-skill-resolution.service";
@@ -43,7 +41,6 @@ export const agentRowColumns = {
   liveDeploymentVersionId: agentsTable.liveDeploymentVersionId,
   model: agentsTable.model,
   name: agentsTable.name,
-  appOrganizationId: appsTable.organizationId,
   ownerId: agentsTable.ownerId,
   appId: agentsTable.appId,
   prompt: agentsTable.prompt,
@@ -64,7 +61,6 @@ type RawAgentRow = {
   liveDeploymentVersionId: AgentDeploymentVersionId | null;
   model: string;
   name: string;
-  appOrganizationId: OrganizationId;
   ownerId: AccountId;
   appId: AppId;
   prompt: string;
@@ -99,7 +95,6 @@ function toAgentRow(row: RawAgentRow): AgentRow {
             row.liveDeploymentVersionId,
             "Agent live deployment version ID",
           ),
-    appOrganizationId: readOrganizationId(row.appOrganizationId, "Agent App organization ID"),
     ownerId: readAccountId(row.ownerId, "Agent owner ID"),
     appId: readAppId(row.appId, "Agent app ID"),
     visibility: readAgentVisibility(row.visibility),

--- a/apps/api/src/modules/agents/application/agent-types.ts
+++ b/apps/api/src/modules/agents/application/agent-types.ts
@@ -1,12 +1,5 @@
 import type { Agent } from "@mosoo/contracts/agent";
-import type {
-  AccountId,
-  AgentDeploymentVersionId,
-  AgentId,
-  EnvironmentId,
-  OrganizationId,
-  AppId,
-} from "@mosoo/id";
+import type { AccountId, AgentDeploymentVersionId, AgentId, EnvironmentId, AppId } from "@mosoo/id";
 
 export interface AgentRow {
   configJson: string;
@@ -26,5 +19,4 @@ export interface AgentRow {
   status: Agent["status"];
   updatedAt: number;
   visibility: Agent["visibility"];
-  appOrganizationId: OrganizationId;
 }

--- a/apps/api/src/modules/apps/application/app.service.ts
+++ b/apps/api/src/modules/apps/application/app.service.ts
@@ -16,7 +16,6 @@ export function toAppSummary(row: AppRow): AppSummary {
     defaultEnvironmentId: row.defaultEnvironmentId,
     id: row.id,
     name: row.name,
-    organizationId: row.organizationId,
     ownerAccountId: row.ownerAccountId,
     slug: row.slug,
   };

--- a/apps/api/src/modules/cost/application/cost-query.service.ts
+++ b/apps/api/src/modules/cost/application/cost-query.service.ts
@@ -190,12 +190,13 @@ export async function getAgentCostCard({
   runPurposes = [],
   viewer,
 }: AgentCostCardInput): Promise<AgentCostCardView> {
+  const app = await ensureAppOwnership(database, viewer.id, appId);
   const { agent } = await ensureAppAgentOwner(database, viewer.id, { agentId, appId });
   const [header, card] = await Promise.all([
     getAgentHeader(database, agentId),
     buildAttributionCard(database, {
       agentId,
-      organizationId: agent.appOrganizationId,
+      organizationId: app.organizationId,
       appId: agent.appId,
       range,
       runPurposes,

--- a/apps/api/tests/agent-detail-model.test.ts
+++ b/apps/api/tests/agent-detail-model.test.ts
@@ -29,7 +29,6 @@ const AGENT_ROW: AgentRow = {
   liveDeploymentVersionId: "01J0000000000000000000006A",
   model: "gpt-5.4",
   name: "Agent",
-  appOrganizationId: "01J00000000000000000000006",
   ownerId: "01J00000000000000000000001",
   appId: "01J0000000000000000000000P",
   prompt: "Private prompt",

--- a/apps/api/tests/agent-mcp-config-binding.test.ts
+++ b/apps/api/tests/agent-mcp-config-binding.test.ts
@@ -223,7 +223,6 @@ const agent: AgentRow = {
   liveDeploymentVersionId: null,
   model: "gpt-5.4",
   name: "Agent",
-  appOrganizationId: "01J00000000000000000000006",
   ownerId: "01J00000000000000000000001",
   appId: "01J00000000000000000000007",
   prompt: "Help",

--- a/apps/api/tests/agent-package-draft.test.ts
+++ b/apps/api/tests/agent-package-draft.test.ts
@@ -175,7 +175,6 @@ describe("agent package draft", () => {
       liveDeploymentVersionId: null,
       model: "gpt-5.4",
       name: "Imported Agent",
-      appOrganizationId: DRAFT_IDS.organization,
       ownerId: DRAFT_IDS.owner,
       appId: DRAFT_IDS.app,
       prompt: "Help",

--- a/apps/api/tests/app-provisioning.test.ts
+++ b/apps/api/tests/app-provisioning.test.ts
@@ -85,7 +85,6 @@ describe("App provisioning boundary", () => {
         defaultEnvironmentId: "env-1",
         id: "app-1",
         name: "Default App",
-        organizationId: "org-1",
         ownerAccountId: "account-1",
         slug: "default",
       },

--- a/apps/web/src/domains/app/api/app-client.ts
+++ b/apps/web/src/domains/app/api/app-client.ts
@@ -4,7 +4,7 @@ import type { OrganizationId } from "@mosoo/contracts/id";
 import { graphql } from "@/gql";
 import type { AppListQuery } from "@/gql/graphql";
 import { requestGraphQL } from "@/platform/http/graphql-client";
-import { toAccountId, toEnvironmentId, toOrganizationId, toAppId } from "@/routes/typed-id";
+import { toAccountId, toEnvironmentId, toAppId } from "@/routes/typed-id";
 
 const APP_LIST_QUERY = graphql(/* GraphQL */ `
   query AppList($organizationId: ULID!) {
@@ -13,7 +13,6 @@ const APP_LIST_QUERY = graphql(/* GraphQL */ `
       defaultEnvironmentId
       id
       name
-      organizationId
       ownerAccountId
       slug
     }
@@ -26,7 +25,6 @@ function toAppSummary(app: AppListQuery["appList"][number]): AppSummary {
     defaultEnvironmentId:
       app.defaultEnvironmentId === null ? null : toEnvironmentId(app.defaultEnvironmentId),
     id: toAppId(app.id),
-    organizationId: toOrganizationId(app.organizationId),
     ownerAccountId: toAccountId(app.ownerAccountId),
   };
 }

--- a/apps/web/src/gql/gql.ts
+++ b/apps/web/src/gql/gql.ts
@@ -50,7 +50,7 @@ type Documents = {
     "\n  mutation RestartDriver($input: RuntimeStateOperationInput!) {\n    restartDriver(input: $input) {\n      affectedSessionCount\n      agentId\n      ok\n      operation\n    }\n  }\n": typeof types.RestartDriverDocument,
     "\n  mutation RecreateSandbox($input: RuntimeStateOperationInput!) {\n    recreateSandbox(input: $input) {\n      affectedSessionCount\n      agentId\n      ok\n      operation\n    }\n  }\n": typeof types.RecreateSandboxDocument,
     "\n  mutation ResetAgentState($input: RuntimeStateOperationInput!) {\n    resetAgentState(input: $input) {\n      affectedSessionCount\n      agentId\n      ok\n      operation\n    }\n  }\n": typeof types.ResetAgentStateDocument,
-    "\n  query AppList($organizationId: ULID!) {\n    appList(organizationId: $organizationId) {\n      createdAt\n      defaultEnvironmentId\n      id\n      name\n      organizationId\n      ownerAccountId\n      slug\n    }\n  }\n": typeof types.AppListDocument,
+    "\n  query AppList($organizationId: ULID!) {\n    appList(organizationId: $organizationId) {\n      createdAt\n      defaultEnvironmentId\n      id\n      name\n      ownerAccountId\n      slug\n    }\n  }\n": typeof types.AppListDocument,
     "\n  fragment CostTotalsFields on CostAggregate {\n    activeUsers\n    cacheCreationTokens\n    cacheReadTokens\n    inputTokens\n    outputTokens\n    requestCount\n    totalCostUsd\n    unpricedRequestCount\n  }\n": typeof types.CostTotalsFieldsFragmentDoc,
     "\n  fragment CostDailyFields on CostDailyPoint {\n    activeUsers\n    cacheCreationTokens\n    cacheReadTokens\n    date\n    inputTokens\n    outputTokens\n    requestCount\n    totalCostUsd\n    unpricedRequestCount\n  }\n": typeof types.CostDailyFieldsFragmentDoc,
     "\n  fragment CostAgentFields on CostAgentRow {\n    activeUsers\n    agentId\n    agentName\n    cacheCreationTokens\n    cacheReadTokens\n    debugCostUsd\n    evalCostUsd\n    inputTokens\n    outputTokens\n    ownerEmail\n    ownerId\n    ownerName\n    previousCostUsd\n    previewCostUsd\n    productionCostUsd\n    requestCount\n    scheduledCostUsd\n    totalCostUsd\n    unpricedRequestCount\n  }\n": typeof types.CostAgentFieldsFragmentDoc,
@@ -159,7 +159,7 @@ const documents: Documents = {
     "\n  mutation RestartDriver($input: RuntimeStateOperationInput!) {\n    restartDriver(input: $input) {\n      affectedSessionCount\n      agentId\n      ok\n      operation\n    }\n  }\n": types.RestartDriverDocument,
     "\n  mutation RecreateSandbox($input: RuntimeStateOperationInput!) {\n    recreateSandbox(input: $input) {\n      affectedSessionCount\n      agentId\n      ok\n      operation\n    }\n  }\n": types.RecreateSandboxDocument,
     "\n  mutation ResetAgentState($input: RuntimeStateOperationInput!) {\n    resetAgentState(input: $input) {\n      affectedSessionCount\n      agentId\n      ok\n      operation\n    }\n  }\n": types.ResetAgentStateDocument,
-    "\n  query AppList($organizationId: ULID!) {\n    appList(organizationId: $organizationId) {\n      createdAt\n      defaultEnvironmentId\n      id\n      name\n      organizationId\n      ownerAccountId\n      slug\n    }\n  }\n": types.AppListDocument,
+    "\n  query AppList($organizationId: ULID!) {\n    appList(organizationId: $organizationId) {\n      createdAt\n      defaultEnvironmentId\n      id\n      name\n      ownerAccountId\n      slug\n    }\n  }\n": types.AppListDocument,
     "\n  fragment CostTotalsFields on CostAggregate {\n    activeUsers\n    cacheCreationTokens\n    cacheReadTokens\n    inputTokens\n    outputTokens\n    requestCount\n    totalCostUsd\n    unpricedRequestCount\n  }\n": types.CostTotalsFieldsFragmentDoc,
     "\n  fragment CostDailyFields on CostDailyPoint {\n    activeUsers\n    cacheCreationTokens\n    cacheReadTokens\n    date\n    inputTokens\n    outputTokens\n    requestCount\n    totalCostUsd\n    unpricedRequestCount\n  }\n": types.CostDailyFieldsFragmentDoc,
     "\n  fragment CostAgentFields on CostAgentRow {\n    activeUsers\n    agentId\n    agentName\n    cacheCreationTokens\n    cacheReadTokens\n    debugCostUsd\n    evalCostUsd\n    inputTokens\n    outputTokens\n    ownerEmail\n    ownerId\n    ownerName\n    previousCostUsd\n    previewCostUsd\n    productionCostUsd\n    requestCount\n    scheduledCostUsd\n    totalCostUsd\n    unpricedRequestCount\n  }\n": types.CostAgentFieldsFragmentDoc,
@@ -376,7 +376,7 @@ export function graphql(source: "\n  mutation ResetAgentState($input: RuntimeSta
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  query AppList($organizationId: ULID!) {\n    appList(organizationId: $organizationId) {\n      createdAt\n      defaultEnvironmentId\n      id\n      name\n      organizationId\n      ownerAccountId\n      slug\n    }\n  }\n"): typeof import('./graphql').AppListDocument;
+export function graphql(source: "\n  query AppList($organizationId: ULID!) {\n    appList(organizationId: $organizationId) {\n      createdAt\n      defaultEnvironmentId\n      id\n      name\n      ownerAccountId\n      slug\n    }\n  }\n"): typeof import('./graphql').AppListDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/apps/web/src/gql/graphql.ts
+++ b/apps/web/src/gql/graphql.ts
@@ -930,7 +930,7 @@ export type AppListQueryVariables = Exact<{
 }>;
 
 
-export type AppListQuery = { appList: Array<{ createdAt: string, defaultEnvironmentId: PlatformId | null, id: PlatformId, name: string, organizationId: PlatformId, ownerAccountId: PlatformId, slug: string }> };
+export type AppListQuery = { appList: Array<{ createdAt: string, defaultEnvironmentId: PlatformId | null, id: PlatformId, name: string, ownerAccountId: PlatformId, slug: string }> };
 
 type CostTotalsFields_CostAgentRow_Fragment = { activeUsers: number, cacheCreationTokens: number, cacheReadTokens: number, inputTokens: number, outputTokens: number, requestCount: number, totalCostUsd: number, unpricedRequestCount: number };
 
@@ -2750,7 +2750,6 @@ export const AppListDocument = new TypedDocumentString(`
     defaultEnvironmentId
     id
     name
-    organizationId
     ownerAccountId
     slug
   }

--- a/pkgs/contracts/src/app/app.contract.ts
+++ b/pkgs/contracts/src/app/app.contract.ts
@@ -1,11 +1,10 @@
-import type { AccountId, EnvironmentId, OrganizationId, AppId } from "../id/id.contract";
+import type { AccountId, EnvironmentId, AppId } from "../id/id.contract";
 
 export interface AppSummary {
   createdAt: string;
   defaultEnvironmentId: EnvironmentId | null;
   id: AppId;
   name: string;
-  organizationId: OrganizationId;
   ownerAccountId: AccountId;
   slug: string;
 }


### PR DESCRIPTION
## Summary
- remove `organizationId` from user-visible `AppSummary` contracts, GraphQL App payloads, Web generated output, and the Web App client mapper
- remove internal `AgentRow.appOrganizationId` from Agent repository/model rows
- derive billing Organization shell for Agent cost cards from explicit App ownership proof instead of carrying it on Agent rows

## Verification
- `RUN_INSTALL=0 RUN_SUBMODULE_UPDATE=0 bash ./init.sh development`
- `just graphql-codegen`
- `just graphql-codegen-check`
- `just tc-package @mosoo/contracts`
- `just tc-package @mosoo/api`
- `just tc-package @mosoo/web`
- `just fmt-check`
- `git diff --check`
- `just test-file apps/api/tests/app-provisioning.test.ts`
- `just test-file apps/api/tests/api-web-boundary.test.ts`
- `just test-file apps/web/tests/api-client-boundary.test.ts`
- `just test-file apps/api/tests/cost-query-app.test.ts`
- `just test-file apps/api/tests/agent-detail-model.test.ts`
- `just test-file apps/api/tests/agent-package-draft.test.ts`
- `just test-file apps/api/tests/agent-mcp-config-binding.test.ts`
- `just test-file apps/api/tests/onboarding-bootstrap.test.ts`

## Notes
- Stacked on `codex/app-boundary-phase15-agent-fixture-cleanup`.
- This slice changed GraphQL schema/documents/generated output, so GraphQL codegen ran.
- No DB schema, migration, or baseline changes; `db-regen` was not run.
- The colleague PR that was closed out-of-band is intentionally ignored.