### PR TITLE
fix(i18n): translate Chinese product copy and pin UI formatters to English

### DIFF
--- a/apps/api/src/modules/agent-builder/application/agent-builder-component-planner-policy.service.ts
+++ b/apps/api/src/modules/agent-builder/application/agent-builder-component-planner-policy.service.ts
@@ -35,7 +35,7 @@ const REMOTE_MCP_OPTION_KEY = "action:create_remote_mcp_server";
 
 const OPTIONAL_COMPONENT_SPECS = [
   {
-    askText: "可以。你可以从当前可见的 Skills 中选择要绑定到这个 Agent 的能力，也可以先跳过。",
+    askText: "Sure. You can select capabilities to bind to this Agent from the currently visible Skills, or skip for now.",
     fieldPath: "skillIds",
     intentPatterns: [/\bskills?\b/iu, /\bpdf\b/iu, /\bdocx\b/iu, /\bxlsx\b/iu, /\bpptx\b/iu],
     listKey: "skills",
@@ -50,10 +50,10 @@ const OPTIONAL_COMPONENT_SPECS = [
     actionOptionKey: REMOTE_MCP_OPTION_KEY,
     actionSummary: "Open the secure remote MCP server creation UI.",
     actionText:
-      "创建远程 MCP server 需要打开专用安全配置 UI。Builder 会在 Agent Manifest 中引用创建后的 server，不把 credential 写进 YAML；点击 Create remote MCP server 继续。",
-    askText: "可以。你可以选择已有 MCP server，或通过安全 UI 创建新的远程 MCP server。",
+      "Creating a remote MCP server requires opening a dedicated secure configuration UI. The Builder references the created server in the Agent Manifest and does not write credentials into the YAML. Click Create remote MCP server to continue.",
+    askText: "Sure. You can select an existing MCP server, or create a new remote MCP server through the secure UI.",
     fieldPath: "mcpServerIds",
-    intentPatterns: [/\bmcp\b/iu, /\bserver\b/iu, /远程\s*mcp/iu],
+    intentPatterns: [/\bmcp\b/iu, /\bserver\b/iu, /\bremote\s*mcp\b/iu],
     listKey: "mcpServers",
     nodeKey: "ask_mcp_servers",
     optionPrefix: "mcp_server:",
@@ -171,7 +171,7 @@ function createComponentDraftPatchPlannerOutput(input: {
   readonly spec: OptionalComponentSpec;
 }): AgentBuilderPlannerOutput {
   return {
-    assistantText: "已选择组件。我会把这些绑定写入当前 Agent Manifest。",
+    assistantText: "Components selected. I'll write these bindings into the current Agent Manifest.",
     intentSummary: `Bind selected optional ${input.spec.fieldPath}.`,
     mode: "draft_patch",
     nodes: [
@@ -220,7 +220,7 @@ function createComponentDraftPatchWithRemoteMcpActionPlannerOutput(input: {
   return {
     ...patchOutput,
     assistantText:
-      "已选择已有 MCP server。我会先把它写入当前 Agent Manifest；新的远程 MCP server 需要通过安全 UI 继续创建。",
+      "Existing MCP server selected. I'll write it into the current Agent Manifest first; creating a new remote MCP server still needs to be done through the secure UI.",
     intentSummary:
       "Bind selected optional MCP servers and open the secure remote MCP server creation UI.",
     nodes: [...patchOutput.nodes, ...actionOutput.nodes],
@@ -265,7 +265,7 @@ export function planAgentBuilderOptionalComponentStructuredReply(input: {
 
   if (input.reply.mode !== "multi_select" && input.reply.mode !== "free_text") {
     return createAgentBuilderPlainTextPlannerOutput({
-      assistantText: "这个结构化回复的输入模式不属于当前组件选择流程；请重新选择组件。",
+      assistantText: "This structured reply's input mode doesn't belong to the current component selection flow. Please select components again.",
       intentSummary: "Reject a structured reply mode that does not match the component question.",
       plannerRunId: input.context.plannerRunId,
     });
@@ -273,7 +273,7 @@ export function planAgentBuilderOptionalComponentStructuredReply(input: {
 
   if (input.reply.skipped) {
     return createAgentBuilderPlainTextPlannerOutput({
-      assistantText: "已跳过这组可选组件；后续仍然可以回到 Builder 添加。",
+      assistantText: "Skipped this set of optional components. You can always come back to the Builder to add them later.",
       intentSummary: "Skip optional component binding.",
       plannerRunId: input.context.plannerRunId,
     });
@@ -295,7 +295,7 @@ export function planAgentBuilderOptionalComponentStructuredReply(input: {
 
     if (selectedAsset === null) {
       return createAgentBuilderPlainTextPlannerOutput({
-        assistantText: "有组件不在当前可见资产里。我不能直接绑定不可见资源；请重新选择。",
+        assistantText: "Some components aren't among the currently visible assets. I can't bind resources that aren't visible — please select again.",
         intentSummary:
           "Reject an optional component selection that is not visible in planner context.",
         plannerRunId: input.context.plannerRunId,

--- a/apps/api/src/modules/agent-builder/application/agent-builder-environment-planner-policy.service.ts
+++ b/apps/api/src/modules/agent-builder/application/agent-builder-environment-planner-policy.service.ts
@@ -89,7 +89,7 @@ export function createAgentBuilderEnvironmentQuestionPlannerOutput(input: {
 
   return {
     assistantText:
-      "基础 Agent 已经完整；下一步需要选择、创建或跳过 Environment。这个选择会决定工具运行的执行环境。",
+      "The base Agent is complete. The next step is to select, create, or skip an Environment. This choice determines the execution environment where tools run.",
     intentSummary: "Ask the user to configure Quickstart Step 2 Environment.",
     mode: "question",
     nodes: [node],
@@ -116,7 +116,7 @@ function createEnvironmentDraftPatchPlannerOutput(input: {
   readonly environmentName: string;
 }): AgentBuilderPlannerOutput {
   return {
-    assistantText: `已选择 Environment：${input.environmentName}。我会把它绑定到当前 Agent Manifest。`,
+    assistantText: `Environment selected: ${input.environmentName}. I'll bind it to the current Agent Manifest.`,
     intentSummary: "Bind the selected Environment to the Agent draft.",
     mode: "draft_patch",
     nodes: [
@@ -146,7 +146,7 @@ function createCreateEnvironmentGuidancePlannerOutput(
   return createAgentBuilderActionPlannerOutput({
     actionKey: CREATE_ENVIRONMENT_ACTION_KEY,
     assistantText:
-      "创建新的 Environment 需要打开专用安全配置 UI。运行环境脚本、包配置和凭据由 Environment 配置表面处理；点击 Create Environment 继续。",
+      "Creating a new Environment requires opening a dedicated secure configuration UI. Runtime scripts, package configuration, and credentials are handled by the Environment configuration surface. Click Create Environment to continue.",
     context,
     intentSummary: "Guide the user to the safe Environment creation UI.",
     label: "Create Environment",
@@ -159,7 +159,7 @@ function createSkipEnvironmentDecisionPlannerOutput(
 ): AgentBuilderPlannerOutput {
   return {
     assistantText:
-      "已收到跳过 Environment 的选择。我会把这个决定记录到当前 Agent Manifest；后续仍然可以回到 Builder 补上 Environment。",
+      "Got it — skipping the Environment. I'll record this decision in the current Agent Manifest. You can always come back to the Builder to add an Environment later.",
     intentSummary: "Persist the skipped Environment decision in the Agent draft.",
     mode: "draft_patch",
     nodes: [
@@ -198,7 +198,7 @@ export function planAgentBuilderEnvironmentStructuredReply(input: {
   if (input.reply.mode !== "single_select" && input.reply.mode !== "free_text") {
     return createAgentBuilderPlainTextPlannerOutput({
       assistantText:
-        "这个结构化回复的输入模式不属于 Environment 选择流程；请重新选择或输入 Environment 配置。",
+        "This structured reply's input mode doesn't belong to the Environment selection flow. Please select again or enter an Environment configuration.",
       intentSummary: "Reject a structured reply mode that does not match the Environment question.",
       plannerRunId: input.context.plannerRunId,
     });
@@ -210,7 +210,7 @@ export function planAgentBuilderEnvironmentStructuredReply(input: {
   ) {
     return createAgentBuilderPlainTextPlannerOutput({
       assistantText:
-        "这个结构化回复和当前 Environment 问题不匹配；请重新选择一个选项或输入自定义说明。",
+        "This structured reply doesn't match the current Environment question. Please select an option again or enter a custom description.",
       intentSummary: "Reject a malformed Environment structured reply.",
       plannerRunId: input.context.plannerRunId,
     });
@@ -248,7 +248,7 @@ export function planAgentBuilderEnvironmentStructuredReply(input: {
   if (selectedEnvironment === undefined || selectedEnvironment === null) {
     return createAgentBuilderPlainTextPlannerOutput({
       assistantText:
-        "这个 Environment 不在当前可见资产里。我不能直接绑定不可见资源；请重新选择一个可见 Environment。",
+        "This Environment isn't among the currently visible assets. I can't bind resources that aren't visible — please select a visible Environment instead.",
       intentSummary: "Reject an Environment selection that is not visible in planner context.",
       plannerRunId: input.context.plannerRunId,
     });

--- a/apps/api/src/modules/agent-builder/application/agent-builder-lightweight-planner-policy.service.ts
+++ b/apps/api/src/modules/agent-builder/application/agent-builder-lightweight-planner-policy.service.ts
@@ -31,7 +31,7 @@ export function createDefaultAgentBuilderLightweightPlanner(): AgentBuilderLight
 
       if (structuredReply !== null) {
         return createAgentBuilderPlainTextPlannerOutput({
-          assistantText: "这个结构化问题已过期或不再是当前步骤；请继续描述要调整的内容。",
+          assistantText: "This structured question is stale or no longer the current step. Please continue describing what you'd like to adjust.",
           intentSummary: "Reject a stale structured Builder reply.",
           plannerRunId: context.plannerRunId,
         });

--- a/apps/api/src/modules/agent-builder/application/agent-builder-llm-planner.service.ts
+++ b/apps/api/src/modules/agent-builder/application/agent-builder-llm-planner.service.ts
@@ -528,7 +528,7 @@ export function createAgentBuilderLlmPlanner(input: {
       }
 
       reportAgentBuilderProgress(plannerInput.progress, {
-        message: "正在调用 System Agent 模型规划 Builder 输出",
+        message: "Calling the System Agent model to plan the Builder output",
         stage: "planner:llm",
       });
 

--- a/apps/api/src/modules/agent-builder/application/agent-builder-planner-turn.service.ts
+++ b/apps/api/src/modules/agent-builder/application/agent-builder-planner-turn.service.ts
@@ -153,7 +153,7 @@ function sanitizeNonDraftQuickstartActions(input: {
   return createAgentBuilderActionPlannerOutput({
     actionKey: "apply_agent_config",
     assistantText:
-      "这个 Agent 已经存在。我会把当前配置当成 Manifest refactor 来处理，不会重新带你走 Quickstart 初始化；如果右侧配置已经正确，可以点击 Apply changes 写回 Agent。",
+      "This Agent already exists. I'll treat the current configuration as a Manifest refactor instead of walking you through Quickstart initialization again. If the configuration on the right is already correct, click Apply changes to write it back to the Agent.",
     context: input.context,
     intentSummary: "Rewrite non-draft Quickstart action to Agent Manifest refactor apply.",
     label: "Apply changes",
@@ -170,7 +170,7 @@ async function runPlanner(input: {
   readonly viewer: AuthenticatedViewer;
 }): Promise<AgentBuilderPlannerExecution> {
   reportAgentBuilderProgress(input.progress, {
-    message: "正在读取当前配置并规划下一步",
+    message: "Reading the current configuration and planning the next step",
     stage: "planner:lightweight",
   });
 
@@ -222,7 +222,7 @@ export async function appendAgentBuilderPlannerTurnResult(
     const userMessageId = createAgentBuilderMessageId();
 
     reportAgentBuilderProgress(input.progress, {
-      message: "正在读取 Draft、历史消息和可见资产",
+      message: "Reading the Draft, message history, and visible assets",
       stage: "context",
     });
 
@@ -252,7 +252,7 @@ export async function appendAgentBuilderPlannerTurnResult(
     const requestDigest = await createAgentBuilderRequestDigest(plannerContext);
 
     reportAgentBuilderProgress(input.progress, {
-      message: "正在保存 Builder 结果",
+      message: "Saving the Builder result",
       stage: "ledger",
     });
 

--- a/apps/api/src/modules/agent-builder/application/agent-builder-workflow-planner-policy.service.ts
+++ b/apps/api/src/modules/agent-builder/application/agent-builder-workflow-planner-policy.service.ts
@@ -50,7 +50,7 @@ export function planAgentBuilderRefactorTurn(
   return createAgentBuilderActionPlannerOutput({
     actionKey: APPLY_AGENT_CONFIG_ACTION_KEY,
     assistantText:
-      "我会把当前 Agent 当成已存在的 Manifest 来协助 refactor：可以继续修改名称、描述、模型、系统提示词，或调整 Environment、Skill、MCP 绑定；不会重新带你走 Quickstart 初始化步骤。如果右侧配置已经是你想保存的版本，可以点击 Apply changes 写回 Agent 配置。",
+      "I'll treat the current Agent as an existing Manifest and help you refactor it: you can keep editing the name, description, model, and system prompt, or adjust the Environment, Skill, and MCP bindings. I won't walk you through the Quickstart initialization steps again. If the configuration on the right is already the version you want to save, click Apply changes to write it back to the Agent configuration.",
     context,
     intentSummary: "Continue lightweight Agent Manifest refactor.",
     label: "Apply changes",
@@ -70,7 +70,7 @@ export function planAgentBuilderWorkflowTurn(
   if (workflowState.activeStageId === "create_agent") {
     return createAgentBuilderPlainTextPlannerOutput({
       assistantText:
-        "我需要先补齐 Agent type、名称、描述、运行时、模型和系统提示词，才能创建这个 Agent。",
+        "I need the Agent type, name, description, runtime, model, and system prompt filled in before I can create this Agent.",
       intentSummary: "Guide the user to complete Quickstart Step 1.",
       plannerRunId: context.plannerRunId,
     });
@@ -93,7 +93,7 @@ export function planAgentBuilderWorkflowTurn(
     ) {
       return createNextActionPlannerOutput({
         assistantText:
-          "Step 1 的 Agent 必填字段已经齐全。先点击 Create this agent 保存并初始化这个 Agent，然后继续配置 Environment。",
+          "All required Agent fields for Step 1 are complete. Click Create this agent first to save and initialize this Agent, then continue configuring the Environment.",
         context,
         intentSummary: "Ask the user to apply Quickstart Step 1 before Step 2.",
         nextAction: {
@@ -113,7 +113,7 @@ export function planAgentBuilderWorkflowTurn(
   if (workflowState.nextAction.kind === "open_preview") {
     return createNextActionPlannerOutput({
       assistantText:
-        "配置已经可以进入 Preview。你可以点击 Test in Chat 复用 preview 会话进行真实测试。",
+        "The configuration is ready for Preview. You can click Test in Chat to reuse the preview session for real testing.",
       context,
       intentSummary: "Guide the user to open Builder Preview.",
       nextAction: workflowState.nextAction,
@@ -122,7 +122,7 @@ export function planAgentBuilderWorkflowTurn(
   }
 
   return createAgentBuilderPlainTextPlannerOutput({
-    assistantText: "我会继续根据当前 Manifest 帮你调整 Agent 配置。",
+    assistantText: "I'll keep helping you adjust the Agent configuration based on the current Manifest.",
     intentSummary: "Continue lightweight Agent Manifest refinement.",
     plannerRunId: context.plannerRunId,
   });

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/terminal-run-release.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/terminal-run-release.ts
@@ -37,7 +37,7 @@ function createFinalizedDriverRunError(input: {
       details: {
         driverInstanceId: input.driverInstanceId,
       },
-      message: "本轮已中断。工作区和上下文已保留，请重新发送刚才的请求。",
+      message: "This turn was interrupted. Your workspace and context have been preserved — please resend your last request.",
       retryable: true,
     };
   }

--- a/apps/api/tests/agent-builder-system-agent-lightweight-rpc.test.ts
+++ b/apps/api/tests/agent-builder-system-agent-lightweight-rpc.test.ts
@@ -1601,7 +1601,7 @@ describe("Agent Builder System Agent lightweight RPC", () => {
 
     expect(plannerOutput?.mode).toBe("plain_text");
     expect(plannerOutput?.nodes).toEqual([]);
-    expect(staleReplyResult.messages.at(-1)?.contentText).toContain("已过期");
+    expect(staleReplyResult.messages.at(-1)?.contentText).toContain("stale");
   });
 
   test("emits a secure create-Environment action for create-new Environment replies", async () => {

--- a/apps/api/tests/driver-finalization-repair.test.ts
+++ b/apps/api/tests/driver-finalization-repair.test.ts
@@ -20,7 +20,8 @@ import type { SqliteD1Database } from "./helpers/public-api-http-test-fixture";
 const FINALIZE_RUN_ID = "01J0000000000000000000000T" as SessionRunId;
 const FINALIZE_COMMAND_ID = "01J0000000000000000000000V" as DriverCommandId;
 const FINALIZE_CLOUDFLARE_SESSION_ID = "01J0000000000000000000000W";
-const TURN_INTERRUPTED_MESSAGE = "本轮已中断。工作区和上下文已保留，请重新发送刚才的请求。";
+const TURN_INTERRUPTED_MESSAGE =
+  "This turn was interrupted. Your workspace and context have been preserved — please resend your last request.";
 
 interface TerminalEventRow {
   content_text: string;

--- a/apps/web/src/routes/agent/components/cost-tab.tsx
+++ b/apps/web/src/routes/agent/components/cost-tab.tsx
@@ -193,7 +193,7 @@ export function AgentCostTab({ agentId, appId }: { agentId: string; appId: strin
               className="border-border grid grid-cols-[120px_minmax(160px,1fr)_130px_130px_100px] items-center border-b px-4 py-3 text-sm last:border-b-0"
             >
               <div className="text-muted-foreground text-xs" suppressHydrationWarning>
-                {new Date(session.createdAt).toLocaleString()}
+                {new Date(session.createdAt).toLocaleString("en-US")}
               </div>
               <div className="min-w-0">
                 <div className="text-foreground truncate font-medium">{session.actorName}</div>

--- a/apps/web/src/routes/agent/components/logs-tab.tsx
+++ b/apps/web/src/routes/agent/components/logs-tab.tsx
@@ -49,7 +49,7 @@ function formatRelativeTime(iso: string): string {
   if (diff < 7 * day) {
     return `${Math.floor(diff / day)}d ago`;
   }
-  return new Date(iso).toLocaleDateString(undefined, { day: "numeric", month: "short" });
+  return new Date(iso).toLocaleDateString("en-US", { day: "numeric", month: "short" });
 }
 
 function EmptyState(): ReactElement {

--- a/apps/web/src/routes/agent/components/settings-dialog-channels-view.tsx
+++ b/apps/web/src/routes/agent/components/settings-dialog-channels-view.tsx
@@ -47,7 +47,7 @@ function readMetadataString(
   return trimmed.length > 0 ? trimmed : null;
 }
 
-const TIMESTAMP_FORMATTER = new Intl.DateTimeFormat(undefined, {
+const TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
   dateStyle: "medium",
   timeStyle: "short",
 });

--- a/apps/web/src/routes/agent/components/versions-tab.tsx
+++ b/apps/web/src/routes/agent/components/versions-tab.tsx
@@ -9,7 +9,7 @@ import { getRuntimeInfo } from "../runtime-catalog";
 import { RuntimeIcon } from "./runtime-icon";
 
 function formatVersionTime(value: string): string {
-  return new Date(value).toLocaleString(undefined, {
+  return new Date(value).toLocaleString("en-US", {
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",

--- a/apps/web/src/routes/cost/cost-model.ts
+++ b/apps/web/src/routes/cost/cost-model.ts
@@ -51,19 +51,19 @@ export const RUN_PURPOSE_FILTERS: { label: string; value: CostRunPurpose | "all"
   { label: "Preview", value: "preview" },
 ];
 
-const CURRENCY_FORMATTER_PRECISE = new Intl.NumberFormat(undefined, {
+const CURRENCY_FORMATTER_PRECISE = new Intl.NumberFormat("en-US", {
   currency: "USD",
   maximumFractionDigits: 2,
   style: "currency",
 });
 
-const CURRENCY_FORMATTER_WHOLE = new Intl.NumberFormat(undefined, {
+const CURRENCY_FORMATTER_WHOLE = new Intl.NumberFormat("en-US", {
   currency: "USD",
   maximumFractionDigits: 0,
   style: "currency",
 });
 
-const COMPACT_NUMBER_FORMATTER = new Intl.NumberFormat(undefined, {
+const COMPACT_NUMBER_FORMATTER = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 1,
   notation: "compact",
 });

--- a/apps/web/src/routes/environments/environment-list-table.tsx
+++ b/apps/web/src/routes/environments/environment-list-table.tsx
@@ -67,7 +67,7 @@ export function EnvironmentListTable({
           <div className="text-fg-2 text-[12px]">{networkLabel(environment)}</div>
           <div className="text-fg-2 font-mono text-[12px]">{environment.usedByAgentCount}</div>
           <div className="text-fg-3 text-[12px]" suppressHydrationWarning>
-            {new Date(environment.updatedAt).toLocaleDateString()}
+            {new Date(environment.updatedAt).toLocaleDateString("en-US")}
           </div>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/apps/web/src/routes/files/files.route.tsx
+++ b/apps/web/src/routes/files/files.route.tsx
@@ -112,7 +112,7 @@ function formatBytes(size: number): string {
 }
 
 function formatDateTime(value: string): string {
-  return new Intl.DateTimeFormat(undefined, {
+  return new Intl.DateTimeFormat("en-US", {
     day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",

--- a/apps/web/src/routes/settings/access-tokens-tab.tsx
+++ b/apps/web/src/routes/settings/access-tokens-tab.tsx
@@ -52,7 +52,7 @@ function formatDateTime(value: string | null): string {
     return "Never";
   }
 
-  return new Date(value).toLocaleString(undefined, {
+  return new Date(value).toLocaleString("en-US", {
     dateStyle: "medium",
     timeStyle: "short",
   });

--- a/apps/web/src/shared/ui/session-events/feed-display.ts
+++ b/apps/web/src/shared/ui/session-events/feed-display.ts
@@ -7,7 +7,7 @@ import type { SessionTurnStatus } from "./turns";
 const MAX_PREVIEW_LENGTH = 180;
 
 export function formatEventTime(iso: string): string {
-  return new Date(iso).toLocaleTimeString(undefined, {
+  return new Date(iso).toLocaleTimeString("en-US", {
     hour: "2-digit",
     minute: "2-digit",
     second: "2-digit",


### PR DESCRIPTION
## Summary

- Translate Chinese product copy that surfaced in the otherwise English-only console to English.
- Affected the Agent Builder planner services (assistant text, progress messages, error/guidance copy) and the interrupted-turn runtime message.
- Pin web `Intl` number/date formatters to `en-US` so a Chinese-locale browser no longer renders token counts as `2.3万` or dates as `2026/6/22`.

## Why

- The product UI is English-only (see the existing `keeps the App console root free of Chinese copy` boundary test), but several agent-builder planner outputs and one runtime error message were authored in Chinese and shown directly to users.
- Number/date formatters used the browser's default locale, so the Cost page leaked Chinese-locale formatting (`2.3万 tokens`, `2026/6/22`) into the English UI. The codebase already pins some formatters to `en-US` (`agent-table`, `skills/format`); this aligns the rest.

## Verification

- Commands: `bun build` per changed file passes (syntax). Full `just test` / `bun test` could not be run in this checkout because the `agent-driver` workspace package lives in an uninitialized private submodule.
- Manual steps: traced every test assertion that depends on a changed product string; updated the two that do (`agent-builder-system-agent-lightweight-rpc` stale-reply assertion and the `driver-finalization-repair` interrupted-message constant). Remaining Chinese in tests is intentional input/mock fixture data and the CJK-guard regex.

## Risk And Blast Radius

- Affected packages: `@mosoo/api` (agent-builder + runtime), `@mosoo/web`.
- Affected user flows or APIs: Agent Builder chat copy, interrupted-turn error message, Cost/Logs/Versions/Files/Environments/Access-tokens timestamp and number formatting. No API contract or control-flow changes — string/locale only.
- Rollback: revert the two commits.

## Evidence

- UI/UX: the reported issue shows the Cost page rendering `2.3万 tokens` / `2.3万 cache read` and `2026/6/22` timestamps under a Chinese-locale browser; pinning formatters to `en-US` resolves it.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: accuracy/tone of the translated assistant copy in the agent-builder planner services.
- Known trade-offs: formatters are hard-pinned to `en-US` rather than introducing an i18n layer, matching the current English-only product and existing `en-US` usages.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `fix`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: will sign if prompted
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: formatting fix described in Evidence
- [x] Generated files: none hand-edited

## Generated Files, Schema, And Lockfile

- N/A — no generated/schema/lockfile changes.
