### PR TITLE
fix(runtime): reconcile stale driver runs

### DIFF
--- a/apps/api/src/modules/runtime/application/session-runs/stale-run-reconciliation.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/stale-run-reconciliation.service.ts
@@ -1,7 +1,7 @@
 import type { RunError } from "@mosoo/contracts/session-run";
 import { driverInstancesTable, sessionRunsTable } from "@mosoo/db";
 import type { SessionId, SessionRunId } from "@mosoo/id";
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, lte, or, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/sqlite-core";
 
 import { getAppDatabase } from "../../../../platform/db/drizzle";
@@ -15,8 +15,14 @@ export interface ActiveRunDriverRow {
   driver_status: string | null;
   driver_updated_at: number | null;
   run_id: SessionRunId;
+  session_id: SessionId;
   run_trace_id: string | null;
   run_updated_at: number;
+}
+
+export interface StaleActiveRunReconciliationResult {
+  readonly reconciledRunIds: readonly SessionRunId[];
+  readonly reconciledSessionIds: readonly SessionId[];
 }
 
 function latestRuntimeObservationMs(row: ActiveRunDriverRow): number {
@@ -54,21 +60,43 @@ function shouldFailActiveRunAsStale(row: ActiveRunDriverRow, nowMs: number): boo
 
 const runDriverInstancesTable = alias(driverInstancesTable, "run_driver");
 
+const ACTIVE_SESSION_RUN_STATUSES = ["queued", "booting", "running", "waiting_input"] as const;
+
+function activeRunDriverColumns() {
+  return {
+    driver_error_message: runDriverInstancesTable.errorMessage,
+    driver_last_heartbeat_at: runDriverInstancesTable.lastHeartbeatAt,
+    driver_status: runDriverInstancesTable.status,
+    driver_updated_at: runDriverInstancesTable.updatedAt,
+    run_id: sessionRunsTable.id,
+    run_trace_id: sessionRunsTable.traceId,
+    run_updated_at: sessionRunsTable.updatedAt,
+    session_id: sessionRunsTable.sessionId,
+  };
+}
+
+function latestRuntimeObservationSql() {
+  return sql<number>`MAX(
+    ${sessionRunsTable.updatedAt},
+    COALESCE(${runDriverInstancesTable.updatedAt}, 0),
+    COALESCE(${runDriverInstancesTable.lastHeartbeatAt}, 0)
+  )`;
+}
+
+function staleActiveRunPredicate(nowMs: number) {
+  return or(
+    inArray(runDriverInstancesTable.status, ["failed", "stopped"]),
+    lte(latestRuntimeObservationSql(), nowMs - RUNTIME_SOCKET_TIMEOUT_MS),
+  );
+}
+
 async function findStaleActiveRun(
   database: D1Database,
   sessionId: SessionId,
 ): Promise<ActiveRunDriverRow | null> {
   const row =
     (await getAppDatabase(database)
-      .select({
-        driver_error_message: runDriverInstancesTable.errorMessage,
-        driver_last_heartbeat_at: runDriverInstancesTable.lastHeartbeatAt,
-        driver_status: runDriverInstancesTable.status,
-        driver_updated_at: runDriverInstancesTable.updatedAt,
-        run_id: sessionRunsTable.id,
-        run_trace_id: sessionRunsTable.traceId,
-        run_updated_at: sessionRunsTable.updatedAt,
-      })
+      .select(activeRunDriverColumns())
       .from(sessionRunsTable)
       .leftJoin(
         runDriverInstancesTable,
@@ -77,7 +105,7 @@ async function findStaleActiveRun(
       .where(
         and(
           eq(sessionRunsTable.sessionId, sessionId),
-          inArray(sessionRunsTable.status, ["queued", "booting", "running", "waiting_input"]),
+          inArray(sessionRunsTable.status, ACTIVE_SESSION_RUN_STATUSES),
         ),
       )
       .orderBy(
@@ -94,16 +122,32 @@ async function findStaleActiveRun(
   return shouldFailActiveRunAsStale(row, currentTimestampMs()) ? row : null;
 }
 
-export async function reconcileStaleActiveSessionRun(
+async function findStaleActiveRuns(
   database: D1Database,
-  sessionId: SessionId,
-): Promise<boolean> {
-  const staleRun = await findStaleActiveRun(database, sessionId);
+  input: {
+    readonly limit: number;
+    readonly nowMs: number;
+  },
+): Promise<ActiveRunDriverRow[]> {
+  return getAppDatabase(database)
+    .select(activeRunDriverColumns())
+    .from(sessionRunsTable)
+    .leftJoin(
+      runDriverInstancesTable,
+      eq(runDriverInstancesTable.id, sessionRunsTable.driverInstanceId),
+    )
+    .where(
+      and(
+        inArray(sessionRunsTable.status, ACTIVE_SESSION_RUN_STATUSES),
+        staleActiveRunPredicate(input.nowMs),
+      ),
+    )
+    .orderBy(asc(sessionRunsTable.updatedAt), asc(sessionRunsTable.id))
+    .limit(input.limit)
+    .all();
+}
 
-  if (!staleRun) {
-    return false;
-  }
-
+async function failStaleActiveRun(database: D1Database, staleRun: ActiveRunDriverRow) {
   const error = staleRunError(staleRun);
   const outcome = await setSessionRunStatus(database, {
     error,
@@ -127,4 +171,43 @@ export async function reconcileStaleActiveSessionRun(
       return false;
     }
   }
+}
+
+export async function reconcileStaleActiveSessionRun(
+  database: D1Database,
+  sessionId: SessionId,
+): Promise<boolean> {
+  const staleRun = await findStaleActiveRun(database, sessionId);
+
+  if (!staleRun) {
+    return false;
+  }
+
+  return failStaleActiveRun(database, staleRun);
+}
+
+export async function reconcileStaleActiveSessionRuns(
+  database: D1Database,
+  input: {
+    readonly limit: number;
+  },
+): Promise<StaleActiveRunReconciliationResult> {
+  const staleRuns = await findStaleActiveRuns(database, {
+    limit: input.limit,
+    nowMs: currentTimestampMs(),
+  });
+  const reconciledRunIds: SessionRunId[] = [];
+  const reconciledSessionIds = new Set<SessionId>();
+
+  for (const staleRun of staleRuns) {
+    if (await failStaleActiveRun(database, staleRun)) {
+      reconciledRunIds.push(staleRun.run_id);
+      reconciledSessionIds.add(staleRun.session_id);
+    }
+  }
+
+  return {
+    reconciledRunIds,
+    reconciledSessionIds: [...reconciledSessionIds],
+  };
 }

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/maintenance.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/maintenance.ts
@@ -5,28 +5,51 @@ import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
 import { getAppDatabase } from "../../../../platform/db/drizzle";
 import { currentTimestampMs } from "../../../../time";
 import { toDriverInstanceStatusLifecycleEventName } from "../../domain/driver-instance-lifecycle.machine";
+import { RUNTIME_SOCKET_TIMEOUT_MS } from "../../domain/runtime-config";
 import { driverInstanceExpiresAt } from "./status";
 
 export async function cleanupDriverInstances(bindings: ApiBindings): Promise<void> {
   const now = currentTimestampMs();
+  const failedStatusPatch = {
+    expiresAt: driverInstanceExpiresAt(now),
+    status: "failed",
+    statusChangedAt: now,
+    statusEvent: toDriverInstanceStatusLifecycleEventName("failed"),
+    statusSeq: sql`${driverInstancesTable.statusSeq} + 1`,
+    statusSource: "maintenance",
+    updatedAt: now,
+  } as const;
 
   await getAppDatabase(bindings.DB)
     .update(driverInstancesTable)
     .set({
+      ...failedStatusPatch,
       errorMessage: sql`COALESCE(${driverInstancesTable.errorMessage}, 'Boot token expired.')`,
-      expiresAt: driverInstanceExpiresAt(now),
-      status: "failed",
-      statusChangedAt: now,
-      statusEvent: toDriverInstanceStatusLifecycleEventName("failed"),
-      statusSeq: sql`${driverInstancesTable.statusSeq} + 1`,
-      statusSource: "maintenance",
-      updatedAt: now,
     })
     .where(
       and(
         sql`${driverInstancesTable.status} = 'provisioning'`,
         isNull(driverInstancesTable.bootTokenUsedAt),
         lte(driverInstancesTable.bootTokenExpiresAt, now),
+      ),
+    )
+    .run();
+
+  await getAppDatabase(bindings.DB)
+    .update(driverInstancesTable)
+    .set({
+      ...failedStatusPatch,
+      closeCode: sql`COALESCE(${driverInstancesTable.closeCode}, 1011)`,
+      closeReason: sql`COALESCE(${driverInstancesTable.closeReason}, 'runtime.heartbeat_timeout')`,
+      errorMessage: sql`COALESCE(${driverInstancesTable.errorMessage}, 'Runtime driver heartbeat timed out.')`,
+    })
+    .where(
+      and(
+        inArray(driverInstancesTable.status, ["connecting", "ready", "stopping"]),
+        lte(
+          sql<number>`COALESCE(${driverInstancesTable.lastHeartbeatAt}, ${driverInstancesTable.updatedAt})`,
+          now - RUNTIME_SOCKET_TIMEOUT_MS,
+        ),
       ),
     )
     .run();

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-lifecycle.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-lifecycle.service.ts
@@ -178,11 +178,11 @@ export class RuntimeSubjectLifecycleService {
     const subject = await this.getHandle(input.runtimeSubjectId);
     const isCold = record === null || record.status === "cold";
 
-    await measureOptional(input.timing, "runtimeSubject.prepareFilesystem", () =>
-      prepareRuntimeSubjectFilesystem(subject),
-    );
-
     try {
+      await measureOptional(input.timing, "runtimeSubject.prepareFilesystem", () =>
+        prepareRuntimeSubjectFilesystem(subject),
+      );
+
       if (isCold) {
         const restoring = await measureOptional(input.timing, "runtimeSubject.markRestoring", () =>
           markRuntimeSubjectRestoring(this.#bindings.DB, {

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service.ts
@@ -9,8 +9,10 @@ import { isTruthy } from "../../../../shared/truthiness";
 import { toIsoString } from "../../../../time";
 import { repairStaleSessionDeleteCleanups } from "../../../sessions/application/session-cleanup.service";
 import { appendSessionRuntimeEvents } from "../../../sessions/application/session-event-write.service";
+import { syncSessionViewerState } from "../../../sessions/application/session-viewer-events.service";
 import { RESCHEDULING_RECONNECT_WINDOW_MS } from "../../../sessions/domain/session-lifecycle";
 import { createSessionLifecycleTerminatedEvent } from "../../application/session-runs/session-run-view-events.service";
+import { reconcileStaleActiveSessionRuns } from "../../application/session-runs/stale-run-reconciliation.service";
 import { cleanupDriverInstances } from "../driver-instance/maintenance";
 import { repairRuntimeCommandRecords } from "../session-runs/runtime-command-store.repository";
 import { createSessionStatusTransitionPatch } from "../session-runs/session-lifecycle-projection.repository";
@@ -249,6 +251,14 @@ export async function runSandboxMaintenance(bindings: ApiBindings): Promise<void
 
   await repairRuntimeCommandRecords(bindings.DB, { nowMs: now });
   await cleanupDriverInstances(bindings);
+  const staleRunReconciliation = await reconcileStaleActiveSessionRuns(bindings.DB, {
+    limit: MAINTENANCE_BATCH_SIZE,
+  });
+  await processInBatches(
+    staleRunReconciliation.reconciledSessionIds,
+    RESCHEDULING_TIMEOUT_IO_BATCH_SIZE,
+    async (sessionId) => syncSessionViewerState(bindings, sessionId),
+  );
   await expireStaleReschedulingSessions(bindings);
   await repairStaleSessionDeleteCleanups(bindings, {
     limit: MAINTENANCE_BATCH_SIZE,

--- a/apps/api/tests/driver-instance-record.test.ts
+++ b/apps/api/tests/driver-instance-record.test.ts
@@ -18,6 +18,7 @@ import {
   markDriverInstanceReady,
   recordDriverInstanceHello,
 } from "../src/modules/runtime/infrastructure/driver-instance/lifecycle";
+import { cleanupDriverInstances } from "../src/modules/runtime/infrastructure/driver-instance/maintenance";
 import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
 import { SqliteD1Database } from "./helpers/sqlite-d1";
 
@@ -301,6 +302,21 @@ describe("driver instance records", () => {
     ).resolves.toMatchObject({
       id: DRIVER_INSTANCE_ID,
       status: "ready",
+    });
+  });
+
+  test("maintenance fails stale live driver records", async () => {
+    const database = createDriverInstanceRecordDatabase();
+    insertDriverRecord(database, {
+      status: "ready",
+      updatedAt: 1,
+    });
+
+    await cleanupDriverInstances(createBindings(database));
+
+    await expect(readDriverRecord(database)).resolves.toMatchObject({
+      errorMessage: "Runtime driver heartbeat timed out.",
+      status: "failed",
     });
   });
 

--- a/apps/api/tests/runtime-subject-lifecycle.test.ts
+++ b/apps/api/tests/runtime-subject-lifecycle.test.ts
@@ -18,8 +18,10 @@ function createRuntimeSubjectLifecycleDatabase(): SqliteD1Database {
 
   database.execute(`
     CREATE TABLE sandbox (
+      bind_mount_ready integer DEFAULT false NOT NULL,
       claim_expires_at integer,
       claim_owner text,
+      created_at integer NOT NULL,
       global_mounts_json text DEFAULT '[]' NOT NULL,
       id text PRIMARY KEY NOT NULL,
       inactive_deadline_at integer,
@@ -34,6 +36,8 @@ function createRuntimeSubjectLifecycleDatabase(): SqliteD1Database {
       status_operation_id text,
       status_seq integer DEFAULT 0 NOT NULL,
       status_source text DEFAULT 'system' NOT NULL,
+      subject_id text NOT NULL,
+      subject_kind text NOT NULL,
       updated_at integer NOT NULL
     );
 
@@ -68,6 +72,7 @@ async function insertRuntimeSubject(
         INSERT INTO sandbox (
           claim_expires_at,
           claim_owner,
+          created_at,
           id,
           inactive_deadline_at,
           kind,
@@ -79,14 +84,17 @@ async function insertRuntimeSubject(
           status_event,
           status_seq,
           status_source,
+          subject_id,
+          subject_kind,
           updated_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
     )
     .bind(
       null,
       null,
+      1,
       RUNTIME_SUBJECT_ID,
       1,
       "cattle",
@@ -98,6 +106,8 @@ async function insertRuntimeSubject(
       `runtime_subject.${input.status === "backing_up" ? "back_up" : input.status}`,
       input.statusSeq ?? 0,
       "test",
+      "01J00000000000000000000009",
+      "session",
       1,
     )
     .run();
@@ -131,7 +141,7 @@ async function readRuntimeSubject(database: D1Database): Promise<{
   return row;
 }
 
-function createSandboxHandle(): SandboxHandle {
+function createSandboxHandle(options: { readonly prepareError?: Error } = {}): SandboxHandle {
   const unavailable = async () => {
     throw new Error("Unexpected sandbox test method call.");
   };
@@ -143,7 +153,11 @@ function createSandboxHandle(): SandboxHandle {
     destroy: unavailable,
     exec: unavailable,
     getSession: unavailable,
-    mkdir: async () => {},
+    mkdir: async () => {
+      if (options.prepareError) {
+        throw options.prepareError;
+      }
+    },
     mountBucket: unavailable,
     readFile: unavailable,
     restoreBackup: unavailable,
@@ -156,11 +170,14 @@ function createSandboxHandle(): SandboxHandle {
   } as SandboxHandle;
 }
 
-function createBindings(database: D1Database): ApiBindings {
+function createBindings(
+  database: D1Database,
+  options: { readonly prepareError?: Error } = {},
+): ApiBindings {
   return {
     DB: database,
     SANDBOX_FILE_BUCKET_LOCAL: "true",
-    runtimeSubjectHandleFactory: () => createSandboxHandle(),
+    runtimeSubjectHandleFactory: () => createSandboxHandle(options),
   } as unknown as ApiBindings;
 }
 
@@ -328,6 +345,47 @@ describe("runtime subject lifecycle machine", () => {
       last_error: null,
       last_error_code: null,
       status: "active",
+    });
+  });
+
+  test("clears activation claim when filesystem preparation fails", async () => {
+    const database = createRuntimeSubjectLifecycleDatabase();
+    const prepareError = new Error("Runtime subject filesystem prepare timed out after 15000ms.");
+
+    await expect(
+      createRuntimeSubjectLifecycleService(createBindings(database, { prepareError })).activate({
+        executionOwnerUserId: "01J00000000000000000000002",
+        kind: "cattle",
+        runtimeSubjectId: RUNTIME_SUBJECT_ID,
+        spaceAliases: [],
+        subjectId: "01J00000000000000000000009",
+        subjectKind: "session",
+      }),
+    ).rejects.toThrow("Runtime subject filesystem prepare timed out after 15000ms.");
+
+    const row = await database
+      .prepare(
+        `
+          SELECT claim_expires_at, claim_owner, last_error, last_error_code, status
+          FROM sandbox
+          WHERE id = ?
+        `,
+      )
+      .bind(RUNTIME_SUBJECT_ID)
+      .first<{
+        claim_expires_at: number | null;
+        claim_owner: string | null;
+        last_error: string | null;
+        last_error_code: string | null;
+        status: string;
+      }>();
+
+    expect(row).toEqual({
+      claim_expires_at: null,
+      claim_owner: null,
+      last_error: "Runtime subject filesystem prepare timed out after 15000ms.",
+      last_error_code: "runtime.subject_activation_failed",
+      status: "error",
     });
   });
 });

--- a/apps/api/tests/session-run-reconciliation.test.ts
+++ b/apps/api/tests/session-run-reconciliation.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { reconcileStaleActiveSessionRun } from "../src/modules/runtime/application/session-runs/stale-run-reconciliation.service";
+import {
+  reconcileStaleActiveSessionRun,
+  reconcileStaleActiveSessionRuns,
+} from "../src/modules/runtime/application/session-runs/stale-run-reconciliation.service";
 import {
   createPublicHttpContractDatabase,
   insertNonOwnerSession,
@@ -54,6 +57,69 @@ describe("session run reconciliation", () => {
     await expect(
       reconcileStaleActiveSessionRun(database, "01J0000000000000000000000B"),
     ).resolves.toBe(true);
+
+    const run = await database
+      .prepare("SELECT error_code, status FROM session_run WHERE id = ?")
+      .bind("run-stale")
+      .first<{ error_code: string | null; status: string }>();
+    expect(run).toMatchObject({
+      status: "failed",
+    });
+    expect(run?.error_code).toBeString();
+  });
+
+  test("reconciles stale active runs in batches", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertNonOwnerSession(database);
+
+    await database
+      .prepare(
+        `
+          INSERT INTO session_run (
+            id,
+            session_id,
+            agent_id,
+            created_by_account_id,
+            trigger,
+            status,
+            provider,
+            model,
+            runtime_id,
+            trace_id,
+            created_at,
+            updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+      )
+      .bind(
+        "run-stale",
+        "01J0000000000000000000000B",
+        "01J00000000000000000000009",
+        "01J00000000000000000000002",
+        "user_prompt",
+        "running",
+        "openai",
+        "gpt-5.4",
+        "openai-runtime",
+        "trace-stale",
+        1,
+        1,
+      )
+      .run();
+    await database
+      .prepare("UPDATE session SET last_run_id = ?, status = ? WHERE id = ?")
+      .bind("run-stale", "RUNNING", "01J0000000000000000000000B")
+      .run();
+
+    await expect(
+      reconcileStaleActiveSessionRuns(database, {
+        limit: 10,
+      }),
+    ).resolves.toEqual({
+      reconciledRunIds: ["run-stale"],
+      reconciledSessionIds: ["01J0000000000000000000000B"],
+    });
 
     const run = await database
       .prepare("SELECT error_code, status FROM session_run WHERE id = ?")


### PR DESCRIPTION
## Summary
- fail stale live driver records during scheduled runtime maintenance
- reconcile stale active session runs in maintenance and sync open session viewers
- cover batch run reconciliation and stale live driver cleanup with tests

## Verification
- bun test apps/api/tests/session-run-reconciliation.test.ts apps/api/tests/driver-instance-record.test.ts apps/api/tests/runtime-subject-maintenance.test.ts
- bun run --cwd apps/api tc
- bun run fmt:check:path apps/api/src/modules/runtime/application/session-runs/stale-run-reconciliation.service.ts apps/api/src/modules/runtime/infrastructure/driver-instance/maintenance.ts apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service.ts apps/api/tests/session-run-reconciliation.test.ts apps/api/tests/driver-instance-record.test.ts