### PR TITLE
chore(driver): bump agent driver submodule and add driver-update

### DIFF
--- a/justfile
+++ b/justfile
@@ -156,6 +156,10 @@ driver-repo-export:
 driver-submodule-smoke:
     bun run driver:submodule:smoke
 
+# Update the Agent Driver submodule to upstream HEAD.
+driver-update:
+    git submodule update --init --remote --checkout apps/driver
+
 # Deploy API and Web production targets.
 deploy: check
     bun run deploy


### PR DESCRIPTION
## Summary

- Bump `apps/driver` submodule from `c81ea71` to `415628f` (six upstream commits: access snapshot rename, capability snapshots, OpenAI MCP wiring, live OpenAI smoke test, ACP fallback Docker bundling, standalone CI with tracked `bun.lock`).
- Add `just driver-update` to fetch upstream Agent Driver `main` with `git submodule update --init --remote --checkout apps/driver`.

## Why

- Bring the monorepo driver submodule current with upstream fixes and capabilities (MCP wiring, ACP fallback runtime, CI).
- Give maintainers a single documented command to refresh the submodule pointer, matching the skills submodule workflow in `CONTRIBUTING.md`.

## Verification

- Commands (`just check`, `just test-file <path>`, `just graphql-codegen`, etc.):
  - `just --list` (confirms `driver-update` recipe is registered)
  - Full `just check` not run for this pointer-only monorepo diff; upstream driver changes are covered by the standalone repo CI added in `415628f`.
- Manual steps:
  - Verified staged diff is limited to the gitlink and `justfile` recipe.

## Risk And Blast Radius

- Affected packages: `apps/driver` (submodule), `justfile` tooling.
- Affected user flows or APIs: Agent Driver runtime behavior delivered via the updated submodule (OpenAI MCP, ACP fallback, access snapshots).
- Rollback: Revert this PR to restore the previous submodule pointer (`c81ea71`).

## Evidence

- UI/UX: N/A
- API or behavior: Submodule advances to commits that wire authorized MCP servers into OpenAI/Codex config and bundle OpenCode ACP fallback in Docker.
- Logs, recordings, or test output: `just --list` shows `driver-update`; commit passed local `prek` commit-msg and pre-push hooks.

## Compatibility

- Public contract changes: None in the monorepo surface; driver protocol changes are contained in the bumped submodule.
- Env or config changes: None at monorepo level; see upstream driver release notes for Docker ACP fallback env vars.
- Deployment or migration: Redeploy or rebuild driver images after merge if production pins this submodule.

## Reviewer Focus

- Closest review areas: Submodule pointer correctness (`415628f`), `driver-update` recipe flags (`--remote --checkout`), alignment with `CONTRIBUTING.md` submodule bump guidance.
- Known trade-offs: `driver-update` does not run `bun install`; developers may still need a root install after a lockfile-changing bump.

## Required Checks

- [x] PR title: `type(scope): subject` (e.g. `fix(fmt): restore pre-commit checks`)
- [x] Type: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`, `build`, `ci`, `style`, or `revert`
- [x] Subject starts lowercase; `!` only for intentional breaking changes (e.g. `feat(api)!: remove legacy session field`)
- [x] Branch follows `type/scope-subject` when maintained in this repository; fork branch names may vary
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: if prompted by CLA Assistant, every human contributor has signed by posting the exact required PR comment
- [ ] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence, or N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A, or list touched artifacts:
- GraphQL codegen (`just graphql-codegen`): N/A
- DB baseline (`just db-regen`): N/A
- Lockfile (`bun.lock`): N/A (monorepo lockfile unchanged; upstream driver now tracks its own `bun.lock`)
- Confirm no hand-edits to generated paths (`schema.generated.graphql`, `apps/web/src/gql/**`, `pkgs/db/drizzle/**`): N/A