### PR TITLE
docs(prd): relink orphaned credentials in PRD index

### DIFF
--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -42,6 +42,7 @@ Implementation contracts and shipped product behavior. Each PRD is the high-read
 - [MCP (Connector)](./mcp-interaction.md)
 - [Skill](./skill-interaction.md)
 - [Space](./space-interaction.md)
+- [Credentials](./credentials.md) — Provider and MCP secrets owned by the active App; runtime resolves them from that same App boundary.
 
 Surface boundary: public HTTPS exposure is an Agent API Endpoint inside one App. Thread is the public conversation object, Session is the runtime record, and Thread files are scoped to the admitted Thread/backing Session. Organization remains account and billing context, not a public API authorization boundary.
 


### PR DESCRIPTION
## Summary

- The App boundary migration (#34) rewrote `docs/prd/README.md` and removed the `Credentials` entry along with the genuinely-deleted historical governance docs (`identity-access.md`, `rbac.md`).
- But `credentials.md` was **not** deleted — it still exists and now describes **current** App-owned behavior (it was even updated in that same commit). It was left orphaned from the canonical PRD index.
- Re-added the `Credentials` link under **Surfaces & channels**, with current-state framing (App-owned Provider/MCP secrets), so every PRD is reachable from the index again.

## Why

The PRD index (`docs/prd/README.md`) is the navigation entry point for product contracts. `credentials.md` is current, maintained, and cross-linked from other PRDs, but a reader starting at the index could no longer find it. Restoring the link removes the only orphaned-from-index PRD.

## Verification

- Commands: enumerated `docs/prd/*.md` and confirmed every file (except `README.md`) is now linked from the index — zero orphans after the change.
- Manual steps: confirmed via `git show dff17955^:docs/prd/README.md` that the link existed before #34 and was dropped by that commit, and that `credentials.md` is current (not historical).
- Also scanned all `*.md`/`*.ts`/`*.mdx` for references to the docs deleted in the last 24h (`identity-access`, `rbac`, `published-agent-api-surface`, `agent-file-browser`, `agent-runtime-logs`, `project-app-boundary`) — no dangling references remain.

## Risk And Blast Radius

- Affected packages: docs only.
- Affected user flows or APIs: none.
- Rollback: revert this one-line commit.

## Evidence

- UI/UX: N/A (docs only).
- API or behavior: no behavior change.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: placement of the `Credentials` entry in the index (chose **Surfaces & channels** next to MCP/Skill/Space, matching the App Resources grouping in `app-boundary.md`).

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `docs`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A (docs only)
- [x] Generated files: none touched

## Generated Files, Schema, And Lockfile

- N/A
