### PR TITLE
feat(web): allow attachment upload before preview session is initialized

### DIFF
--- a/apps/web/src/features/session-chat/session-composer.tsx
+++ b/apps/web/src/features/session-chat/session-composer.tsx
@@ -13,8 +13,6 @@ interface SessionComposerError {
 
 interface SessionComposerProps {
   composerError: SessionComposerError | null;
-  fileUploadDisabled?: boolean;
-  fileUploadDisabledReason?: string | null;
   fileInputRef: React.RefObject<HTMLInputElement | null>;
   input: string;
   inputRef: React.RefObject<HTMLTextAreaElement | null>;
@@ -83,8 +81,6 @@ function SessionResourceChips({
 
 export function SessionComposer({
   composerError,
-  fileUploadDisabled = false,
-  fileUploadDisabledReason = null,
   fileInputRef,
   input,
   inputRef,
@@ -152,13 +148,7 @@ export function SessionComposer({
             multiple
             className="hidden"
             aria-label="Attach files"
-            disabled={fileUploadDisabled}
             onChange={(event) => {
-              if (fileUploadDisabled) {
-                event.target.value = "";
-                return;
-              }
-
               if (event.target.files) {
                 onFilesSelected([...event.target.files]);
               }
@@ -168,15 +158,11 @@ export function SessionComposer({
           />
           <button
             type="button"
-            disabled={fileUploadDisabled}
             onClick={() => {
-              if (!fileUploadDisabled) {
-                fileInputRef.current?.click();
-              }
+              fileInputRef.current?.click();
             }}
             className="text-fg-3 hover:bg-ink-900/[0.05] hover:text-fg-1 inline-flex size-7 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed disabled:opacity-40"
             aria-label="Attach file"
-            title={fileUploadDisabledReason ?? undefined}
           >
             <Paperclip className="size-4" />
           </button>

--- a/apps/web/src/routes/agent/components/agent-session-panel-rules.ts
+++ b/apps/web/src/routes/agent/components/agent-session-panel-rules.ts
@@ -28,11 +28,6 @@ export interface RuntimeReadyWaitInput {
   waitForRuntimeReadyOnNewSession: boolean;
 }
 
-export interface SessionFileUploadBlockInput {
-  activeSessionId: string | null;
-  tone: AgentSessionPanelTone;
-}
-
 export function getReadinessBlockMessage(readiness: AgentReadiness | null): string | null {
   if (readiness === null || readiness.issues.length === 0 || readiness.ready) {
     return null;
@@ -85,10 +80,6 @@ export function shouldWaitForRuntimeReadyOnNewSession(input: RuntimeReadyWaitInp
 
 export function getSessionControlMode(tone: AgentSessionPanelTone): SessionControlMode {
   return tone === "preview" ? "reset" : "new_session";
-}
-
-export function shouldBlockSessionFileUpload(input: SessionFileUploadBlockInput): boolean {
-  return input.tone === "preview" && input.activeSessionId === null;
 }
 
 export function createSessionAutoTitle(typedText: string): string {

--- a/apps/web/src/routes/agent/components/agent-session-panel.tsx
+++ b/apps/web/src/routes/agent/components/agent-session-panel.tsx
@@ -21,7 +21,7 @@ import { Button } from "@/shared/ui/button";
 import { isTruthy } from "../../../shared/lib/truthiness";
 import { AgentReadinessBlockersBanner } from "./agent-readiness-blockers-banner";
 import { AgentSessionPanelHeader } from "./agent-session-panel-header";
-import { getSessionControlMode, shouldBlockSessionFileUpload } from "./agent-session-panel-rules";
+import { getSessionControlMode } from "./agent-session-panel-rules";
 import {
   deriveSessionPill,
   readinessBlockSummary,
@@ -95,13 +95,6 @@ export function AgentSessionPanel({
       },
     ];
   });
-  const fileUploadDisabled = shouldBlockSessionFileUpload({
-    activeSessionId: model.activeSessionId,
-    tone,
-  });
-  const fileUploadDisabledReason = fileUploadDisabled
-    ? "Send a test message before attaching files to this preview chat."
-    : null;
   const sessionLoadErrorMessage = previewResetMode
     ? "Failed to load the previous preview chat. You can still send a new test message."
     : "Failed to load previous sessions. You can still start a new live run.";
@@ -119,7 +112,7 @@ export function AgentSessionPanel({
     : model.handleStartNewSession;
 
   const handleUploadFiles = async (files: File[]): Promise<void> => {
-    if (files.length === 0 || fileUploadDisabled) {
+    if (files.length === 0) {
       return;
     }
 
@@ -296,8 +289,6 @@ export function AgentSessionPanel({
 
           <SessionComposer
             composerError={model.composerError}
-            fileUploadDisabled={fileUploadDisabled}
-            fileUploadDisabledReason={fileUploadDisabledReason}
             fileInputRef={model.fileInputRef}
             input={model.input}
             inputRef={model.inputRef}

--- a/apps/web/tests/agent-session-panel-boundary.test.ts
+++ b/apps/web/tests/agent-session-panel-boundary.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 
 import {
   getSessionControlMode,
-  shouldBlockSessionFileUpload,
   shouldWaitForRuntimeReadyOnNewSession,
 } from "../src/routes/agent/components/agent-session-panel-rules";
 import {
@@ -35,14 +34,6 @@ describe("agent session panel boundary", () => {
   test("uses Reset chat instead of New session in Preview mode", () => {
     expect(getSessionControlMode("preview")).toBe("reset");
     expect(getSessionControlMode("consume")).toBe("new_session");
-  });
-
-  test("blocks Preview file upload until a preview chat session exists", () => {
-    expect(shouldBlockSessionFileUpload({ activeSessionId: null, tone: "preview" })).toBe(true);
-    expect(shouldBlockSessionFileUpload({ activeSessionId: "session_1", tone: "preview" })).toBe(
-      false,
-    );
-    expect(shouldBlockSessionFileUpload({ activeSessionId: null, tone: "consume" })).toBe(false);
   });
 
   test("resets all known Preview chat sessions instead of falling back to older history", () => {


### PR DESCRIPTION
## Summary

- Allow users to attach/upload files in the preview chat composer before a session is initialized. The attachment button is no longer disabled when no active preview session exists.

## Why

- The composer disabled the attachment button until the user sent a first message in a preview chat, so files could not be attached on a fresh, uninitialized session.
- The upload handler already creates a session on demand (`ensureActiveSession` → `createSessionAndSelect`), so the block was an artificial restriction. Selecting a file now creates the session and uploads in one step.

## Verification

- Commands:
  - `bun run --filter @mosoo/web test` → 132 pass / 0 fail
  - `bun run --filter @mosoo/web tc` → exit 0
  - `vp lint` + `vp fmt --check` on changed files → clean
- Manual steps: open an agent preview with no session, click the paperclip, pick a file — a session is created and the file uploads as a pending chip.

## Risk And Blast Radius

- Affected packages: `@mosoo/web`
- Affected user flows: agent preview chat composer file attachment
- Rollback: revert this commit

## Evidence

- UI/UX: attachment button in the preview composer is enabled without an active session (the disabled/greyed state shown in the issue screenshot is removed).
- Test output: see Verification above.

## Compatibility

- Public contract changes: none
- Env or config changes: none
- Deployment or migration: none

## Reviewer Focus

- Removal of `shouldBlockSessionFileUpload` and the `fileUploadDisabled` / `fileUploadDisabledReason` plumbing across `agent-session-panel-rules.ts`, `agent-session-panel.tsx`, and `session-composer.tsx`.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `feat`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: behavior described in Evidence

## Generated Files, Schema, And Lockfile

- N/A
