### PR TITLE
feat(app-builder): add builder model selector

### DIFF
--- a/apps/api/src/modules/agent-builder/application/agent-builder-llm-planner.service.ts
+++ b/apps/api/src/modules/agent-builder/application/agent-builder-llm-planner.service.ts
@@ -432,7 +432,6 @@ async function callOpenAiShapePlanner(input: {
         ],
         model: input.model,
         response_format: createAgentBuilderPlannerResponseFormat(),
-        temperature: 0,
       }),
       headers: {
         Accept: "application/json",

--- a/apps/api/src/modules/users/application/viewer-context.service.ts
+++ b/apps/api/src/modules/users/application/viewer-context.service.ts
@@ -67,6 +67,17 @@ function createAccountProfile(
   };
 }
 
+function normalizeSystemAgentModel(input: SetSystemAgentModelInput): SystemAgentModelSetting {
+  const modelId = input.modelId.trim();
+  const vendor = input.vendor.trim();
+
+  if (!isTruthy(modelId) || !isTruthy(vendor)) {
+    throw new Error("System Agent model and provider are required.");
+  }
+
+  return { modelId, vendor };
+}
+
 export async function getSystemAgentModel(
   database: D1Database,
   accountId: AccountId,
@@ -217,9 +228,32 @@ export async function updateProfile(
 }
 
 export async function setSystemAgentModel(
-  _database: D1Database,
-  _viewer: AuthenticatedViewer,
-  _input: SetSystemAgentModelInput,
+  database: D1Database,
+  viewer: AuthenticatedViewer,
+  input: SetSystemAgentModelInput,
 ): Promise<AccountProfile> {
-  throw new Error("System Agent model selection requires an App App.");
+  const systemAgentModel = normalizeSystemAgentModel(input);
+  const updated =
+    (await getAppDatabase(database)
+      .update(accountsTable)
+      .set({
+        systemAgentModel,
+        updatedAt: currentTimestampMs(),
+      })
+      .where(eq(accountsTable.id, viewer.id))
+      .returning({
+        imageUrl: accountsTable.image,
+        name: accountsTable.name,
+        systemAgentModel: accountsTable.systemAgentModel,
+      })
+      .get()) ?? null;
+
+  if (updated === null) {
+    throw new Error("Account not found.");
+  }
+
+  return createAccountProfile(
+    { ...viewer, imageUrl: updated.imageUrl, name: updated.name },
+    parseSystemAgentModel(updated.systemAgentModel),
+  );
 }

--- a/apps/api/tests/agent-builder-system-agent-lightweight-rpc.test.ts
+++ b/apps/api/tests/agent-builder-system-agent-lightweight-rpc.test.ts
@@ -977,6 +977,7 @@ describe("Agent Builder System Agent lightweight RPC", () => {
       expect(fetchUrls).toEqual(["https://api.openai.com/v1/chat/completions"]);
       expect(fetchHeaders[0]?.get("authorization")).toBe("Bearer sk-unit-agent-builder");
       expect(fetchBodies[0]?.["model"]).toBe("gpt-5.4");
+      expect(fetchBodies[0]).not.toHaveProperty("temperature");
       expect(fetchBodies[0]?.["response_format"]).toMatchObject({
         json_schema: {
           name: "agent_builder_planner_output",

--- a/apps/api/tests/viewer-organization-context.test.ts
+++ b/apps/api/tests/viewer-organization-context.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import type { AuthenticatedViewer } from "../src/modules/auth/application/viewer-auth.service";
-import { getViewer, updateProfile } from "../src/modules/users/application/viewer-context.service";
+import {
+  getViewer,
+  setSystemAgentModel,
+  updateProfile,
+} from "../src/modules/users/application/viewer-context.service";
 import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
 import { SqliteD1Database } from "./helpers/sqlite-d1";
 
@@ -180,6 +184,37 @@ describe("viewer organization context", () => {
       modelId: "model-1",
       vendor: "openai",
     });
+  });
+
+  test("updates the System Agent model setting", async () => {
+    const database = createViewerContextDatabase();
+
+    const account = await setSystemAgentModel(database, VIEWER, {
+      modelId: " gpt-5.5 ",
+      vendor: " openai ",
+    });
+
+    expect(account.systemAgentModel).toEqual({
+      modelId: "gpt-5.5",
+      vendor: "openai",
+    });
+
+    const viewer = await getViewer(database, {} as ApiBindings, VIEWER);
+    expect(viewer.account?.systemAgentModel).toEqual({
+      modelId: "gpt-5.5",
+      vendor: "openai",
+    });
+  });
+
+  test("rejects an empty System Agent model setting", async () => {
+    const database = createViewerContextDatabase();
+
+    await expect(
+      setSystemAgentModel(database, VIEWER, {
+        modelId: " ",
+        vendor: "openai",
+      }),
+    ).rejects.toThrow("System Agent model and provider are required.");
   });
 
   test("reads the account name and image from the database, not the session", async () => {

--- a/apps/web/src/routes/agent/components/agent-builder/agent-builder-model-picker.tsx
+++ b/apps/web/src/routes/agent/components/agent-builder/agent-builder-model-picker.tsx
@@ -1,7 +1,7 @@
 import type { Viewer } from "@mosoo/contracts/account";
 import { SYSTEM_AGENT_RUNTIME_ID } from "@mosoo/runtime-catalog";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronDown, Zap } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import type { ReactElement } from "react";
 
 import { setSystemAgentModel } from "@/domains/user/api/user-client";
@@ -133,7 +133,6 @@ export function AgentBuilderModelPicker({
           type="button"
           variant="ghost"
         >
-          <Zap className="size-3.5" />
           <span className="truncate text-[12px] font-medium">{triggerLabel}</span>
           <ChevronDown className="size-3.5" />
         </Button>

--- a/apps/web/src/routes/agent/components/agent-builder/agent-builder-model-picker.tsx
+++ b/apps/web/src/routes/agent/components/agent-builder/agent-builder-model-picker.tsx
@@ -1,0 +1,170 @@
+import type { Viewer } from "@mosoo/contracts/account";
+import { SYSTEM_AGENT_RUNTIME_ID } from "@mosoo/runtime-catalog";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, Zap } from "lucide-react";
+import type { ReactElement } from "react";
+
+import { setSystemAgentModel } from "@/domains/user/api/user-client";
+import { userKeys, useViewerQuery } from "@/domains/user/query/user-queries";
+import { listAvailableAgentModels } from "@/domains/vendor-credential/api/vendor-credential-client";
+import { toAppId } from "@/routes/typed-id";
+import { Button } from "@/shared/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
+
+import {
+  findCurrentModelEntry,
+  listLockedVendorLabels,
+  listModelPickerEntries,
+} from "../editor/model-picker-availability";
+import {
+  ModelPickerEmptyItem,
+  ModelPickerItem,
+  ModelProviderLink,
+} from "../editor/model-picker-ui";
+
+interface SystemAgentModelSelection {
+  readonly modelId: string;
+  readonly vendor: string;
+}
+
+function sameSelection(
+  left: SystemAgentModelSelection | null,
+  right: SystemAgentModelSelection,
+): boolean {
+  return left?.modelId === right.modelId && left.vendor === right.vendor;
+}
+
+function updateViewerSystemAgentModel(
+  viewer: Viewer | undefined,
+  systemAgentModel: SystemAgentModelSelection | null,
+): Viewer | undefined {
+  if (viewer?.account === null || viewer?.account === undefined) {
+    return viewer;
+  }
+
+  return {
+    ...viewer,
+    account: {
+      ...viewer.account,
+      systemAgentModel,
+    },
+  };
+}
+
+export function AgentBuilderModelPicker({
+  appId,
+  onError,
+}: {
+  appId: string;
+  onError: (message: string | null) => void;
+}): ReactElement {
+  const typedAppId = toAppId(appId);
+  const queryClient = useQueryClient();
+  const viewerQuery = useViewerQuery();
+  const currentSelection = viewerQuery.data?.account?.systemAgentModel ?? null;
+  const currentModelId = currentSelection?.modelId ?? null;
+  const currentVendorId = currentSelection?.vendor ?? null;
+  const entriesQuery = useQuery({
+    queryFn: async () =>
+      listAvailableAgentModels({
+        appId: typedAppId,
+        currentModelId,
+        currentVendorId,
+        runtimeId: SYSTEM_AGENT_RUNTIME_ID,
+      }),
+    queryKey: [
+      "available-agent-models",
+      appId,
+      SYSTEM_AGENT_RUNTIME_ID,
+      currentModelId,
+      currentVendorId,
+    ],
+  });
+  const mutation = useMutation({
+    mutationFn: setSystemAgentModel,
+    onError: (error: unknown) => {
+      onError(error instanceof Error ? error.message : "Failed to update Builder model.");
+    },
+    onMutate: () => {
+      onError(null);
+    },
+    onSuccess: (systemAgentModel) => {
+      queryClient.setQueryData<Viewer>(userKeys.viewer(), (viewer) =>
+        updateViewerSystemAgentModel(viewer, systemAgentModel),
+      );
+      void queryClient.invalidateQueries({ queryKey: userKeys.viewer() });
+    },
+  });
+  const entries = entriesQuery.data ?? [];
+  const pickerEntries = listModelPickerEntries(entries, currentModelId, currentVendorId);
+  const currentEntry = findCurrentModelEntry(entries, currentModelId, currentVendorId);
+  const hasAvailable = entries.some((entry) => entry.available);
+  const lockedVendors = listLockedVendorLabels(entries);
+  const loading = entriesQuery.isLoading || viewerQuery.isLoading;
+  const disabled = loading || mutation.isPending;
+  const triggerLabel =
+    loading || mutation.isPending
+      ? "Model..."
+      : (currentEntry?.displayName ?? (hasAvailable ? "Model" : "No models"));
+
+  function pickModel(selection: SystemAgentModelSelection): void {
+    if (sameSelection(currentSelection, selection) || mutation.isPending) {
+      return;
+    }
+
+    mutation.mutate(selection);
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          aria-label="Select Agent Builder model"
+          className="text-muted-foreground hover:text-foreground max-w-[180px] gap-1.5 px-2.5"
+          disabled={disabled}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          <Zap className="size-3.5" />
+          <span className="truncate text-[12px] font-medium">{triggerLabel}</span>
+          <ChevronDown className="size-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-[320px]" side="top" sideOffset={8}>
+        <DropdownMenuLabel>Builder model</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <div className="max-h-[280px] overflow-y-auto">
+          {pickerEntries.length === 0 ? <ModelPickerEmptyItem /> : null}
+          {pickerEntries.map((entry) => (
+            <ModelPickerItem
+              entry={entry}
+              key={`${entry.vendorId}:${entry.modelId}`}
+              onPick={() => {
+                pickModel({
+                  modelId: entry.modelId,
+                  vendor: entry.vendorId,
+                });
+              }}
+              selected={
+                entry.modelId === currentSelection?.modelId &&
+                entry.vendorId === currentSelection.vendor
+              }
+            />
+          ))}
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <ModelProviderLink lockedVendors={lockedVendors} />
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/routes/agent/components/agent-builder/agent-builder-panel.tsx
+++ b/apps/web/src/routes/agent/components/agent-builder/agent-builder-panel.tsx
@@ -1,13 +1,14 @@
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import type { AgentBuilderDraftPatchSectionId } from "@mosoo/contracts/agent-builder";
 import { SendHorizontal } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import type { FormEvent } from "react";
 import type { ReactElement } from "react";
 
 import type { AgentBuilderMessage } from "@/domains/agent-builder/api/agent-builder-client";
 import { takeAgentBuilderInitialMessage } from "@/domains/agent-builder/initial-message";
 import { useAgentBuilderSystemAgentSession } from "@/domains/agent-builder/query/use-agent-builder-system-agent-session";
+import { useMountEffect } from "@/shared/hooks/use-mount-effect";
 import { Button } from "@/shared/ui/button";
 
 import type { Agent } from "../../agent.types";
@@ -24,6 +25,7 @@ import type {
   AgentBuilderActionHandler,
   AgentBuilderActionDisabled,
 } from "./agent-builder-message-card";
+import { AgentBuilderModelPicker } from "./agent-builder-model-picker";
 import { getLatestActionableStructuredReplyMessageId } from "./agent-builder-structured-reply-state";
 import { canSubmitAgentBuilderTurn } from "./agent-builder-submit-gate";
 
@@ -36,6 +38,24 @@ function combineBuilderActionDisabled(input: {
   }
 
   return input.actionDisabled;
+}
+
+function AgentBuilderInitialMessageSubmitter({
+  agentId,
+  onSubmit,
+}: {
+  readonly agentId: string;
+  readonly onSubmit: (inputText: string) => void;
+}): ReactElement | null {
+  useMountEffect(() => {
+    const initialMessage = takeAgentBuilderInitialMessage(agentId)?.trim() ?? "";
+
+    if (initialMessage.length > 0) {
+      onSubmit(initialMessage.slice(0, 4000));
+    }
+  });
+
+  return null;
 }
 
 export function AgentBuilderPanel({
@@ -65,6 +85,7 @@ export function AgentBuilderPanel({
 }): ReactElement {
   const [inputText, setInputText] = useState("");
   const [clientPatchError, setClientPatchError] = useState<string | null>(null);
+  const [modelSelectionError, setModelSelectionError] = useState<string | null>(null);
   const [autoApplyPending, setAutoApplyPending] = useState(false);
   const applyAutoPatch = useCallback(
     async (turnMessages: AgentBuilderMessage[]): Promise<void> => {
@@ -119,20 +140,6 @@ export function AgentBuilderPanel({
     },
     [canSubmitBuilderTurn, submitSystemAgentTurn],
   );
-  // The creation flow can stash the user's first Builder message (template or
-  // free text). Send it once the submit gate opens; take() clears the stash,
-  // so the effect stays idempotent under StrictMode.
-  useEffect(() => {
-    if (!canSubmitBuilderTurn) {
-      return;
-    }
-
-    const initialMessage = takeAgentBuilderInitialMessage(agent.id)?.trim() ?? "";
-
-    if (initialMessage.length > 0) {
-      submitBuilderTurn(initialMessage.slice(0, 4000));
-    }
-  }, [agent.id, canSubmitBuilderTurn, submitBuilderTurn]);
   const assistantRuntime = useAgentBuilderAssistantRuntime({
     isBusy: systemAgentSession.isBusy || autoApplyPending,
     isSendDisabled: !canSubmitBuilderTurn,
@@ -164,6 +171,13 @@ export function AgentBuilderPanel({
 
   return (
     <AssistantRuntimeProvider runtime={assistantRuntime}>
+      {canSubmitBuilderTurn ? (
+        <AgentBuilderInitialMessageSubmitter
+          agentId={agent.id}
+          key={agent.id}
+          onSubmit={submitBuilderTurn}
+        />
+      ) : null}
       <div className="bg-bg-1 flex h-full min-h-0 flex-col overflow-hidden">
         <div className="min-h-0 flex-1 overflow-y-auto p-4">
           {systemAgentSession.historyError !== null ? (
@@ -209,6 +223,11 @@ export function AgentBuilderPanel({
               {clientPatchError}
             </div>
           ) : null}
+          {modelSelectionError ? (
+            <div className="border-destructive/30 bg-destructive/5 text-destructive mb-2 rounded-lg border px-3 py-2 text-[12px]">
+              {modelSelectionError}
+            </div>
+          ) : null}
           {actionError ? (
             <div className="border-destructive/30 bg-destructive/5 text-destructive mb-2 rounded-lg border px-3 py-2 text-[12px]">
               {actionError}
@@ -226,6 +245,7 @@ export function AgentBuilderPanel({
               placeholder="Message Agent Builder"
               value={inputText}
             />
+            <AgentBuilderModelPicker appId={agent.appId} onError={setModelSelectionError} />
             <Button disabled={!canSubmit} size="icon-sm" type="submit">
               <SendHorizontal />
             </Button>

--- a/apps/web/src/shared/hooks/use-mount-effect.ts
+++ b/apps/web/src/shared/hooks/use-mount-effect.ts
@@ -1,0 +1,5 @@
+import { useEffect } from "react";
+
+export function useMountEffect(effect: () => void | (() => void)): void {
+  useEffect(effect, []);
+}


### PR DESCRIPTION
## Summary

- Add a compact Agent Builder model selector next to the Builder composer send button.
- Persist the selected System Agent model on the viewer account via `setSystemAgentModel`.
- Reuse the existing available-model catalog/readiness UI so unavailable models still route users to Provider setup.
- Remove the forced `temperature: 0` from the Builder planner request because newer OpenAI models reject it.

## Why

- Agent Builder model selection should be configurable from the Builder composer, not only through backend defaults.
- The selector needs to reflect App-level Provider credentials and keep the Builder model independent from the draft agent runtime/model.
- Live testing with the configured local OpenAI Provider reached the planner but exposed the `temperature` incompatibility, so the request now lets the provider default apply.

## Verification

- Commands (`just check`, `just test-file <path>`, `just graphql-codegen`, etc.):
  - `just test-file apps/api/tests/agent-builder-system-agent-lightweight-rpc.test.ts`
  - `just test-file apps/api/tests/viewer-organization-context.test.ts`
  - `just tc-package @mosoo/api`
  - `just tc-package @mosoo/web`
  - `bun run --filter @mosoo/api lint`
  - `bun run --filter @mosoo/web lint`
  - `just fmt-check-path apps/api/src/modules/agent-builder/application/agent-builder-llm-planner.service.ts`
  - `just fmt-check-path apps/api/tests/agent-builder-system-agent-lightweight-rpc.test.ts`
  - `git diff --check`
- Manual steps:
  - Logged in locally via the `@mosoo.ai` development login channel.
  - Configured an OpenAI Provider credential in the local App.
  - Confirmed the Agent Builder model selector lists available OpenAI System Agent models after Provider setup.
  - Sent `你的背后是啥模型` through the local Agent Builder System Agent WebSocket flow and confirmed the persisted planner run completed with an OpenAI model.

## Risk And Blast Radius

- Affected packages:
  - `@mosoo/api`
  - `@mosoo/web`
- Affected user flows or APIs:
  - Agent Builder composer model selection.
  - Viewer account System Agent model persistence.
  - Agent Builder LLM planner calls for OpenAI-shaped providers.
- Rollback:
  - Revert this commit to remove the Builder selector and restore previous planner request shape.

## Evidence

- UI/UX: verified locally at `http://localhost:5173/agent/01KV8D76SRCXQR88JQ9RP3G34R`; screenshot not attached.
- API or behavior:
  - `setSystemAgentModel` now persists and reads back the account-level System Agent model.
  - Local Agent Builder planner run persisted `provider=openai`, `status=completed` after model selection and Provider setup.
- Logs, recordings, or test output:
  - Local WebSocket smoke output returned `ok=true terminal=completed` for the Builder System Agent turn.

## Compatibility

- Public contract changes:
  - None. Uses existing GraphQL fields/mutations for System Agent model selection.
- Env or config changes:
  - None.
- Deployment or migration:
  - None. No DB baseline or migration changes in this PR.

## Reviewer Focus

- Closest review areas:
  - Whether System Agent model selection belongs on account scope for this iteration.
  - Cache invalidation/query-key behavior for the new Builder model selector.
  - Removing `temperature` from Builder planner requests for OpenAI-shaped providers.
- Known trade-offs:
  - The selector is intentionally compact and scoped to the Builder composer; broader model-management UX remains in Providers/model catalog surfaces.

## Required Checks

- [x] PR title: `type(scope): subject` (e.g. `fix(fmt): restore pre-commit checks`)
- [x] Type: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`, `build`, `ci`, `style`, or `revert`
- [x] Subject starts lowercase; `!` only for intentional breaking changes (e.g. `feat(api)!: remove legacy session field`)
- [x] Branch follows `type/scope-subject` when maintained in this repository; fork branch names may vary
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: if prompted by CLA Assistant, every human contributor has signed by posting the exact required PR comment
- [x] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence, or N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A, or list touched artifacts: N/A
- GraphQL codegen (`just graphql-codegen`): N/A, no GraphQL schema/query shape changes requiring regenerated artifacts.
- DB baseline (`just db-regen`): N/A
- Lockfile (`bun.lock`): N/A
- Confirm no hand-edits to generated paths (`schema.generated.graphql`, `apps/web/src/gql/**`, `pkgs/db/drizzle/**`): confirmed
