### PR TITLE
fix(runtime): materialize declared sandbox artifacts

### DIFF
--- a/apps/api/src/modules/runtime/application/session-artifacts/session-artifact-prompt.service.ts
+++ b/apps/api/src/modules/runtime/application/session-artifacts/session-artifact-prompt.service.ts
@@ -1,0 +1,16 @@
+const RUNTIME_ARTIFACT_MANIFEST_PROMPT = [
+  "Runtime artifact delivery:",
+  "When you create files that the user should download or keep as session outputs, write a JSON manifest at `.mosoo/artifacts.json` relative to the current working directory after the output files exist.",
+  'Use this shape: {"artifacts":[{"path":"dist/output.txt","contentType":"text/plain"}]}.',
+  "Only include intended deliverables. Artifact paths must be relative to the current working directory.",
+].join("\n");
+
+export function appendRuntimeArtifactContextToPrompt(prompt: string): string {
+  const profilePrompt = prompt.trim();
+
+  if (profilePrompt.length === 0) {
+    return RUNTIME_ARTIFACT_MANIFEST_PROMPT;
+  }
+
+  return [profilePrompt, RUNTIME_ARTIFACT_MANIFEST_PROMPT].join("\n\n");
+}

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/events.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/events.ts
@@ -56,6 +56,12 @@ import type {
   RuntimeSessionLink,
 } from "./event-types";
 import { readNativeResumeRef } from "./native-resume-ref-event";
+import {
+  RUNTIME_ARTIFACT_MANIFEST_PATH,
+  getRuntimeArtifactFileName,
+  isRuntimeArtifactManifestPath,
+  readRuntimeArtifactManifestEntries,
+} from "./runtime-artifact-manifest";
 import { getRuntimeSessionLink } from "./session-link.repository";
 export type {
   AppRuntimeDriverEventsResult,
@@ -157,7 +163,7 @@ async function recordRuntimeFileChanges(input: {
   const sandboxId = input.link.sandboxId;
   const createdBy = resolveRuntimeOutputCreator(input.link);
   const changes = readRuntimeEventFileChanges(input.event).filter(
-    (change) => change.change === "upsert",
+    (change) => change.change === "upsert" && !isRuntimeArtifactManifestPath(change.path),
   );
 
   if (changes.length === 0) {
@@ -213,6 +219,125 @@ async function recordRuntimeFileChanges(input: {
       }
     },
   );
+}
+
+async function recordRuntimeArtifactManifest(input: {
+  bindings: ApiBindings;
+  event: RuntimeEventEnvelope;
+  link: RuntimeSessionLink;
+}): Promise<void> {
+  const sessionId = input.link.sessionId;
+  const sandboxId = input.link.sandboxId;
+  const createdBy = resolveRuntimeOutputCreator(input.link);
+
+  if (sessionId === null || sandboxId === null || createdBy === null) {
+    return;
+  }
+
+  const parsedSessionId = parsePlatformId<SessionId>(sessionId, "runtime output session ID");
+  let conversation;
+
+  try {
+    conversation = await getRuntimeConversationSession(input.bindings.DB, parsedSessionId);
+  } catch (error) {
+    logWarn("runtime.file_artifact.manifest_session_lookup_failed", {
+      ...createErrorLogContext(error),
+      driverInstanceId: input.event.driverInstanceId ?? null,
+      sandboxId,
+      sessionId,
+    });
+    return;
+  }
+
+  if (conversation === null) {
+    return;
+  }
+
+  try {
+    await withDisposedRpcResource(
+      await getRuntimeSubjectKeepAliveHandle(input.bindings, sandboxId),
+      async (sandbox) => {
+        const sandboxSession = await sandbox.getSession(conversation.sandboxSessionId);
+        const manifestPath = resolveSandboxReadPath(
+          conversation.cwd,
+          RUNTIME_ARTIFACT_MANIFEST_PATH,
+        );
+        let manifestBytes: Uint8Array;
+
+        try {
+          manifestBytes = await readSandboxFileBytes(sandboxSession, manifestPath);
+        } catch {
+          return;
+        }
+
+        let manifestEntries;
+
+        try {
+          manifestEntries = readRuntimeArtifactManifestEntries(manifestBytes);
+        } catch (error) {
+          logWarn("runtime.file_artifact.manifest_invalid", {
+            ...createErrorLogContext(error),
+            driverInstanceId: input.event.driverInstanceId ?? null,
+            path: RUNTIME_ARTIFACT_MANIFEST_PATH,
+            sandboxId,
+            sessionId,
+          });
+          return;
+        }
+
+        if (manifestEntries.length === 0) {
+          return;
+        }
+
+        const existingFiles = await fileStore.listReadySessionFiles(
+          input.bindings.DB,
+          parsedSessionId,
+        );
+        const recordedArtifacts = new Set(
+          existingFiles
+            .filter((file) => file.kind === "artifact")
+            .map((file) => `${file.name}\0${file.size}`),
+        );
+
+        for (const entry of manifestEntries) {
+          try {
+            const readPath = resolveSandboxReadPath(conversation.cwd, entry.path);
+            const bytes = await readSandboxFileBytes(sandboxSession, readPath);
+            const fileName = getRuntimeArtifactFileName(entry.path);
+            const artifactKey = `${fileName}\0${bytes.length}`;
+
+            if (recordedArtifacts.has(artifactKey)) {
+              continue;
+            }
+
+            await fileStore.recordRuntimeOutput({
+              bindings: input.bindings,
+              body: bytes,
+              contentType: entry.contentType,
+              createdBy,
+              path: entry.path,
+              sessionId: parsedSessionId,
+            });
+            recordedArtifacts.add(artifactKey);
+          } catch (error) {
+            logWarn("runtime.file_artifact.manifest_record_failed", {
+              ...createErrorLogContext(error),
+              path: entry.path,
+              sandboxId,
+              sessionId,
+            });
+          }
+        }
+      },
+    );
+  } catch (error) {
+    logWarn("runtime.file_artifact.manifest_finalize_failed", {
+      ...createErrorLogContext(error),
+      driverInstanceId: input.event.driverInstanceId ?? null,
+      sandboxId,
+      sessionId,
+    });
+  }
 }
 
 export async function appRuntimeDriverEvents(
@@ -349,6 +474,14 @@ export async function appRuntimeDriverEvents(
       continue;
     }
 
+    if (event.kind === "run.completed") {
+      await recordRuntimeArtifactManifest({
+        bindings,
+        event,
+        link,
+      });
+    }
+
     if (event.kind === "permission.requested") {
       const request = readRuntimeEventPermissionRequest(event);
 
@@ -405,7 +538,11 @@ export async function appRuntimeDriverEvents(
       usage = nextUsage;
     };
 
-    appendRuntimeDriverCanonicalSideEffects(event, { setSessionTitle, setUsage, transitions });
+    appendRuntimeDriverCanonicalSideEffects(event, {
+      setSessionTitle,
+      setUsage,
+      transitions,
+    });
 
     for (const liveEvent of liveEvents) {
       nextLiveState = applyAgUiEventToSessionLiveState(nextLiveState, liveEvent);

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/runtime-artifact-manifest.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/runtime-artifact-manifest.ts
@@ -1,0 +1,124 @@
+export const RUNTIME_ARTIFACT_MANIFEST_PATH = ".mosoo/artifacts.json";
+export const RUNTIME_ARTIFACT_MANIFEST_MAX_FILES = 20;
+export const RUNTIME_ARTIFACT_MANIFEST_MAX_BYTES = 256 * 1024;
+
+export interface RuntimeArtifactManifestEntry {
+  readonly contentType: string | null;
+  readonly path: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function normalizeRuntimeArtifactPath(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalizedPath = value.trim().replaceAll("\\", "/");
+
+  if (
+    normalizedPath.length === 0 ||
+    normalizedPath.includes("\0") ||
+    normalizedPath.startsWith("/")
+  ) {
+    return null;
+  }
+
+  const segments: string[] = [];
+
+  for (const segment of normalizedPath.split("/")) {
+    if (segment.length === 0 || segment === ".") {
+      continue;
+    }
+
+    if (segment === "..") {
+      return null;
+    }
+
+    segments.push(segment);
+  }
+
+  return segments.length === 0 ? null : segments.join("/");
+}
+
+export function getRuntimeArtifactFileName(path: string): string {
+  const normalizedPath = normalizeRuntimeArtifactPath(path);
+
+  if (normalizedPath === null) {
+    throw new Error("Runtime artifact path must be a relative file path.");
+  }
+
+  const name = normalizedPath.split("/").at(-1);
+
+  if (name === undefined) {
+    throw new Error("Runtime artifact path must include a file name.");
+  }
+
+  return name;
+}
+
+export function isRuntimeArtifactManifestPath(path: string): boolean {
+  const normalizedPath = path.trim().replaceAll("\\", "/");
+
+  return (
+    normalizedPath === RUNTIME_ARTIFACT_MANIFEST_PATH ||
+    normalizedPath === `./${RUNTIME_ARTIFACT_MANIFEST_PATH}` ||
+    normalizedPath.endsWith(`/${RUNTIME_ARTIFACT_MANIFEST_PATH}`)
+  );
+}
+
+function readContentType(record: Record<string, unknown>): string | null {
+  const contentType = record["contentType"] ?? record["mimeType"];
+
+  if (typeof contentType !== "string") {
+    return null;
+  }
+
+  const normalizedContentType = contentType.trim();
+  return normalizedContentType.length === 0 ? null : normalizedContentType;
+}
+
+function readArtifactRecords(value: unknown): readonly unknown[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (isRecord(value) && Array.isArray(value["artifacts"])) {
+    return value["artifacts"];
+  }
+
+  return [];
+}
+
+export function readRuntimeArtifactManifestEntries(
+  bytes: Uint8Array,
+): RuntimeArtifactManifestEntry[] {
+  if (bytes.byteLength > RUNTIME_ARTIFACT_MANIFEST_MAX_BYTES) {
+    throw new Error("Runtime artifact manifest is too large.");
+  }
+
+  const parsed = JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+
+  return readArtifactRecords(parsed)
+    .slice(0, RUNTIME_ARTIFACT_MANIFEST_MAX_FILES)
+    .flatMap((entry): RuntimeArtifactManifestEntry[] => {
+      if (!isRecord(entry)) {
+        return [];
+      }
+
+      const path = normalizeRuntimeArtifactPath(entry["path"]);
+
+      if (path === null || isRuntimeArtifactManifestPath(path)) {
+        return [];
+      }
+
+      return [
+        {
+          contentType: readContentType(entry),
+          path,
+        },
+      ];
+    });
+}

--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-execution-spec.builder.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-execution-spec.builder.ts
@@ -8,6 +8,7 @@ import type {
 } from "@mosoo/id";
 import type { DriverNativeRuntimeRef } from "agent-driver/runtime";
 
+import { appendRuntimeArtifactContextToPrompt } from "../../application/session-artifacts/session-artifact-prompt.service";
 import type {
   DriverBootMcpServer,
   DriverExecutionSpec,
@@ -182,7 +183,7 @@ export async function buildExecutionSpec(
       variables: { ...input.profile.envVars },
     },
     model: input.profile.model,
-    profilePrompt: input.profile.prompt,
+    profilePrompt: appendRuntimeArtifactContextToPrompt(input.profile.prompt),
     provider: input.profile.provider,
     providerOptions: input.profile.providerOptions,
     session: {

--- a/apps/api/tests/api-driver-boundary.test.ts
+++ b/apps/api/tests/api-driver-boundary.test.ts
@@ -268,6 +268,9 @@ describe("API to driver boundary", () => {
     });
 
     expect(execution.configRevision.runId).toBe(API_DRIVER_BOUNDARY_IDS.sessionRun);
+    expect(execution.profilePrompt).toContain("You are a helpful runtime.");
+    expect(execution.profilePrompt).toContain("Runtime artifact delivery:");
+    expect(execution.profilePrompt).toContain(".mosoo/artifacts.json");
     expect(execution.environment.variables).toEqual({
       EXISTING_ENV: "kept",
     });

--- a/apps/api/tests/runtime-artifact-manifest.test.ts
+++ b/apps/api/tests/runtime-artifact-manifest.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, test } from "bun:test";
+
+import { createRuntimeEvent } from "@mosoo/runtime-events";
+
+import { createBaseLiveState } from "../src/modules/runtime/infrastructure/driver-instance/event-projection";
+import type { RuntimeSessionLink } from "../src/modules/runtime/infrastructure/driver-instance/event-types";
+import { appRuntimeDriverEvents } from "../src/modules/runtime/infrastructure/driver-instance/events";
+import {
+  RUNTIME_ARTIFACT_MANIFEST_MAX_FILES,
+  isRuntimeArtifactManifestPath,
+  normalizeRuntimeArtifactPath,
+  readRuntimeArtifactManifestEntries,
+} from "../src/modules/runtime/infrastructure/driver-instance/runtime-artifact-manifest";
+import type { SandboxHandle } from "../src/modules/runtime/infrastructure/sandbox-handles";
+import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
+import { API_DRIVER_BOUNDARY_IDS } from "./api-driver-boundary-fixtures";
+import {
+  PUBLIC_API_TEST_IDS,
+  PublicApiMemoryFileBucket,
+  createPublicHttpContractDatabase,
+  createPublicHttpTestBindings,
+  insertOwnerSession,
+  nowMsForTest,
+} from "./helpers/public-api-http-test-fixture";
+
+const encoder = new TextEncoder();
+
+function manifest(value: unknown): Uint8Array {
+  return encoder.encode(JSON.stringify(value));
+}
+
+function encodeBase64(value: string): string {
+  const bytes = encoder.encode(value);
+  let binary = "";
+
+  for (const byte of bytes) {
+    binary += String.fromCodePoint(byte);
+  }
+
+  return btoa(binary);
+}
+
+function createSandboxHandle(files: ReadonlyMap<string, string>): SandboxHandle {
+  const unavailable = async () => {
+    throw new Error("Unexpected sandbox test method call.");
+  };
+  const successfulCommand = async () => ({
+    exitCode: 0,
+    stderr: "",
+    stdout: "",
+    success: true,
+  });
+  const readFile: SandboxHandle["readFile"] = async (path) => {
+    const content = files.get(path);
+
+    if (content === undefined) {
+      throw new Error(`Missing sandbox test file: ${path}`);
+    }
+
+    return {
+      content: encodeBase64(content),
+      encoding: "base64",
+    };
+  };
+
+  return {
+    createBackup: unavailable,
+    createSession: unavailable,
+    deleteSession: unavailable,
+    destroy: unavailable,
+    exec: successfulCommand,
+    getSession: async () => ({
+      exec: successfulCommand,
+      mkdir: unavailable,
+      readFile,
+      startProcess: unavailable,
+      watch: unavailable,
+      writeFile: unavailable,
+    }),
+    mkdir: unavailable,
+    mountBucket: unavailable,
+    readFile,
+    restoreBackup: unavailable,
+    setKeepAlive: unavailable,
+    startProcess: unavailable,
+    terminal: unavailable,
+    watch: unavailable,
+    writeFile: unavailable,
+    wsConnect: unavailable,
+  };
+}
+
+describe("runtime artifact manifest", () => {
+  test("parses the small sandbox artifact outbox contract", () => {
+    const entries = readRuntimeArtifactManifestEntries(
+      manifest({
+        artifacts: [
+          {
+            contentType: " text/markdown ",
+            path: "./dist\\resume.md",
+          },
+          {
+            mimeType: "application/pdf",
+            path: "resume.pdf",
+          },
+          {
+            path: "../secret.txt",
+          },
+          {
+            path: "/workspace/session/absolute.txt",
+          },
+          {
+            path: ".mosoo/artifacts.json",
+          },
+        ],
+      }),
+    );
+
+    expect(entries).toEqual([
+      {
+        contentType: "text/markdown",
+        path: "dist/resume.md",
+      },
+      {
+        contentType: "application/pdf",
+        path: "resume.pdf",
+      },
+    ]);
+  });
+
+  test("keeps artifact paths relative to the runtime cwd", () => {
+    expect(normalizeRuntimeArtifactPath("a/./b.txt")).toBe("a/b.txt");
+    expect(normalizeRuntimeArtifactPath("../b.txt")).toBeNull();
+    expect(normalizeRuntimeArtifactPath("/tmp/b.txt")).toBeNull();
+    expect(normalizeRuntimeArtifactPath("")).toBeNull();
+  });
+
+  test("recognizes the manifest path in relative and absolute event payloads", () => {
+    expect(isRuntimeArtifactManifestPath(".mosoo/artifacts.json")).toBe(true);
+    expect(isRuntimeArtifactManifestPath("./.mosoo/artifacts.json")).toBe(true);
+    expect(isRuntimeArtifactManifestPath("/workspace/session/.mosoo/artifacts.json")).toBe(true);
+    expect(isRuntimeArtifactManifestPath("dist/output.txt")).toBe(false);
+  });
+
+  test("bounds manifest fanout", () => {
+    const artifacts = Array.from(
+      { length: RUNTIME_ARTIFACT_MANIFEST_MAX_FILES + 1 },
+      (_, index) => ({
+        path: `artifact-${index}.txt`,
+      }),
+    );
+
+    expect(readRuntimeArtifactManifestEntries(manifest({ artifacts }))).toHaveLength(
+      RUNTIME_ARTIFACT_MANIFEST_MAX_FILES,
+    );
+  });
+
+  test("records declared sandbox outputs as session artifacts on run completion", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertOwnerSession(database);
+
+    await database
+      .prepare(
+        `
+          INSERT INTO sandbox_session (
+            cloudflare_session_id,
+            created_at,
+            cwd,
+            origin_json,
+            sandbox_id,
+            session_id,
+            status,
+            updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+      )
+      .bind(
+        API_DRIVER_BOUNDARY_IDS.sandboxSession,
+        nowMsForTest(),
+        "/workspace/session",
+        "{}",
+        PUBLIC_API_TEST_IDS.sandbox,
+        PUBLIC_API_TEST_IDS.ownerSession,
+        "active",
+        nowMsForTest(),
+      )
+      .run();
+
+    const bucket = new PublicApiMemoryFileBucket();
+    const sandbox = createSandboxHandle(
+      new Map([
+        [
+          "/workspace/session/.mosoo/artifacts.json",
+          JSON.stringify({
+            artifacts: [
+              {
+                contentType: "text/plain",
+                path: "dist/resume.txt",
+              },
+            ],
+          }),
+        ],
+        ["/workspace/session/dist/resume.txt", "Improved resume"],
+      ]),
+    );
+    const bindings = {
+      ...createPublicHttpTestBindings(database, {
+        fileBucket: bucket as unknown as R2Bucket,
+      }),
+      runtimeSubjectHandleFactory: () => sandbox,
+    } as ApiBindings;
+    const link: RuntimeSessionLink = {
+      agentId: PUBLIC_API_TEST_IDS.agent,
+      callerId: PUBLIC_API_TEST_IDS.ownerAccount,
+      creatorId: PUBLIC_API_TEST_IDS.ownerAccount,
+      executionOwnerId: PUBLIC_API_TEST_IDS.ownerAccount,
+      sandboxId: PUBLIC_API_TEST_IDS.sandbox,
+      sandboxKind: "cattle",
+      sandboxSubjectKind: "session",
+      sessionId: PUBLIC_API_TEST_IDS.ownerSession,
+      sessionRunId: PUBLIC_API_TEST_IDS.run,
+      sessionRunStatus: "running",
+      traceId: "trace-artifact-manifest",
+    };
+    const event = createRuntimeEvent({
+      driverInstanceId: PUBLIC_API_TEST_IDS.driverOwner,
+      id: API_DRIVER_BOUNDARY_IDS.runtimeEvent,
+      kind: "run.completed",
+      occurredAt: "2026-06-22T00:00:00.000Z",
+      payload: {
+        run: {
+          completedAt: "2026-06-22T00:00:00.000Z",
+          error: null,
+          startedAt: null,
+          status: "completed",
+        },
+      },
+      runId: PUBLIC_API_TEST_IDS.run,
+      sessionId: PUBLIC_API_TEST_IDS.ownerSession,
+    });
+
+    await appRuntimeDriverEvents(bindings, {
+      currentLiveState: createBaseLiveState({
+        callerId: link.callerId,
+        creatorId: link.creatorId,
+        driverInstanceId: PUBLIC_API_TEST_IDS.driverOwner,
+        sessionId: link.sessionId,
+      }),
+      driverInstanceId: PUBLIC_API_TEST_IDS.driverOwner,
+      events: [
+        {
+          event,
+          eventId: "source-run-completed-artifacts",
+          occurredAt: 1,
+        },
+      ],
+      link,
+    });
+
+    const row = await database
+      .prepare(
+        `
+          SELECT mime_type, name, owner_id, owner_kind, purpose, scope_id, scope_kind, session_kind, size
+            FROM file_record
+           WHERE session_kind = 'artifact'
+        `,
+      )
+      .first<{
+        mime_type: string;
+        name: string;
+        owner_id: string;
+        owner_kind: string;
+        purpose: string;
+        scope_id: string;
+        scope_kind: string;
+        session_kind: string;
+        size: number;
+      }>();
+
+    expect(row).toEqual({
+      mime_type: "text/plain",
+      name: "resume.txt",
+      owner_id: PUBLIC_API_TEST_IDS.ownerSession,
+      owner_kind: "session",
+      purpose: "session_artifact",
+      scope_id: PUBLIC_API_TEST_IDS.ownerSession,
+      scope_kind: "session",
+      session_kind: "artifact",
+      size: 15,
+    });
+    expect([...bucket.objects.values()]).toEqual([
+      expect.objectContaining({
+        body: "Improved resume",
+        contentType: "text/plain",
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a runtime-agnostic sandbox artifact manifest at `.mosoo/artifacts.json`
- append the artifact manifest contract to the shared driver profile prompt so Claude/OpenAI/OpenCode-style harnesses receive the same rule
- materialize declared sandbox outputs through the existing `recordRuntimeOutput()` path on `run.completed`
- cover manifest parsing and end-to-end run-completed artifact recording with API tests

## Verification
- `bash ./init.sh development`
- `bunx prettier --check apps/api/src/modules/runtime/infrastructure/driver-instance/events.ts apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-execution-spec.builder.ts apps/api/tests/api-driver-boundary.test.ts apps/api/src/modules/runtime/application/session-artifacts/session-artifact-prompt.service.ts apps/api/src/modules/runtime/infrastructure/driver-instance/runtime-artifact-manifest.ts apps/api/tests/runtime-artifact-manifest.test.ts feature_list.json progress.md`
- `bun test apps/api/tests/runtime-artifact-manifest.test.ts apps/api/tests/api-driver-boundary.test.ts apps/api/tests/session-resource-files.test.ts`
- `bunx tsc --noEmit --pretty false -p apps/api/tsconfig.json`
- `bun run --filter @mosoo/api test`
