### PR TITLE
docs(prd): sync stale Debug nav label to Terminal in agent-type

### DIFF
--- a/docs/prd/agent-type.md
+++ b/docs/prd/agent-type.md
@@ -89,7 +89,7 @@ flowchart LR
     B2 --> B3[Configure has no kind selector]
     B3 --> B4[Publish has a single visibility path]
     B4 --> B5[Settings always has Reset agent-state]
-    B5 --> B6[Iterate nav always has Debug]
+    B5 --> B6[Iterate nav always has Terminal]
   end
 
   subgraph After["After · Pet/Cattle dual shape"]


### PR DESCRIPTION
## Summary

- Fix a leftover term-drift node in `docs/prd/agent-type.md`: the "Before" IA diagram still labeled the iterate nav as **Debug**, while #52 had already renamed every other occurrence in this same file to **Terminal** after #49 replaced the Debug dropdown with a flat Terminal tab.

## Why

- #49 (`feat(web): replace Debug dropdown with Terminal tab`) removed the Debug nav entirely. #52 synced the doc but missed the `B6` node in the Before/After mermaid diagram, leaving the file internally contradictory: the After diagram says the nav has `Terminal` while the Before diagram says `Debug`, falsely implying the Pet/Cattle kind split renamed it. The rename actually came from #49, independent of the kind feature.

## Verification

- Commands: none required (doc-only, mermaid label text).
- Manual steps: grepped `docs/` for remaining `Debug` references — only two remain, both correct: `agent-terminal.md` keeps a deliberate "as of #49 the Debug dropdown was removed" history note, and `runtime-session-kernel.md` uses "Debug" for its distinct App-owner **Diagnostics** surface, not the editor toolbar tab.

## Risk And Blast Radius

- Affected packages: docs only (`docs/prd/agent-type.md`).
- Affected user flows or APIs: none.
- Rollback: revert this commit.

## Evidence

- UI/UX: N/A (documentation only).

## Compatibility

- Public contract changes: none.
- Env or config changes: none.

## Reviewer Focus

- Confirm the Before-diagram label should track current nav terminology (Terminal) rather than the pre-#49 historical name.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Subject starts lowercase
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A
- [x] Generated files: none touched
