### PR TITLE
perf(web): lazy-load WebGL background on login route

### DIFF
--- a/apps/web/src/routes/login/landing/unicorn.tsx
+++ b/apps/web/src/routes/login/landing/unicorn.tsx
@@ -1,6 +1,17 @@
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import type { ReactElement } from "react";
-import { UnicornScene } from "unicornstudio-react";
+
+// `unicornstudio-react` bundles the full ~1.3 MB WebGL engine. The landing page
+// is the first thing every unauthenticated visitor loads, and this background is
+// purely decorative (aria-hidden, non-interactive, behind the content). Loading
+// it lazily keeps the engine out of the login route's critical path: the form and
+// copy paint immediately and the aurora streams in once its chunk arrives. The
+// runtime SDK is fetched separately from the CDN below, so deferring the wrapper
+// costs nothing visually.
+const UnicornScene = lazy(async () => {
+  const mod = await import("unicornstudio-react");
+  return { default: mod.UnicornScene };
+});
 
 // Shared Unicorn Studio WebGL background. A single SDK version is used across the
 // whole landing so the global runtime loads once and every scene renders on the
@@ -26,13 +37,15 @@ export function UnicornBackground({ sceneId }: { sceneId: string }): ReactElemen
       aria-hidden="true"
       className="pointer-events-none absolute inset-0 z-0 [&>div]:!h-full [&>div]:!w-full"
     >
-      <UnicornScene
-        projectId={sceneId}
-        sdkUrl={UNICORN_SDK_URL}
-        width="100%"
-        height="100%"
-        onError={() => setFailed(true)}
-      />
+      <Suspense fallback={null}>
+        <UnicornScene
+          projectId={sceneId}
+          sdkUrl={UNICORN_SDK_URL}
+          width="100%"
+          height="100%"
+          onError={() => setFailed(true)}
+        />
+      </Suspense>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- The login/landing page is the first thing every unauthenticated visitor loads. Its initial JS chunk shipped a **1.29 MB `unicornstudio-react` WebGL engine** even though the background it powers is purely decorative (`aria-hidden`, non-interactive) and the runtime SDK is fetched separately from a CDN at mount time.
- Defer the engine with `React.lazy` + `Suspense` so the form and copy paint immediately and the engine streams in afterward in its own async chunk.

## Why

- That 1.29 MB sat on the critical path of the entry page for zero visual benefit at first paint. Deferring it is the single highest-impact page-load win in the app.
- **`login.route` initial chunk: 1,477 kB → 203 kB (gzip 325 kB → 66 kB).** The engine now lives in a separate async chunk loaded only after the page paints (and only when the WebGL background actually mounts).

## Verification

- Commands: `vp build` (production build) — `login.route` chunk confirmed at 203 kB; WebGL engine isolated into its own ~1.27 MB async chunk. `tsc --noEmit` clean. `vp lint` clean on the changed file.
- Manual steps: lazy boundary uses the same `React.lazy` pattern already used app-wide in `route-registry.tsx`; `Suspense fallback={null}` preserves the existing "no background until ready" behavior, and the existing `onError` CDN-failure fallback is unchanged.

## Risk And Blast Radius

- Affected packages: `@mosoo/web`.
- Affected user flows or APIs: login/landing page background rendering only. No API or behavior change.
- Rollback: revert the single-file commit.

## Evidence

- UI/UX: visual end-state is unchanged by design — the same WebGL aurora renders in the same place; only its *load timing* moves off the critical path (it fades in a beat later instead of blocking first paint). No appearance change to screenshot.
- Build output: `login.route` 1,477 kB → 203 kB; new async engine chunk ~1.27 MB loaded post-paint.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: `apps/web/src/routes/login/landing/unicorn.tsx`.
- Known trade-offs: the aurora background appears a fraction later (after its async chunk loads) instead of being part of the initial bundle — the intended behavior for a decorative element.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `perf`
- [x] Subject starts lowercase
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: appearance unchanged — see Evidence
- [x] Generated files: none touched

## Generated Files, Schema, And Lockfile

- N/A — single source file changed; no generated paths touched.
