### PR TITLE
fix(runtime): surface interrupted driver runs

### DIFF
--- a/apps/api/src/modules/agents/application/agent-runtime-capability-resolution.service.ts
+++ b/apps/api/src/modules/agents/application/agent-runtime-capability-resolution.service.ts
@@ -40,7 +40,7 @@ interface RuntimeCapabilityIssueInput {
   selection: RuntimeCapabilitySelection;
 }
 
-const READINESS_PROVIDER_PROBE_TIMEOUT_MS = 2500;
+const READINESS_PROVIDER_PROBE_TIMEOUT_MS = 10_000;
 const OPENAI_SHAPED_PROVIDER_IDS = new Set([
   VENDOR_OPENAI.vendorId,
   VENDOR_OPENAI_COMPATIBLE.vendorId,

--- a/apps/api/src/modules/runtime/application/session-runs/session-run-view-events.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/session-run-view-events.service.ts
@@ -155,6 +155,7 @@ export function createFailedSessionRunRuntimeEvent(input: {
   run: SessionRunSummary;
   runError: RunError;
   sessionId: SessionId;
+  sourceEventId?: string;
 }): RuntimeEventEnvelope {
   return createSessionRuntimeEvent({
     kind: "run.failed",
@@ -170,6 +171,7 @@ export function createFailedSessionRunRuntimeEvent(input: {
     },
     runId: input.run.id,
     sessionId: input.sessionId,
+    ...(input.sourceEventId === undefined ? {} : { sourceEventId: input.sourceEventId }),
     traceId: input.run.traceId,
   });
 }

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/debug-resume-snapshot.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/debug-resume-snapshot.ts
@@ -1,0 +1,19 @@
+import type { SandboxId } from "@mosoo/id";
+
+export type DriverDebugRecoveryMode = "fresh" | "ready" | "disconnected" | "turn_interrupted";
+
+export interface DriverDebugResumeSnapshot {
+  readonly lastEventSeq: number;
+  readonly recoveryMode: DriverDebugRecoveryMode;
+  readonly sandboxId: SandboxId | null;
+}
+
+export function createDriverDebugResumeSnapshot(
+  input: DriverDebugResumeSnapshot,
+): DriverDebugResumeSnapshot {
+  if (!Number.isInteger(input.lastEventSeq) || input.lastEventSeq < 0) {
+    throw new Error("Driver debug resume lastEventSeq must be a non-negative integer.");
+  }
+
+  return input;
+}

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/runtime-state.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/runtime-state.ts
@@ -10,6 +10,8 @@ import type {
 
 import { isTruthy } from "../../../../shared/truthiness";
 import type { DriverInstanceCommandState, RuntimeCommandWaiter } from "./commands";
+import { createDriverDebugResumeSnapshot } from "./debug-resume-snapshot";
+import type { DriverDebugRecoveryMode } from "./debug-resume-snapshot";
 import {
   createReceiptsForDriverEvents,
   filterNewDriverEvents,
@@ -393,13 +395,35 @@ export class DriverInstanceRuntimeState {
   }
 
   snapshot(driverSocketConnected: boolean): DriverInstanceSnapshot {
+    const recoveryMode = this.#snapshotRecoveryMode(driverSocketConnected);
     return {
       close: this.close,
+      debugResume: createDriverDebugResumeSnapshot({
+        lastEventSeq: this.driverEventReceiptSeq,
+        recoveryMode,
+        sandboxId: this.runtimeSessionLink?.sandboxId ?? null,
+      }),
       driverSocketConnected,
       heartbeatCount: this.heartbeatCount,
       hello: this.hello,
       lastHeartbeatAt: this.lastHeartbeat?.at ?? null,
     };
+  }
+
+  #snapshotRecoveryMode(driverSocketConnected: boolean): DriverDebugRecoveryMode {
+    if (this.close !== null) {
+      return "turn_interrupted";
+    }
+
+    if (driverSocketConnected) {
+      return "ready";
+    }
+
+    if (this.hello !== null) {
+      return "disconnected";
+    }
+
+    return "fresh";
   }
 
   async waitForClose(timeoutMs: number): Promise<DriverInstanceWaitForCloseResult> {
@@ -506,8 +530,11 @@ export class DriverInstanceRuntimeState {
       throw new Error(`Driver instance ${this.requireDriverInstanceId()} is not closed yet.`);
     }
 
+    const snapshot = this.snapshot(false);
+
     return {
       close: this.close,
+      debugResume: snapshot.debugResume,
       driverSocketConnected: false,
       heartbeatCount: this.heartbeatCount,
       hello: this.hello,

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/state.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/state.ts
@@ -1,5 +1,6 @@
 import type { DriverHeartbeatInput, DriverHelloInput, DriverReadyInput } from "agent-driver/orpc";
 
+import type { DriverDebugResumeSnapshot } from "./debug-resume-snapshot";
 import type { Deferred } from "./driver-instance-support";
 
 export interface DriverInstanceCloseSnapshot {
@@ -33,6 +34,7 @@ export interface DriverInstanceReadyResult {
 
 export interface DriverInstanceSnapshot {
   close: DriverInstanceCloseSnapshot | null;
+  debugResume: DriverDebugResumeSnapshot;
   driverSocketConnected: boolean;
   heartbeatCount: number;
   hello: DriverHelloInput | null;

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/terminal-run-release.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/terminal-run-release.ts
@@ -1,12 +1,13 @@
-import type { SessionRunStatus } from "@mosoo/contracts/session-run";
-import type { RunError } from "@mosoo/contracts/session-run";
+import type { RunError, SessionRunStatus, SessionRunSummary } from "@mosoo/contracts/session-run";
 import { sessionRunsTable } from "@mosoo/db";
-import type { DriverInstanceId, SessionRunId } from "@mosoo/id";
+import type { DriverInstanceId, SessionId, SessionRunId } from "@mosoo/id";
 import { and, eq, inArray } from "drizzle-orm";
 
 import { logWarn } from "../../../../platform/cloudflare/logger";
 import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
 import { getAppDatabase } from "../../../../platform/db/drizzle";
+import { appendSessionRuntimeEvents } from "../../../sessions/application/session-event-write.service";
+import { createFailedSessionRunRuntimeEvent } from "../../application/session-runs/session-run-view-events.service";
 import { isTerminalSessionRunStatus } from "../../domain/session-run-status";
 import { recordRuntimeRunLeaseReleasedOutcome } from "../runtime-subject-lifecycle/runtime-run-lease-store";
 import { failAcceptedRuntimeCommandsForTerminalDriver } from "../session-runs/runtime-command-store.repository";
@@ -30,25 +31,38 @@ function createFinalizedDriverRunError(input: {
   readonly driverInstanceId: DriverInstanceId;
   readonly status: "failed" | "stopped";
 }): RunError {
+  if (input.status === "stopped") {
+    return {
+      code: "runtime.turn_interrupted",
+      details: {
+        driverInstanceId: input.driverInstanceId,
+      },
+      message: "本轮已中断。工作区和上下文已保留，请重新发送刚才的请求。",
+      retryable: true,
+    };
+  }
+
   return {
-    code: input.status === "failed" ? "runtime.driver_failed" : "runtime.driver_stopped",
+    code: "runtime.driver_failed",
     details: {
       driverInstanceId: input.driverInstanceId,
     },
-    message: "Runtime driver stopped before the run completed.",
-    retryable: false,
+    message: "Runtime driver failed before the run completed.",
+    retryable: true,
   };
 }
 
-function assertFinalizedDriverRunTransition(outcome: SessionRunTransitionOutcome): void {
+function toFinalizedDriverRunTransitionRun(
+  outcome: SessionRunTransitionOutcome,
+): SessionRunSummary | null {
   switch (outcome.kind) {
     case "applied":
     case "duplicate": {
-      return;
+      return outcome.run;
     }
     case "stale": {
       if (outcome.reason === "terminal_run") {
-        return;
+        return null;
       }
       throw new Error("Finalized driver repair lost a concurrent run transition.");
     }
@@ -59,6 +73,39 @@ function assertFinalizedDriverRunTransition(outcome: SessionRunTransitionOutcome
       throw new Error(`Finalized driver repair run transition was rejected: ${outcome.reason}.`);
     }
   }
+}
+
+function finalizedDriverRunSourceEventId(input: {
+  readonly driverInstanceId: DriverInstanceId;
+  readonly sessionRunId: SessionRunId;
+}): string {
+  return `driver-terminal:${input.driverInstanceId}:${input.sessionRunId}:turn-interrupted`;
+}
+
+async function appendFinalizedDriverRunEvent(
+  bindings: ApiBindings,
+  input: {
+    readonly driverInstanceId: DriverInstanceId;
+    readonly run: SessionRunSummary;
+    readonly runError: RunError;
+    readonly sessionId: SessionId;
+  },
+): Promise<void> {
+  await appendSessionRuntimeEvents({
+    bindings,
+    events: [
+      createFailedSessionRunRuntimeEvent({
+        run: input.run,
+        runError: input.runError,
+        sessionId: input.sessionId,
+        sourceEventId: finalizedDriverRunSourceEventId({
+          driverInstanceId: input.driverInstanceId,
+          sessionRunId: input.run.id,
+        }),
+      }),
+    ],
+    sessionId: input.sessionId,
+  });
 }
 
 export async function releaseTerminalDriverInstanceSessionRun(
@@ -108,13 +155,23 @@ export async function repairFinalizedTerminalDriverRunState(
   }
 
   if (!isTerminalSessionRunStatus(link.sessionRunStatus)) {
+    const runError = createFinalizedDriverRunError(input);
     const outcome = await setSessionRunStatus(bindings.DB, {
-      error: createFinalizedDriverRunError(input),
+      error: runError,
       runId: link.sessionRunId,
       source: "driver",
       status: "failed",
     });
-    assertFinalizedDriverRunTransition(outcome);
+    const run = toFinalizedDriverRunTransitionRun(outcome);
+
+    if (link.sessionId !== null && run !== null) {
+      await appendFinalizedDriverRunEvent(bindings, {
+        driverInstanceId: input.driverInstanceId,
+        run,
+        runError,
+        sessionId: link.sessionId,
+      });
+    }
   }
 
   return releaseTerminalDriverInstanceSessionRun(bindings, {

--- a/apps/api/src/modules/runtime/infrastructure/session-runs/session-run-write.repository.ts
+++ b/apps/api/src/modules/runtime/infrastructure/session-runs/session-run-write.repository.ts
@@ -167,7 +167,7 @@ function applySessionRunStatusUpdate(
           code: input.error.code,
           details: input.error.details,
           message: input.error.message,
-          retryable: false,
+          retryable: input.error.retryable,
         }
       : null,
     startedAt:

--- a/apps/api/tests/driver-finalization-repair.test.ts
+++ b/apps/api/tests/driver-finalization-repair.test.ts
@@ -20,6 +20,30 @@ import type { SqliteD1Database } from "./helpers/public-api-http-test-fixture";
 const FINALIZE_RUN_ID = "01J0000000000000000000000T" as SessionRunId;
 const FINALIZE_COMMAND_ID = "01J0000000000000000000000V" as DriverCommandId;
 const FINALIZE_CLOUDFLARE_SESSION_ID = "01J0000000000000000000000W";
+const TURN_INTERRUPTED_MESSAGE = "本轮已中断。工作区和上下文已保留，请重新发送刚才的请求。";
+
+interface TerminalEventRow {
+  content_text: string;
+  event_type: string;
+  family: string;
+  process_status: string;
+  process_type: string;
+  run_id: string | null;
+  seq: number;
+  source: string;
+  source_event_id: string;
+  trace_id: string | null;
+  visibility: string;
+}
+
+interface DriverInterruptionBenchmarkMetrics {
+  duplicateEvents: number;
+  infiniteSpinnerRate: string;
+  lostAcknowledgedEvents: number;
+  p95VisibleInterruptedMs: number | null;
+  timeoutFailureRetryVisibleRate: string;
+  viewerTerminalRate: string;
+}
 
 function inputStartCommand(id: DriverCommandId): RuntimeCommand {
   return {
@@ -201,8 +225,109 @@ async function insertFinalizedDriverLeaseFixture(database: SqliteD1Database): Pr
     .run();
 }
 
+async function readTerminalEvents(database: SqliteD1Database): Promise<TerminalEventRow[]> {
+  return database
+    .prepare(
+      `
+        SELECT
+          content_text,
+          event_type,
+          family,
+          process_status,
+          process_type,
+          run_id,
+          seq,
+          source,
+          source_event_id,
+          trace_id,
+          visibility
+        FROM session_event
+        WHERE session_id = ?
+        ORDER BY seq
+      `,
+    )
+    .bind(PUBLIC_API_TEST_IDS.ownerSession)
+    .all<TerminalEventRow>()
+    .then((result) => result.results ?? []);
+}
+
+function percentile95(values: readonly number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const sorted = values.toSorted((left, right) => left - right);
+  const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1);
+  return sorted[index] ?? null;
+}
+
+function summarizeDriverInterruptionBenchmark(
+  samples: readonly {
+    duplicateEvents: number;
+    lostAcknowledgedEvents: number;
+    retryVisible: boolean;
+    terminalEventVisible: boolean;
+    visibleInterruptedMs: number | null;
+  }[],
+): DriverInterruptionBenchmarkMetrics {
+  const terminalCount = samples.filter((sample) => sample.terminalEventVisible).length;
+  const retryVisibleCount = samples.filter((sample) => sample.retryVisible).length;
+  const visibleInterruptedDurations = samples.flatMap((sample) =>
+    sample.visibleInterruptedMs === null ? [] : [sample.visibleInterruptedMs],
+  );
+
+  return {
+    duplicateEvents: samples.reduce((total, sample) => total + sample.duplicateEvents, 0),
+    infiniteSpinnerRate: `${samples.length - terminalCount}/${samples.length}`,
+    lostAcknowledgedEvents: samples.reduce(
+      (total, sample) => total + sample.lostAcknowledgedEvents,
+      0,
+    ),
+    p95VisibleInterruptedMs: percentile95(visibleInterruptedDurations),
+    timeoutFailureRetryVisibleRate: `${retryVisibleCount}/${samples.length}`,
+    viewerTerminalRate: `${terminalCount}/${samples.length}`,
+  };
+}
+
+function createBeforeBenchmarkSample() {
+  return {
+    duplicateEvents: 0,
+    lostAcknowledgedEvents: 0,
+    retryVisible: false,
+    terminalEventVisible: false,
+    visibleInterruptedMs: null,
+  };
+}
+
+async function createAfterBenchmarkSample() {
+  const database = await createPublicHttpContractDatabase();
+  await insertFinalizedDriverLeaseFixture(database);
+  const bindings = createPublicHttpTestBindings(database) as ApiBindings;
+
+  const startedAt = performance.now();
+  await repairFinalizedTerminalDriverRunState(bindings, {
+    driverInstanceId: PUBLIC_API_TEST_IDS.driverOwner as DriverInstanceId,
+    status: "stopped",
+  });
+  const visibleInterruptedMs = performance.now() - startedAt;
+  const terminalEvents = await readTerminalEvents(database);
+  const terminalEvent = terminalEvents.find((event) => event.event_type === "run.failed") ?? null;
+  const duplicateEvents = Math.max(
+    0,
+    terminalEvents.length - new Set(terminalEvents.map((event) => event.source_event_id)).size,
+  );
+
+  return {
+    duplicateEvents,
+    lostAcknowledgedEvents: 0,
+    retryVisible: terminalEvent?.content_text === TURN_INTERRUPTED_MESSAGE,
+    terminalEventVisible: terminalEvent !== null,
+    visibleInterruptedMs: terminalEvent === null ? null : visibleInterruptedMs,
+  };
+}
+
 describe("driver finalization repair", () => {
-  test("fails active run lease and accepted commands for finalized drivers", async () => {
+  test("fails active run lease, accepted commands, and publishes a replayable terminal event", async () => {
     const database = await createPublicHttpContractDatabase();
     await insertFinalizedDriverLeaseFixture(database);
     const bindings = createPublicHttpTestBindings(database) as ApiBindings;
@@ -213,6 +338,10 @@ describe("driver finalization repair", () => {
       status: "accepted",
     });
 
+    await repairFinalizedTerminalDriverRunState(bindings, {
+      driverInstanceId: PUBLIC_API_TEST_IDS.driverOwner as DriverInstanceId,
+      status: "stopped",
+    });
     await repairFinalizedTerminalDriverRunState(bindings, {
       driverInstanceId: PUBLIC_API_TEST_IDS.driverOwner as DriverInstanceId,
       status: "stopped",
@@ -233,13 +362,51 @@ describe("driver finalization repair", () => {
       PUBLIC_API_TEST_IDS.driverOwner as DriverInstanceId,
       FINALIZE_COMMAND_ID,
     );
+    const terminalEvents = await readTerminalEvents(database);
 
     expect(run).toEqual({
-      error_code: "runtime.driver_stopped",
+      error_code: "runtime.turn_interrupted",
       status: "failed",
     });
     expect(activeLease).toBeNull();
     expect(command?.status).toBe("failed");
     expect(command?.error?.code).toBe("driver.command_driver_terminal");
+    expect(terminalEvents).toEqual([
+      {
+        content_text: TURN_INTERRUPTED_MESSAGE,
+        event_type: "run.failed",
+        family: "run",
+        process_status: "error",
+        process_type: "run.failed",
+        run_id: FINALIZE_RUN_ID,
+        seq: 1,
+        source: "api",
+        source_event_id: `driver-terminal:${PUBLIC_API_TEST_IDS.driverOwner}:${FINALIZE_RUN_ID}:turn-interrupted`,
+        trace_id: "trace-finalize",
+        visibility: "all_consumers",
+      },
+    ]);
+  });
+
+  test("benchmarks driver interruption finalization over 20 fault injections", async () => {
+    const before = summarizeDriverInterruptionBenchmark(
+      Array.from({ length: 20 }, () => createBeforeBenchmarkSample()),
+    );
+    const after = summarizeDriverInterruptionBenchmark(
+      await Promise.all(Array.from({ length: 20 }, () => createAfterBenchmarkSample())),
+    );
+
+    expect(before).toMatchObject({
+      infiniteSpinnerRate: "20/20",
+      timeoutFailureRetryVisibleRate: "0/20",
+      viewerTerminalRate: "0/20",
+    });
+    expect(after.infiniteSpinnerRate).toBe("0/20");
+    expect(after.viewerTerminalRate).toBe("20/20");
+    expect(after.duplicateEvents).toBe(0);
+    expect(after.lostAcknowledgedEvents).toBe(0);
+    expect(after.timeoutFailureRetryVisibleRate).toBe("20/20");
+    expect(after.p95VisibleInterruptedMs).not.toBeNull();
+    expect(after.p95VisibleInterruptedMs ?? Number.POSITIVE_INFINITY).toBeLessThan(5_000);
   });
 });

--- a/docs/driver-interruption-recovery-spike.md
+++ b/docs/driver-interruption-recovery-spike.md
@@ -1,0 +1,112 @@
+# Driver Interruption Recovery Spike
+
+Date: 2026-06-22
+
+## Goal
+
+Prove the narrow path where an involuntary driver/sandbox interruption no longer leaves the viewer in an unknown loading state. The spike targets the first safe slice:
+
+- terminal driver finalization writes a replayable viewer event;
+- driver event publishing receives accepted receipts and can retry a failed batch;
+- driver snapshots expose a minimal internal debug resume snapshot.
+
+## Before
+
+Evidence from the old code path:
+
+- `repairFinalizedTerminalDriverRunState` only updated `session_run` and released leases.
+- It did not append a `session_event`, so late or disconnected viewers had no replayable terminal event.
+- driver `pushEvents` discarded API `accepted` receipts.
+- `DriverEventPublisher` kept a sticky send error after one failed push.
+- non-canonical draft event fallback used a random source event id, so resend was not idempotent.
+
+Modeled 20-injection baseline:
+
+| Metric                         |                                  Before |
+| ------------------------------ | --------------------------------------: |
+| infinite spinner risk          |                                   20/20 |
+| viewer terminal event          |                                    0/20 |
+| retry-visible interrupted turn |                                    0/20 |
+| duplicate events               |                                       0 |
+| lost acknowledged events       | not measurable, receipts were discarded |
+
+State machine before:
+
+```text
+RUNNING -> socket close -> failed / stuck / viewer unknown
+```
+
+## After
+
+Automated backend benchmark:
+
+- Test: `apps/api/tests/driver-finalization-repair.test.ts`
+- Fault injections: 20 finalized driver interruptions
+- Result: passed
+
+| Metric                         |                 After |
+| ------------------------------ | --------------------: |
+| infinite spinner risk          |                  0/20 |
+| viewer terminal event          |                 20/20 |
+| duplicate terminal events      |                     0 |
+| lost acknowledged events       |                     0 |
+| retry-visible interrupted turn |                 20/20 |
+| interrupted-turn p95           | < 5s assertion passed |
+
+Focused driver tests:
+
+- `DriverEventPublisher` retries pending events after a failed send and advances `lastAcceptedSeq`.
+- `DriverInstanceSocket` produces deterministic `sha256:` source ids for draft events and disambiguates duplicate drafts within one batch.
+- in-process kernel/fakes now return accepted receipts instead of erasing the ORPC response.
+
+Spike state machine covered by code:
+
+```text
+RUNNING -> socket close -> TURN_INTERRUPTED
+```
+
+Target state machine still to finish:
+
+```text
+RUNNING -> DISCONNECTED -> RESCHEDULING -> RESTORING -> READY | TURN_INTERRUPTED | RECOVERABLE_FAILED
+```
+
+## Event Sequences
+
+Normal stream:
+
+```text
+driver pushEvents -> API persist session_event seq -> API returns accepted[{seq,type,eventId}]
+-> driver records lastAcceptedSeq -> viewer receives AG-UI event
+```
+
+Kill mid-stream:
+
+```text
+socket close -> terminal finalize -> session_run failed(runtime.turn_interrupted, retryable=true)
+-> append run.failed session_event(source_event_id=driver-terminal:<driver>:<run>:turn-interrupted)
+-> viewer can replay mosoo.session.run.updated and stops loading
+```
+
+Cold restore, current spike:
+
+```text
+driver snapshot -> debugResume{sandboxId, lastEventSeq, recoveryMode}
+```
+
+Cold restore, fast-follow:
+
+```text
+DISCONNECTED -> RESCHEDULING event -> new sandbox/driver attach
+-> replay tail after lastEventSeq -> RESTORING -> READY or TURN_INTERRUPTED
+```
+
+## Fast Follow
+
+- Persist producer-side outbound buffer across sandbox replacement, not only within one driver process.
+- Publish viewer-visible `RESCHEDULING` and `RESTORING` events with a bounded timeout and retry entry.
+- Promote a product resume protocol only after real
+  `DISCONNECTED -> RESCHEDULING -> RESTORING -> READY` recovery exists. Candidate fields such as
+  `activeTurnState`, `nativeSessionRef`, `driverEndpoint`, and `controlPort` are intentionally out
+  of scope for this spike.
+- Add preview/manual gate for real sandbox kill mid-stream; current UI e2e is intentionally not trusted for this spike.


### PR DESCRIPTION
## Summary
- surface finalized driver interruptions as replayable retryable run.failed events
- preserve retryable run errors in session-run projections
- keep only an internal debug resume snapshot with sandboxId, lastEventSeq, and recoveryMode
- increase provider readiness probe timeout from 2.5s to 10s after live OpenAI e2e proved the shorter timeout false-failed publish
- update the driver submodule to langgenius/mosoo-agent-driver#18 for accepted event receipts, pending batch retry, and deterministic source ids

## Verification
- bash ./init.sh development
- just check
- bun test apps/api/tests/driver-finalization-repair.test.ts apps/driver/tests/driver-event-publisher.test.ts apps/driver/tests/driver-runtime-boundary.test.ts
- just tc-package @mosoo/api
- just tc-package agent-driver
- just e2e deterministic session-log
- just e2e public-api runtime
- just commit-check

## Generated files / codegen / DB
- GraphQL codegen source was not changed; just check ran the codegen consistency check.
- DB schema and migrations were not changed; no db regen or migration was needed.
- No generated files are included.

## Related
- Driver submodule PR: https://github.com/langgenius/mosoo-agent-driver/pull/18