### PR TITLE
chore(github): enforce pr ship policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 Skip inapplicable sections. Fill Summary, Why, Verification, and Required Checks. External contributors may mark repository-maintainer-only items as N/A.
 
+**Ship PR only:** base `main` (or `release/*`); branch `type/scope-subject` (no tool/agent prefixes). See `CONTRIBUTING.md` → *Pull Requests*.
+
 First-time human contributors may be asked by CLA Assistant to sign `CLA.md`. If prompted, reply in the PR conversation with exactly: `I have read the CLA Document and I hereby sign the CLA`. Do not paste the signature into this PR description.
 
 ## Summary

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Skip inapplicable sections. Fill Summary, Why, Verification, and Required Checks. External contributors may mark repository-maintainer-only items as N/A.
 
-**Ship PR only:** base `main` (or `release/*`); branch `type/scope-subject` (no tool/agent prefixes). See `CONTRIBUTING.md` → *Pull Requests*.
+**Ship PR only:** base `main` (or `release/*`); branch `type/scope-subject` (no tool/agent prefixes). See `CONTRIBUTING.md` → _Pull Requests_.
 
 First-time human contributors may be asked by CLA Assistant to sign `CLA.md`. If prompted, reply in the PR conversation with exactly: `I have read the CLA Document and I hereby sign the CLA`. Do not paste the signature into this PR description.
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,13 +1,12 @@
 name: PR Check
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
       - reopened
       - ready_for_review
-      - converted_to_draft
 
 permissions:
   contents: read
@@ -19,15 +18,11 @@ concurrency:
 jobs:
   check:
     name: Repository check
-    if: >-
-      github.event.pull_request.draft == false ||
-      github.event.pull_request.base.ref == 'main' ||
-      startsWith(github.event.pull_request.base.ref, 'release/')
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
           submodules: true
           persist-credentials: false

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,6 +7,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - converted_to_draft
 
 permissions:
   contents: read
@@ -18,7 +19,10 @@ concurrency:
 jobs:
   check:
     name: Repository check
-    if: github.event.pull_request.draft == false
+    if: >-
+      github.event.pull_request.draft == false ||
+      github.base_ref == 'main' ||
+      startsWith(github.base_ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,7 +1,7 @@
 name: PR Check
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
@@ -21,12 +21,13 @@ jobs:
     name: Repository check
     if: >-
       github.event.pull_request.draft == false ||
-      github.base_ref == 'main' ||
-      startsWith(github.base_ref, 'release/')
+      github.event.pull_request.base.ref == 'main' ||
+      startsWith(github.event.pull_request.base.ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
           submodules: true
           persist-credentials: false

--- a/.github/workflows/pr-commits-lint.yml
+++ b/.github/workflows/pr-commits-lint.yml
@@ -1,6 +1,12 @@
 name: PR Commits Lint
 
 on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
   pull_request_target:
     types:
       - opened
@@ -13,14 +19,24 @@ permissions:
 jobs:
   lint-pr-commits:
     name: Validate PR commits
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
       - name: Fetch pull request head
+        if: github.event_name == 'pull_request_target'
         run: git fetch --no-tags origin ${{ github.event.pull_request.head.sha }}
 
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/pr-commits-lint.yml
+++ b/.github/workflows/pr-commits-lint.yml
@@ -1,10 +1,9 @@
 name: PR Commits Lint
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
-      - edited
       - reopened
       - synchronize
 
@@ -18,7 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
+
+      - name: Fetch pull request head
+        run: git fetch --no-tags origin ${{ github.event.pull_request.head.sha }}
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/pr-ship-policy.yml
+++ b/.github/workflows/pr-ship-policy.yml
@@ -1,0 +1,52 @@
+name: PR Ship Policy
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+      - edited
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  ship-policy:
+    name: Ship policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce ship-only pull requests
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          case "$BASE_REF" in
+            main)
+              echo "Ship lane: base is main."
+              ;;
+            release/*)
+              echo "Ship lane: release branch base is allowed."
+              ;;
+            *)
+              echo "::error::Pull requests must target main (or release/*). Got base: ${BASE_REF}. Integration stacks must not use GitHub PRs between side branches."
+              exit 1
+              ;;
+          esac
+
+          # Belt-and-suspenders: ruleset blocks new tool-prefixed branches on push.
+          # This still catches old branches, forks, and PRs opened before the ruleset.
+          if echo "$HEAD_REF" | grep -Eiq '^(codex|cursor|claude|agent|copilot|aider|devin|windsurf|codegen|opencode|grok)(/|$)'; then
+            echo "::error::Head branch '${HEAD_REF}' uses a blocked tool/agent prefix. Use type/scope-subject under feat|fix|docs|... instead."
+            exit 1
+          fi
+
+          echo "Ship policy passed for head=${HEAD_REF} base=${BASE_REF}."

--- a/.github/workflows/pr-ship-policy.yml
+++ b/.github/workflows/pr-ship-policy.yml
@@ -1,7 +1,7 @@
 name: PR Ship Policy
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
@@ -24,8 +24,8 @@ jobs:
     steps:
       - name: Enforce ship-only pull requests
         env:
-          BASE_REF: ${{ github.base_ref }}
-          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,9 +264,12 @@ Use `!` only for intentional breaking changes. Every Issue and PR must be self-a
 ### Pull Requests
 
 - Open PRs **only to `main`** (or `release/*`). No PR chains between feature branches.
-- Fork PRs are supported; repository checks use `pull_request_target` so CI runs without enabling fork workflow write tokens.
+- Private-stage PRs should use branches in the upstream repository so required `pull_request` checks can run.
+- Fork PRs are usable only when private fork workflows are enabled, or when a maintainer handles verification and bypass explicitly.
+- Metadata gates support fork PRs through `pull_request_target`; upstream branch PRs still use `pull_request`.
+- Repository code checks stay on `pull_request`.
 - Branch names use `type/scope-subject` above.
-- Run `just check` before marking ready for review. CI runs the same gate on `main` PRs, including drafts.
+- Run `just check` before marking ready for review. CI runs the same gate for non-draft `pull_request` PRs.
 - Big pivots: update the boundary docs first, then prefer **one umbrella PR** with `just check` and boundary tests as the review contract.
 
 ### Enforced Commit Policy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,6 +261,13 @@ chore/dev-docs-layout
 
 Use `!` only for intentional breaking changes. Every Issue and PR must be self-assigned. PRs should keep a clear scope, describe verification results, and explicitly state whether they include generated files, GraphQL codegen, or DB baseline updates.
 
+### Pull Requests
+
+- Open PRs **only to `main`** (or `release/*`). No PR chains between feature branches.
+- Branch names use `type/scope-subject` above.
+- Run `just check` before marking ready for review. CI runs the same gate on `main` PRs, including drafts.
+- Big pivots: update the boundary docs first, then prefer **one umbrella PR** with `just check` and boundary tests as the review contract.
+
 ### Enforced Commit Policy
 
 Commit quality is enforced by automation, not contributor memory:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,6 +264,7 @@ Use `!` only for intentional breaking changes. Every Issue and PR must be self-a
 ### Pull Requests
 
 - Open PRs **only to `main`** (or `release/*`). No PR chains between feature branches.
+- Fork PRs are supported; repository checks use `pull_request_target` so CI runs without enabling fork workflow write tokens.
 - Branch names use `type/scope-subject` above.
 - Run `just check` before marking ready for review. CI runs the same gate on `main` PRs, including drafts.
 - Big pivots: update the boundary docs first, then prefer **one umbrella PR** with `just check` and boundary tests as the review contract.


### PR DESCRIPTION
## Summary

- Add a PR ship policy workflow for base branch and head branch naming rules.
- Add dual-event commit metadata validation: same-repo PRs use `pull_request`, fork PR metadata validation uses `pull_request_target`.
- Document the private-stage upstream-branch PR path and surface the ship lane requirement in the PR template.

## Why

- Private fork PR workflows are disabled, so metadata-only fork gates need a safe event that still runs.
- Repository code checks must not execute fork head code through `pull_request_target`.
- This PR itself needs a same-repo `pull_request` commit-lint path so the existing required check can run before the new target workflow is on `main`.

## Verification

- Commands:
  - `just fmt-check-path .github`
  - `just fmt-check-path CONTRIBUTING.md`
  - `ruby -e 'require "yaml"; %w[.github/workflows/pr-check.yml .github/workflows/pr-commits-lint.yml .github/workflows/pr-ship-policy.yml .github/workflows/pr-title-lint.yml].each { |f| YAML.load_file(f); puts "ok #{f}" }'`
  - `perl -e 'alarm 20; exec @ARGV' actionlint .github/workflows/pr-check.yml .github/workflows/pr-commits-lint.yml .github/workflows/pr-ship-policy.yml`
  - `bun scripts/validate-commit-range.ts upstream/main HEAD`
- Manual steps:
  - Closed the fork-based PR #32.
  - Confirmed `pr-check.yml` remains on `pull_request` and is not part of this final PR diff.
  - Confirmed `pull_request_target` paths only read PR metadata / commit metadata and do not run repository code checks.

## Risk And Blast Radius

- Affected packages: GitHub Actions and contribution docs only.
- Affected user flows or APIs: PR creation, validation, and merge policy only.
- Rollback: revert the workflow, PR template, and contribution guide changes.

## Evidence

- UI/UX: N/A.
- API or behavior: `gh` confirmed private fork PR workflows are disabled, so this PR now comes from an upstream repository branch.
- Logs, recordings, or test output: local formatter, YAML parse, actionlint, commit policy, and pre-push hooks passed.

## Compatibility

- Public contract changes: N/A.
- Env or config changes: N/A.
- Deployment or migration: N/A.

## Reviewer Focus

- Closest review areas: GitHub Actions event boundaries and branch/base policy text.
- Known trade-offs: Full repository checks still require `pull_request`; fork PRs need org-level private fork workflow support or maintainer verification.

## Required Checks

- [x] PR title: `type(scope): subject`.
- [x] Type: `chore`.
- [x] Subject starts lowercase; no breaking change marker.
- [x] Branch follows `type/scope-subject` for this repository.
- [x] Commits: `type(scope): subject`, English only.
- [x] CLA: existing human contributor; no CLA prompt in this local flow.
- [x] Self-assigned.
- [x] Diff scoped; no unrelated cleanup.
- [x] UI/UX: N/A.
- [x] Generated files, codegen, DB baseline, lockfile only when required; none touched.

## Generated Files, Schema, And Lockfile

- N/A.
- GraphQL codegen: N/A.
- DB baseline: N/A.
- Lockfile: N/A.
- Confirm no hand-edits to generated paths: no generated paths touched.
