### PR TITLE
feat(openapi): add thread file upload endpoint

### DIFF
--- a/apps/api/src/adapters/http/routes/public-api-openapi.ts
+++ b/apps/api/src/adapters/http/routes/public-api-openapi.ts
@@ -5,6 +5,7 @@ import {
   PUBLIC_THREAD_API_THREADS_MAX_LIMIT,
   PUBLIC_THREAD_EVENTS_DEFAULT_LIMIT,
   PUBLIC_THREAD_EVENTS_MAX_LIMIT,
+  PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES,
   PUBLIC_API_VERSION,
 } from "@mosoo/contracts/public-api";
 
@@ -58,6 +59,17 @@ const EXAMPLE_SESSION_FILE = {
   mimeType: "text/plain",
   name: "brief.txt",
   size: 19,
+};
+
+const EXAMPLE_FILE_UPLOAD_SUMMARY = {
+  contentType: "text/plain",
+  expectedSize: 19,
+  expiresAt: "2026-05-20T00:02:00.000Z",
+  fileId: EXAMPLE_FILE_ID,
+  partSize: null,
+  path: `session-files/${EXAMPLE_FILE_ID}/brief.txt`,
+  status: "pending",
+  strategy: "single_put",
 };
 
 function platformIdPathParameter(input: {
@@ -443,6 +455,33 @@ export function createPublicApiOpenApiDocument(origin: string): PublicApiOpenApi
           ),
         },
         summary: "Add a Thread file",
+      }),
+    },
+    "/threads/{threadId}/files/uploads": {
+      post: operation({
+        description: `Creates a files API upload session scoped to this Thread. The request only supplies file metadata; Mosoo resolves the backing App and Session from the Thread and creates a session attachment upload. MVP public uploads must be ${PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES} bytes or fewer and use single PUT.`,
+        parameters: [threadIdParameter],
+        security: ACCESS_TOKEN_SECURITY,
+        requestBody: jsonRequestBody(
+          {
+            $ref: "#/components/schemas/CreateThreadFileUploadRequest",
+          },
+          {
+            file: {
+              contentType: "text/plain",
+              name: "brief.txt",
+              size: 19,
+            },
+          },
+        ),
+        success: {
+          "201": jsonResponse(
+            "Created files API upload session.",
+            { $ref: "#/components/schemas/FileUploadSummary" },
+            EXAMPLE_FILE_UPLOAD_SUMMARY,
+          ),
+        },
+        summary: "Create a Thread file upload",
       }),
     },
     "/threads/{threadId}/files/{fileId}": {

--- a/apps/api/src/adapters/http/routes/public-api-route.ts
+++ b/apps/api/src/adapters/http/routes/public-api-route.ts
@@ -23,6 +23,7 @@ import {
   parseThreadEventsLimit,
   readCreateThreadRequest,
   readCreateThreadFileRequest,
+  readCreateThreadFileUploadRequest,
   readSendEventsRequest,
 } from "./public-thread-api-request";
 import type { ParsedCreateThreadRequest } from "./public-thread-api-request";
@@ -251,6 +252,20 @@ export function registerPublicApiRoute(app: Hono<ApiGatewayEnvironment>) {
           caller.viewer,
           threadId,
           await readCreateThreadFileRequest(c),
+        ),
+      201,
+    ),
+  );
+
+  v1.post("/threads/:threadId/files/uploads", async (c) =>
+    runPublicThreadFileRoute(
+      c,
+      async ({ caller, service, threadId }) =>
+        service.createPublicThreadFileUpload(
+          c.env,
+          caller.viewer,
+          threadId,
+          await readCreateThreadFileUploadRequest(c),
         ),
       201,
     ),

--- a/apps/api/src/adapters/http/routes/public-thread-api-request.ts
+++ b/apps/api/src/adapters/http/routes/public-thread-api-request.ts
@@ -1,4 +1,5 @@
 import type {
+  CreatePublicThreadFileUploadRequest,
   CreatePublicThreadFileRequest,
   PublicThreadApiSendEventsRequest,
 } from "@mosoo/contracts/public-api";
@@ -7,6 +8,7 @@ import {
   PUBLIC_THREAD_EVENTS_MAX_LIMIT,
   PUBLIC_THREAD_CLIENT_EXTERNAL_REF_MAX_LENGTH,
   PUBLIC_THREAD_FILE_ID_MAX_LENGTH,
+  PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES,
   PUBLIC_THREAD_INPUT_TEXT_MAX_LENGTH,
   PUBLIC_THREAD_JSON_BODY_MAX_BYTES,
 } from "@mosoo/contracts/public-api";
@@ -47,6 +49,12 @@ const THREAD_EVENT_PERMISSION_DECISION_FIELDS: ReadonlySet<string> = new Set([
 ]);
 const THREAD_EVENT_USER_INTERRUPT_FIELDS: ReadonlySet<string> = new Set(["type", "runId"]);
 const THREAD_FILE_REQUEST_FIELDS: ReadonlySet<string> = new Set(["fileId"]);
+const THREAD_FILE_UPLOAD_REQUEST_FIELDS: ReadonlySet<string> = new Set(["file"]);
+const THREAD_FILE_UPLOAD_FILE_FIELDS: ReadonlySet<string> = new Set([
+  "name",
+  "contentType",
+  "size",
+]);
 const CREATE_THREAD_REQUEST_FIELDS: ReadonlySet<string> = new Set([
   "input",
   "files",
@@ -202,6 +210,16 @@ function readStringField(input: Record<string, unknown>, field: string): string 
 
   if (typeof value !== "string" || value.trim().length === 0) {
     throw publicInvalidRequest(`${field} is required.`);
+  }
+
+  return value;
+}
+
+function readSafeIntegerField(input: Record<string, unknown>, field: string): number {
+  const value = input[field];
+
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) {
+    throw publicInvalidRequest(`${field} must be an integer.`);
   }
 
   return value;
@@ -482,6 +500,44 @@ export async function readCreateThreadFileRequest(
       readLimitedStringField(body, "fileId", PUBLIC_THREAD_FILE_ID_MAX_LENGTH),
       "fileId",
     ) as FileId,
+  };
+}
+
+export async function readCreateThreadFileUploadRequest(
+  c: RawJsonRequestContext,
+): Promise<CreatePublicThreadFileUploadRequest> {
+  const body = await readJsonBodyWithLimit(c, PUBLIC_THREAD_JSON_BODY_MAX_BYTES);
+
+  if (!isRecord(body)) {
+    throw publicInvalidRequest("Request body must be an object.");
+  }
+
+  assertOnlyFields(body, THREAD_FILE_UPLOAD_REQUEST_FIELDS, "thread file upload request");
+  const file = body["file"];
+
+  if (!isRecord(file)) {
+    throw publicInvalidRequest("file must be an object.");
+  }
+
+  assertOnlyFields(file, THREAD_FILE_UPLOAD_FILE_FIELDS, "thread file upload file");
+  const size = readSafeIntegerField(file, "size");
+
+  if (size < 0) {
+    throw publicInvalidRequest("file.size must be a non-negative integer.");
+  }
+
+  if (size > PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES) {
+    throw publicInvalidRequest(
+      `file.size must be ${PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES} bytes or fewer.`,
+    );
+  }
+
+  return {
+    file: {
+      contentType: readStringField(file, "contentType"),
+      name: readStringField(file, "name"),
+      size,
+    },
   };
 }
 

--- a/apps/api/src/modules/public-api/public-thread-file-api.service.ts
+++ b/apps/api/src/modules/public-api/public-thread-file-api.service.ts
@@ -1,6 +1,7 @@
-import type { FileEntry, FileRecord } from "@mosoo/contracts/file";
+import type { CreateFileUploadResponse, FileEntry, FileRecord } from "@mosoo/contracts/file";
 import type { PublicThreadFile } from "@mosoo/contracts/public-api";
 import type {
+  CreatePublicThreadFileUploadRequest,
   CreatePublicThreadFileRequest,
   PublicThreadFileListResponse,
   PublicThreadFileResponse,
@@ -42,7 +43,7 @@ function toPublicThreadFile(file: FileEntry | FileRecord): PublicThreadFile {
   return {
     committed: true,
     createdAt: file.createdAt,
-    id: parsePlatformId(file.id, "File ID") as FileId,
+    id: parsePlatformId<FileId>(file.id, "File ID"),
     kind: file.sessionKind ?? "attachment",
     mimeType: file.mimeType,
     name: file.name,
@@ -64,6 +65,20 @@ export async function listPublicThreadFiles(
       })
     ).files.map(toPublicThreadFile),
   };
+}
+
+export async function createPublicThreadFileUpload(
+  bindings: ApiBindings,
+  caller: AuthenticatedViewer,
+  threadId: PublicThreadId,
+  input: CreatePublicThreadFileUploadRequest,
+): Promise<CreateFileUploadResponse> {
+  const { appId, sessionId } = await admitPublicThreadFileAccess(bindings, caller, threadId);
+  return fileStore.createSessionResourceUpload(bindings, caller, {
+    appId,
+    file: input.file,
+    sessionId,
+  });
 }
 
 export async function createPublicThreadFile(

--- a/apps/api/tests/api-web-boundary-fixtures.ts
+++ b/apps/api/tests/api-web-boundary-fixtures.ts
@@ -1,3 +1,4 @@
+import type { CreateFileUploadResponse } from "@mosoo/contracts/file";
 import type { PublicThreadSummary } from "@mosoo/contracts/public-api";
 import type { SessionFile, SessionSummary } from "@mosoo/contracts/session";
 import type { SessionRunSummary } from "@mosoo/contracts/session-run";
@@ -184,5 +185,18 @@ export function createSessionFile(): SessionFile {
     mimeType: "text/plain",
     name: "brief.txt",
     size: 19,
+  };
+}
+
+export function createFileUploadSummary(): CreateFileUploadResponse {
+  return {
+    contentType: "text/plain",
+    expectedSize: 19,
+    expiresAt: "2026-05-20T00:02:00.000Z",
+    fileId: PUBLIC_API_TEST_IDS.file,
+    partSize: null,
+    path: `session-files/${PUBLIC_API_TEST_IDS.file}/brief.txt`,
+    status: "pending",
+    strategy: "single_put",
   };
 }

--- a/apps/api/tests/api-web-boundary.test.ts
+++ b/apps/api/tests/api-web-boundary.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { PUBLIC_API_ERROR_CODES } from "@mosoo/contracts/public-api";
+import {
+  PUBLIC_API_ERROR_CODES,
+  PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES,
+} from "@mosoo/contracts/public-api";
 import type { AgentSessionEventBatch } from "@mosoo/contracts/session";
 import { PLATFORM_ID_INPUT_PATTERN } from "@mosoo/id";
 import { isEnumType, isInputObjectType, isObjectType } from "graphql";
@@ -11,12 +14,14 @@ import {
   parseOptionalBoolean,
   readCreateThreadRequest,
   readCreateThreadFileRequest,
+  readCreateThreadFileUploadRequest,
   readSendEventsRequest,
 } from "../src/adapters/http/routes/public-thread-api-request";
 import { PublicApiError } from "../src/modules/public-api/public-api-errors";
 import { toPublicThreadEventBatch } from "../src/modules/public-api/public-thread-api-presenter";
 import {
   createChunkedJsonRequest,
+  createFileUploadSummary,
   createRunSummary,
   createSessionFile,
   createSessionSummary,
@@ -284,6 +289,7 @@ describe("API to web boundary", () => {
       "/threads/{threadId}/events",
       "/threads/{threadId}/events/stream",
       "/threads/{threadId}/files",
+      "/threads/{threadId}/files/uploads",
       "/threads/{threadId}/files/{fileId}",
       "/threads/{threadId}/unarchive",
     ]);
@@ -419,6 +425,19 @@ describe("API to web boundary", () => {
     const fileProperties = openApiSchemaProperties("ThreadFile");
     expectProperties(fileProperties, ["committed", "createdAt", "id", "kind", "name", "size"]);
     expectNoProperties(fileProperties, ["objectKey", "path", "scopeId", "scopeKind"]);
+
+    const uploadProperties = openApiSchemaProperties("FileUploadSummary");
+    expectProperties(uploadProperties, [
+      "contentType",
+      "expectedSize",
+      "expiresAt",
+      "fileId",
+      "partSize",
+      "path",
+      "status",
+      "strategy",
+    ]);
+    expectNoProperties(uploadProperties, ["purpose", "scopeId", "scopeKind", "target"]);
   });
 
   test("parses the Public Thread API create-work body shape", async () => {
@@ -580,6 +599,11 @@ describe("API to web boundary", () => {
 
   test("keeps Public Thread file OpenAPI examples aligned with public readers and responses", async () => {
     const requestExample = openApiJsonRequestExample("/threads/{threadId}/files", "post");
+    const uploadRequestExample = openApiJsonRequestExample(
+      "/threads/{threadId}/files/uploads",
+      "post",
+    );
+    const uploadSummary = createFileUploadSummary();
     const sessionFile = createSessionFile();
 
     await expect(
@@ -599,12 +623,36 @@ describe("API to web boundary", () => {
       fileId: PUBLIC_API_TEST_IDS.file,
     });
 
+    await expect(
+      readCreateThreadFileUploadRequest({
+        req: {
+          raw: new Request(
+            `https://api.example.com/api/v1/threads/${PUBLIC_API_TEST_IDS.nonOwnerSession}/files/uploads`,
+            {
+              body: JSON.stringify(uploadRequestExample),
+              headers: { "Content-Type": "application/json" },
+              method: "POST",
+            },
+          ),
+        },
+      }),
+    ).resolves.toEqual({
+      file: {
+        contentType: "text/plain",
+        name: "brief.txt",
+        size: 19,
+      },
+    });
+
     expect(openApiJsonResponseExample("/threads/{threadId}/files", "get", "200")).toEqual({
       files: [sessionFile],
     });
     expect(openApiJsonResponseExample("/threads/{threadId}/files", "post", "201")).toEqual({
       file: sessionFile,
     });
+    expect(openApiJsonResponseExample("/threads/{threadId}/files/uploads", "post", "201")).toEqual(
+      uploadSummary,
+    );
   });
 
   test("accepts the three public thread event input shapes", async () => {
@@ -703,6 +751,57 @@ describe("API to web boundary", () => {
                 contentType: "text/plain",
                 mountPath: "/workspace/brief.txt",
                 name: "brief.txt",
+              }),
+              headers: { "Content-Type": "application/json" },
+              method: "POST",
+            },
+          ),
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_request",
+      status: 400,
+    });
+
+    await expect(
+      readCreateThreadFileUploadRequest({
+        req: {
+          raw: new Request(
+            `https://api.example.com/api/v1/threads/${PUBLIC_API_TEST_IDS.nonOwnerSession}/files/uploads`,
+            {
+              body: JSON.stringify({
+                file: {
+                  contentType: "text/plain",
+                  name: "too-large.txt",
+                  size: PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES + 1,
+                },
+              }),
+              headers: { "Content-Type": "application/json" },
+              method: "POST",
+            },
+          ),
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_request",
+      status: 400,
+    });
+
+    await expect(
+      readCreateThreadFileUploadRequest({
+        req: {
+          raw: new Request(
+            `https://api.example.com/api/v1/threads/${PUBLIC_API_TEST_IDS.nonOwnerSession}/files/uploads`,
+            {
+              body: JSON.stringify({
+                file: {
+                  contentType: "text/plain",
+                  name: "brief.txt",
+                  size: 19,
+                },
+                target: {
+                  kind: "session",
+                },
               }),
               headers: { "Content-Type": "application/json" },
               method: "POST",

--- a/apps/api/tests/public-thread-api.e2e.test.ts
+++ b/apps/api/tests/public-thread-api.e2e.test.ts
@@ -1057,6 +1057,124 @@ describe("Public Thread API e2e", () => {
     });
   });
 
+  test("creates a Thread file upload through the public files API contract", async () => {
+    const database = await createPublicHttpContractDatabase();
+    const app = createPublicThreadApiTestApp();
+
+    await withProviderProbeMock(async () => {
+      const createThreadResponse = await requestPublicApi(
+        app,
+        database,
+        new Request(`https://api.example.com/api/v1/agents/${PUBLIC_API_TEST_IDS.agent}/threads`, {
+          body: JSON.stringify({
+            client_external_ref: "thread-upload-contract",
+          }),
+          headers: {
+            Authorization: bearer(TOKENS.owner),
+            "Content-Type": "application/json",
+          },
+          method: "POST",
+        }),
+      );
+      expect(createThreadResponse.status).toBe(201);
+      const threadId = expectString(
+        expectRecord(expectRecord(await readJson(createThreadResponse))["thread"])["id"],
+      );
+
+      const fileBody = "Launch note.\n";
+      const fileSize = new TextEncoder().encode(fileBody).byteLength;
+      const createUploadResponse = await requestPublicApi(
+        app,
+        database,
+        new Request(`https://api.example.com/api/v1/threads/${threadId}/files/uploads`, {
+          body: JSON.stringify({
+            file: {
+              contentType: "text/plain",
+              name: "launch-note.txt",
+              size: fileSize,
+            },
+          }),
+          headers: {
+            Authorization: bearer(TOKENS.owner),
+            "Content-Type": "application/json",
+          },
+          method: "POST",
+        }),
+      );
+      expect(createUploadResponse.status).toBe(201);
+
+      const upload = expectRecord(await readJson(createUploadResponse));
+      const fileId = expectString(upload["fileId"]);
+      expect(upload).toMatchObject({
+        contentType: "text/plain",
+        expectedSize: fileSize,
+        partSize: null,
+        path: `session-files/${fileId}/launch-note.txt`,
+        status: "pending",
+        strategy: "single_put",
+      });
+      expectNoProperties(upload, ["purpose", "scopeId", "scopeKind", "target", "upload"]);
+
+      const pendingFileRow = await database
+        .prepare(
+          `SELECT mime_type, owner_id, owner_kind, path, purpose, scope_id, scope_kind, session_kind, size, status
+             FROM file_record
+            WHERE id = ?`,
+        )
+        .bind(fileId)
+        .first<{
+          mime_type: string | null;
+          owner_id: string;
+          owner_kind: string;
+          path: string;
+          purpose: string;
+          scope_id: string;
+          scope_kind: string;
+          session_kind: string;
+          size: number;
+          status: string;
+        }>();
+      expect(pendingFileRow).toEqual({
+        mime_type: "text/plain",
+        owner_id: threadId,
+        owner_kind: "session",
+        path: `attachment/${fileId}/launch-note.txt`,
+        purpose: "session_attachment",
+        scope_id: threadId,
+        scope_kind: "session",
+        session_kind: "attachment",
+        size: fileSize,
+        status: "pending",
+      });
+
+      const uploadRow = await database
+        .prepare(
+          `SELECT expected_size, file_id, part_size, scope_id, scope_kind, status, strategy
+             FROM file_upload
+            WHERE file_id = ?`,
+        )
+        .bind(fileId)
+        .first<{
+          expected_size: number;
+          file_id: string;
+          part_size: number | null;
+          scope_id: string;
+          scope_kind: string;
+          status: string;
+          strategy: string;
+        }>();
+      expect(uploadRow).toEqual({
+        expected_size: fileSize,
+        file_id: fileId,
+        part_size: null,
+        scope_id: threadId,
+        scope_kind: "session",
+        status: "pending",
+        strategy: "single_put",
+      });
+    });
+  });
+
   test("rejects public Thread file claims that are not claimable owner drafts", async () => {
     const database = await createPublicHttpContractDatabase();
     const app = createPublicThreadApiTestApp();

--- a/pkgs/contracts/src/http/public-api-core.contract.ts
+++ b/pkgs/contracts/src/http/public-api-core.contract.ts
@@ -10,6 +10,8 @@ import type {
 } from "@mosoo/id";
 
 import type { AgentKind } from "../agent/agent.contract";
+import { SINGLE_PUT_THRESHOLD_BYTES } from "../file/file.contract";
+import type { CreateFileUploadRequest } from "../file/file.contract";
 import type { UserWarning } from "../session/session-run.contract";
 import {
   SESSION_PROCESS_EVENT_STATUSES,
@@ -26,6 +28,7 @@ export const PUBLIC_API_VERSION = "v1";
 export const PUBLIC_THREAD_INPUT_TEXT_MAX_LENGTH = 32_000;
 export const PUBLIC_THREAD_CLIENT_EXTERNAL_REF_MAX_LENGTH = 255;
 export const PUBLIC_THREAD_FILE_ID_MAX_LENGTH = 26;
+export const PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES = SINGLE_PUT_THRESHOLD_BYTES;
 export const PUBLIC_THREAD_ID_PATTERN = PLATFORM_ID_INPUT_PATTERN;
 export const PUBLIC_THREAD_JSON_BODY_MAX_BYTES = PUBLIC_THREAD_INPUT_TEXT_MAX_LENGTH + 8192;
 export const PUBLIC_THREAD_API_THREADS_MAX_LIMIT = 100;
@@ -184,6 +187,10 @@ export interface PublicThreadApiListThreadEventsResponse {
 
 export interface CreatePublicThreadFileRequest {
   fileId: FileId;
+}
+
+export interface CreatePublicThreadFileUploadRequest {
+  file: CreateFileUploadRequest["file"];
 }
 
 export interface PublicThreadFile {

--- a/pkgs/contracts/src/http/public-api-openapi.contract.ts
+++ b/pkgs/contracts/src/http/public-api-openapi.contract.ts
@@ -1,12 +1,14 @@
 import { PLATFORM_ID_INPUT_PATTERN } from "@mosoo/id";
 
 import { AGENT_KIND_VALUES } from "../agent/agent.contract.ts";
+import { FILE_UPLOAD_STATUSES, FILE_UPLOAD_STRATEGIES } from "../file/file.contract";
 import {
   PUBLIC_API_ERROR_CODES,
   PUBLIC_THREAD_CLIENT_EXTERNAL_REF_MAX_LENGTH,
   PUBLIC_THREAD_EVENT_LOG_STATUSES,
   PUBLIC_THREAD_EVENT_LOG_TYPES,
   PUBLIC_THREAD_FILE_ID_MAX_LENGTH,
+  PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES,
   PUBLIC_THREAD_INPUT_TEXT_MAX_LENGTH,
 } from "./public-api-core.contract";
 
@@ -137,6 +139,95 @@ export const PUBLIC_API_OPENAPI_SCHEMAS = {
       },
     },
     required: ["fileId"],
+    type: "object",
+  },
+  CreateThreadFileUploadRequest: {
+    additionalProperties: false,
+    description: "Request body for creating a files API upload session scoped to this Thread.",
+    properties: {
+      file: {
+        additionalProperties: false,
+        description: "Metadata for the file bytes that will be uploaded.",
+        properties: {
+          contentType: {
+            description: "MIME type for the file bytes.",
+            minLength: 1,
+            type: "string",
+          },
+          name: {
+            description: "Original file name to record for this Thread attachment.",
+            minLength: 1,
+            type: "string",
+          },
+          size: {
+            description:
+              "File size in bytes. Public Thread upload creation currently accepts single-put uploads only.",
+            maximum: PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES,
+            minimum: 0,
+            type: "integer",
+          },
+        },
+        required: ["name", "contentType", "size"],
+        type: "object",
+      },
+    },
+    required: ["file"],
+    type: "object",
+  },
+  FileUploadSummary: {
+    additionalProperties: false,
+    description: "Files API upload session summary returned after creating an upload target.",
+    properties: {
+      contentType: {
+        description: "Normalized MIME type the upload expects.",
+        type: "string",
+      },
+      expectedSize: {
+        description: "Expected file size in bytes for integrity validation.",
+        minimum: 0,
+        type: "integer",
+      },
+      expiresAt: {
+        description: "Timestamp (RFC 3339) when this upload session expires.",
+        format: "date-time",
+        type: "string",
+      },
+      fileId: {
+        ...createPublicApiPlatformIdSchema({
+          maxLength: PUBLIC_THREAD_FILE_ID_MAX_LENGTH,
+          minLength: 1,
+        }),
+        description: "File ID (bare ULID) for this upload session.",
+      },
+      partSize: {
+        description: "Multipart part size in bytes, or null when the upload uses single PUT.",
+        minimum: 1,
+        type: ["integer", "null"],
+      },
+      path: {
+        description: "Materialized file path exposed by the files API upload summary.",
+        minLength: 1,
+        type: "string",
+      },
+      status: {
+        description: "Current files API upload session status.",
+        enum: FILE_UPLOAD_STATUSES,
+      },
+      strategy: {
+        description: "Files API upload transfer strategy selected for the file size.",
+        enum: FILE_UPLOAD_STRATEGIES,
+      },
+    },
+    required: [
+      "contentType",
+      "expectedSize",
+      "expiresAt",
+      "fileId",
+      "partSize",
+      "path",
+      "status",
+      "strategy",
+    ],
     type: "object",
   },
   ErrorResponse: {


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/threads/{threadId}/files/uploads` to create a Thread-scoped file upload session through the public OpenAPI surface.
- Reuse the existing file upload contract shape and route the service through `fileStore.createSessionResourceUpload` so uploads stay within the centralized file store flow.
- Document the endpoint in the public OpenAPI schema and cover routing, schema, and public thread behavior with tests.

## Validation

- `just fmt-check-path pkgs/contracts/src/http`
- `just fmt-check-path apps/api/src/adapters/http/routes`
- `just fmt-check-path apps/api/src/modules/public-api`
- `just fmt-check-path apps/api/tests`
- `just tc-package @mosoo/contracts`
- `just tc-package @mosoo/api`
- `vp exec bun test apps/api/tests/api-web-boundary.test.ts apps/api/tests/public-thread-api.e2e.test.ts`

## Generated files / codegen / DB baseline

- Generated files: no
- GraphQL codegen: no
- DB baseline updates: no
