### PR TITLE
refactor(files): move agent package admission into file store

### DIFF
--- a/apps/api/src/modules/agents/application/agent-package-file.service.ts
+++ b/apps/api/src/modules/agents/application/agent-package-file.service.ts
@@ -1,14 +1,11 @@
 import { MAX_AGENT_PACKAGE_ARCHIVE_BYTES } from "@mosoo/agent-package";
-import { fileRecordsTable } from "@mosoo/db";
-import type { AccountId, FileId, AppId } from "@mosoo/id";
-import { eq } from "drizzle-orm";
+import type { FileId, AppId } from "@mosoo/id";
 
 import { createErrorLogContext, logError } from "../../../platform/cloudflare/logger";
 import type { ApiBindings } from "../../../platform/cloudflare/worker-types";
-import { getAppDatabase } from "../../../platform/db/drizzle";
-import { currentTimestampMs } from "../../../time";
 import { ensureAppOwnership } from "../../apps/application/app.service";
 import type { AuthenticatedViewer } from "../../auth/application/viewer-auth.service";
+import type { AdmittedAgentPackageFile } from "../../files/application/file-store";
 import { fileStore, normalizeFileName } from "../../files/application/file-store";
 
 export const AGENT_PACKAGE_CONTENT_TYPE = "application/zip";
@@ -18,20 +15,6 @@ export interface CreatedAgentPackageFile {
   fileId: FileId;
   fileName: string;
   size: number;
-}
-
-interface AgentPackageFileAdmissionRecord {
-  createdBy: AccountId;
-  expiresAtMs: number | null;
-  id: FileId;
-  name: string;
-  ownerId: string;
-  ownerKind: string;
-  purpose: string;
-  scopeId: string | null;
-  scopeKind: string;
-  size: number;
-  status: string;
 }
 
 function isSupportedAgentPackageFileName(fileName: string): boolean {
@@ -133,64 +116,7 @@ export async function createAgentPackageFile(input: {
   }
 }
 
-async function getAgentPackageFileAdmissionRecord(
-  database: D1Database,
-  fileId: FileId,
-): Promise<AgentPackageFileAdmissionRecord | null> {
-  return (
-    (await getAppDatabase(database)
-      .select({
-        createdBy: fileRecordsTable.createdByAccountId,
-        expiresAtMs: fileRecordsTable.expiresAt,
-        id: fileRecordsTable.id,
-        name: fileRecordsTable.name,
-        ownerId: fileRecordsTable.ownerId,
-        ownerKind: fileRecordsTable.ownerKind,
-        purpose: fileRecordsTable.purpose,
-        scopeId: fileRecordsTable.scopeId,
-        scopeKind: fileRecordsTable.scopeKind,
-        size: fileRecordsTable.size,
-        status: fileRecordsTable.status,
-      })
-      .from(fileRecordsTable)
-      .where(eq(fileRecordsTable.id, fileId))
-      .limit(1)
-      .get()) ?? null
-  );
-}
-
-function assertPackageFileAdmitted(input: {
-  file: AgentPackageFileAdmissionRecord;
-  nowMs: number;
-  appId: AppId;
-  viewerId: AccountId;
-}): void {
-  const { file } = input;
-
-  if (file.purpose !== "agent_package") {
-    throw new Error("Agent package file purpose must be agent_package.");
-  }
-
-  if (file.scopeKind !== "agent_package") {
-    throw new Error("Agent package file must use the agent_package scope.");
-  }
-
-  if (file.scopeId !== input.appId || file.ownerKind !== "app" || file.ownerId !== input.appId) {
-    throw new Error("Agent package file does not belong to the target App.");
-  }
-
-  if (file.createdBy !== input.viewerId) {
-    throw new Error("Agent package file does not belong to the importing user.");
-  }
-
-  if (file.status !== "ready") {
-    throw new Error("Agent package file is not ready.");
-  }
-
-  if (file.expiresAtMs === null || file.expiresAtMs <= input.nowMs) {
-    throw new Error("Agent package file is expired.");
-  }
-
+function assertPackageFileArchiveShape(file: AdmittedAgentPackageFile): void {
   if (!isSupportedAgentPackageFileName(file.name)) {
     throw new Error("Agent package file must use .agent.");
   }
@@ -203,21 +129,12 @@ export async function readAgentPackageArchiveFile(input: {
   fileId: FileId;
   appId: AppId;
   viewer: AuthenticatedViewer;
-}): Promise<{ archiveBytes: Uint8Array; file: AgentPackageFileAdmissionRecord }> {
-  await ensureAppOwnership(input.bindings.DB, input.viewer.id, input.appId);
-
-  const file = await getAgentPackageFileAdmissionRecord(input.bindings.DB, input.fileId);
-
-  if (file === null) {
-    throw new Error("Agent package file was not found.");
-  }
-
-  assertPackageFileAdmitted({
-    file,
-    nowMs: currentTimestampMs(),
+}): Promise<{ archiveBytes: Uint8Array; file: AdmittedAgentPackageFile }> {
+  const file = await fileStore.admitAgentPackageFile(input.bindings, input.viewer, {
     appId: input.appId,
-    viewerId: input.viewer.id,
+    fileId: input.fileId,
   });
+  assertPackageFileArchiveShape(file);
 
   const response = await fileStore.streamContent(input.bindings, input.viewer, input.fileId);
 

--- a/apps/api/src/modules/files/application/file-store.ts
+++ b/apps/api/src/modules/files/application/file-store.ts
@@ -92,6 +92,17 @@ export interface RuntimeOutputFileInput {
   sessionId: SessionId;
 }
 
+export interface AgentPackageFileAdmissionInput {
+  appId: AppId;
+  fileId: FileId;
+}
+
+export interface AdmittedAgentPackageFile {
+  id: FileId;
+  name: string;
+  size: number;
+}
+
 export interface SessionResourcePathEntry {
   id: FileId;
   name: string;
@@ -101,6 +112,11 @@ export interface SessionResourcePathEntry {
 
 export interface FileStore {
   abortUpload(bindings: ApiBindings, viewer: AuthenticatedViewer, fileId: FileId): Promise<void>;
+  admitAgentPackageFile(
+    bindings: ApiBindings,
+    viewer: AuthenticatedViewer,
+    input: AgentPackageFileAdmissionInput,
+  ): Promise<AdmittedAgentPackageFile>;
   claimToSession(
     bindings: ApiBindings,
     viewer: AuthenticatedViewer,
@@ -393,6 +409,68 @@ async function createDownload(
   return {
     method: "GET",
     url: `/api/files/${fileId}/content?disposition=${encodeURIComponent(disposition)}`,
+  };
+}
+
+async function admitAgentPackageFile(
+  bindings: ApiBindings,
+  viewer: AuthenticatedViewer,
+  input: AgentPackageFileAdmissionInput,
+): Promise<AdmittedAgentPackageFile> {
+  await ensureAppOwnership(bindings.DB, viewer.id, input.appId);
+
+  const file =
+    (await getAppDatabase(bindings.DB)
+      .select({
+        createdBy: fileRecordsTable.createdByAccountId,
+        expiresAtMs: fileRecordsTable.expiresAt,
+        id: fileRecordsTable.id,
+        name: fileRecordsTable.name,
+        ownerId: fileRecordsTable.ownerId,
+        ownerKind: fileRecordsTable.ownerKind,
+        purpose: fileRecordsTable.purpose,
+        scopeId: fileRecordsTable.scopeId,
+        scopeKind: fileRecordsTable.scopeKind,
+        size: fileRecordsTable.size,
+        status: fileRecordsTable.status,
+      })
+      .from(fileRecordsTable)
+      .where(eq(fileRecordsTable.id, input.fileId))
+      .limit(1)
+      .get()) ?? null;
+
+  if (file === null) {
+    throw new Error("Agent package file was not found.");
+  }
+
+  if (file.purpose !== "agent_package") {
+    throw new Error("Agent package file purpose must be agent_package.");
+  }
+
+  if (file.scopeKind !== "agent_package") {
+    throw new Error("Agent package file must use the agent_package scope.");
+  }
+
+  if (file.scopeId !== input.appId || file.ownerKind !== "app" || file.ownerId !== input.appId) {
+    throw new Error("Agent package file does not belong to the target App.");
+  }
+
+  if (file.createdBy !== viewer.id) {
+    throw new Error("Agent package file does not belong to the importing user.");
+  }
+
+  if (file.status !== "ready") {
+    throw new Error("Agent package file is not ready.");
+  }
+
+  if (file.expiresAtMs === null || file.expiresAtMs <= currentTimestampMs()) {
+    throw new Error("Agent package file is expired.");
+  }
+
+  return {
+    id: file.id,
+    name: file.name,
+    size: file.size,
   };
 }
 
@@ -763,6 +841,7 @@ export {
 
 export const fileStore: FileStore = {
   abortUpload,
+  admitAgentPackageFile,
   claimToSession,
   completeUpload,
   createDownload,

--- a/apps/api/tests/file-store-boundary.test.ts
+++ b/apps/api/tests/file-store-boundary.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+
+function readTypeScriptFiles(directory: URL): { path: string; text: string }[] {
+  const files: { path: string; text: string }[] = [];
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const entryUrl = new URL(`${entry.name}${entry.isDirectory() ? "/" : ""}`, directory);
+
+    if (entry.isDirectory()) {
+      files.push(...readTypeScriptFiles(entryUrl));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith(".ts")) {
+      files.push({
+        path: entryUrl.pathname,
+        text: readFileSync(entryUrl, "utf8"),
+      });
+    }
+  }
+
+  return files;
+}
+
+describe("Files application boundary", () => {
+  test("keeps agent package file-record admission behind FileStore", () => {
+    const agentApplicationFiles = readTypeScriptFiles(
+      new URL("../src/modules/agents/application/", import.meta.url),
+    );
+    const offenders = agentApplicationFiles
+      .filter((file) => /\bfileRecordsTable\b/.test(file.text))
+      .map((file) => file.path);
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- move agent package file admission checks into the Files application boundary via `fileStore.admitAgentPackageFile`
- keep `.agent` archive filename and max-size checks in the agent package service
- add a focused boundary test so agents/application does not reach into `fileRecordsTable` again

## Validation

- `just test-file apps/api/tests/agent-package-file-import.test.ts`
- `just test-file apps/api/tests/file-store-boundary.test.ts`
- `just fmt-check-path apps/api/src/modules/files/application/file-store.ts`
- `just fmt-check-path apps/api/src/modules/agents/application/agent-package-file.service.ts`
- `just fmt-check-path apps/api/tests/file-store-boundary.test.ts`

## Notes

- `just tc-package @mosoo/api` was attempted, but current `upstream/main` fails in `apps/api/src/adapters/durable-objects/sandbox-rpc-methods.ts:108` because `UnknownSandboxRpcForwardMethod` now includes `callDesktop` and `getDesktopStreamUrl`; this PR does not touch that file.
- Generated files: none.
- GraphQL codegen: not touched.
- DB baseline updates: none.
- Supersedes #73, which used a blocked `codex/` branch prefix.
