### PR TITLE
test(bench): add benchmark-lite sandbox suite

### DIFF
--- a/benchmarks/sandbox-agent/README.md
+++ b/benchmarks/sandbox-agent/README.md
@@ -39,6 +39,18 @@ Run the default benchmark set:
 just bench-sandbox-agent --repeat 3 --concurrency 1
 ```
 
+Run the public-benchmark-inspired suite:
+
+```bash
+just bench-sandbox-agent --suite benchmark_lite --repeat 1 --concurrency 1
+```
+
+Run the default runtime/API checks plus the benchmark-inspired suite:
+
+```bash
+just bench-sandbox-agent --suite full --repeat 1 --concurrency 1
+```
+
 Artifacts are written under `outputs/sandbox-agent-bench/<run-id>/` by default:
 
 - `results.json`: full machine-readable result set.
@@ -69,6 +81,12 @@ just bench-sandbox-agent-preflight
 # Run defaults once.
 just bench-sandbox-agent
 
+# Run benchmark-inspired cases only.
+just bench-sandbox-agent --suite benchmark_lite
+
+# Run defaults plus benchmark-inspired cases.
+just bench-sandbox-agent --suite full
+
 # Repeat each default scenario 5 times with two concurrent cases.
 just bench-sandbox-agent --repeat 5 --concurrency 2
 
@@ -96,6 +114,17 @@ Use these fields first:
 - `tokenCompletedMs`: time until the expected token is observed.
 - `completedMs`: time until a terminal run status is observed after the token.
 - `terminalRunStatus`: terminal run status if observed.
+
+Suites:
+
+- `default`: six runtime/API scenarios that keep the Agent simple and measure dispatch, sandbox startup, streaming, follow-up, structured output, long input, and Thread lifecycle behavior.
+- `benchmark_lite`: nine public benchmark-inspired prompts covering MMLU-style knowledge, GPQA-style science reasoning, GSM8K-style arithmetic, HumanEval/MBPP-style coding, SWE-bench-style patch reasoning, BFCL-style function-call planning, IFEval-style instruction constraints, and structured extraction.
+- `full`: `default` plus `benchmark_lite`.
+
+The `benchmark_lite` suite is intentionally not a formal reproduction of those public
+leaderboards. It uses compact original prompts and deterministic token scoring so this
+harness can keep measuring sandbox execution success and latency. Treat the score as a
+Mosoo sandbox regression signal, not as a comparable public model score.
 
 Layer attribution:
 

--- a/benchmarks/sandbox-agent/prompts.json
+++ b/benchmarks/sandbox-agent/prompts.json
@@ -8,6 +8,36 @@
     "event_stream",
     "thread_lifecycle"
   ],
+  "suites": {
+    "benchmark_lite": [
+      "benchmark_mmlu_cs",
+      "benchmark_gpqa_science",
+      "benchmark_gsm8k_reasoning",
+      "benchmark_humaneval_code",
+      "benchmark_mbpp_python",
+      "benchmark_swe_patch",
+      "benchmark_bfcl_tool_call",
+      "benchmark_ifeval_constraints",
+      "benchmark_json_extraction"
+    ],
+    "full": [
+      "smoke_first_turn",
+      "same_thread_followup",
+      "structured_output",
+      "long_context",
+      "event_stream",
+      "thread_lifecycle",
+      "benchmark_mmlu_cs",
+      "benchmark_gpqa_science",
+      "benchmark_gsm8k_reasoning",
+      "benchmark_humaneval_code",
+      "benchmark_mbpp_python",
+      "benchmark_swe_patch",
+      "benchmark_bfcl_tool_call",
+      "benchmark_ifeval_constraints",
+      "benchmark_json_extraction"
+    ]
+  },
   "scenarios": [
     {
       "id": "smoke_first_turn",
@@ -73,6 +103,87 @@
       "expectedToken": "BENCH_INTERRUPT_STARTED",
       "prompt": "Begin a deliberately verbose answer. First print {{expectedToken}}, then continue with a long numbered list from 1 to 200. Do not use tools.",
       "description": "Optional resilience case that sends user_interrupt shortly after run acceptance. Enable explicitly with --scenario interrupt_run."
+    },
+    {
+      "id": "benchmark_mmlu_cs",
+      "category": "benchmark-knowledge",
+      "mode": "create_thread",
+      "title": "MMLU-style computer science MCQ",
+      "expectedToken": "BENCH_MMLU_CS_B",
+      "prompt": "Answer this multiple-choice question. Reply with exactly the token for the correct option and no other text.\\n\\nQuestion: Which SQL isolation level prevents dirty reads but can still allow non-repeatable reads?\\nA. BENCH_MMLU_CS_A = READ UNCOMMITTED\\nB. BENCH_MMLU_CS_B = READ COMMITTED\\nC. BENCH_MMLU_CS_C = SERIALIZABLE\\nD. BENCH_MMLU_CS_D = AUTOCOMMIT",
+      "description": "A lightweight MMLU-inspired professional knowledge multiple-choice item with deterministic token scoring."
+    },
+    {
+      "id": "benchmark_gpqa_science",
+      "category": "benchmark-reasoning",
+      "mode": "create_thread",
+      "title": "GPQA-style science reasoning",
+      "expectedToken": "BENCH_GPQA_SCIENCE_C",
+      "prompt": "Answer this science reasoning question. Reply with exactly the token for the correct option and no other text.\\n\\nQuestion: For an ideal reversible Carnot engine, which change increases thermal efficiency when all other relevant quantities remain valid?\\nA. BENCH_GPQA_SCIENCE_A = Lower the hot reservoir temperature while holding the cold reservoir fixed.\\nB. BENCH_GPQA_SCIENCE_B = Raise the cold reservoir temperature while holding the hot reservoir fixed.\\nC. BENCH_GPQA_SCIENCE_C = Raise the hot reservoir temperature while holding the cold reservoir fixed.\\nD. BENCH_GPQA_SCIENCE_D = Increase the working gas amount while holding both reservoir temperatures fixed.",
+      "description": "A lightweight GPQA-inspired science reasoning item using multiple-choice token scoring."
+    },
+    {
+      "id": "benchmark_gsm8k_reasoning",
+      "category": "benchmark-math",
+      "mode": "create_thread",
+      "title": "GSM8K-style arithmetic reasoning",
+      "expectedToken": "BENCH_GSM8K_C",
+      "prompt": "Solve the word problem. Reply with exactly the token for the correct option and no other text.\\n\\nMira buys 3 notebooks for $4 each and 2 pens for $1.50 each. She pays with a $20 bill. How much change should she receive?\\nA. BENCH_GSM8K_A = $3\\nB. BENCH_GSM8K_B = $4\\nC. BENCH_GSM8K_C = $5\\nD. BENCH_GSM8K_D = $8",
+      "description": "A GSM8K-inspired grade-school arithmetic item with exact-answer token scoring."
+    },
+    {
+      "id": "benchmark_humaneval_code",
+      "category": "benchmark-coding",
+      "mode": "create_thread",
+      "title": "HumanEval-style code selection",
+      "expectedToken": "BENCH_HUMANEVAL_B",
+      "prompt": "Choose the Python implementation that passes the tests. Reply with exactly the token for the correct option and no other text.\\n\\nTask: Implement unique_preserve_order(items), returning the first occurrence of each value while preserving input order.\\nTests:\\n- unique_preserve_order([3, 1, 3, 2, 1]) == [3, 1, 2]\\n- unique_preserve_order([]) == []\\n- unique_preserve_order(['a', 'b', 'a']) == ['a', 'b']\\n\\nA. BENCH_HUMANEVAL_A\\n```python\\ndef unique_preserve_order(items):\\n    return sorted(set(items))\\n```\\nB. BENCH_HUMANEVAL_B\\n```python\\ndef unique_preserve_order(items):\\n    seen = set()\\n    result = []\\n    for item in items:\\n        if item not in seen:\\n            seen.add(item)\\n            result.append(item)\\n    return result\\n```\\nC. BENCH_HUMANEVAL_C\\n```python\\ndef unique_preserve_order(items):\\n    return list(set(items))\\n```\\nD. BENCH_HUMANEVAL_D\\n```python\\ndef unique_preserve_order(items):\\n    return items[::-1]\\n```",
+      "description": "A HumanEval-inspired coding correctness item scored by selecting the implementation token."
+    },
+    {
+      "id": "benchmark_mbpp_python",
+      "category": "benchmark-coding",
+      "mode": "create_thread",
+      "title": "MBPP-style Python problem",
+      "expectedToken": "BENCH_MBPP_D",
+      "prompt": "Choose the Python function that satisfies the task and tests. Reply with exactly the token for the correct option and no other text.\\n\\nTask: Return the sum of the squares of even numbers in nums.\\nTests:\\n- f([1, 2, 3, 4]) == 20\\n- f([5, 7]) == 0\\n- f([-2, 2]) == 8\\n\\nA. BENCH_MBPP_A = `def f(nums): return sum(nums) ** 2`\\nB. BENCH_MBPP_B = `def f(nums): return sum(n*n for n in nums if n % 2 == 1)`\\nC. BENCH_MBPP_C = `def f(nums): return sum(n for n in nums if n % 2 == 0)`\\nD. BENCH_MBPP_D = `def f(nums): return sum(n*n for n in nums if n % 2 == 0)`",
+      "description": "An MBPP-inspired basic Python programming item with unit-test-style prompt evidence."
+    },
+    {
+      "id": "benchmark_swe_patch",
+      "category": "benchmark-agentic-coding",
+      "mode": "create_thread",
+      "title": "SWE-bench-style patch selection",
+      "expectedToken": "BENCH_SWE_PATCH_C",
+      "prompt": "You are reviewing a small bug report and candidate patches. Reply with exactly the token for the patch that best fixes the issue and no other text.\\n\\nBug: `parsePort(value)` should accept decimal strings for ports 1 through 65535 and reject empty strings, floats, hex, zero, negative numbers, and values above 65535.\\nCurrent code:\\n```ts\\nexport function parsePort(value: string): number {\\n  const port = Number(value);\\n  if (!Number.isFinite(port)) throw new Error('invalid port');\\n  return port;\\n}\\n```\\n\\nA. BENCH_SWE_PATCH_A = Keep `Number(value)` and only check `port > 0`.\\nB. BENCH_SWE_PATCH_B = Use `parseInt(value, 10)` and check `port <= 65535`.\\nC. BENCH_SWE_PATCH_C = Require `/^[1-9]\\\\d*$/`, convert with `Number`, then check `port <= 65535`.\\nD. BENCH_SWE_PATCH_D = Accept any numeric value and clamp it into the valid range.",
+      "description": "A small SWE-bench-inspired issue-resolution item scored by selecting a patch token."
+    },
+    {
+      "id": "benchmark_bfcl_tool_call",
+      "category": "benchmark-tool-use",
+      "mode": "create_thread",
+      "title": "BFCL-style tool-call planning",
+      "expectedToken": "BENCH_BFCL_C",
+      "prompt": "Choose the valid tool call for the user request. Reply with exactly the token for the correct option and no other text.\\n\\nAvailable function:\\n```json\\n{\\n  \"name\": \"create_calendar_event\",\\n  \"parameters\": {\\n    \"title\": \"string\",\\n    \"start_iso\": \"string\",\\n    \"duration_minutes\": \"integer\",\\n    \"attendee_emails\": \"string[]\"\\n  }\\n}\\n```\\nUser request: Schedule a 30 minute design review titled Mobile launch review for 2026-07-02 14:00 UTC with ana@example.com and bo@example.com.\\n\\nA. BENCH_BFCL_A = `create_calendar_event({\"title\":\"Mobile launch review\",\"date\":\"2026-07-02\",\"attendees\":\"ana@example.com,bo@example.com\"})`\\nB. BENCH_BFCL_B = `create_calendar_event({\"title\":\"Mobile launch review\",\"start_iso\":\"2026-07-02T14:00:00Z\",\"duration_minutes\":\"30\",\"attendee_emails\":[\"ana@example.com\",\"bo@example.com\"]})`\\nC. BENCH_BFCL_C = `create_calendar_event({\"title\":\"Mobile launch review\",\"start_iso\":\"2026-07-02T14:00:00Z\",\"duration_minutes\":30,\"attendee_emails\":[\"ana@example.com\",\"bo@example.com\"]})`\\nD. BENCH_BFCL_D = `send_email({\"subject\":\"Mobile launch review\",\"to\":[\"ana@example.com\",\"bo@example.com\"]})`",
+      "description": "A BFCL-inspired function-calling correctness item that does not require real tools."
+    },
+    {
+      "id": "benchmark_ifeval_constraints",
+      "category": "benchmark-instruction-following",
+      "mode": "create_thread",
+      "title": "IFEval-style constraint following",
+      "expectedToken": "BENCH_IFEVAL_A",
+      "prompt": "Choose the candidate response that satisfies all constraints. Reply with exactly the token for the correct option and no other text.\\n\\nOriginal instruction: Write exactly two sentences. Do not use commas. Include the word latency exactly once. End with the word done.\\n\\nA. BENCH_IFEVAL_A = `Measure latency today. Then report done`\\nB. BENCH_IFEVAL_B = `Measure latency, then report done.`\\nC. BENCH_IFEVAL_C = `Measure latency today. Then report latency done`\\nD. BENCH_IFEVAL_D = `Measure today and report done`",
+      "description": "An IFEval-inspired verifiable-instruction item scored by selecting the compliant candidate token."
+    },
+    {
+      "id": "benchmark_json_extraction",
+      "category": "benchmark-structured-output",
+      "mode": "create_thread",
+      "title": "Structured extraction",
+      "expectedToken": "BENCH_JSON_EXTRACT_OK",
+      "prompt": "Extract the values from the note and return one compact JSON object with keys token, project, priority, due_date, owners. Set token to {{expectedToken}}. Do not use Markdown.\\n\\nNote: Project Atlas has priority P1. It is due on 2026-07-15. Owners are Lina Chen and Omar Patel.",
+      "description": "A structured extraction item inspired by JSON/value-accuracy benchmarks."
     }
   ]
 }

--- a/benchmarks/sandbox-agent/report-template.md
+++ b/benchmarks/sandbox-agent/report-template.md
@@ -12,6 +12,7 @@
 | Agent profile            | Default/simple Agent, no Skills/MCP/Spaces |
 | Runtime                  |                                            |
 | Cloudflare account check |                                            |
+| Suite(s)                 |                                            |
 | Total cases              |                                            |
 | Success rate             |                                            |
 | p50 first assistant text |                                            |
@@ -38,6 +39,15 @@
 | `long_context`         |          |         |                   |                   |              |              |       |
 | `event_stream`         |          |         |                   |                   |              |              |       |
 | `thread_lifecycle`     |          |         |                   |                   |              |              |       |
+| `benchmark_mmlu_cs`    |          |         |                   |                   |              |              |       |
+| `benchmark_gpqa_science` |        |         |                   |                   |              |              |       |
+| `benchmark_gsm8k_reasoning` |    |         |                   |                   |              |              |       |
+| `benchmark_humaneval_code` |      |         |                   |                   |              |              |       |
+| `benchmark_mbpp_python` |         |         |                   |                   |              |              |       |
+| `benchmark_swe_patch`  |          |         |                   |                   |              |              |       |
+| `benchmark_bfcl_tool_call` |      |         |                   |                   |              |              |       |
+| `benchmark_ifeval_constraints` | |         |                   |                   |              |              |       |
+| `benchmark_json_extraction` |    |         |                   |                   |              |              |       |
 
 ## Failures
 
@@ -51,6 +61,7 @@
 - Warm continuation signal:
 - Streaming signal:
 - Lifecycle/API control signal:
+- Benchmark-lite score:
 - Main bottleneck hypothesis:
 
 ## Follow-ups

--- a/benchmarks/sandbox-agent/sandbox-agent-bench.ts
+++ b/benchmarks/sandbox-agent/sandbox-agent-bench.ts
@@ -22,6 +22,7 @@ interface CliOptions {
   pollMs: number;
   repeat: number;
   scenarios: string[];
+  suites: string[];
   timeoutMs: number;
 }
 
@@ -40,6 +41,7 @@ interface ScenarioDefinition {
 interface PromptCatalog {
   defaultScenarios: string[];
   scenarios: ScenarioDefinition[];
+  suites?: Record<string, string[]>;
   version: number;
 }
 
@@ -131,7 +133,7 @@ const REPO_ROOT = resolvePath(CURRENT_DIR, "../..");
 const PROMPTS_PATH = join(CURRENT_DIR, "prompts.json");
 const DEFAULT_BASE_URL = "http://127.0.0.1:8787";
 const DEFAULT_OUTPUT_ROOT = join(REPO_ROOT, "outputs", "sandbox-agent-bench");
-const DEFAULT_TIMEOUT_MS = 240_000;
+const DEFAULT_TIMEOUT_MS = 360_000;
 const DEFAULT_POLL_MS = 500;
 const TERMINAL_GRACE_MS = 30_000;
 
@@ -164,6 +166,7 @@ Options:
   --pat <token>             Mosoo Personal Access Token. Prefer env or hidden prompt.
   --env-file <path>         Optional env file to load before reading env vars.
   --scenario <id>           Scenario to run. Repeat flag for multiple. Defaults to prompts.json defaults.
+  --suite <name>            Scenario suite to run. Repeat flag for multiple. Ignored when --scenario is set.
   --repeat <n>              Attempts per scenario. Default: 1.
   --concurrency <n>         Concurrent case count. Default: 1.
   --output-dir <path>       Artifact directory. Default: outputs/sandbox-agent-bench/<run-id>.
@@ -181,6 +184,7 @@ Environment:
   MOSOO_BENCH_OUTPUT_DIR
   MOSOO_BENCH_REPEAT
   MOSOO_BENCH_CONCURRENCY
+  MOSOO_BENCH_SUITE          Comma-separated suite names.
 `);
 }
 
@@ -225,6 +229,7 @@ function parseArgs(argv: string[]): { command: Command; options: Partial<CliOpti
   const rest = first === command ? args : argv;
   const options: Partial<CliOptions> = {};
   const scenarios: string[] = [];
+  const suites: string[] = [];
 
   for (let index = 0; index < rest.length; index += 1) {
     const arg = rest[index] ?? "";
@@ -252,6 +257,13 @@ function parseArgs(argv: string[]): { command: Command; options: Partial<CliOpti
     if (arg === "--scenario" || arg.startsWith("--scenario=")) {
       const read = takeValue(rest, index, "--scenario");
       scenarios.push(read.value);
+      index = read.nextIndex;
+      continue;
+    }
+
+    if (arg === "--suite" || arg.startsWith("--suite=")) {
+      const read = takeValue(rest, index, "--suite");
+      suites.push(read.value);
       index = read.nextIndex;
       continue;
     }
@@ -326,7 +338,56 @@ function parseArgs(argv: string[]): { command: Command; options: Partial<CliOpti
     options.scenarios = scenarios;
   }
 
+  if (suites.length > 0) {
+    options.suites = suites;
+  }
+
   return { command, options };
+}
+
+function parseCommaList(value: string | undefined): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function dedupePreservingOrder(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    if (seen.has(value)) {
+      continue;
+    }
+
+    seen.add(value);
+    result.push(value);
+  }
+
+  return result;
+}
+
+function expandSuites(catalog: PromptCatalog, suiteNames: string[]): string[] {
+  if (suiteNames.length === 0) {
+    return catalog.defaultScenarios;
+  }
+
+  const scenarios = suiteNames.flatMap((suiteName) => {
+    if (suiteName === "default") {
+      return catalog.defaultScenarios;
+    }
+
+    const suite = catalog.suites?.[suiteName];
+    if (!suite) {
+      const knownSuites = ["default", ...Object.keys(catalog.suites ?? {})].join(", ");
+      throw new Error(`Unknown suite: ${suiteName}. Known suites: ${knownSuites}`);
+    }
+
+    return suite;
+  });
+
+  return dedupePreservingOrder(scenarios);
 }
 
 function parseEnvLine(line: string): { key: string; value: string } | null {
@@ -496,7 +557,10 @@ async function resolveConfig(
       parsePositiveInteger(process.env["MOSOO_BENCH_POLL_MS"] ?? `${DEFAULT_POLL_MS}`, "pollMs"),
     repeat:
       cliOptions.repeat ?? parsePositiveInteger(process.env["MOSOO_BENCH_REPEAT"] ?? "1", "repeat"),
-    scenarios: cliOptions.scenarios ?? catalog.defaultScenarios,
+    scenarios:
+      cliOptions.scenarios ??
+      expandSuites(catalog, cliOptions.suites ?? parseCommaList(process.env["MOSOO_BENCH_SUITE"])),
+    suites: cliOptions.suites ?? parseCommaList(process.env["MOSOO_BENCH_SUITE"]),
     timeoutMs:
       cliOptions.timeoutMs ??
       parsePositiveInteger(
@@ -930,6 +994,7 @@ async function runCreateThreadScenario(
   attempt: number,
 ): Promise<CaseResult> {
   const startedAt = performance.now();
+  let createThreadMs: number | null = null;
   let threadId: string | null = null;
 
   try {
@@ -938,6 +1003,7 @@ async function runCreateThreadScenario(
       longContext: createLongContext(),
     });
     const created = await createThread(config, scenario, attempt, prompt);
+    createThreadMs = created.elapsedMs;
     threadId = created.threadId;
     const poll = await pollThreadForToken(config, {
       expectedToken: scenario.expectedToken,
@@ -949,7 +1015,7 @@ async function runCreateThreadScenario(
       attempt,
       category: scenario.category,
       completedMs: poll.completedMs,
-      createThreadMs: created.elapsedMs,
+      createThreadMs,
       error: null,
       firstAssistantTextMs: poll.firstAssistantTextMs,
       mode: scenario.mode,
@@ -964,7 +1030,7 @@ async function runCreateThreadScenario(
     };
   } catch (error) {
     return createEmptyFailure(scenario, attempt, error, {
-      createThreadMs: null,
+      createThreadMs,
       threadId,
     });
   }

--- a/benchmarks/sandbox-agent/scenario-table.md
+++ b/benchmarks/sandbox-agent/scenario-table.md
@@ -9,9 +9,27 @@
 | `event_stream`         | yes     | Public API SSE | `/events/stream` event delivery                             | Stream emits expected token                                 | create accepted -> stream token   |
 | `thread_lifecycle`     | yes     | Public API     | retrieve/list/archive/unarchive/delete                      | Lifecycle calls return OK around completed run              | lifecycle operation total         |
 | `interrupt_run`        | no      | Public API     | `user_interrupt` event path                                 | Interrupt event is accepted and terminal status is recorded | interrupt accepted -> terminal    |
+| `benchmark_mmlu_cs`    | no      | Public API     | MMLU-style professional knowledge MCQ                       | Correct option token appears                               | create accepted -> token complete |
+| `benchmark_gpqa_science` | no    | Public API     | GPQA-style science reasoning MCQ                            | Correct option token appears                               | create accepted -> token complete |
+| `benchmark_gsm8k_reasoning` | no | Public API     | GSM8K-style arithmetic reasoning                            | Correct option token appears                               | create accepted -> token complete |
+| `benchmark_humaneval_code` | no | Public API     | HumanEval-style code correctness selection                  | Correct implementation token appears                       | create accepted -> token complete |
+| `benchmark_mbpp_python` | no     | Public API     | MBPP-style Python problem selection                         | Correct implementation token appears                       | create accepted -> token complete |
+| `benchmark_swe_patch`  | no      | Public API     | SWE-bench-style issue/patch reasoning                       | Correct patch token appears                                | create accepted -> token complete |
+| `benchmark_bfcl_tool_call` | no  | Public API     | BFCL-style function-call planning                           | Correct tool-call token appears                            | create accepted -> token complete |
+| `benchmark_ifeval_constraints` | no | Public API  | IFEval-style verifiable instruction selection               | Correct compliant-candidate token appears                  | create accepted -> token complete |
+| `benchmark_json_extraction` | no | Public API     | Structured extraction / value-accuracy style output         | Expected JSON token appears                                | create accepted -> token complete |
+
+## Suites
+
+| Suite | Scenarios | Purpose |
+| ----- | --------- | ------- |
+| `default` | The six default runtime/API scenarios | Fast smoke and latency baseline. |
+| `benchmark_lite` | The nine `benchmark_*` scenarios | Public benchmark-inspired scoring dimensions without Skills/MCP/Spaces. |
+| `full` | `default` plus `benchmark_lite` | Broader regression and latency run. |
 
 ## Intentional V1 Boundaries
 
 - The benchmark Agent should stay simple: default Agent profile, no Skills, no MCP servers, no Spaces, and one known-working runtime credential.
 - Provider API keys are configured in the local Mosoo service before the run. The benchmark harness should not need the model provider key unless a later setup mode creates or configures Agents automatically.
 - Cloudflare authentication is used for operator visibility and diagnostics. The core benchmark path is still local Mosoo control plane -> Cloudflare online execution plane.
+- The `benchmark_lite` suite is benchmark-inspired, not a reproduction of public leaderboards. It uses original, compact prompts with deterministic token scoring so success rate and latency remain attributable to this sandbox path.


### PR DESCRIPTION
## Summary

- Rebases #62 onto the current `main` and reduces it to its net-new delta: the `benchmark_lite` / `full` scenario suites for the sandbox-agent harness.
- Adds the `--suite <name>` flag and `MOSOO_BENCH_SUITE` env, nine public-benchmark-inspired prompts, suite docs in the README, a scenario table, and a report-template update.
- Raises the default run timeout to 360s and preserves `createThreadMs` on create-thread failures.
- Authored by @KurosawaGeeker (original PR #62); rebased and committed here with that authorship preserved.

## Why

- #62 was opened from an old base, before the equivalent harness landed on `main` via #63. A direct rebase therefore produced add/add conflicts on the harness files that #63 already added.
- #62 also cannot be updated in place: its head fork is private (maintainer pushes are not honored for private forks), and its `codex/`-prefixed branch is rejected by the repo Ship Policy. This `type/scope-subject` branch is the repo-sanctioned way to land the work.
- The first six commits of #62 duplicated content already merged via #63; only the `benchmark_lite` suite is genuinely new, so the rebase collapses to that single, bisectable delta (+239 / -4).

## Verification

- Commands: `bun build benchmarks/sandbox-agent/sandbox-agent-bench.ts` (syntax/type entry compiles); `prompts.json` validated as JSON with `suites` = `benchmark_lite`, `full`.
- Manual steps: confirmed the merged README/`bench.ts` retain all of `main`'s harness content (Docker preflight row, Troubleshooting, `.env` auto-load, `mst_` PAT) and only add the suite feature on top. No leftover conflict markers.

## Risk And Blast Radius

- Affected packages: `benchmarks/sandbox-agent` only (docs + the standalone bench runner). No app/runtime/db code.
- Affected user flows or APIs: none.
- Rollback: revert this squash commit; the directory returns to the #63 baseline.

## Evidence

- UI/UX: N/A (no UI change).
- API or behavior: bench-only tooling; not part of the shipped product surface.

## Compatibility

- Public contract changes: none.
- Env or config changes: adds optional `MOSOO_BENCH_SUITE` for the bench runner only.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: `benchmarks/sandbox-agent/sandbox-agent-bench.ts` suite expansion logic and `prompts.json` suite definitions.
- Known trade-offs: `benchmark_lite` is intentionally not a formal reproduction of public leaderboards; it is a sandbox regression signal only (documented in the README).

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type is one of the allowed conventional types (`test`)
- [x] Subject starts lowercase; no breaking `!`
- [x] Branch follows `type/scope-subject` (`test/sandbox-agent-benchmark-suite`)
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: N/A (no new human contributor signature required here)
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A
- [x] Generated files: none touched

## Generated Files, Schema, And Lockfile

- N/A — no generated/codegen/DB/lockfile paths touched.

---

Supersedes #62 (closing it as superseded, with author attribution preserved on the commit).
