### PR TITLE
fix(web): stop forcing scroll to bottom after user takes over scrolling

### DIFF
--- a/apps/web/src/features/session-chat/use-session-chat-layout-state.ts
+++ b/apps/web/src/features/session-chat/use-session-chat-layout-state.ts
@@ -2,6 +2,10 @@ import type { SessionViewMessage } from "@mosoo/ag-ui-session";
 import { useEffect, useRef } from "react";
 import type { RefObject } from "react";
 
+// Once the user scrolls more than this far from the bottom, treat them as having
+// taken over scroll control and stop forcing the view back down on new content.
+const STICK_TO_BOTTOM_THRESHOLD_PX = 32;
+
 function getLastMessageSignature(message: SessionViewMessage | null): string | null {
   if (message === null) {
     return null;
@@ -47,6 +51,35 @@ export function useSessionChatLayoutState(
   const previousLastMessageIdRef = useRef<string | null>(null);
   const previousMessageCountRef = useRef(0);
   const previousLastMessageSignatureRef = useRef<string | null>(null);
+  // Whether new content should keep pinning the view to the bottom. Flips to false
+  // as soon as the user scrolls up (takes over control via the mouse wheel) and back
+  // to true once they return to the bottom.
+  const stickToBottomRef = useRef(true);
+
+  // Track the user's scroll position so we know whether they have taken over control.
+  useEffect(() => {
+    const viewport = messagesEndRef.current?.closest<HTMLElement>(
+      "[data-slot=scroll-area-viewport]",
+    );
+
+    if (!viewport) {
+      return;
+    }
+
+    const syncStickToBottom = (): void => {
+      const distanceFromBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+      stickToBottomRef.current = distanceFromBottom <= STICK_TO_BOTTOM_THRESHOLD_PX;
+    };
+
+    // Don't sync on mount: the default (stick to bottom) preserves the initial
+    // scroll-to-bottom even when a session loads with history above the fold.
+    // Only a real user scroll should hand control over.
+    viewport.addEventListener("scroll", syncStickToBottom, { passive: true });
+
+    return () => {
+      viewport.removeEventListener("scroll", syncStickToBottom);
+    };
+  }, []);
 
   // Scroll position is an external browser state, so keep this sync at the hook boundary.
   useEffect(() => {
@@ -68,6 +101,12 @@ export function useSessionChatLayoutState(
       !lastMessageContentChanged &&
       !scrollSignal
     ) {
+      return;
+    }
+
+    // The user has scrolled up to read earlier content; don't yank them back to the
+    // bottom on new events or streaming output until they return there themselves.
+    if (!stickToBottomRef.current) {
       return;
     }
 


### PR DESCRIPTION
## Summary

- When the user scrolls up in the session chat (taking over scroll control via the mouse wheel), new events and streaming output no longer force the view back to the bottom.
- Auto-scroll resumes automatically once the user returns to the bottom themselves.

## Why

- Previously every new message, streaming chunk, or event called `scrollIntoView`, yanking the user back to the bottom even while they were reading earlier content — making it impossible to review history during an active stream.

## Verification

- Commands: `bunx tsc --noEmit` (apps/web), `vp lint apps/web/src/features/session-chat/`, `vp fmt --check` — all pass.
- Manual steps: open an agent session with a streaming response; scroll up mid-stream and confirm the view stays put as new content arrives; scroll back to the bottom and confirm auto-scroll resumes.

## Risk And Blast Radius

- Affected packages: `@mosoo/web` (`features/session-chat/use-session-chat-layout-state.ts` only).
- Affected user flows or APIs: session chat auto-scroll behavior.
- Rollback: revert the single commit.

## Evidence

- UI/UX: this is a dynamic scroll-during-stream interaction rather than a static visual change, so a still screenshot does not capture it; behavior is described under Verification. Happy to attach a screen recording if preferred.
- Behavior: auto-scroll is now gated on whether the viewport is within 32px of the bottom; the gate flips only on real user scroll events, so the initial scroll-to-bottom on session load is preserved.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: `use-session-chat-layout-state.ts` scroll listener and the stick-to-bottom gate.
- Known trade-offs: relies on `scrollIntoView` firing a scroll event to re-arm stickiness; intentionally does not sync stickiness on mount so loading a session with history still scrolls to the latest message.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `fix`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: if prompted by CLA Assistant, every human contributor has signed
- [ ] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence, or N/A (dynamic interaction — see Evidence)
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A — no generated artifacts touched.
