### PR TITLE
docs(prd): drop Files from runtime config-change bindings

### DIFF
--- a/docs/prd/runtime-state-operations.md
+++ b/docs/prd/runtime-state-operations.md
@@ -36,7 +36,7 @@ The answer is:
 
 The two documents use one hard rule:
 
-> Runtime operations may briefly move active Sessions into an updating/rescheduling state, but they must not switch an existing Session to a newer DeploymentVersion, Environment revision, Skill set, MCP set, Files, model, provider, or runtime.
+> Runtime operations may briefly move active Sessions into an updating/rescheduling state, but they must not switch an existing Session to a newer DeploymentVersion, Environment revision, Skill set, MCP set, model, provider, or runtime.
 
 When product copy talks to a caller, say **Thread**. When implementation or runtime copy talks about the frozen execution record, say **Session** or **AgentSession**.
 
@@ -102,7 +102,7 @@ The dangerous failure modes are:
 | Rename Agent or edit description               | `direct-update`                                | None                                  | None                               | Unchanged   |
 | Edit prompt                                    | `restart-process` when live runtime must apply | New live version for future Sessions  | Restart Agent process              | Preserved   |
 | Edit model, provider, Skills, MCP, or options  | `patch-and-restart`                            | New live version for future Sessions  | Patch native config and restart    | Preserved   |
-| Edit Environment or Files bindings     | `recreate-preserving-state`                    | New live version for future Sessions  | Recreate sandbox and restore state | Preserved   |
+| Edit Environment binding                       | `recreate-preserving-state`                    | New live version for future Sessions  | Recreate sandbox and restore state | Preserved   |
 | Clear Pet runtime-local state                  | `reset-agent-state`                            | None                                  | Reset Pet runtime subject          | Cleared     |
 | Change runtime driver or Agent type after lock | Fork Agent                                     | New Agent identity, not in-place save | No operation on the source Agent   | Source kept |
 


### PR DESCRIPTION
## Summary

- Fix a doc-vs-code contradiction in `docs/prd/runtime-state-operations.md` introduced by the `Space -> Files` rename in #66. Files is no longer a manifest binding (removed in #64, clarified in #67), so it must not appear as an editable binding that drives a runtime operation.

## Why

- #66 mechanically rewrote `Storage/Space` to `Files`. In the Operation Decision Matrix that produced the row "Edit Environment or **Files** bindings -> `recreate-preserving-state`", and in the hard rule it added `Files` to the list of session-frozen fields.
- This contradicts the shipped contract. `AgentConfigChangeSnapshot` (`pkgs/contracts/src/agent/agent-config-change-plan.contract.ts`) carries no file/space field; `classifyAgentConfigChanges` only emits `recreate-preserving-state` for an `environmentId` change. The Spaces classifier was deleted in #64.
- It also contradicts `agent-manifest.md` (Files are "scoped at upload / session time, not a Manifest binding") and #67's intent.

## Verification

- Commands: none (docs-only).
- Manual steps: grepped all docs for Files-as-binding / removed Space-mount language; cross-checked the matrix against `agent-config-change-plan.contract.ts`. Only `runtime-state-operations.md` carried the contradiction; all other `Files` references are already correct.

## Risk And Blast Radius

- Affected packages: docs only.
- Affected user flows or APIs: none.
- Rollback: revert this commit.

## Evidence

- UI/UX: N/A (docs only).
- API or behavior: no behavior change.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Confirm only Environment (not Files) should trigger `recreate-preserving-state`, matching `classifyAgentConfigChanges`.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `docs`
- [x] Subject starts lowercase; no breaking change
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A
- [x] Generated files: none touched

## Generated Files, Schema, And Lockfile

- N/A
