### PR TITLE
fix(web/console): remove hardcoded Active badge from Apps list card

### DIFF
--- a/apps/web/src/routes/apps/apps-list.route.tsx
+++ b/apps/web/src/routes/apps/apps-list.route.tsx
@@ -43,10 +43,6 @@ function AppCard({
         ) : null}
         <ChevronRight className="text-fg-3 group-hover:text-fg-1 size-4 shrink-0 transition-colors" />
       </div>
-      <div className="text-fg-2 flex items-center gap-1.5 text-xs">
-        <span className="size-1.5 rounded-full bg-green-500" />
-        Active
-      </div>
       <div className="text-muted-foreground text-xs">{agentLabel}</div>
     </button>
   );


### PR DESCRIPTION
## Summary

- Remove the hardcoded "Active" status badge (green dot + "Active" text) from each App card in the Org-layer Apps list.

## Why

- The badge was a static literal rendered on every App card regardless of the App's real state, so it conveyed no information and was visual noise. Removing it is a pure-frontend, zero-risk cleanup.

## Verification

- Commands: `vp tc` / `vp lint` could not be run in this environment (`vp` toolchain not installed). The change is a pure JSX deletion with no newly-unused imports, so there is no type/lint impact.
- Manual steps: N/A — static markup removal only.

## Risk And Blast Radius

- Affected packages: `apps/web`
- Affected user flows or APIs: Org-layer Apps list card rendering only. No data, query, or API change.
- Rollback: revert this commit.

## Evidence

- UI/UX: removes lines 46-49 of `apps-list.route.tsx` (the `<div>` with the green dot `<span>` and the literal text `Active`). Screenshot capture not feasible here (dev server requires the `vp` toolchain, unavailable in this environment). The "Current" badge on the active App is untouched.

## Compatibility

- Public contract changes: none
- Env or config changes: none
- Deployment or migration: none

## Reviewer Focus

- Closest review areas: `apps/web/src/routes/apps/apps-list.route.tsx` `AppCard`
- Known trade-offs: none

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `fix`
- [x] Subject starts lowercase
- [x] Branch follows repo convention
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: sign if prompted
- [x] Self-assigned or maintainer assigned
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: see Evidence
- [x] Generated files: none touched
