### PR TITLE
fix(runtime): recover subject activation claims

### DIFF
--- a/apps/api/src/modules/runtime/application/session-runs/prewarm-agent-session-runtime.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/prewarm-agent-session-runtime.service.ts
@@ -77,6 +77,7 @@ export async function prewarmAgentSessionRuntime(
         executionOwnerUserId: hydrated.value.profile.session.origin.executionOwnerUserId,
         kind: hydrated.value.profile.kind,
         runtimeSubjectId: sandboxId,
+        purpose: "prewarm",
         spaceAliases: hydrated.value.profile.session.spaceAliases,
         subjectId: hydrated.value.profile.sandbox.subjectId,
         subjectKind: hydrated.value.profile.sandbox.subjectKind,

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-errors.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-errors.ts
@@ -2,6 +2,7 @@ import type { RuntimeSubjectErrorCode } from "@mosoo/contracts/sandbox";
 
 const RECOVERABLE_RUNTIME_SUBJECT_ERROR_CODES: ReadonlySet<RuntimeSubjectErrorCode> = new Set([
   "runtime.conversation_mount_failed",
+  "runtime.subject_activation_failed",
 ]);
 
 export class RuntimeSubjectBackupNotReadyError extends Error {

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-lifecycle.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-lifecycle.service.ts
@@ -54,6 +54,7 @@ import {
   markRuntimeSubjectActive,
   markRuntimeSubjectRestoreApplied,
   markRuntimeSubjectRestoring,
+  preemptRuntimeSubjectActivationClaim,
   recordRuntimeConversationSessionActive,
   recordRuntimeConversationSessionClosed,
   recordRuntimeConversationSessionError,
@@ -64,6 +65,11 @@ import type { ReadyRuntimeSubjectBackupRecord } from "./runtime-subject-store";
 const RUNTIME_SUBJECT_ACTIVATION_CLAIM_TTL_MS = 10 * 60_000;
 const RUNTIME_SUBJECT_ACTIVATION_CLAIM_WAIT_MAX_MS = 8_000;
 const RUNTIME_SUBJECT_ACTIVATION_CLAIM_POLL_INTERVAL_MS = 250;
+const INTERACTIVE_ACTIVATION_CLAIM_OWNER_PREFIX = "interactive-activation-";
+const PREWARM_ACTIVATION_CLAIM_OWNER_PREFIX = "prewarm-activation-";
+const MAINTENANCE_CLAIM_OWNER_PREFIXES = ["scheduled-", "immediate-"] as const;
+
+export type RuntimeSubjectActivationPurpose = "interactive" | "prewarm";
 
 export interface ActivateRuntimeSubjectInput {
   readonly executionOwnerUserId: AccountId;
@@ -71,6 +77,7 @@ export interface ActivateRuntimeSubjectInput {
   readonly onSpaceMountFailed?: (alias: SpaceAliasBinding, error: unknown) => Promise<void>;
   readonly onSpaceMountSucceeded?: (alias: SpaceAliasBinding) => Promise<void>;
   readonly diagnosticContext?: RuntimeDiagnosticContext;
+  readonly purpose?: RuntimeSubjectActivationPurpose;
   readonly runtimeSubjectId: SandboxId;
   readonly spaceAliases: SpaceAliasBinding[];
   readonly subjectId: PlatformId;
@@ -96,6 +103,33 @@ function hasActiveRuntimeSubjectClaim(
 ): boolean {
   return (
     record.claimOwner !== null && record.claimExpiresAt !== null && record.claimExpiresAt > now
+  );
+}
+
+function createRuntimeSubjectActivationClaimOwner(
+  purpose: RuntimeSubjectActivationPurpose,
+): string {
+  const prefix =
+    purpose === "prewarm"
+      ? PREWARM_ACTIVATION_CLAIM_OWNER_PREFIX
+      : INTERACTIVE_ACTIVATION_CLAIM_OWNER_PREFIX;
+
+  return `${prefix}${crypto.randomUUID()}`;
+}
+
+function isPrewarmActivationClaim(record: RuntimeSubjectActivationRecord): boolean {
+  return record.claimOwner?.startsWith(PREWARM_ACTIVATION_CLAIM_OWNER_PREFIX) ?? false;
+}
+
+function isClaimableRuntimeSubjectStatus(record: RuntimeSubjectActivationRecord): boolean {
+  return record.status === "active" || record.status === "cold" || record.status === "error";
+}
+
+function isUnstartedMaintenanceClaim(record: RuntimeSubjectActivationRecord): boolean {
+  return (
+    record.status === "active" &&
+    record.claimOwner !== null &&
+    MAINTENANCE_CLAIM_OWNER_PREFIXES.some((prefix) => record.claimOwner?.startsWith(prefix))
   );
 }
 
@@ -140,9 +174,10 @@ export class RuntimeSubjectLifecycleService {
   }
 
   async activate(input: ActivateRuntimeSubjectInput): Promise<ActiveRuntimeSubject> {
-    const claimOwner = `activation-${crypto.randomUUID()}`;
+    const purpose = input.purpose ?? "interactive";
+    const claimOwner = createRuntimeSubjectActivationClaimOwner(purpose);
     const record = await measureOptional(input.timing, "runtimeSubject.admitLifecycle", () =>
-      this.#admitActivation(input, claimOwner),
+      this.#admitActivation(input, claimOwner, purpose),
     );
     const subject = await this.getHandle(input.runtimeSubjectId);
     const isCold = record === null || record.status === "cold";
@@ -311,6 +346,7 @@ export class RuntimeSubjectLifecycleService {
   async #admitActivation(
     input: ActivateRuntimeSubjectInput,
     claimOwner: string,
+    purpose: RuntimeSubjectActivationPurpose,
   ): Promise<RuntimeSubjectActivationRecord | null> {
     const now = currentTimestampMs();
     const claimExpiresAt = now + RUNTIME_SUBJECT_ACTIVATION_CLAIM_TTL_MS;
@@ -345,6 +381,7 @@ export class RuntimeSubjectLifecycleService {
         claimExpiresAt,
         claimOwner,
         now,
+        purpose,
         record: createdByAnotherActivation,
       });
     }
@@ -354,6 +391,7 @@ export class RuntimeSubjectLifecycleService {
       claimExpiresAt,
       claimOwner,
       now,
+      purpose,
       record,
     });
   }
@@ -363,6 +401,7 @@ export class RuntimeSubjectLifecycleService {
     readonly claimExpiresAt: number;
     readonly claimOwner: string;
     readonly now: number;
+    readonly purpose: RuntimeSubjectActivationPurpose;
     readonly record: RuntimeSubjectActivationRecord;
   }): Promise<RuntimeSubjectActivationRecord> {
     let record = input.record;
@@ -373,6 +412,23 @@ export class RuntimeSubjectLifecycleService {
 
     if (record.status === "backing_up" || record.status === "destroying") {
       throw new Error("Runtime subject is busy with lifecycle maintenance.");
+    }
+
+    if (this.#canPreemptRuntimeSubjectClaim(input, record, "prewarm_only")) {
+      const preempted = await this.#preemptRuntimeSubjectClaim(input, record);
+
+      if (preempted) {
+        return record;
+      }
+
+      const refreshed = await getRuntimeSubjectActivationRecord(
+        this.#bindings.DB,
+        input.activation.runtimeSubjectId,
+      );
+      if (!refreshed) {
+        throw new Error("Runtime subject activation could not refresh the lifecycle record.");
+      }
+      record = refreshed;
     }
 
     // A concurrent activation can hold the claim through `cold` / `restoring` for tens of
@@ -408,6 +464,14 @@ export class RuntimeSubjectLifecycleService {
     }
 
     if (hasActiveRuntimeSubjectClaim(record, currentTimestampMs())) {
+      const preempted = this.#canPreemptRuntimeSubjectClaim(input, record, "all_low_priority")
+        ? await this.#preemptRuntimeSubjectClaim(input, record)
+        : false;
+
+      if (preempted) {
+        return record;
+      }
+
       throw new Error("Runtime subject is claimed by lifecycle maintenance.");
     }
 
@@ -431,6 +495,55 @@ export class RuntimeSubjectLifecycleService {
     }
 
     return record;
+  }
+
+  #canPreemptRuntimeSubjectClaim(
+    input: {
+      readonly purpose: RuntimeSubjectActivationPurpose;
+    },
+    record: RuntimeSubjectActivationRecord,
+    mode: "all_low_priority" | "prewarm_only",
+  ): boolean {
+    if (
+      input.purpose !== "interactive" ||
+      record.claimOwner === null ||
+      record.claimExpiresAt === null
+    ) {
+      return false;
+    }
+
+    if (!isClaimableRuntimeSubjectStatus(record)) {
+      return false;
+    }
+
+    if (isPrewarmActivationClaim(record)) {
+      return true;
+    }
+
+    return mode === "all_low_priority" && isUnstartedMaintenanceClaim(record);
+  }
+
+  async #preemptRuntimeSubjectClaim(
+    input: {
+      readonly activation: ActivateRuntimeSubjectInput;
+      readonly claimExpiresAt: number;
+      readonly claimOwner: string;
+    },
+    record: RuntimeSubjectActivationRecord,
+  ): Promise<boolean> {
+    if (record.claimOwner === null || record.claimExpiresAt === null) {
+      return false;
+    }
+
+    return preemptRuntimeSubjectActivationClaim(this.#bindings.DB, {
+      claimExpiresAt: input.claimExpiresAt,
+      claimOwner: input.claimOwner,
+      expectedClaimExpiresAt: record.claimExpiresAt,
+      expectedClaimOwner: record.claimOwner,
+      expectedStatus: record.status,
+      now: currentTimestampMs(),
+      runtimeSubjectId: input.activation.runtimeSubjectId,
+    });
   }
 
   async #restoreLastBackup(input: {

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-record-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-record-store.ts
@@ -302,6 +302,41 @@ export async function claimRuntimeSubjectActivation(
   return Boolean(claimed?.id);
 }
 
+export async function preemptRuntimeSubjectActivationClaim(
+  database: D1Database,
+  input: {
+    readonly claimExpiresAt: number;
+    readonly claimOwner: string;
+    readonly expectedClaimExpiresAt: number;
+    readonly expectedClaimOwner: string;
+    readonly expectedStatus: RuntimeSubjectStatus;
+    readonly now: number;
+    readonly runtimeSubjectId: SandboxId;
+  },
+): Promise<boolean> {
+  const preempted =
+    (await getAppDatabase(database)
+      .update(sandboxesTable)
+      .set({
+        claimExpiresAt: input.claimExpiresAt,
+        claimOwner: input.claimOwner,
+        updatedAt: input.now,
+      })
+      .where(
+        and(
+          eq(sandboxesTable.id, input.runtimeSubjectId),
+          eq(sandboxesTable.status, input.expectedStatus),
+          inArray(sandboxesTable.status, RUNTIME_SUBJECT_CLAIMABLE_STATUSES),
+          eq(sandboxesTable.claimOwner, input.expectedClaimOwner),
+          eq(sandboxesTable.claimExpiresAt, input.expectedClaimExpiresAt),
+        ),
+      )
+      .returning({ id: sandboxesTable.id })
+      .get()) ?? null;
+
+  return Boolean(preempted?.id);
+}
+
 export async function markRuntimeSubjectRestoring(
   database: D1Database,
   input: {

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store.ts
@@ -28,6 +28,7 @@ export {
   markRuntimeSubjectFailed,
   markRuntimeSubjectOperationStarted,
   markRuntimeSubjectOperationRepairNeeded,
+  preemptRuntimeSubjectActivationClaim,
   markRuntimeSubjectRestoreApplied,
   markRuntimeSubjectRestoring,
 } from "./runtime-subject-record-store";

--- a/apps/api/tests/runtime-subject-lifecycle.test.ts
+++ b/apps/api/tests/runtime-subject-lifecycle.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, test } from "bun:test";
 
 import { decideRuntimeSubjectTransition } from "../src/modules/runtime/domain/runtime-subject-lifecycle.machine";
+import { createRuntimeSubjectLifecycleService } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-lifecycle.service";
 import {
   advanceRuntimeSubjectOperationStatus,
   markRuntimeSubjectCold,
   markRuntimeSubjectOperationStarted,
 } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store";
+import type { SandboxHandle } from "../src/modules/runtime/infrastructure/sandbox-handles";
+import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
 import { SqliteD1Database } from "./helpers/sqlite-d1";
+
+const RUNTIME_SUBJECT_ID = "01J0000000000000000000000D";
 
 function createRuntimeSubjectLifecycleDatabase(): SqliteD1Database {
   const database = new SqliteD1Database();
@@ -31,6 +36,18 @@ function createRuntimeSubjectLifecycleDatabase(): SqliteD1Database {
       status_source text DEFAULT 'system' NOT NULL,
       updated_at integer NOT NULL
     );
+
+    CREATE TABLE sandbox_backup (
+      created_at integer NOT NULL,
+      dir text NOT NULL,
+      error_message text,
+      id text PRIMARY KEY NOT NULL,
+      keep integer NOT NULL,
+      sandbox_id text NOT NULL,
+      status text NOT NULL,
+      ttl_seconds integer NOT NULL,
+      updated_at integer NOT NULL
+    );
   `);
 
   return database;
@@ -39,6 +56,8 @@ function createRuntimeSubjectLifecycleDatabase(): SqliteD1Database {
 async function insertRuntimeSubject(
   database: D1Database,
   input: {
+    readonly lastError?: string | null;
+    readonly lastErrorCode?: string | null;
     readonly status: string;
     readonly statusSeq?: number;
   },
@@ -68,12 +87,12 @@ async function insertRuntimeSubject(
     .bind(
       null,
       null,
-      "01J0000000000000000000000D",
+      RUNTIME_SUBJECT_ID,
       1,
       "cattle",
       null,
-      null,
-      null,
+      input.lastError ?? null,
+      input.lastErrorCode ?? null,
       null,
       input.status,
       `runtime_subject.${input.status === "backing_up" ? "back_up" : input.status}`,
@@ -95,7 +114,7 @@ async function readRuntimeSubject(database: D1Database): Promise<{
       `
         SELECT status, status_event, status_seq, status_source
         FROM sandbox
-        WHERE id = '01J0000000000000000000000D'
+        WHERE id = '${RUNTIME_SUBJECT_ID}'
       `,
     )
     .first<{
@@ -110,6 +129,39 @@ async function readRuntimeSubject(database: D1Database): Promise<{
   }
 
   return row;
+}
+
+function createSandboxHandle(): SandboxHandle {
+  const unavailable = async () => {
+    throw new Error("Unexpected sandbox test method call.");
+  };
+
+  return {
+    createBackup: unavailable,
+    createSession: unavailable,
+    deleteSession: unavailable,
+    destroy: unavailable,
+    exec: unavailable,
+    getSession: unavailable,
+    mkdir: async () => {},
+    mountBucket: unavailable,
+    readFile: unavailable,
+    restoreBackup: unavailable,
+    setKeepAlive: async () => {},
+    startProcess: unavailable,
+    terminal: unavailable,
+    watch: unavailable,
+    writeFile: unavailable,
+    wsConnect: unavailable,
+  } as SandboxHandle;
+}
+
+function createBindings(database: D1Database): ApiBindings {
+  return {
+    DB: database,
+    SANDBOX_FILE_BUCKET_LOCAL: "true",
+    runtimeSubjectHandleFactory: () => createSandboxHandle(),
+  } as unknown as ApiBindings;
 }
 
 describe("runtime subject lifecycle machine", () => {
@@ -181,6 +233,101 @@ describe("runtime subject lifecycle machine", () => {
       status_event: "runtime_subject.active",
       status_seq: 7,
       status_source: "test",
+    });
+  });
+
+  test("lets interactive activation preempt best-effort prewarm activation claims", async () => {
+    const database = createRuntimeSubjectLifecycleDatabase();
+    await insertRuntimeSubject(database, { status: "cold" });
+    await database
+      .prepare(
+        `
+          UPDATE sandbox
+          SET claim_owner = ?, claim_expires_at = ?
+          WHERE id = ?
+        `,
+      )
+      .bind("prewarm-activation-stalled", Date.now() + 60_000, RUNTIME_SUBJECT_ID)
+      .run();
+
+    const activation = await createRuntimeSubjectLifecycleService(
+      createBindings(database),
+    ).activate({
+      executionOwnerUserId: "01J00000000000000000000002",
+      kind: "cattle",
+      runtimeSubjectId: RUNTIME_SUBJECT_ID,
+      spaceAliases: [],
+      subjectId: "01J00000000000000000000009",
+      subjectKind: "session",
+    });
+
+    expect(activation.subject).toBeTruthy();
+    const row = await database
+      .prepare(
+        `
+          SELECT claim_expires_at, claim_owner, status
+          FROM sandbox
+          WHERE id = ?
+        `,
+      )
+      .bind(RUNTIME_SUBJECT_ID)
+      .first<{
+        claim_expires_at: number | null;
+        claim_owner: string | null;
+        status: string;
+      }>();
+
+    expect(row).toEqual({
+      claim_expires_at: null,
+      claim_owner: null,
+      status: "active",
+    });
+  });
+
+  test("lets interactive activation retry after activation failures", async () => {
+    const database = createRuntimeSubjectLifecycleDatabase();
+    await insertRuntimeSubject(database, {
+      lastError: "Runtime subject filesystem prepare timed out after 15000ms.",
+      lastErrorCode: "runtime.subject_activation_failed",
+      status: "error",
+      statusSeq: 7,
+    });
+
+    const activation = await createRuntimeSubjectLifecycleService(
+      createBindings(database),
+    ).activate({
+      executionOwnerUserId: "01J00000000000000000000002",
+      kind: "cattle",
+      runtimeSubjectId: RUNTIME_SUBJECT_ID,
+      spaceAliases: [],
+      subjectId: "01J00000000000000000000009",
+      subjectKind: "session",
+    });
+
+    expect(activation.subject).toBeTruthy();
+    const row = await database
+      .prepare(
+        `
+          SELECT claim_expires_at, claim_owner, last_error, last_error_code, status
+          FROM sandbox
+          WHERE id = ?
+        `,
+      )
+      .bind(RUNTIME_SUBJECT_ID)
+      .first<{
+        claim_expires_at: number | null;
+        claim_owner: string | null;
+        last_error: string | null;
+        last_error_code: string | null;
+        status: string;
+      }>();
+
+    expect(row).toEqual({
+      claim_expires_at: null,
+      claim_owner: null,
+      last_error: null,
+      last_error_code: null,
+      status: "active",
     });
   });
 });


### PR DESCRIPTION
## Summary

- Mark prewarm runtime-subject activations as best-effort lifecycle claims.
- Let interactive activation preempt stale or low-priority prewarm and unstarted maintenance claims.
- Treat `runtime.subject_activation_failed` as recoverable so filesystem prepare timeouts can retry.

## Why

- Interactive session startup could fail behind a best-effort prewarm claim with `Runtime subject is claimed by lifecycle maintenance.`
- A filesystem prepare timeout moved the runtime subject into `error`, but the activation failure code was not recoverable, so later interactive activation could not repair the subject.

## Verification

- Commands:
  - `just test-file apps/api/tests/runtime-subject-lifecycle.test.ts`
  - `just tc-package @mosoo/api`
  - `just fmt-check-path apps/api/src/modules/runtime/application/session-runs/prewarm-agent-session-runtime.service.ts`
  - `just fmt-check-path apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle`
  - `just fmt-check-path apps/api/tests/runtime-subject-lifecycle.test.ts`
  - `bash ./init.sh development`
- Manual steps:
  - Confirmed the local `5173` -> `8788` GraphQL proxy returns `HTTP/1.1 200 OK` for `/api/graphql` with the expected missing-query response.
  - Confirmed the `@mosoo.ai` development backdoor login returns `200` after local env initialization; unrelated to this runtime diff, but used to verify the current local stack.

## Risk And Blast Radius

- Affected packages: `@mosoo/api` runtime subject lifecycle.
- Affected user flows or APIs: interactive session/runtime startup after prewarm, maintenance claims, or recoverable activation failures.
- Rollback: revert this commit to restore the previous strict lifecycle-claim behavior.

## Evidence

- UI/UX: N/A, no visible UI changes.
- API or behavior:
  - Added lifecycle tests for interactive preemption of prewarm activation claims.
  - Added lifecycle tests for retry after `runtime.subject_activation_failed`.
- Logs, recordings, or test output:
  - `just test-file apps/api/tests/runtime-subject-lifecycle.test.ts`: 5 pass, 0 fail.
  - `just tc-package @mosoo/api`: exited with code 0.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas:
  - Claim preemption rules in `runtime-subject-lifecycle.service.ts`.
  - Compare-and-swap update in `preemptRuntimeSubjectActivationClaim`.
  - Recoverable error classification for `runtime.subject_activation_failed`.
- Known trade-offs:
  - Interactive activation can now preempt explicitly low-priority prewarm claims and unstarted maintenance claims, but still does not preempt active destructive or restore operations.

## Required Checks

- [x] PR title: `type(scope): subject` (e.g. `fix(fmt): restore pre-commit checks`)
- [x] Type: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`, `build`, `ci`, `style`, or `revert`
- [x] Subject starts lowercase; `!` only for intentional breaking changes (e.g. `feat(api)!: remove legacy session field`)
- [x] Branch follows `type/scope-subject` when maintained in this repository; fork branch names may vary
- [x] Commits: `type(scope): subject`, English only
- [x] CLA: if prompted by CLA Assistant, every human contributor has signed by posting the exact required PR comment
- [ ] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence, or N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A, or list touched artifacts: N/A
- GraphQL codegen (`just graphql-codegen`): N/A, no GraphQL schema or document changes
- DB baseline (`just db-regen`): N/A, no DB schema changes
- Lockfile (`bun.lock`): N/A
- Confirm no hand-edits to generated paths (`schema.generated.graphql`, `apps/web/src/gql/**`, `pkgs/db/drizzle/**`): confirmed