### PR TITLE
feat(web): replace Debug dropdown with direct Terminal tab in agent editor toolbar

### DIFF
--- a/apps/web/src/routes/agent/agent-detail.route.tsx
+++ b/apps/web/src/routes/agent/agent-detail.route.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, ChevronDown, Settings, TerminalSquare } from "lucide-react";
+import { ArrowLeft, Settings, TerminalSquare } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
@@ -8,12 +8,6 @@ import { useAgentDetailQuery, useAgentEditorStateQuery } from "@/domains/agent/q
 import { useAuth } from "@/domains/auth/use-auth";
 import { cn } from "@/shared/lib/class-names";
 import { Button } from "@/shared/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/shared/ui/dropdown-menu";
 import { Sheet, SheetContent, SheetTitle } from "@/shared/ui/sheet";
 
 import { isTruthy } from "../../shared/lib/truthiness";
@@ -40,8 +34,6 @@ const MODE_TABS: { id: DetailMode; label: string; ownerOnly?: boolean }[] = [
   { id: "logs", label: "Logs", ownerOnly: true },
   { id: "cost", label: "Cost", ownerOnly: true },
 ];
-
-const DEBUG_MODES = new Set<DetailMode>(["terminal"]);
 
 interface DebugModeItem {
   icon: LucideIcon;
@@ -151,40 +143,27 @@ function AgentDetailHeader({
                   </button>,
                 ],
           )}
-          {debugItems.length > 0 ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  className={cn(
-                    "flex items-center gap-1 rounded-lg px-3.5 py-1.5 text-[13px] font-medium outline-none transition-all",
-                    DEBUG_MODES.has(mode)
-                      ? "bg-ink-100 text-fg-1"
-                      : "text-muted-foreground hover:bg-accent",
-                  )}
-                >
-                  Debug
-                  <ChevronDown aria-hidden="true" size={14} />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {debugItems.map((item) => {
-                  const Icon = item.icon;
-                  return (
-                    <DropdownMenuItem
-                      key={item.id}
-                      onSelect={() => {
-                        onSelectMode(item.id);
-                      }}
-                    >
-                      <Icon aria-hidden="true" size={14} />
-                      <span className="flex-1">{item.label}</span>
-                    </DropdownMenuItem>
-                  );
-                })}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : null}
+          {debugItems.map((item) => {
+            const Icon = item.icon;
+            return (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => {
+                  onSelectMode(item.id);
+                }}
+                className={cn(
+                  "flex items-center gap-1.5 rounded-lg px-3.5 py-1.5 text-[13px] font-medium transition-all",
+                  mode === item.id
+                    ? "bg-ink-100 text-fg-1"
+                    : "text-muted-foreground hover:bg-accent",
+                )}
+              >
+                <Icon aria-hidden="true" size={14} />
+                {item.label}
+              </button>
+            );
+          })}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- Replaces the "Debug" dropdown tab in the agent editor top toolbar with a direct "Terminal" tab. Clicking it switches straight to terminal mode — no dropdown menu in between.

## Why

- The "Debug" dropdown only ever contained a single item ("Terminal"), so the extra dropdown interaction added a needless click. A direct tab is simpler and matches the other toolbar tabs (Dev / Preview / Logs / Cost).

## Verification

- Commands: `tsc --noEmit` on `apps/web` shows no errors for the edited file (only the pre-existing, unrelated `vite-plus/client` generated-types warning).
- Manual steps: open an agent as owner → toolbar now shows a "Terminal" tab (with terminal icon) instead of a "Debug ▾" dropdown; clicking it opens terminal mode and the tab highlights as active.

## Risk And Blast Radius

- Affected packages: `apps/web`
- Affected user flows or APIs: agent editor toolbar navigation only. Terminal access gating (owner-only, `agentKindSupportsOwnerTerminal`) is unchanged — the same `canShowAgentDebugMenuItem` policy still controls whether the entry renders.
- Rollback: revert this commit.

## Evidence

- UI/UX: visible change is the toolbar tab. Before: `Debug ▾` dropdown whose only item is `Terminal`. After: a direct `Terminal` tab.

## Compatibility

- Public contract changes: none
- Env or config changes: none
- Deployment or migration: none

## Reviewer Focus

- Closest review areas: `apps/web/src/routes/agent/agent-detail.route.tsx` — removed `DropdownMenu`/`ChevronDown`/`DEBUG_MODES` usage; render `debugItems` as direct tab buttons.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `feat`
- [x] Subject starts lowercase
- [x] Branch follows repo convention
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: change described in Evidence
- [x] Generated files: none touched
