### PR TITLE
fix(repo): restore repository check

### DIFF
--- a/apps/api/src/adapters/durable-objects/sandbox-rpc-methods.ts
+++ b/apps/api/src/adapters/durable-objects/sandbox-rpc-methods.ts
@@ -1,7 +1,6 @@
 import type { Sandbox as CloudflareSandbox } from "@cloudflare/sandbox";
 
 export const SANDBOX_RPC_FORWARD_METHODS = [
-  "callDesktop",
   "callTunnels",
   "checkChanges",
   "cleanupCompletedProcesses",
@@ -20,7 +19,6 @@ export const SANDBOX_RPC_FORWARD_METHODS = [
   "exists",
   "exposePort",
   "getContainerPlacementId",
-  "getDesktopStreamUrl",
   "getExposedPorts",
   "getProcess",
   "getProcessLogs",

--- a/apps/api/src/modules/agent-builder/application/agent-builder-draft-patch-assets.ts
+++ b/apps/api/src/modules/agent-builder/application/agent-builder-draft-patch-assets.ts
@@ -80,7 +80,7 @@ function parseReferenceId(
     return parseSkillId(value, label);
   }
 
-  throw new Error(`Unsupported draft patch reference target type: ${spec.targetType}`);
+  throw new Error(`Unsupported draft patch reference target type: ${String(spec.targetType)}`);
 }
 
 function createDraftPatchReference(

--- a/apps/api/src/modules/agent-builder/application/agent-builder-ids.ts
+++ b/apps/api/src/modules/agent-builder/application/agent-builder-ids.ts
@@ -117,5 +117,5 @@ export function parseAgentBuilderBindableAssetId(input: {
     return parseSkillId(input.value, input.label ?? "skillId");
   }
 
-  throw new Error(`Unsupported Agent Builder asset type: ${input.assetType}`);
+  throw new Error(`Unsupported Agent Builder asset type: ${String(input.assetType)}`);
 }

--- a/apps/api/src/modules/agents/application/agent-command.service.ts
+++ b/apps/api/src/modules/agents/application/agent-command.service.ts
@@ -205,7 +205,7 @@ export async function updateAgentConfig(
     runtimeId,
     updatedAt: timestampMs,
   };
-  const [specSkills] = await Promise.all([listAgentSpecSkillsByIds(database, skillIds)]);
+  const specSkills = await listAgentSpecSkillsByIds(database, skillIds);
   const spec = await buildAgentSpecForPreparedProfile(database, {
     agent: nextAgent,
     environment: preparedEnvironment.environment,

--- a/apps/api/tests/file-upload-access.test.ts
+++ b/apps/api/tests/file-upload-access.test.ts
@@ -689,7 +689,9 @@ describe("file upload access", () => {
     const allBody = (await allResponse.json()) as FileEntryListing;
 
     expect(allResponse.status).toBe(200);
-    expect(allBody.files.map((file) => file.id).sort()).toEqual([FILE_ID, LIBRARY_FILE_ID].sort());
+    expect(allBody.files.map((file) => file.id).toSorted()).toEqual(
+      [FILE_ID, LIBRARY_FILE_ID].toSorted(),
+    );
 
     const sessionResponse = await createHttpApp().request(
       `${PUBLIC_API_PREFIX}/files?appId=${fixture.ids.appId}&sessionId=${SESSION_ID}`,

--- a/apps/api/tests/session-resource-files.test.ts
+++ b/apps/api/tests/session-resource-files.test.ts
@@ -552,17 +552,17 @@ describe("session resource files", () => {
     const bindings = { DB: database } as ApiBindings;
 
     const allFiles = await fileStore.list(bindings, VIEWER, { appId: APP_ID });
-    const allFileIds = allFiles.files.map((file) => file.id).sort();
+    const allFileIds = allFiles.files.map((file) => file.id).toSorted();
 
-    expect(allFileIds).toEqual([ARTIFACT_FILE_ID, FILE_ID, LIBRARY_FILE_ID].sort());
+    expect(allFileIds).toEqual([ARTIFACT_FILE_ID, FILE_ID, LIBRARY_FILE_ID].toSorted());
 
     const sessionFiles = await fileStore.list(bindings, VIEWER, {
       appId: APP_ID,
       sessionId: SESSION_ID,
     });
 
-    expect(sessionFiles.files.map((file) => file.id).sort()).toEqual(
-      [ARTIFACT_FILE_ID, FILE_ID].sort(),
+    expect(sessionFiles.files.map((file) => file.id).toSorted()).toEqual(
+      [ARTIFACT_FILE_ID, FILE_ID].toSorted(),
     );
 
     const artifacts = await fileStore.list(bindings, VIEWER, {

--- a/apps/web/src/app/account-menu.tsx
+++ b/apps/web/src/app/account-menu.tsx
@@ -125,7 +125,7 @@ export function AccountMenu({
             className="cursor-pointer rounded-md"
             onSelect={() => {
               void (async () => {
-                await authClient.signOut();
+                await authClient["signOut"]();
                 globalThis.location.href = "/login";
               })();
             }}

--- a/apps/web/src/domains/auth/use-auth.ts
+++ b/apps/web/src/domains/auth/use-auth.ts
@@ -31,9 +31,17 @@ function isAuthUser(value: unknown): value is AuthUser {
   );
 }
 
+function getSessionUser(data: unknown): unknown {
+  if (data === null || typeof data !== "object" || !("user" in data)) {
+    return undefined;
+  }
+
+  return data.user;
+}
+
 export function useAuth(): AuthState {
   const session = authClient.useSession();
-  const sessionUser = session.data?.user;
+  const sessionUser = getSessionUser(session.data);
 
   return {
     loading: session.isPending,

--- a/apps/web/src/domains/file/api/files.ts
+++ b/apps/web/src/domains/file/api/files.ts
@@ -1,9 +1,9 @@
-import {
-  FILE_STATUSES,
-  type FileEntryListing,
-  type FileListQuery as FileListRequest,
-  type FileEntry,
-  type FileStatus,
+import { FILE_STATUSES } from "@mosoo/contracts/file";
+import type {
+  FileEntry,
+  FileEntryListing,
+  FileListQuery as FileListRequest,
+  FileStatus,
 } from "@mosoo/contracts/file";
 
 import { graphql } from "@/gql";

--- a/apps/web/src/routes/files/files.route.tsx
+++ b/apps/web/src/routes/files/files.route.tsx
@@ -43,10 +43,9 @@ function SegmentedButtonGroup<T extends string>({
   value: T;
 }): ReactElement {
   return (
-    <div
+    <fieldset
       aria-label={label}
-      className="bg-card border-border-strong inline-flex h-8 overflow-hidden rounded-md border"
-      role="group"
+      className="bg-card border-border-strong m-0 inline-flex h-8 min-w-0 overflow-hidden rounded-md border p-0"
     >
       {options.map((option) => (
         <button
@@ -66,7 +65,7 @@ function SegmentedButtonGroup<T extends string>({
           {option.label}
         </button>
       ))}
-    </div>
+    </fieldset>
   );
 }
 

--- a/apps/web/src/routes/login/use-login.ts
+++ b/apps/web/src/routes/login/use-login.ts
@@ -115,7 +115,7 @@ export function useLoginFlow(): LoginFlow {
   async function handleGoogleLogin(): Promise<void> {
     setError(null);
 
-    const result = await authClient.signIn.social({
+    const result = await authClient["signIn"].social({
       callbackURL: redirectPath,
       errorCallbackURL: loginErrorCallbackUrl,
       provider: "google",
@@ -144,7 +144,7 @@ export function useLoginFlow(): LoginFlow {
         return;
       }
 
-      const result = await authClient.emailOtp.sendVerificationOtp({
+      const result = await authClient["emailOtp"].sendVerificationOtp({
         email: normalizedEmail,
         type: "sign-in",
       });
@@ -176,7 +176,7 @@ export function useLoginFlow(): LoginFlow {
 
     try {
       const normalizedEmail = email.trim();
-      const result = await authClient.signIn.emailOtp({
+      const result = await authClient["signIn"].emailOtp({
         email: normalizedEmail,
         name: deriveNameFromEmail(normalizedEmail),
         otp,

--- a/pkgs/agent-package/tests/archive-entry-admission.test.ts
+++ b/pkgs/agent-package/tests/archive-entry-admission.test.ts
@@ -105,7 +105,9 @@ describe("agent package archive entry admission", () => {
   test("rejects manifest declarations that target reserved package files", () => {
     const archive = createStoredZipArchive([
       {
-        body: textToArchiveBytes(createPackageManifestJson({ avatar: "manifest.json" })),
+        body: textToArchiveBytes(
+          createPackageManifestJson({ skills: [{ name: "Reserved", path: "manifest.json" }] }),
+        ),
         path: "manifest.json",
       },
       {
@@ -240,7 +242,6 @@ function createPackageManifestJson(
     provider: "anthropic",
     runtime: "claude-agent-sdk",
     skills: input.skills ?? [],
-    spaceBindings: [],
     version: "1.0.0",
   });
 }


### PR DESCRIPTION
## Summary
- Bump the agent driver submodule to the formatter-only driver fix in langgenius/mosoo-agent-driver#17.
- Fix repository lint issues surfaced after the formatter gate: `toSorted()`, type-only imports, semantic grouping markup, explicit template-string coercion, and single-promise handling.
- Fix type/test issues now reached by the full check: auth client index-signature access, Sandbox RPC method whitelist alignment with `@cloudflare/sandbox@0.12.1`, and a stale agent-package manifest fixture.

## Root cause
The previous PR check stopped at all-repo formatting, so later lint/type/test failures were hidden. Once the driver formatting issue was fixed, `bun run check` continued and exposed existing repository-check failures on current `main`.

## Validation
- `env -u AGENT_DRIVER_LIVE_ANTHROPIC_API_KEY -u ANTHROPIC_API_KEY -u AGENT_DRIVER_LIVE_OPENAI_API_KEY -u OPENAI_API_KEY bun run check`
- `bun run --filter @mosoo/agent-package test`
- `bun run --filter @mosoo/ag-ui-session test`

Note: a direct local `bun run --filter agent-driver test` with my Anthropic live key present failed the live Anthropic smoke. The PR workflow does not inject live provider secrets, and the CI-mode check above skipped live tests and passed.

## Generated files / codegen / DB
- Generated files: no
- GraphQL codegen: no
- DB baseline update: no