### PR TITLE
feat(web): rename sidebar nav item Overview to Install

### DIFF
--- a/apps/web/src/app/navigation.tsx
+++ b/apps/web/src/app/navigation.tsx
@@ -36,7 +36,7 @@ interface AppNavSection {
 const NAV_SECTIONS: AppNavSection[] = [
   {
     items: [
-      { icon: LayoutDashboard, label: "Overview", path: "/" },
+      { icon: LayoutDashboard, label: "Install", path: "/" },
       { icon: Inbox, label: "Threads", path: "/threads" },
       { icon: Bot, label: "Agents", path: "/agent" },
       { icon: Files, label: "Files", path: "/files" },

--- a/apps/web/tests/app-navigation-boundary.test.ts
+++ b/apps/web/tests/app-navigation-boundary.test.ts
@@ -6,15 +6,15 @@ function readSource(path: string): string {
 }
 
 describe("App navigation boundary", () => {
-  test("puts App Overview before Agent-first surfaces", () => {
+  test("puts App Install before Agent-first surfaces", () => {
     const source = readSource("../src/app/navigation.tsx");
-    const overviewIndex = source.indexOf('label: "Overview"');
+    const installIndex = source.indexOf('label: "Install"');
     const threadsIndex = source.indexOf('label: "Threads"');
     const agentsIndex = source.indexOf('label: "Agents"');
 
-    expect(overviewIndex).toBeGreaterThan(-1);
-    expect(overviewIndex).toBeLessThan(threadsIndex);
-    expect(overviewIndex).toBeLessThan(agentsIndex);
+    expect(installIndex).toBeGreaterThan(-1);
+    expect(installIndex).toBeLessThan(threadsIndex);
+    expect(installIndex).toBeLessThan(agentsIndex);
     expect(source).toContain('path: "/"');
     expect(source).not.toContain('label: "Members"');
   });


### PR DESCRIPTION
## Summary

- Rename the first sidebar nav item in the app console from **Overview** to **Install** in `apps/web/src/app/navigation.tsx`.
- Update `apps/web/tests/app-navigation-boundary.test.ts` to assert the new `Install` label so the ordering boundary test stays green.

## Why

- The page behind this nav item is the install guide ("Hand Mosoo to your agent" / `npx mosoo login --token ...` to install the `@mosoo` skill), so "Install" describes it accurately while "Overview" was misleading. Only the visible label changes — the route (`/`) and the `AppOverviewPage` / `AppOverviewInstallGuide` component identifiers are untouched.

## Verification

- Commands: `bun test apps/web/tests/app-navigation-boundary.test.ts` → 3 pass / 0 fail.
- Manual steps: N/A — `vp`-based dev stack is unavailable in the agent sandbox, so a live screenshot could not be captured.

## Risk And Blast Radius

- Affected packages: `apps/web`
- Affected user flows or APIs: app console sidebar label only; no route, behavior, or API change.
- Rollback: revert this commit.

## Evidence

- UI/UX: before screenshot is attached in the originating issue (YEF-705). Label text changes from "Overview" to "Install"; nav position, icon, and target route are unchanged.
- Test output: navigation boundary suite passes (3 tests).

## Compatibility

- Public contract changes: none
- Env or config changes: none
- Deployment or migration: none

## Reviewer Focus

- Closest review areas: `apps/web/src/app/navigation.tsx`, `apps/web/tests/app-navigation-boundary.test.ts`
- Known trade-offs: none

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `feat`
- [x] Subject starts lowercase
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: before screenshot in linked issue; live after-screenshot N/A (no dev stack in sandbox)
