### PR TITLE
docs(prd): stop listing Files as a Manifest binding

### DIFF
--- a/docs/prd/agent-manifest.md
+++ b/docs/prd/agent-manifest.md
@@ -12,7 +12,7 @@
 
 The Agent Manifest is the **declarative product configuration** of a Mosoo Agent:
 
-- It uses **a small set of stable fields** to spell out who an Agent is, which runtime it runs on, which model it uses, which system prompt it follows, and which Skills / MCP / Files / Environment it has installed.
+- It uses **a small set of stable fields** to spell out who an Agent is, which runtime it runs on, which model it uses, which system prompt it follows, and which Skills / MCP / Environment it has installed.
 - Upstream: the Agent owner edits it through a UI form, or lets **Agent Builder** generate it.
 - Downstream: any tool — Agent Builder, the CLI, CI, a future IDE plugin — can read the same Manifest and package it into a **`.agent` file** to distribute, fork, and import across Apps, instances, and the community.
 
@@ -68,7 +68,7 @@ The real problem is not "how do we merge every vendor's fields into one," but ra
 
 ### What Agent authors can do
 
-- Define a long-lived Agent with a small set of stable fields: `kind`, runtime, model, system prompt, Skills, MCP, Environment, Files.
+- Define a long-lived Agent with a small set of stable fields: `kind`, runtime, model, system prompt, Skills, MCP, Environment.
 - Let Agent Builder take over the complex editing work: say in natural language "give me an agent that can read Linear tickets," and Builder translates it into a Manifest patch.
 - Export the Agent as a **`.agent` package** to send to another developer, upload to the community, or fork into another App.
 - Import someone else's `.agent` package: the Manifest lands, assets are reused, and **credentials / tokens are not carried along with it**.
@@ -76,7 +76,7 @@ The real problem is not "how do we merge every vendor's fields into one," but ra
 ### What the UI makes clear
 
 - Whether this Agent **renders successfully right now** — whether the config is in effect and whether it is still running the way you last saved it.
-- When any one of model / runtime / credential / MCP / Files is unavailable, the UI **shows a clear grayed-out state** with a fix-it entry point, instead of silently swapping in a substitute for you.
+- When any one of model / runtime / credential / MCP / Environment is unavailable, the UI **shows a clear grayed-out state** with a fix-it entry point, instead of silently swapping in a substitute for you.
 - When the actual state inside the Sandbox disagrees with the Manifest, there is a **clear drift indicator** — and the UI will not reverse-write over it.
 
 ### What advanced users can do
@@ -116,7 +116,7 @@ flowchart LR
 
 ## 4. The minimal common set + the "full-power VPS" mental model
 
-What we are building is the **overall unification of heterogeneous vendors** — so at the product layer the Manifest only ever appears as a **"minimal common set"**: runtime / model / system prompt / Skills / MCP / Environment / Files.
+What we are building is the **overall unification of heterogeneous vendors** — so at the product layer the Manifest only ever appears as a **"minimal common set"**: runtime / model / system prompt / Skills / MCP / Environment.
 
 For configuration that is **not on the user's side** (vendor-private parameters, native CLI settings, login caches, reasoning_effort, performance tuning, and so on), our principles are:
 
@@ -158,7 +158,7 @@ The Manifest is a minimal common set → it is impossible to move all of the Ope
 | **Advanced Sandbox Mode**        | The Terminal / advanced entry point that operates the Sandbox directly. It can change native state, but **cannot break through** the Files / Credential / Network boundaries.                                                                               |
 | **Import / Adopt**               | Explicitly absorb certain observed config from the Sandbox back into the Manifest. **By default this never happens automatically.**                                                                                                                         |
 | **Fork Agent**                   | Take a clean copy: the Manifest + asset bindings are copied over, while runtime state / login state / session history / cost are left behind.                                                                                                               |
-| **Readiness (grayed-out state)** | When any one of runtime / model / credential / MCP / Environment / Files is unavailable, the Manifest is **kept**, but the frontend shows a clear grayed-out state + a fix-it path; it does **not** auto-swap the runtime and does not auto-swap the model. |
+| **Readiness (grayed-out state)** | When any one of runtime / model / credential / MCP / Environment is unavailable, the Manifest is **kept**, but the frontend shows a clear grayed-out state + a fix-it path; it does **not** auto-swap the runtime and does not auto-swap the model. |
 | **Unavailable Model**            | A model that was selected before but is no longer in the dynamic model list. The Manifest still keeps it, the UI marks it Unavailable, and the user switches it manually.                                                                                   |
 
 ---
@@ -174,7 +174,7 @@ The Manifest is a minimal common set → it is impossible to move all of the Ope
 | Skills                                                     | Built-in capability bindings                      |                                                    ✅ |
 | MCP Servers                                                | External tool / connector bindings                |                                                    ✅ |
 | Environment                                                | Reference to a runtime container template         |                                                    ✅ |
-| File references                                            | Uploaded or packaged file references, if this Agent uses them |                                           ✅ |
+| Files (uploads / session attachments / artifacts)          | Files an Agent reads or produces at run time                  | ❌ → scoped at upload / session time, not a Manifest binding (see [Files API contract](./files-api-contract.md)) |
 | Vendor native config (`config.toml` / `settings.json` / …) | Vendor-private                                    |                               ❌ → Sandbox / Terminal |
 | Login state / CLI cache / vendor session state             | Runtime-internal state                            | ❌ → Pet Sandbox state / Cattle Session Sandbox state |
 | Performance / auto-switching / reasoning effort            | Vendor-private preferences                        |                               ❌ → Runtime / Advanced |
@@ -190,7 +190,7 @@ The Manifest is a minimal common set → it is impossible to move all of the Ope
 | 1. Getting started        | Fill in name, description                                  | The form shows only stable product semantics                       |
 | 2. Choose runtime / model | Pick from dropdowns                                        | See the list of runtimes + models available to the current App     |
 | 3. Write the prompt       | Fill in the system prompt                                  | The platform stores the prompt as part of the Manifest             |
-| 4. Attach capabilities    | Skills / MCP / Environment / Files, each in its own group | Clear section boundaries, no nesting into each other               |
+| 4. Attach capabilities    | Skills / MCP / Environment, each in its own group         | Clear section boundaries, no nesting into each other               |
 | 5. Check readiness        | The UI validates automatically                             | Any unavailable item is grayed out with its reason + a fix-it path |
 | 6. Save / Publish         | One click                                                  | Enters the Manifest state machine: draft / preview / live          |
 

--- a/docs/prd/app-builder.md
+++ b/docs/prd/app-builder.md
@@ -30,8 +30,7 @@ App
         │   ├── Prompt
         │   ├── Environment
         │   ├── Skills
-        │   ├── MCP servers
-        │   └── Files
+        │   └── MCP servers
         ├── Preview / Logs / Cost
         └── Publish / API access / Channels
 ```
@@ -181,7 +180,7 @@ The first-level creation page should include:
   - One tab per Agent draft.
   - Tab title equals the editable Agent name in that Agent form.
   - Each tab contains Agent name, Agent description, `How it runs`,
-    model/provider, system prompt, Skills, MCP servers, Files, and Environment
+    model/provider, system prompt, Skills, MCP servers, and Environment
     fields.
   - Switching tabs changes only the visible Agent form. It must not overwrite,
     duplicate, or reset other Agents' values.


### PR DESCRIPTION
## Summary

- `feat(files)!: replace spaces with scoped files` (#64) removed the App-owned Space resource and the `spaces[]` Manifest binding; the canonical `AgentManifest` now has no file/space field and Files are scoped at upload/session time.
- The follow-up `docs(prd): align Space references to scoped Files model` (#66) mechanically renamed `Space → Files` in the product-narrative prose, which preserved the old *manifest-binding* semantics and left the docs contradicting both the contract and themselves. This PR removes Files from the Manifest binding/readiness/"in the Manifest" lists while keeping the legitimate App-resource and session-time references.

`docs/prd/agent-manifest.md`
- Drop Files from the "stable fields" / "minimal common set" / installed-capabilities lists.
- Drop Files from the readiness grayed-out lists (the resolution target types have no file kind).
- Rewrite the §6 "in the Manifest" row: Files are `❌ → scoped at upload / session time, not a Manifest binding`, linking the Files API contract.
- Drop Files from the Builder "Attach capabilities" form group.
- Kept the Files access boundary (Advanced Sandbox Mode) and the session-startup `prepares Environment / Files / Credential` line — both correct under the scoped-Files model.

`docs/prd/app-builder.md`
- Remove Files from the Agent runtime-resources tree and the per-Agent draft form field list, matching the manifest stable-sections list (`manifestVersion, kind, metadata, runtime, prompts, skills, mcpServers, environment, advanced`) that #66 already corrected in the same doc, and the actual editor draft shape in `apps/web/src/routes/agent/components/editor/draft.ts` (which has `environmentId`, `mcpServers`, `skills` only).
- Left the App-level Files Library references (App resource tree, `Agent → Files → Environment → Test` progress) untouched — those reflect Files as an App resource, which is correct.

## Why

- Cross-checked against `pkgs/contracts/src/agent/agent-manifest.contract.ts` (`AgentManifest` = advanced/environment/kind/manifestVersion/mcpServers/metadata/prompts/runtime/skills — no files), `docs/prd/files-api-contract.md` ("scoped at upload/session time", MVP scope kinds `agent_package | app_draft | library | session`), and the #64 supersession note in `docs/prd/space-interaction.md` ("The manifest no longer carries any Space or file binding at all").

## Verification

- Commands: docs-only change; no code touched. `grep` sweep confirms no remaining `spaces` field references in docs and no doc presents Files/Space as a Manifest binding.
- Manual steps: re-read both docs for internal consistency against the manifest contract and the agent editor draft shape.

## Risk And Blast Radius

- Affected packages: `docs/` only.
- Affected user flows or APIs: none.
- Rollback: revert this commit.

## Evidence

- UI/UX: N/A (docs only).
- API or behavior: N/A.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Confirm Files should not appear in any Manifest binding / readiness list, given Files are scoped at upload/session time and Agents *read* Files rather than bind them.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `docs`
- [x] Subject starts lowercase; no `!`
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A
- [x] Generated files: none
