### PR TITLE
chore(dev): include blog in just dev startup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,12 +88,13 @@ Start the regular local stack:
 just dev
 ```
 
-This command runs local D1 migration first, then starts the driver build, API Worker, and web app.
+This command runs local D1 migration first, then starts the driver build, API Worker, web app, and blog.
 
 Default local URLs:
 
 - Web: `http://localhost:5173`
 - API: `http://localhost:8787`
+- Blog: `http://localhost:4321/blog` (Astro dev server; mounted at the `/blog` base path with `trailingSlash: "never"`, so the URL must be `/blog` with no trailing slash — `/` and `/blog/` both 404)
 
 Local login:
 

--- a/README.md
+++ b/README.md
@@ -87,5 +87,6 @@ just dev
 
 - Web: `http://localhost:5173`
 - API: `http://localhost:8787`
+- Blog: `http://localhost:4321/blog`
 - Regular email login uses OTP.
 - In local development, email addresses ending with `@mosoo.ai` skip OTP and log in directly.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "deploy": "vp run -w deploy:api && vp run -w deploy:web",
     "deploy:api": "vp run --filter @mosoo/api deploy",
     "deploy:web": "vp run --filter @mosoo/web deploy",
-    "dev": "vp run --filter @mosoo/api --filter @mosoo/web --parallel dev",
+    "dev": "vp run --filter @mosoo/api --filter @mosoo/web --filter @mosoo/blog --parallel dev",
     "driver:repo:export": "vp exec bun scripts/export-driver-standalone-repo.ts",
     "driver:submodule:smoke": "vp exec bun scripts/check-driver-submodule-cutover.ts",
     "e2e:deterministic": "./e2e/run-deterministic.sh",


### PR DESCRIPTION
## Summary

- Add `--filter @mosoo/blog` to the root `dev` script so `just dev` starts the blog Astro dev server alongside the API Worker and web app.
- Document the local blog URL (`http://localhost:4321/blog`) in `README.md` and `CONTRIBUTING.md`, including the `/blog` base path and `trailingSlash: "never"` caveat.

## Why

- Previously the blog was not part of the dev stack (`just dev` only ran `@mosoo/api` + `@mosoo/web`), so it had to be started manually. Developers hitting `:5173/blog` or `:4321/` got 404s and assumed the blog was broken. Bundling it into `just dev` makes the full stack come up with one command.

## Verification

- Commands: `vp fmt --check package.json README.md CONTRIBUTING.md` → passes.
- Manual steps: ran `vp run --filter @mosoo/blog --parallel dev` and probed the server:
  - `http://localhost:4321/` → 404 (expected; base is `/blog`)
  - `http://localhost:4321/blog` → 200, title `Mosoo blog · Notes from the bamboo grove`

## Risk And Blast Radius

- Affected packages: root `package.json` dev script, docs only.
- Affected user flows or APIs: local development startup only. No production/runtime/build change (prod still embeds `apps/blog/dist` into `apps/web/dist/blog/` via the web build).
- Rollback: revert this commit.

## Evidence

- UI/UX: N/A (no visual change to the app).
- API or behavior: see Verification HTTP codes above.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review area: the single-line change to the `dev` script in `package.json`.
- Known trade-offs: blog dev server adds another process to `just dev`; runs on the default Astro port `4321` (outside the reserved `5173`/`5174` and preview `5180+` ranges).

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `chore`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A — no generated artifacts touched.
