### PR TITLE
fix(app-boundary): remove final legacy copy and publish input

### DIFF
--- a/apps/api/tests/agent-deployment-version-atomicity.test.ts
+++ b/apps/api/tests/agent-deployment-version-atomicity.test.ts
@@ -77,7 +77,6 @@ describe("agent deployment version atomicity", () => {
       publishAgent(createPublicHttpTestBindings(database) as ApiBindings, OWNER_VIEWER, {
         agentId: DRAFT_AGENT_ID,
         appId: PUBLIC_API_TEST_IDS.app,
-        visibility: "private",
       }),
     );
 

--- a/apps/web/src/routes/agent/components/create-agent-launcher.tsx
+++ b/apps/web/src/routes/agent/components/create-agent-launcher.tsx
@@ -30,7 +30,7 @@ const AGENT_TEMPLATES: readonly AgentTemplate[] = [
     description: "Answers repeat questions in Slack.",
     key: "slack-qa-assistant",
     message:
-      "Create a Slack Q&A assistant that answers my team's repeat questions. It should stay concise, cite the source it used, and ask a clarifying question when the request is ambiguous.",
+      "Create a Slack Q&A assistant that answers repeat questions from my support notes. It should stay concise, cite the source it used, and ask a clarifying question when the request is ambiguous.",
     title: "Slack Q&A assistant",
   },
   {

--- a/apps/web/src/routes/agent/components/settings-dialog-channels-view.tsx
+++ b/apps/web/src/routes/agent/components/settings-dialog-channels-view.tsx
@@ -287,8 +287,8 @@ function ComingSoonPanel({ channelLabel }: { channelLabel: string }) {
       <Inbox className="text-muted-foreground mx-auto mb-3 size-8" />
       <div className="text-foreground text-sm font-medium">{channelLabel} support is coming</div>
       <p className="text-muted-foreground mx-auto mt-2 max-w-sm text-xs leading-relaxed">
-        We're working on letting agents talk to your team through {channelLabel}. Pick another
-        channel for now, or come back soon.
+        We're working on letting agents receive and answer messages through {channelLabel}. Pick
+        another channel for now, or come back soon.
       </p>
     </div>
   );

--- a/apps/web/src/routes/agent/components/settings-dialog-discord-setup.tsx
+++ b/apps/web/src/routes/agent/components/settings-dialog-discord-setup.tsx
@@ -15,7 +15,7 @@ import type { ChannelInlineSetupAgent } from "./settings-dialog-channel-agent";
 const DISCORD_RELAY_SECRET_LABEL = "Relay Secret";
 const DISCORD_DEVELOPER_PORTAL_URL = "https://discord.com/developers/applications";
 const DiscordSetupCaveat =
-  "Save validates the bot token with Discord. The Gateway connection starts after the binding exists; send a real DM or guild mention after saving to verify delivery in your workspace.";
+  "Save validates the bot token with Discord. The Gateway connection starts after the binding exists; send a real DM or guild mention after saving to verify delivery in your Discord server.";
 const DiscordIntentsPrerequisite =
   "Before connecting, open your app in the Discord Developer Portal → Bot → Privileged Gateway Intents and enable Message Content Intent. Without it Discord closes the Gateway with discord_gateway_disallowed_intents and the bot cannot read message text.";
 

--- a/apps/web/src/routes/agent/lifecycle/distribution-panel.tsx
+++ b/apps/web/src/routes/agent/lifecycle/distribution-panel.tsx
@@ -58,7 +58,7 @@ export function DistributionPanel({
             <span className="text-foreground font-medium">
               {isLive ? "live" : "draft (publish to enable)"}
             </span>
-            . Personal-token authenticated, access-gated, executes under owner's shadow RBAC.
+            . Personal-token authenticated, access-gated, and executed as the App owner's Agent.
           </p>
         </div>
         {onOpenSettings ? (

--- a/apps/web/src/routes/agent/lifecycle/kind-fork-dialog.tsx
+++ b/apps/web/src/routes/agent/lifecycle/kind-fork-dialog.tsx
@@ -13,7 +13,7 @@ import {
 import type { AgentKind } from "../agent.types";
 
 const KIND_LABELS: Record<AgentKind, { title: string; tagline: string; icon: typeof Bot }> = {
-  pet: { title: "Assistant Agent", tagline: "Always-on teammate", icon: Bot },
+  pet: { title: "Assistant Agent", tagline: "Always-on assistant", icon: Bot },
   cattle: { title: "Task Agent", tagline: "On-demand worker", icon: Zap },
 };
 

--- a/apps/web/src/routes/app-overview/app-overview.route.tsx
+++ b/apps/web/src/routes/app-overview/app-overview.route.tsx
@@ -72,7 +72,7 @@ function QuickstartPanel({ metrics }: { metrics: AppOverviewMetrics }) {
         <div>
           <h2 className="text-foreground text-sm font-semibold">Quickstart</h2>
           <p className="text-muted-foreground mt-0.5 text-xs">
-            {completeCount} of {items.length} App setup steps complete
+            {completeCount} of {items.length} quickstart steps complete
           </p>
         </div>
       </div>
@@ -285,7 +285,7 @@ export function AppOverviewPage() {
   if (activeApp === null) {
     return (
       <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
-        {appsLoading ? "Loading app…" : "No app available."}
+        {appsLoading ? "Loading App…" : "No App available."}
       </div>
     );
   }

--- a/apps/web/src/routes/login/auth-card.tsx
+++ b/apps/web/src/routes/login/auth-card.tsx
@@ -174,7 +174,7 @@ export function LoginAuthCard({
           )}
 
           <p className="text-fg-3 pt-2 text-center text-[13px]">
-            If this is your first time, we&apos;ll create your App workspace after verification.
+            If this is your first time, we&apos;ll create your default App after verification.
           </p>
         </div>
       </div>

--- a/apps/web/src/routes/login/landing/deploy-section.tsx
+++ b/apps/web/src/routes/login/landing/deploy-section.tsx
@@ -87,7 +87,7 @@ const CARDS = [
     tag: "Web UI",
     visual: <WebUiMock />,
     title: "Or click through the console",
-    desc: "Manage agents, spaces, credentials, and cost from a console your whole team can use, no terminal required.",
+    desc: "Manage agents, spaces, credentials, and cost from a console you can operate, no terminal required.",
   },
   {
     tag: "Self-host",

--- a/apps/web/src/routes/onboarding/onboarding.route.tsx
+++ b/apps/web/src/routes/onboarding/onboarding.route.tsx
@@ -136,7 +136,7 @@ function OnboardingProvisioningScreen() {
     <div className="bg-background fixed inset-0 flex items-center justify-center">
       <div className="flex flex-col items-center gap-4">
         <Loader2 className="text-primary size-8 animate-spin" />
-        <p className="text-muted-foreground text-sm">Creating your App workspace…</p>
+        <p className="text-muted-foreground text-sm">Creating your default App…</p>
       </div>
     </div>
   );
@@ -151,11 +151,9 @@ function OnboardingErrorScreen({ error, onRetry }: { error: string | null; onRet
 
       <div className="flex flex-1 items-center justify-center">
         <div className="w-full max-w-[520px] px-6">
-          <h2 className="text-foreground text-center text-2xl font-semibold">
-            Workspace setup failed
-          </h2>
+          <h2 className="text-foreground text-center text-2xl font-semibold">App setup failed</h2>
           <p className="text-muted-foreground mt-2 text-center text-sm">
-            {isTruthy(error) ? error : "Mosoo could not create your default App workspace."}
+            {isTruthy(error) ? error : "Mosoo could not create your default App."}
           </p>
 
           <div className="mt-6">

--- a/apps/web/tests/app-overview-boundary.test.ts
+++ b/apps/web/tests/app-overview-boundary.test.ts
@@ -12,7 +12,7 @@ describe("App overview boundary", () => {
     const combinedSource = `${routeSource}\n${modelSource}`;
 
     expect(routeSource).toContain("Quickstart");
-    expect(routeSource).toContain("App setup steps complete");
+    expect(routeSource).toContain("quickstart steps complete");
     expect(routeSource).toContain("No threads have run in this App yet.");
     expect(routeSource).toContain("Last 30 days in this App");
     expect(routeSource).toContain('to="/channels"');


### PR DESCRIPTION
## Summary
- Remove the stale `visibility: "private"` publish input from the deployment atomicity test while keeping persisted private visibility assertions.
- Replace remaining user-visible workspace/team/RBAC copy in login, onboarding, Agent distribution/settings/launcher, Discord setup, login landing, and App overview surfaces.
- Update the App overview boundary test to assert quickstart copy while continuing to reject old Organization/member/join/setup wording.

## Verification
- `RUN_INSTALL=0 RUN_SUBMODULE_UPDATE=0 bash ./init.sh development`
- `just test-file apps/api/tests/agent-deployment-version-atomicity.test.ts`
- `vp exec bun test apps/web/tests/login-landing-boundary.test.ts apps/web/tests/channels-ia-boundary.test.ts apps/web/tests/app-navigation-boundary.test.ts apps/web/tests/app-route-registry-boundary.test.ts apps/web/tests/app-overview-boundary.test.ts apps/web/tests/agent-runtime-lock-boundary.test.ts apps/web/tests/thread-compose-boundary.test.ts apps/api/tests/api-web-boundary.test.ts`
- `just tc-package @mosoo/api`
- `just tc-package @mosoo/web`
- `just fmt-check`
- `vp run graphql:codegen:check`
- `git diff --check`
- Source-only residue scan for Share with me / package sharing / AgentCollaborator / shadow RBAC / organization visibility: no matches.
- Non-shell `organization_id` CREATE TABLE parser scan: no matches.

## Codegen
- No GraphQL schema/documents changed; `graphql:codegen` was not run. `graphql:codegen:check` passed.
- No DB schema/baseline changed; `db:regen` was not run.