### PR TITLE
chore(github): enforce pr ship policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 Skip inapplicable sections. Fill Summary, Why, Verification, and Required Checks. External contributors may mark repository-maintainer-only items as N/A.
 
+**Ship PR only:** base `main` (or `release/*`); branch `type/scope-subject` (no tool/agent prefixes). See `CONTRIBUTING.md` → *Pull Requests*.
+
 First-time human contributors may be asked by CLA Assistant to sign `CLA.md`. If prompted, reply in the PR conversation with exactly: `I have read the CLA Document and I hereby sign the CLA`. Do not paste the signature into this PR description.
 
 ## Summary

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,6 +7,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - converted_to_draft
 
 permissions:
   contents: read
@@ -18,7 +19,10 @@ concurrency:
 jobs:
   check:
     name: Repository check
-    if: github.event.pull_request.draft == false
+    if: >-
+      github.event.pull_request.draft == false ||
+      github.base_ref == 'main' ||
+      startsWith(github.base_ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,7 +1,7 @@
 name: PR Check
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
@@ -21,12 +21,13 @@ jobs:
     name: Repository check
     if: >-
       github.event.pull_request.draft == false ||
-      github.base_ref == 'main' ||
-      startsWith(github.base_ref, 'release/')
+      github.event.pull_request.base.ref == 'main' ||
+      startsWith(github.event.pull_request.base.ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
           submodules: true
           persist-credentials: false

--- a/.github/workflows/pr-commits-lint.yml
+++ b/.github/workflows/pr-commits-lint.yml
@@ -1,10 +1,9 @@
 name: PR Commits Lint
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
-      - edited
       - reopened
       - synchronize
 
@@ -18,7 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
+
+      - name: Fetch pull request head
+        run: git fetch --no-tags origin ${{ github.event.pull_request.head.sha }}
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/pr-ship-policy.yml
+++ b/.github/workflows/pr-ship-policy.yml
@@ -1,0 +1,52 @@
+name: PR Ship Policy
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+      - edited
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  ship-policy:
+    name: Ship policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce ship-only pull requests
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          case "$BASE_REF" in
+            main)
+              echo "Ship lane: base is main."
+              ;;
+            release/*)
+              echo "Ship lane: release branch base is allowed."
+              ;;
+            *)
+              echo "::error::Pull requests must target main (or release/*). Got base: ${BASE_REF}. Integration stacks must not use GitHub PRs between side branches."
+              exit 1
+              ;;
+          esac
+
+          # Belt-and-suspenders: ruleset blocks new tool-prefixed branches on push.
+          # This still catches old branches, forks, and PRs opened before the ruleset.
+          if echo "$HEAD_REF" | grep -Eiq '^(codex|cursor|claude|agent|copilot|aider|devin|windsurf|codegen|opencode|grok)(/|$)'; then
+            echo "::error::Head branch '${HEAD_REF}' uses a blocked tool/agent prefix. Use type/scope-subject under feat|fix|docs|... instead."
+            exit 1
+          fi
+
+          echo "Ship policy passed for head=${HEAD_REF} base=${BASE_REF}."

--- a/.github/workflows/pr-ship-policy.yml
+++ b/.github/workflows/pr-ship-policy.yml
@@ -1,7 +1,7 @@
 name: PR Ship Policy
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
@@ -24,8 +24,8 @@ jobs:
     steps:
       - name: Enforce ship-only pull requests
         env:
-          BASE_REF: ${{ github.base_ref }}
-          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,6 +261,13 @@ chore/dev-docs-layout
 
 Use `!` only for intentional breaking changes. Every Issue and PR must be self-assigned. PRs should keep a clear scope, describe verification results, and explicitly state whether they include generated files, GraphQL codegen, or DB baseline updates.
 
+### Pull Requests
+
+- Open PRs **only to `main`** (or `release/*`). No PR chains between feature branches.
+- Branch names use `type/scope-subject` above.
+- Run `just check` before marking ready for review. CI runs the same gate on `main` PRs, including drafts.
+- Big pivots: update the boundary docs first, then prefer **one umbrella PR** with `just check` and boundary tests as the review contract.
+
 ### Enforced Commit Policy
 
 Commit quality is enforced by automation, not contributor memory:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,6 +264,7 @@ Use `!` only for intentional breaking changes. Every Issue and PR must be self-a
 ### Pull Requests
 
 - Open PRs **only to `main`** (or `release/*`). No PR chains between feature branches.
+- Fork PRs are supported; repository checks use `pull_request_target` so CI runs without enabling fork workflow write tokens.
 - Branch names use `type/scope-subject` above.
 - Run `just check` before marking ready for review. CI runs the same gate on `main` PRs, including drafts.
 - Big pivots: update the boundary docs first, then prefer **one umbrella PR** with `just check` and boundary tests as the review contract.


### PR DESCRIPTION
Skip inapplicable sections. Fill Summary, Why, Verification, and Required Checks. External contributors may mark repository-maintainer-only items as N/A.

**Ship PR only:** base `main` (or `release/*`); branch `type/scope-subject` (no tool/agent prefixes). See `CONTRIBUTING.md` → *Pull Requests*.

First-time human contributors may be asked by CLA Assistant to sign `CLA.md`. If prompted, reply in the PR conversation with exactly: `I have read the CLA Document and I hereby sign the CLA`. Do not paste the signature into this PR description.

## Summary

- Add `pr-ship-policy` workflow to reject PRs that do not target `main` or `release/*`, and to block tool/agent-prefixed head branches.
- Run `pr-check` on draft PRs when the base is `main` or `release/*`.
- Document ship-only PR rules in `CONTRIBUTING.md` and the PR template.

## Why

- Keep a single ship lane into `main` and avoid stacked PR chains between feature branches.
- Enforce `type/scope-subject` branch naming in CI as a belt-and-suspenders guard alongside repository rulesets.
- Let contributors validate against `just check` earlier by running the same gate on draft PRs targeting `main`.

## Verification

- Commands (`just check`, `just test-file <path>`, `just graphql-codegen`, etc.): N/A — docs and GitHub workflow changes only; pre-commit hooks passed on commit and push.
- Manual steps: Reviewed workflow `if` conditions and shell policy script for `main`, `release/*`, and blocked head prefixes.

## Risk And Blast Radius

- Affected packages: N/A
- Affected user flows or APIs: Contributor PR workflow only
- Rollback: Revert this PR; existing open PRs to non-`main` bases will begin failing the new ship-policy check

## Evidence

- UI/UX: N/A
- API or behavior: N/A
- Logs, recordings, or test output: Local `prek` commit-msg and pre-push hooks passed

## Compatibility

- Public contract changes: None
- Env or config changes: None
- Deployment or migration: None

## Reviewer Focus

- Closest review areas: `.github/workflows/pr-ship-policy.yml` base/head checks; `pr-check.yml` draft gating logic
- Known trade-offs: Tool-prefix blocklist in the workflow is intentionally shorter than every possible agent slug; repository rulesets remain the primary push-time guard

## Required Checks

- [x] PR title: `type(scope): subject` (e.g. `fix(fmt): restore pre-commit checks`)
- [x] Type: `chore`
- [x] Subject starts lowercase; `!` only for intentional breaking changes (e.g. `feat(api)!: remove legacy session field`)
- [x] Branch follows `type/scope-subject` when maintained in this repository; fork branch names may vary
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: if prompted by CLA Assistant, every human contributor has signed by posting the exact required PR comment
- [ ] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence, or N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A
- GraphQL codegen (`just graphql-codegen`): N/A
- DB baseline (`just db-regen`): N/A
- Lockfile (`bun.lock`): N/A
- Confirm no hand-edits to generated paths (`schema.generated.graphql`, `apps/web/src/gql/**`, `pkgs/db/drizzle/**`): N/A