### PR TITLE
test(e2e): load repo env for local harnesses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,45 @@
+# Copy this file to .env and fill only the values needed locally.
+# Shell environment variables override values from .env.
+
+# Shared live provider credentials.
+MOSOO_E2E_PROVIDER_API_KEY=
+MOSOO_E2E_OPENAI_API_KEY=
+MOSOO_E2E_ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+
+# Preview live smoke and latency.
+# Defaults to openai when unset.
+MOSOO_E2E_PROVIDER=openai
+
+# Agent Builder live planner.
+MOSOO_E2E_OPENAI_MODEL=
+MOSOO_E2E_REQUIRE_LIVE_PLANNER=0
+
+# Local browser harness.
+MOSOO_E2E_EMAIL=preview-smoke@mosoo.ai
+MOSOO_E2E_BASE_URL=http://localhost:5173
+MOSOO_E2E_WEB_SERVER_COMMAND=
+WEB_DEV_PORT=5173
+WRANGLER_DEV_PORT=
+API_PROXY_TARGET=
+
+# Preview latency output.
+MOSOO_E2E_LATENCY_LABEL=current
+MOSOO_E2E_LATENCY_OUTPUT=.tmp/e2e/preview-latency-current.json
+MOSOO_E2E_GIT_COMMIT=
+
+# Driver live smoke tests.
+AGENT_DRIVER_LIVE_OPENAI_API_KEY=
+AGENT_DRIVER_LIVE_OPENAI_MODEL=gpt-5.4
+AGENT_DRIVER_LIVE_ANTHROPIC_API_KEY=
+AGENT_DRIVER_LIVE_ANTHROPIC_MODEL=claude-sonnet-4-5
+AGENT_DRIVER_LIVE_OPENCODE_PROVIDER=openai
+AGENT_DRIVER_LIVE_OPENCODE_API_KEY=
+AGENT_DRIVER_LIVE_OPENCODE_MODEL=gpt-5.4
+AGENT_DRIVER_LIVE_OPENCODE_SMALL_MODEL=gpt-5-nano
+
+# Optional runtime executable overrides.
+# MOSOO_OPENAI_RUNTIME_EXECUTABLE=/path/to/codex
+# MOSOO_CLAUDE_CODE_EXECUTABLE=/path/to/mosoo-claude-code
+# AGENT_DRIVER_LIVE_OPENCODE_COMMAND=/path/to/opencode

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .tmp
 .wrangler
 .dev.vars
+.env
 .envrc
 .local/
 dist

--- a/e2e/preview-env.sh
+++ b/e2e/preview-env.sh
@@ -14,6 +14,68 @@ preview_env_fail() {
   exit 1
 }
 
+repo_env_default_file() {
+  local root_dir
+
+  root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  printf '%s/.env\n' "$root_dir"
+}
+
+repo_env_unquote_value() {
+  local value="$1"
+
+  if [[ "$value" == \"*\" && "$value" == *\" ]] ||
+    [[ "$value" == \'*\' && "$value" == *\' ]]; then
+    printf '%s\n' "${value:1:${#value}-2}"
+    return
+  fi
+
+  printf '%s\n' "$value"
+}
+
+load_repo_env() {
+  local env_file="${MOSOO_ENV_FILE:-${MOSOO_E2E_ENV_FILE:-}}"
+  local line
+  local line_number=0
+  local key
+  local value
+
+  if [[ -z "$env_file" ]]; then
+    env_file="$(repo_env_default_file)"
+  fi
+
+  if [[ ! -f "$env_file" ]]; then
+    return
+  fi
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+    line="${line%$'\r'}"
+
+    if [[ "$line" =~ ^[[:space:]]*($|#) ]]; then
+      continue
+    fi
+
+    if [[ ! "$line" =~ ^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*(.*)$ ]]; then
+      preview_env_fail "Invalid E2E env line $line_number in $env_file."
+    fi
+
+    key="${BASH_REMATCH[2]}"
+    value="$(printf '%s' "${BASH_REMATCH[3]}" | sed 's/[[:space:]]*$//')"
+
+    if [[ "${!key+x}" == "x" ]]; then
+      continue
+    fi
+
+    value="$(repo_env_unquote_value "$value")"
+    export "$key=$value"
+  done <"$env_file"
+}
+
+load_e2e_env() {
+  load_repo_env
+}
+
 require_preview_smoke_env() {
   local provider="${MOSOO_E2E_PROVIDER:-openai}"
 

--- a/e2e/preview-env.test.ts
+++ b/e2e/preview-env.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 interface PreflightResult {
   exitCode: number;
@@ -20,7 +23,91 @@ function runPreflight(functionName: string, env: Record<string, string> = {}): P
   };
 }
 
+function runEnvCommand(
+  command: string,
+  env: Record<string, string> = {},
+): PreflightResult & {
+  stdout: string;
+} {
+  const result = Bun.spawnSync({
+    cmd: ["bash", "-c", `source ./e2e/preview-env.sh; ${command}`],
+    env: {
+      PATH: process.env["PATH"] ?? "",
+      ...env,
+    },
+  });
+
+  return {
+    exitCode: result.exitCode,
+    stderr: result.stderr.toString(),
+    stdout: result.stdout.toString(),
+  };
+}
+
+async function withEnvFile<T>(content: string, run: (path: string) => T | Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "mosoo-e2e-env-"));
+  const path = join(dir, ".env");
+
+  try {
+    await Bun.write(path, content);
+    return await run(path);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
 describe("Preview live harness environment preflight", () => {
+  test("loads repo env file values", async () => {
+    const result = await withEnvFile(
+      [
+        "MOSOO_E2E_PROVIDER=anthropic",
+        "MOSOO_E2E_PROVIDER_API_KEY='provider-key'",
+        'MOSOO_E2E_BASE_URL="http://localhost:5174"',
+        "WEB_DEV_PORT = 5174",
+      ].join("\n"),
+      (path) =>
+        runEnvCommand(
+          "load_repo_env; printf '%s\\n' \"$MOSOO_E2E_PROVIDER:$MOSOO_E2E_PROVIDER_API_KEY:$MOSOO_E2E_BASE_URL:$WEB_DEV_PORT\"",
+          {
+            MOSOO_ENV_FILE: path,
+          },
+        ),
+    );
+
+    expect(result).toEqual({
+      exitCode: 0,
+      stderr: "",
+      stdout: "anthropic:provider-key:http://localhost:5174:5174\n",
+    });
+  });
+
+  test("keeps shell environment values over repo env file values", async () => {
+    const result = await withEnvFile("MOSOO_E2E_PROVIDER=openai\n", (path) =>
+      runEnvCommand("load_repo_env; printf '%s\\n' \"$MOSOO_E2E_PROVIDER\"", {
+        MOSOO_ENV_FILE: path,
+        MOSOO_E2E_PROVIDER: "anthropic",
+      }),
+    );
+
+    expect(result).toEqual({
+      exitCode: 0,
+      stderr: "",
+      stdout: "anthropic\n",
+    });
+  });
+
+  test("rejects invalid E2E env file lines", async () => {
+    const result = await withEnvFile("not valid\n", (path) =>
+      runEnvCommand("load_repo_env", {
+        MOSOO_ENV_FILE: path,
+      }),
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Invalid E2E env line 1 in ");
+  });
+
   test("accepts the default OpenAI Preview smoke credential inputs", () => {
     expect(runPreflight("require_preview_smoke_env")).toEqual({
       exitCode: 1,

--- a/e2e/run-agent-builder-live-planner.sh
+++ b/e2e/run-agent-builder-live-planner.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+E2E_DIR="$ROOT_DIR/e2e"
+VP_BIN="$ROOT_DIR/node_modules/.bin/vp"
+
+source "$E2E_DIR/preview-env.sh"
+load_repo_env
+
+cd "$ROOT_DIR"
+exec "$VP_BIN" exec bun test --timeout 30000 apps/api/tests/agent-builder-system-agent-live.e2e.test.ts

--- a/e2e/run-agent-builder-smoke.sh
+++ b/e2e/run-agent-builder-smoke.sh
@@ -6,6 +6,9 @@ E2E_DIR="$ROOT_DIR/e2e"
 VP_BIN="$ROOT_DIR/node_modules/.bin/vp"
 PLAYWRIGHT_BIN="$E2E_DIR/node_modules/.bin/playwright"
 
+source "$E2E_DIR/preview-env.sh"
+load_repo_env
+
 if [[ ! -x "$PLAYWRIGHT_BIN" ]]; then
   (cd "$E2E_DIR" && "$VP_BIN" install)
 fi

--- a/e2e/run-deterministic.sh
+++ b/e2e/run-deterministic.sh
@@ -6,6 +6,9 @@ E2E_DIR="$ROOT_DIR/e2e"
 VP_BIN="$ROOT_DIR/node_modules/.bin/vp"
 PLAYWRIGHT_BIN="$E2E_DIR/node_modules/.bin/playwright"
 
+source "$E2E_DIR/preview-env.sh"
+load_repo_env
+
 if [[ ! -x "$PLAYWRIGHT_BIN" ]]; then
   (cd "$E2E_DIR" && "$VP_BIN" install)
 fi

--- a/e2e/run-preview-latency.sh
+++ b/e2e/run-preview-latency.sh
@@ -7,6 +7,7 @@ VP_BIN="$ROOT_DIR/node_modules/.bin/vp"
 PLAYWRIGHT_BIN="$E2E_DIR/node_modules/.bin/playwright"
 
 source "$E2E_DIR/preview-env.sh"
+load_repo_env
 require_preview_latency_env
 
 if [[ ! -x "$PLAYWRIGHT_BIN" ]]; then

--- a/e2e/run-preview-smoke.sh
+++ b/e2e/run-preview-smoke.sh
@@ -7,6 +7,7 @@ VP_BIN="$ROOT_DIR/node_modules/.bin/vp"
 PLAYWRIGHT_BIN="$E2E_DIR/node_modules/.bin/playwright"
 
 source "$E2E_DIR/preview-env.sh"
+load_repo_env
 require_preview_smoke_env
 
 if [[ ! -x "$PLAYWRIGHT_BIN" ]]; then

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "driver:submodule:smoke": "vp exec bun scripts/check-driver-submodule-cutover.ts",
     "e2e:deterministic": "./e2e/run-deterministic.sh",
     "e2e:harness-contract": "vp exec bun test e2e/runtime-signal-collector.test.ts e2e/preview-env.test.ts e2e/preview-live-harness.test.ts",
-    "e2e:agent-builder-live-planner": "vp exec bun test --timeout 30000 apps/api/tests/agent-builder-system-agent-live.e2e.test.ts",
+    "e2e:agent-builder-live-planner": "./e2e/run-agent-builder-live-planner.sh",
     "e2e:agent-builder-smoke": "./e2e/run-agent-builder-smoke.sh",
     "e2e:preview-latency": "./e2e/run-preview-latency.sh",
     "e2e:preview-smoke": "./e2e/run-preview-smoke.sh",


### PR DESCRIPTION
## Summary

- Add a repo-level `.env.example` for shared provider credentials, E2E harness settings, and driver live-test keys.
- Load the repo `.env` from E2E runner scripts before checking live preview credentials.
- Route the Agent Builder live planner command through an E2E runner so it uses the same env-loading path.

## Why

- Local live E2E runs need one shared environment file instead of isolated per-harness exports.
- Provider keys are shared across local API, driver, and E2E workflows, so the repo root is the right boundary.

## Verification

- Commands:
  - `just test-file e2e/preview-env.test.ts`
  - `just e2e-harness-contract`
  - `just fmt-check-path e2e`
  - `just fmt-check-path package.json`
  - `bash -n e2e/preview-env.sh e2e/run-preview-smoke.sh e2e/run-preview-latency.sh e2e/run-agent-builder-smoke.sh e2e/run-agent-builder-live-planner.sh e2e/run-deterministic.sh`
  - `git diff --check`
- Manual steps: N/A

## Risk And Blast Radius

- Affected packages: `e2e`, root package scripts.
- Affected user flows or APIs: local E2E harness startup only.
- Rollback: revert the commit to return to shell-export-only E2E configuration.

## Evidence

- UI/UX: N/A, no visible UI changes.
- API or behavior: E2E env preflight tests cover repo env loading, shell override precedence, invalid line rejection, and provider credential checks.
- Logs, recordings, or test output: focused commands listed above passed locally.

## Compatibility

- Public contract changes: N/A.
- Env or config changes: adds root `.env.example`; real `.env` is ignored; `MOSOO_ENV_FILE` can override the repo env file path and `MOSOO_E2E_ENV_FILE` remains compatible.
- Deployment or migration: N/A.

## Reviewer Focus

- Closest review areas: shell env parsing in `e2e/preview-env.sh`, runner startup order, and `.env.example` key grouping.
- Known trade-offs: the loader intentionally supports a simple `.env` subset instead of full dotenv expansion.

## Required Checks

- [x] PR title: `type(scope): subject` (e.g. `fix(fmt): restore pre-commit checks`)
- [x] Type: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`, `build`, `ci`, `style`, or `revert`
- [x] Subject starts lowercase; `!` only for intentional breaking changes (e.g. `feat(api)!: remove legacy session field`)
- [x] Branch follows `type/scope-subject` when maintained in this repository; fork branch names may vary
- [x] Commits: `type(scope): subject`, English only
- [x] CLA: if prompted by CLA Assistant, every human contributor has signed by posting the exact required PR comment
- [x] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence, or N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- Touched artifacts: N/A
- GraphQL codegen (`just graphql-codegen`): N/A
- DB baseline (`just db-regen`): N/A
- Lockfile (`bun.lock`): N/A
- Confirm no hand-edits to generated paths (`schema.generated.graphql`, `apps/web/src/gql/**`, `pkgs/db/drizzle/**`): confirmed
