### PR TITLE
fix(web): drop '@' prefix from session file mentions

### DIFF
--- a/apps/web/src/features/session-chat/session-resource-mentions.ts
+++ b/apps/web/src/features/session-chat/session-resource-mentions.ts
@@ -26,7 +26,11 @@ export function appendSessionResourceMentionsToMessage(
   message: string,
   mentions: SessionResourceMention[],
 ): string {
-  const paths = uniqueMentions(mentions).map((mention) => `@${mention.path}`);
+  // Reference the file by its plain sandbox-relative path. The agent runtime does
+  // not resolve "@" mentions, so prefixing one would be passed to the model verbatim
+  // and treated as a literal path ("@session-files/...") that does not exist on disk,
+  // forcing the agent to hunt for the real "session-files/..." path. See YEF-713.
+  const paths = uniqueMentions(mentions).map((mention) => mention.path);
 
   if (paths.length === 0) {
     return message;

--- a/apps/web/tests/session-resource-mentions.test.ts
+++ b/apps/web/tests/session-resource-mentions.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import { appendSessionResourceMentionsToMessage } from "../src/features/session-chat/session-resource-mentions";
+import type { SessionResourceMention } from "../src/features/session-chat/session-resource-mentions";
+
+function mention(path: string, name = path): SessionResourceMention {
+  return { id: path, name, path };
+}
+
+describe("appendSessionResourceMentionsToMessage", () => {
+  test("appends the plain sandbox-relative path without an '@' prefix", () => {
+    const result = appendSessionResourceMentionsToMessage("translate to english", [
+      mention("session-files/01KVQ/mosoo Product Concept (standalone).html"),
+    ]);
+
+    expect(result).toBe(
+      "translate to english\n\nsession-files/01KVQ/mosoo Product Concept (standalone).html",
+    );
+    // The agent runtime does not resolve "@" mentions; a prefixed path would be
+    // read verbatim and fail as "file not exist". See YEF-713.
+    expect(result).not.toContain("@session-files");
+  });
+
+  test("returns only the paths when the message is empty", () => {
+    const result = appendSessionResourceMentionsToMessage("   ", [
+      mention("session-files/a/one.txt"),
+      mention("session-files/b/two.txt"),
+    ]);
+
+    expect(result).toBe("session-files/a/one.txt\nsession-files/b/two.txt");
+  });
+
+  test("deduplicates mentions that share a path", () => {
+    const result = appendSessionResourceMentionsToMessage("look", [
+      mention("session-files/a/one.txt"),
+      mention("session-files/a/one.txt"),
+    ]);
+
+    expect(result).toBe("look\n\nsession-files/a/one.txt");
+  });
+
+  test("leaves the message untouched when there are no mentions", () => {
+    expect(appendSessionResourceMentionsToMessage("hello", [])).toBe("hello");
+  });
+});


### PR DESCRIPTION
## Summary

- Stop prefixing uploaded session files with `@` when appending them to a chat message. The agent now receives the plain sandbox-relative path (`session-files/<id>/<name>`) it can open directly.

## Why

- When a user uploads an attachment, the composer appended it as `@session-files/<id>/<name>`. The agent runtime does **not** resolve `@` mentions, so this string reached the model verbatim and was treated as a literal filesystem path. That path does not exist on disk (the file is mounted at `session-files/<id>/<name>` relative to the session cwd), so the agent always reported "file not exist" and then had to `find` the real path in the sandbox before it could read the file. Closes YEF-713.

## Verification

- Commands: `bun test apps/web/tests/session-resource-mentions.test.ts` (4 pass).
- Manual steps: N/A (dependencies not installed in this environment; change is a one-line, type-safe formatter edit covered by the new unit test).

## Risk And Blast Radius

- Affected packages: `@mosoo/web`.
- Affected user flows or APIs: the message text produced when a user attaches a session file in the agent composer.
- Rollback: revert this commit.

## Evidence

- Root cause reproduced in the issue screenshot: agent `Read("@session-files/.../mosoo Product Concept (standalone).html")` → "File does not exist", followed by `find . -name "*mosoo*"` discovering `./session-files/.../mosoo Product Concept (standalone).html`.
- Test output: `4 pass, 0 fail`.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review area: `apps/web/src/features/session-chat/session-resource-mentions.ts`.
- Known trade-offs: the user's own message bubble now shows a bare relative path instead of an `@`-prefixed one. No UI code parses the `@` prefix, so display is unaffected aside from the leading character.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `fix`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [x] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A (no visual component change; text-format only)
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A
