### PR TITLE
fix(blog): remove large rounded-corner card from featured section

### DIFF
--- a/apps/blog/src/components/Hero.astro
+++ b/apps/blog/src/components/Hero.astro
@@ -18,7 +18,7 @@ const dateLabel = featured.data.date.toLocaleDateString("en-US", {
 
 <a
   href={href}
-  class="group block overflow-hidden rounded-[var(--r-2xl)] border border-[color:var(--border)] bg-[color:var(--surface)] shadow-[var(--shadow-sm)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--shadow-lg)]"
+  class="group block"
 >
   <div class="grid grid-cols-1 md:grid-cols-[0.95fr_1.05fr]">
     <div class="md:order-2">
@@ -30,7 +30,7 @@ const dateLabel = featured.data.date.toLocaleDateString("en-US", {
         label={featured.data.category}
       />
     </div>
-    <div class="flex flex-col gap-4 p-6 md:order-1 md:p-8 lg:p-9">
+    <div class="flex flex-col gap-4 pt-5 md:order-1 md:pt-0 md:pr-10 lg:pr-12">
       <div class="font-mono text-[11.5px] font-semibold uppercase tracking-[0.08em] text-[color:var(--fg-muted)]">
         Featured · {dateLabel}
       </div>


### PR DESCRIPTION
## Summary

- Removed the large rounded-corner card treatment from the blog's featured (Hero) section. The featured post no longer renders inside an elevated `rounded-[var(--r-2xl)]` (24px) card with border, surface background, and shadow — it now sits flat within its section.

## Why

- Per request (YEF-686): the featured area on the blog site should not use the large rounded-corner card style.

## Verification

- Commands: `bun run build` in `apps/blog` (astro build) — passes, 5 pages built.
- Manual steps: Built and previewed `apps/blog` locally; confirmed the featured section renders flat (no rounded corners / card chrome) with text aligned to the section edge and a gutter before the image.

## Risk And Blast Radius

- Affected packages: `@mosoo/blog`
- Affected user flows or APIs: Blog index featured section visual only.
- Rollback: revert this commit.

## Evidence

- UI/UX: featured section now flat without the large rounded card. Before/after screenshots attached on the issue.

## Compatibility

- Public contract changes: none
- Env or config changes: none
- Deployment or migration: none

## Reviewer Focus

- Closest review areas: `apps/blog/src/components/Hero.astro`
- Known trade-offs: text column padding adjusted so it aligns to the section edge with a gutter to the image now that the card padding is gone.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `fix`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: sign if prompted
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A
