### PR TITLE
perf(web): lazy-load agent terminal to shrink agent-detail load

### DIFF
--- a/apps/web/src/routes/agent/agent-detail.route.tsx
+++ b/apps/web/src/routes/agent/agent-detail.route.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeft, Settings, TerminalSquare } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 import { useAppSession } from "@/app/session-provider";
@@ -21,10 +21,18 @@ import { LogsTab } from "./components/logs-tab";
 import { PreviewMode } from "./components/preview-mode";
 import { RuntimeIcon } from "./components/runtime-icon";
 import { SettingsSheet } from "./components/settings-dialog";
-import { TerminalMode } from "./components/terminal-mode";
 import { VersionsTab } from "./components/versions-tab";
 import { LifecycleShell } from "./lifecycle/lifecycle-shell";
 import { getRuntimeInfo } from "./runtime-catalog";
+
+// The terminal pulls in the full xterm engine (~250 kB) and its stylesheet, yet
+// it only renders in the debug-only "terminal" mode that most agent visits never
+// open. Loading it lazily keeps xterm out of the agent-detail route's initial
+// chunk so the default modes paint without paying for the terminal.
+const TerminalMode = lazy(async () => {
+  const mod = await import("./components/terminal-mode");
+  return { default: mod.TerminalMode };
+});
 
 type DetailMode = AgentMode | "cost" | "logs" | "terminal";
 
@@ -399,7 +407,11 @@ export function AgentDetailPage() {
         )}
         {mode === "logs" && <LogsTab agentId={agent.id} appId={agent.appId} />}
         {mode === "cost" && <AgentCostTab agentId={agent.id} appId={agent.appId} />}
-        {mode === "terminal" && <TerminalMode key={agent.id} agent={agent} />}
+        {mode === "terminal" && (
+          <Suspense fallback={null}>
+            <TerminalMode key={agent.id} agent={agent} />
+          </Suspense>
+        )}
       </div>
 
       <SettingsSheet


### PR DESCRIPTION
## Summary

- Lazy-load the agent-detail `TerminalMode` via `React.lazy` + `Suspense` so the xterm engine is split into its own on-demand chunk.

## Why

- `agent-detail.route.tsx` statically imported `TerminalMode`, which pulls in `@xterm/xterm` + `@xterm/addon-fit` and the xterm stylesheet (~250 kB raw / ~90 kB gzip).
- The terminal only renders in the debug-only `terminal` mode that most agent visits never open, so every visit to the heaviest route in the app paid for xterm on its initial chunk.

## Verification

- Commands:
  - `vp build` (apps/web) — agent-detail route chunk drops from **1,121.55 kB → 770.50 kB** (gzip **291.51 kB → 201.33 kB**); xterm moves to a new `terminal-mode` chunk (351 kB / 89.9 kB gzip) plus its own 3.93 kB CSS, fetched only on first terminal use.
  - `tsc --noEmit` — clean.
  - `vp lint apps/web/src/routes/agent/agent-detail.route.tsx` — clean.
- Manual steps: terminal mode still mounts on demand; `Suspense fallback={null}` matches the existing lazy-load pattern used for the login WebGL background.

## Risk And Blast Radius

- Affected packages: `@mosoo/web`.
- Affected user flows: agent detail → terminal mode. First open now fetches a small extra chunk; all other modes load less.
- Rollback: revert this commit.

## Evidence

- Build output (gzip): `agent-detail.route` 291.51 kB → 201.33 kB; new `terminal-mode` chunk 89.91 kB loaded only in terminal mode.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: the `lazy()` wrapper and the added `Suspense` boundary around the `mode === "terminal"` render.
- Known trade-offs: terminal mode shows nothing until its chunk loads (no fallback spinner), consistent with the rest of the codebase.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `perf`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A (no visible change)
- [x] Generated files: none

## Generated Files, Schema, And Lockfile

- N/A
