### PR TITLE
feat(web): default-expand install guide skill and drop card chrome

### DIFF
--- a/apps/web/src/routes/app-overview/app-overview-install.tsx
+++ b/apps/web/src/routes/app-overview/app-overview-install.tsx
@@ -79,7 +79,9 @@ export function AppOverviewInstallGuide(): ReactElement {
   const [copied, setCopied] = useState(false);
   const [copyFailed, setCopyFailed] = useState(false);
   const [skillCopied, setSkillCopied] = useState(false);
-  const [showOtherAgents, setShowOtherAgents] = useState(false);
+  // Default to expanded so the @mosoo skill + Copy/Download actions are visible
+  // without an extra click for users on Codex / Cursor / Cline.
+  const [showOtherAgents, setShowOtherAgents] = useState(true);
 
   const createTokenMutation = useMutation({
     mutationFn: async () => createPersonalAccessToken("mosoo CLI"),
@@ -126,7 +128,7 @@ export function AppOverviewInstallGuide(): ReactElement {
   const minting = createTokenMutation.isPending;
 
   return (
-    <section className="border-border bg-card rounded-lg border px-6 py-10">
+    <section className="py-6">
       <div className="mx-auto flex max-w-xl flex-col items-center text-center">
         <h2 className="text-foreground text-2xl font-semibold tracking-tight">
           Hand Mosoo to your agent


### PR DESCRIPTION
## Summary

- Default-expand the "Using another agent? Codex · Cursor · Cline" panel on the App overview install guide, so the @mosoo `SKILL.md` plus the Copy skill / Download SKILL.md actions are visible without an extra click.
- Remove the surrounding card chrome (border + `bg-card` background) so the onboarding content sits flat on the page.

## Why

YEF-671: the skill section was collapsed by default, hiding the most useful "another agent" path behind a click. The card container also added visual weight that the centered single-column onboarding doesn't need — flattening it reads cleaner.

## Verification

- Commands: `vp fmt --check`, `vp lint .`, `vp run tc`, `bun test apps/web/tests/app-overview-boundary.test.ts` (3 pass) — all green.
- Manual: rendered `AppOverviewInstallGuide` in isolation and screenshotted; the skill panel is open on load and the card border/background is gone.

## Risk And Blast Radius

- Affected packages: `@mosoo/web`.
- Affected user flows: App overview install guide (onboarding only). No data, API, or token-handling changes — the CLI token is still minted on demand and only copied.
- Rollback: revert this commit.

## Evidence

- UI/UX: after-screenshot posted on the YEF-671 issue (default-expanded, card removed).

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review area: `apps/web/src/routes/app-overview/app-overview-install.tsx`.
- Known trade-offs: the inner skill panel keeps its own sunken border to group the SKILL.md content now that the outer card is gone.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Subject starts lowercase
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshot in Evidence (on the linked issue)

## Generated Files, Schema, And Lockfile

- N/A — no generated files touched.
