### PR TITLE
ci(feishu): add feishu webhook notification workflow

### DIFF
--- a/.github/workflows/feishu-notify.yml
+++ b/.github/workflows/feishu-notify.yml
@@ -1,0 +1,65 @@
+name: Feishu Notify
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - closed
+  issue_comment:
+    types:
+      - created
+  pull_request_review:
+    types:
+      - submitted
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  notify:
+    name: Notify Feishu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send event to Feishu bot
+        env:
+          FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
+          EVENT: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${FEISHU_WEBHOOK_URL}" ]; then
+            echo "FEISHU_WEBHOOK_URL is not configured; skipping Feishu notification."
+            exit 0
+          fi
+
+          title="GitHub: ${EVENT} / ${ACTION}"
+          url="${GITHUB_SERVER_URL}/${REPO}"
+          text="**${title}**\\n${ACTOR} on \`${REPO}\`\\n[Open](${url})"
+
+          curl --fail --silent --show-error --request POST \
+            --url "${FEISHU_WEBHOOK_URL}" \
+            --header "Content-Type: application/json" \
+            --data @- <<EOF
+          {
+            "msg_type": "interactive",
+            "card": {
+              "header": {
+                "title": { "tag": "plain_text", "content": "${title}" },
+                "template": "blue"
+              },
+              "elements": [
+                { "tag": "div", "text": { "tag": "lark_md", "content": "${text}" } }
+              ]
+            }
+          }
+          EOF


### PR DESCRIPTION
## What

Adds `.github/workflows/feishu-notify.yml` to send GitHub events (PR opened/reopened/closed, issue comment, PR review) to a Feishu custom bot via webhook.

## Why

The repo wanted Feishu notifications on PR/issue activity. I evaluated `junka/feishu-bot-webhook-action` but did not use it:

- No `v2` tag exists (latest is `1.0.11`, published 2024-05-27, unmaintained for over a year).
- Its `action.yml` declares `inputs.webhook`, not `webhook_url` — the common copy-paste snippet is wrong and would silently fail.

Per `AGENTS.md` ("avoid low-value third-party dependencies; prefer lightweight handwritten clients"), this uses a single `curl` step instead, matching the existing `docs-openapi-dispatch.yml` style. No third-party action, no tag drift.

## Behavior

- Triggers on `pull_request_target` / `issue_comment` / `pull_request_review` (fork PRs included).
- Reads `secrets.FEISHU_WEBHOOK_URL`; **skips silently when unset** (same graceful-degrade pattern as `docs-openapi-dispatch.yml`), so CI never goes red from a missing secret.
- Sends an interactive card via the Feishu bot webhook API.
- Explicit `permissions:` and `concurrency:` blocks, consistent with other workflows.

## Required secret

Add `FEISHU_WEBHOOK_URL` in repo Settings → Secrets and variables → Actions. Already configured by maintainer.

## Verification

- `python3 -c 'import yaml; yaml.safe_load(...)'` → YAML OK.
- `prek` pre-commit, commit-msg, and pre-push hooks all passed.
- No `just check` needed — CI-only change, no TS/code touch.