### PR TITLE
style(agent-builder): wrap long planner copy to satisfy formatter

### DIFF
--- a/apps/api/src/modules/agent-builder/application/agent-builder-component-planner-policy.service.ts
+++ b/apps/api/src/modules/agent-builder/application/agent-builder-component-planner-policy.service.ts
@@ -35,7 +35,8 @@ const REMOTE_MCP_OPTION_KEY = "action:create_remote_mcp_server";
 
 const OPTIONAL_COMPONENT_SPECS = [
   {
-    askText: "Sure. You can select capabilities to bind to this Agent from the currently visible Skills, or skip for now.",
+    askText:
+      "Sure. You can select capabilities to bind to this Agent from the currently visible Skills, or skip for now.",
     fieldPath: "skillIds",
     intentPatterns: [/\bskills?\b/iu, /\bpdf\b/iu, /\bdocx\b/iu, /\bxlsx\b/iu, /\bpptx\b/iu],
     listKey: "skills",
@@ -51,7 +52,8 @@ const OPTIONAL_COMPONENT_SPECS = [
     actionSummary: "Open the secure remote MCP server creation UI.",
     actionText:
       "Creating a remote MCP server requires opening a dedicated secure configuration UI. The Builder references the created server in the Agent Manifest and does not write credentials into the YAML. Click Create remote MCP server to continue.",
-    askText: "Sure. You can select an existing MCP server, or create a new remote MCP server through the secure UI.",
+    askText:
+      "Sure. You can select an existing MCP server, or create a new remote MCP server through the secure UI.",
     fieldPath: "mcpServerIds",
     intentPatterns: [/\bmcp\b/iu, /\bserver\b/iu, /\bremote\s*mcp\b/iu],
     listKey: "mcpServers",
@@ -171,7 +173,8 @@ function createComponentDraftPatchPlannerOutput(input: {
   readonly spec: OptionalComponentSpec;
 }): AgentBuilderPlannerOutput {
   return {
-    assistantText: "Components selected. I'll write these bindings into the current Agent Manifest.",
+    assistantText:
+      "Components selected. I'll write these bindings into the current Agent Manifest.",
     intentSummary: `Bind selected optional ${input.spec.fieldPath}.`,
     mode: "draft_patch",
     nodes: [
@@ -265,7 +268,8 @@ export function planAgentBuilderOptionalComponentStructuredReply(input: {
 
   if (input.reply.mode !== "multi_select" && input.reply.mode !== "free_text") {
     return createAgentBuilderPlainTextPlannerOutput({
-      assistantText: "This structured reply's input mode doesn't belong to the current component selection flow. Please select components again.",
+      assistantText:
+        "This structured reply's input mode doesn't belong to the current component selection flow. Please select components again.",
       intentSummary: "Reject a structured reply mode that does not match the component question.",
       plannerRunId: input.context.plannerRunId,
     });
@@ -273,7 +277,8 @@ export function planAgentBuilderOptionalComponentStructuredReply(input: {
 
   if (input.reply.skipped) {
     return createAgentBuilderPlainTextPlannerOutput({
-      assistantText: "Skipped this set of optional components. You can always come back to the Builder to add them later.",
+      assistantText:
+        "Skipped this set of optional components. You can always come back to the Builder to add them later.",
       intentSummary: "Skip optional component binding.",
       plannerRunId: input.context.plannerRunId,
     });
@@ -295,7 +300,8 @@ export function planAgentBuilderOptionalComponentStructuredReply(input: {
 
     if (selectedAsset === null) {
       return createAgentBuilderPlainTextPlannerOutput({
-        assistantText: "Some components aren't among the currently visible assets. I can't bind resources that aren't visible — please select again.",
+        assistantText:
+          "Some components aren't among the currently visible assets. I can't bind resources that aren't visible — please select again.",
         intentSummary:
           "Reject an optional component selection that is not visible in planner context.",
         plannerRunId: input.context.plannerRunId,

--- a/apps/api/src/modules/agent-builder/application/agent-builder-lightweight-planner-policy.service.ts
+++ b/apps/api/src/modules/agent-builder/application/agent-builder-lightweight-planner-policy.service.ts
@@ -31,7 +31,8 @@ export function createDefaultAgentBuilderLightweightPlanner(): AgentBuilderLight
 
       if (structuredReply !== null) {
         return createAgentBuilderPlainTextPlannerOutput({
-          assistantText: "This structured question is stale or no longer the current step. Please continue describing what you'd like to adjust.",
+          assistantText:
+            "This structured question is stale or no longer the current step. Please continue describing what you'd like to adjust.",
           intentSummary: "Reject a stale structured Builder reply.",
           plannerRunId: context.plannerRunId,
         });

--- a/apps/api/src/modules/agent-builder/application/agent-builder-workflow-planner-policy.service.ts
+++ b/apps/api/src/modules/agent-builder/application/agent-builder-workflow-planner-policy.service.ts
@@ -122,7 +122,8 @@ export function planAgentBuilderWorkflowTurn(
   }
 
   return createAgentBuilderPlainTextPlannerOutput({
-    assistantText: "I'll keep helping you adjust the Agent configuration based on the current Manifest.",
+    assistantText:
+      "I'll keep helping you adjust the Agent configuration based on the current Manifest.",
     intentSummary: "Continue lightweight Agent Manifest refinement.",
     plannerRunId: context.plannerRunId,
   });

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/terminal-run-release.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/terminal-run-release.ts
@@ -37,7 +37,8 @@ function createFinalizedDriverRunError(input: {
       details: {
         driverInstanceId: input.driverInstanceId,
       },
-      message: "This turn was interrupted. Your workspace and context have been preserved — please resend your last request.",
+      message:
+        "This turn was interrupted. Your workspace and context have been preserved — please resend your last request.",
       retryable: true,
     };
   }


### PR DESCRIPTION
## Summary

- Apply the repository formatter (`vp fmt`) to four files whose long English strings exceed the line-width rule and must wrap after the `:`.
- No logic change — string contents and behavior are identical; only line wrapping changes.

## Why

- #80 ("translate Chinese product copy and pin UI formatters to English") was a fork PR, so the `pull_request` "Repository check" (which runs `fmt:check`) did not run on it. Its longer English copy pushed several lines past the formatter width, and the violation landed on `main` after merge, turning `fmt:check` red for every subsequent PR. This restores a green `main`.

## Verification

- Commands: `vp fmt --check ...` (the `fmt:check` gate) → "All matched files use the correct format."
- Manual steps: N/A — formatting only.

## Risk And Blast Radius

- Affected packages: `apps/api` (agent-builder planner policy services, runtime terminal-run-release)
- Affected user flows or APIs: none — whitespace/line-wrapping only.
- Rollback: revert this commit.

## Compatibility

- Public contract changes: none
- Env or config changes: none
- Deployment or migration: none

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `style`
- [x] Subject starts lowercase
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A (no visible change)
