### PR TITLE
feat(openapi): add public thread file data plane

### DIFF
--- a/apps/api/src/adapters/http/routes/public-api-openapi.ts
+++ b/apps/api/src/adapters/http/routes/public-api-openapi.ts
@@ -11,7 +11,7 @@ import {
 
 import { createPublicApiOpenApiComponents } from "./public-api-openapi-components";
 
-type HttpMethod = "delete" | "get" | "post";
+type HttpMethod = "delete" | "get" | "post" | "put";
 
 interface OpenApiParameter {
   description?: string;
@@ -49,6 +49,7 @@ interface PublicApiOpenApiDocument {
 const EXAMPLE_AGENT_ID = "01J00000000000000000000001";
 const EXAMPLE_THREAD_ID = "01J00000000000000000000009";
 const EXAMPLE_FILE_ID = "01J0000000000000000000000J";
+const EXAMPLE_ACCOUNT_ID = "01J00000000000000000000002";
 const ACCESS_TOKEN_SECURITY: Array<Record<string, []>> = [{ accessToken: [] }];
 
 const EXAMPLE_SESSION_FILE = {
@@ -70,6 +71,22 @@ const EXAMPLE_FILE_UPLOAD_SUMMARY = {
   path: `session-files/${EXAMPLE_FILE_ID}/brief.txt`,
   status: "pending",
   strategy: "single_put",
+};
+
+const EXAMPLE_FILE_ENTRY = {
+  createdAt: "2026-05-19T00:02:00.000Z",
+  createdBy: EXAMPLE_ACCOUNT_ID,
+  etag: "etag-1",
+  expiresAt: null,
+  id: EXAMPLE_FILE_ID,
+  mimeType: "text/plain",
+  name: "brief.txt",
+  path: `session-files/${EXAMPLE_FILE_ID}/brief.txt`,
+  sessionKind: "attachment",
+  size: 19,
+  status: "ready",
+  updatedAt: "2026-05-19T00:03:00.000Z",
+  version: 1,
 };
 
 function platformIdPathParameter(input: {
@@ -182,6 +199,21 @@ function jsonRequestBodyExamples(
   };
 }
 
+function binaryRequestBody(description: string) {
+  return {
+    content: {
+      "application/octet-stream": {
+        schema: {
+          format: "binary",
+          type: "string",
+        },
+      },
+    },
+    description,
+    required: true,
+  };
+}
+
 function jsonResponse(description: string, schema: Record<string, unknown>, example?: unknown) {
   return {
     content: {
@@ -250,6 +282,39 @@ function operation(
 
 export function createPublicApiOpenApiDocument(origin: string): PublicApiOpenApiDocument {
   const paths = {
+    "/files/{fileId}/complete": {
+      post: operation({
+        description:
+          "Completes a pending single PUT Thread file upload. The file must have been created through POST /threads/{threadId}/files/uploads, uploaded through PUT /files/{fileId}/content, and belong to a public Thread visible to the Access Token caller.",
+        parameters: [fileIdParameter],
+        requestBody: jsonRequestBody(
+          { $ref: "#/components/schemas/CompleteFileUploadRequest" },
+          {},
+        ),
+        security: ACCESS_TOKEN_SECURITY,
+        success: {
+          "200": jsonResponse(
+            "Completed files API upload.",
+            { $ref: "#/components/schemas/CompleteFileUploadResponse" },
+            { file: EXAMPLE_FILE_ENTRY },
+          ),
+        },
+        summary: "Complete Thread file upload",
+      }),
+    },
+    "/files/{fileId}/content": {
+      put: operation({
+        description:
+          "Uploads raw bytes for a pending single PUT Thread file upload. The file must have been created through POST /threads/{threadId}/files/uploads and belong to a public Thread visible to the Access Token caller.",
+        parameters: [fileIdParameter],
+        requestBody: binaryRequestBody("Raw file bytes for the upload session."),
+        security: ACCESS_TOKEN_SECURITY,
+        success: {
+          "200": okResponse("Uploaded."),
+        },
+        summary: "Upload Thread file content",
+      }),
+    },
     "/agents/{agentId}/threads": {
       get: operation({
         description: "Returns Threads created by the authenticated Access Token caller.",

--- a/apps/api/src/adapters/http/routes/public-api-route.ts
+++ b/apps/api/src/adapters/http/routes/public-api-route.ts
@@ -1,3 +1,4 @@
+import type { CompleteFileUploadRequest } from "@mosoo/contracts/file";
 import { PUBLIC_API_VERSION_PREFIX } from "@mosoo/contracts/public-api";
 import type { PublicThreadId } from "@mosoo/id";
 import { Hono } from "hono";
@@ -165,6 +166,27 @@ export function registerPublicApiRoute(app: Hono<ApiGatewayEnvironment>) {
         archived: parseOptionalBoolean(c.req.query("archived")),
       }),
     ),
+  );
+
+  v1.put("/files/:fileId/content", async (c) =>
+    runPublicApiAuthenticatedJson(c, async (caller) => {
+      const service = await loadPublicThreadFileService();
+      await service.putPublicThreadFileContent(c.env, caller.viewer, {
+        body: c.req.raw.body,
+        fileId: parseFileIdParam(c.req.param("fileId")),
+      });
+      return { ok: true };
+    }),
+  );
+
+  v1.post("/files/:fileId/complete", async (c) =>
+    runPublicApiAuthenticatedJson(c, async (caller) => {
+      const service = await loadPublicThreadFileService();
+      return service.completePublicThreadFileUpload(c.env, caller.viewer, {
+        fileId: parseFileIdParam(c.req.param("fileId")),
+        request: await c.req.json<CompleteFileUploadRequest>(),
+      });
+    }),
   );
 
   v1.post("/threads/:threadId/events", async (c) => {

--- a/apps/api/src/modules/public-api/public-thread-file-api.service.ts
+++ b/apps/api/src/modules/public-api/public-thread-file-api.service.ts
@@ -1,4 +1,10 @@
-import type { CreateFileUploadResponse, FileEntry, FileRecord } from "@mosoo/contracts/file";
+import type {
+  CompleteFileUploadRequest,
+  CompleteFileUploadResponse,
+  CreateFileUploadResponse,
+  FileEntry,
+  FileRecord,
+} from "@mosoo/contracts/file";
 import type { PublicThreadFile } from "@mosoo/contracts/public-api";
 import type {
   CreatePublicThreadFileUploadRequest,
@@ -13,8 +19,9 @@ import type { ApiBindings } from "../../platform/cloudflare/worker-types";
 import type { AuthenticatedViewer } from "../auth/application/viewer-auth.service";
 import { FileControlError } from "../files/application/file-control-errors";
 import { fileStore } from "../files/application/file-store";
+import type { ContentBody } from "../files/application/file-store";
 import { publishSessionResourceDelete } from "../sessions/application/session-resource-events.service";
-import { toBackingSessionId } from "./public-thread-ids";
+import { toBackingSessionId, toPublicThreadId } from "./public-thread-ids";
 import { admitPublicSessionCaller } from "./public-thread-session-query.service";
 
 async function admitPublicThreadFileAccess(
@@ -37,6 +44,18 @@ function assertPublicThreadFile(file: FileRecord, sessionId: SessionId): void {
   ) {
     throw new FileControlError(404, "file_not_found", `Thread file ${file.id} was not found.`);
   }
+}
+
+function requirePublicThreadAttachment(file: FileRecord): PublicThreadId {
+  if (
+    file.scope.kind !== "session" ||
+    file.scope.id === null ||
+    file.sessionKind !== "attachment"
+  ) {
+    throw new FileControlError(404, "file_not_found", `Thread file ${file.id} was not found.`);
+  }
+
+  return toPublicThreadId(parsePlatformId<SessionId>(file.scope.id, "File session ID"));
 }
 
 function toPublicThreadFile(file: FileEntry | FileRecord): PublicThreadFile {
@@ -78,6 +97,41 @@ export async function createPublicThreadFileUpload(
     appId,
     file: input.file,
     sessionId,
+  });
+}
+
+export async function putPublicThreadFileContent(
+  bindings: ApiBindings,
+  caller: AuthenticatedViewer,
+  input: {
+    body: ContentBody;
+    fileId: FileId;
+  },
+): Promise<void> {
+  const file = await fileStore.getRecord(bindings, caller, input.fileId);
+  const threadId = requirePublicThreadAttachment(file);
+
+  await admitPublicSessionCaller(bindings.DB, caller, threadId);
+  await fileStore.putContent(bindings, caller, input.fileId, input.body);
+}
+
+export async function completePublicThreadFileUpload(
+  bindings: ApiBindings,
+  caller: AuthenticatedViewer,
+  input: {
+    fileId: FileId;
+    request: CompleteFileUploadRequest;
+  },
+): Promise<CompleteFileUploadResponse> {
+  const file = await fileStore.getRecord(bindings, caller, input.fileId);
+  const threadId = requirePublicThreadAttachment(file);
+
+  await admitPublicSessionCaller(bindings.DB, caller, threadId);
+  return fileStore.completeUpload({
+    bindings,
+    fileId: input.fileId,
+    input: input.request,
+    viewer: caller,
   });
 }
 

--- a/apps/api/tests/api-web-boundary-fixtures.ts
+++ b/apps/api/tests/api-web-boundary-fixtures.ts
@@ -1,4 +1,4 @@
-import type { CreateFileUploadResponse } from "@mosoo/contracts/file";
+import type { CompleteFileUploadResponse, CreateFileUploadResponse } from "@mosoo/contracts/file";
 import type { PublicThreadSummary } from "@mosoo/contracts/public-api";
 import type { SessionFile, SessionSummary } from "@mosoo/contracts/session";
 import type { SessionRunSummary } from "@mosoo/contracts/session-run";
@@ -126,7 +126,7 @@ export function openApiJsonRequestExample(path: string, method: "post"): unknown
 
 function openApiJsonResponseContent(
   path: string,
-  method: "get" | "post",
+  method: "get" | "post" | "put",
   status: string,
 ): Record<string, unknown> {
   const document = createPublicApiOpenApiDocument("https://api.example.com");
@@ -145,7 +145,11 @@ function openApiJsonResponseContent(
   return requireRecord(content["application/json"], `${method} ${path} ${status} JSON content`);
 }
 
-export function openApiJsonResponseExample(path: string, method: "get" | "post", status: string) {
+export function openApiJsonResponseExample(
+  path: string,
+  method: "get" | "post" | "put",
+  status: string,
+) {
   return openApiJsonResponseContent(path, method, status)["example"];
 }
 
@@ -198,5 +202,25 @@ export function createFileUploadSummary(): CreateFileUploadResponse {
     path: `session-files/${PUBLIC_API_TEST_IDS.file}/brief.txt`,
     status: "pending",
     strategy: "single_put",
+  };
+}
+
+export function createCompleteFileUploadResponse(): CompleteFileUploadResponse {
+  return {
+    file: {
+      createdAt: "2026-05-19T00:02:00.000Z",
+      createdBy: PUBLIC_API_TEST_IDS.nonOwnerAccount,
+      etag: "etag-1",
+      expiresAt: null,
+      id: PUBLIC_API_TEST_IDS.file,
+      mimeType: "text/plain",
+      name: "brief.txt",
+      path: `session-files/${PUBLIC_API_TEST_IDS.file}/brief.txt`,
+      sessionKind: "attachment",
+      size: 19,
+      status: "ready",
+      updatedAt: "2026-05-19T00:03:00.000Z",
+      version: 1,
+    },
   };
 }

--- a/apps/api/tests/api-web-boundary.test.ts
+++ b/apps/api/tests/api-web-boundary.test.ts
@@ -21,6 +21,7 @@ import { PublicApiError } from "../src/modules/public-api/public-api-errors";
 import { toPublicThreadEventBatch } from "../src/modules/public-api/public-thread-api-presenter";
 import {
   createChunkedJsonRequest,
+  createCompleteFileUploadResponse,
   createFileUploadSummary,
   createRunSummary,
   createSessionFile,
@@ -283,6 +284,8 @@ describe("API to web boundary", () => {
     expect(document.openapi).toBe("3.1.0");
     expect(document.servers).toEqual([{ url: "https://api.example.com/api/v1" }]);
     expectProperties(document.paths, [
+      "/files/{fileId}/complete",
+      "/files/{fileId}/content",
       "/agents/{agentId}/threads",
       "/threads/{threadId}",
       "/threads/{threadId}/archive",
@@ -293,6 +296,60 @@ describe("API to web boundary", () => {
       "/threads/{threadId}/files/{fileId}",
       "/threads/{threadId}/unarchive",
     ]);
+
+    const uploadContentOperation = document.paths["/files/{fileId}/content"]?.put;
+    expect(uploadContentOperation?.parameters?.map((parameter) => parameter.name)).toContain(
+      "fileId",
+    );
+    expect(uploadContentOperation?.requestBody).toMatchObject({
+      content: {
+        "application/octet-stream": {
+          schema: {
+            format: "binary",
+            type: "string",
+          },
+        },
+      },
+      required: true,
+    });
+    expect(uploadContentOperation?.responses["200"]).toMatchObject({
+      content: {
+        "application/json": {
+          schema: {
+            properties: {
+              ok: { const: true },
+            },
+            required: ["ok"],
+            type: "object",
+          },
+        },
+      },
+    });
+
+    const completeUploadOperation = document.paths["/files/{fileId}/complete"]?.post;
+    expect(completeUploadOperation?.parameters?.map((parameter) => parameter.name)).toContain(
+      "fileId",
+    );
+    expect(completeUploadOperation?.requestBody).toMatchObject({
+      content: {
+        "application/json": {
+          example: {},
+          schema: {
+            $ref: "#/components/schemas/CompleteFileUploadRequest",
+          },
+        },
+      },
+      required: true,
+    });
+    expect(completeUploadOperation?.responses["200"]).toMatchObject({
+      content: {
+        "application/json": {
+          schema: {
+            $ref: "#/components/schemas/CompleteFileUploadResponse",
+          },
+        },
+      },
+    });
 
     const createThreadSchema = document.components.schemas.CreateThreadRequest;
     expect(createThreadSchema.required).not.toContain("input");
@@ -332,9 +389,21 @@ describe("API to web boundary", () => {
     const fileIdParameter = document.paths[
       "/threads/{threadId}/files/{fileId}"
     ]?.delete?.parameters?.find((parameter) => parameter.name === "fileId");
+    const uploadContentFileIdParameter = document.paths[
+      "/files/{fileId}/content"
+    ]?.put?.parameters?.find((parameter) => parameter.name === "fileId");
+    const completeUploadFileIdParameter = document.paths[
+      "/files/{fileId}/complete"
+    ]?.post?.parameters?.find((parameter) => parameter.name === "fileId");
 
     expect(document.info.description).toContain("v1 resource identifiers are bare ULIDs");
-    for (const parameter of [agentIdParameter, threadIdParameter, fileIdParameter]) {
+    for (const parameter of [
+      agentIdParameter,
+      threadIdParameter,
+      fileIdParameter,
+      completeUploadFileIdParameter,
+      uploadContentFileIdParameter,
+    ]) {
       expect(parameter?.description).toContain("v1 IDs are bare ULIDs");
       expect(parameter?.schema).toMatchObject({
         format: "ulid",
@@ -438,6 +507,31 @@ describe("API to web boundary", () => {
       "strategy",
     ]);
     expectNoProperties(uploadProperties, ["purpose", "scopeId", "scopeKind", "target"]);
+
+    const fileEntryProperties = openApiSchemaProperties("FileEntry");
+    expectProperties(fileEntryProperties, [
+      "createdAt",
+      "createdBy",
+      "etag",
+      "expiresAt",
+      "id",
+      "mimeType",
+      "name",
+      "path",
+      "sessionKind",
+      "size",
+      "status",
+      "updatedAt",
+      "version",
+    ]);
+    expectNoProperties(fileEntryProperties, [
+      "objectKey",
+      "owner",
+      "purpose",
+      "scope",
+      "scopeId",
+      "scopeKind",
+    ]);
   });
 
   test("parses the Public Thread API create-work body shape", async () => {
@@ -652,6 +746,9 @@ describe("API to web boundary", () => {
     });
     expect(openApiJsonResponseExample("/threads/{threadId}/files/uploads", "post", "201")).toEqual(
       uploadSummary,
+    );
+    expect(openApiJsonResponseExample("/files/{fileId}/complete", "post", "200")).toEqual(
+      createCompleteFileUploadResponse(),
     );
   });
 

--- a/apps/api/tests/public-thread-api.e2e.test.ts
+++ b/apps/api/tests/public-thread-api.e2e.test.ts
@@ -1060,11 +1060,12 @@ describe("Public Thread API e2e", () => {
   test("creates a Thread file upload through the public files API contract", async () => {
     const database = await createPublicHttpContractDatabase();
     const app = createPublicThreadApiTestApp();
+    const bucket = new PublicApiMemoryFileBucket();
+    const requestThreadApi = (request: Request) =>
+      requestPublicApi(app, database, request, { fileBucket: bucket as unknown as R2Bucket });
 
     await withProviderProbeMock(async () => {
-      const createThreadResponse = await requestPublicApi(
-        app,
-        database,
+      const createThreadResponse = await requestThreadApi(
         new Request(`https://api.example.com/api/v1/agents/${PUBLIC_API_TEST_IDS.agent}/threads`, {
           body: JSON.stringify({
             client_external_ref: "thread-upload-contract",
@@ -1083,9 +1084,7 @@ describe("Public Thread API e2e", () => {
 
       const fileBody = "Launch note.\n";
       const fileSize = new TextEncoder().encode(fileBody).byteLength;
-      const createUploadResponse = await requestPublicApi(
-        app,
-        database,
+      const createUploadResponse = await requestThreadApi(
         new Request(`https://api.example.com/api/v1/threads/${threadId}/files/uploads`, {
           body: JSON.stringify({
             file: {
@@ -1117,13 +1116,14 @@ describe("Public Thread API e2e", () => {
 
       const pendingFileRow = await database
         .prepare(
-          `SELECT mime_type, owner_id, owner_kind, path, purpose, scope_id, scope_kind, session_kind, size, status
+          `SELECT mime_type, object_key, owner_id, owner_kind, path, purpose, scope_id, scope_kind, session_kind, size, status
              FROM file_record
             WHERE id = ?`,
         )
         .bind(fileId)
         .first<{
           mime_type: string | null;
+          object_key: string;
           owner_id: string;
           owner_kind: string;
           path: string;
@@ -1136,6 +1136,7 @@ describe("Public Thread API e2e", () => {
         }>();
       expect(pendingFileRow).toEqual({
         mime_type: "text/plain",
+        object_key: `staging/session/${threadId}/${fileId}`,
         owner_id: threadId,
         owner_kind: "session",
         path: `attachment/${fileId}/launch-note.txt`,
@@ -1171,6 +1172,158 @@ describe("Public Thread API e2e", () => {
         scope_kind: "session",
         status: "pending",
         strategy: "single_put",
+      });
+
+      const uploadContentResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/files/${fileId}/content`, {
+          body: fileBody,
+          headers: {
+            Authorization: bearer(TOKENS.owner),
+            "Content-Type": "text/plain",
+          },
+          method: "PUT",
+        }),
+      );
+      expect(uploadContentResponse.status).toBe(200);
+      expect(await readJson(uploadContentResponse)).toEqual({ ok: true });
+
+      if (!pendingFileRow) {
+        throw new Error("Expected pending public Thread file row.");
+      }
+      const stagingObject = await bucket.get(pendingFileRow.object_key);
+      expect(await stagingObject?.text()).toBe(fileBody);
+
+      const uploadedRow = await database
+        .prepare("SELECT status FROM file_upload WHERE file_id = ?")
+        .bind(fileId)
+        .first<{ status: string }>();
+      expect(uploadedRow).toEqual({ status: "uploading" });
+
+      const nonOwnerUploadResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/files/${fileId}/content`, {
+          body: "non-owner overwrite\n",
+          headers: {
+            Authorization: bearer(TOKENS.nonOwner),
+            "Content-Type": "text/plain",
+          },
+          method: "PUT",
+        }),
+      );
+      expect(nonOwnerUploadResponse.status).toBe(404);
+      expect(expectRecord(await readJson(nonOwnerUploadResponse))["error"]).toMatchObject({
+        code: "not_found",
+      });
+
+      const nonOwnerCompleteResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/files/${fileId}/complete`, {
+          body: JSON.stringify({}),
+          headers: {
+            Authorization: bearer(TOKENS.nonOwner),
+            "Content-Type": "application/json",
+          },
+          method: "POST",
+        }),
+      );
+      expect(nonOwnerCompleteResponse.status).toBe(404);
+      expect(expectRecord(await readJson(nonOwnerCompleteResponse))["error"]).toMatchObject({
+        code: "not_found",
+      });
+
+      const completeUploadResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/files/${fileId}/complete`, {
+          body: JSON.stringify({}),
+          headers: {
+            Authorization: bearer(TOKENS.owner),
+            "Content-Type": "application/json",
+          },
+          method: "POST",
+        }),
+      );
+      expect(completeUploadResponse.status).toBe(200);
+      const completedFile = expectRecord(
+        expectRecord(await readJson(completeUploadResponse))["file"],
+      );
+      expect(completedFile).toMatchObject({
+        createdBy: PUBLIC_API_TEST_IDS.ownerAccount,
+        expiresAt: null,
+        id: fileId,
+        mimeType: "text/plain",
+        name: "launch-note.txt",
+        path: `session-files/${fileId}/launch-note.txt`,
+        sessionKind: "attachment",
+        size: fileSize,
+        status: "ready",
+        version: 1,
+      });
+      expectString(completedFile["createdAt"]);
+      expectString(completedFile["etag"]);
+      expectString(completedFile["updatedAt"]);
+
+      const finalObjectKey = `session/${threadId}/attachment/${fileId}/launch-note.txt`;
+      const finalObject = await bucket.get(finalObjectKey);
+      expect(await finalObject?.text()).toBe(fileBody);
+      expect(await bucket.get(pendingFileRow.object_key)).toBeNull();
+
+      const completedFileRow = await database
+        .prepare(
+          `SELECT committed, expires_at, object_key, status
+             FROM file_record
+            WHERE id = ?`,
+        )
+        .bind(fileId)
+        .first<{
+          committed: number;
+          expires_at: number | null;
+          object_key: string;
+          status: string;
+        }>();
+      expect(completedFileRow).toEqual({
+        committed: 1,
+        expires_at: null,
+        object_key: finalObjectKey,
+        status: "ready",
+      });
+
+      const completedUploadRow = await database
+        .prepare("SELECT status FROM file_upload WHERE file_id = ?")
+        .bind(fileId)
+        .first<{ status: string }>();
+      expect(completedUploadRow).toEqual({ status: "completed" });
+
+      const appDraftFileId = await createPendingAppDraftFile({
+        body: "App draft upload.\n",
+        bucket,
+        database,
+        name: "app-draft.txt",
+      });
+      const appDraftUploadResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/files/${appDraftFileId}/content`, {
+          body: "blocked app draft content\n",
+          headers: {
+            Authorization: bearer(TOKENS.owner),
+            "Content-Type": "text/plain",
+          },
+          method: "PUT",
+        }),
+      );
+      expect(appDraftUploadResponse.status).toBe(404);
+      expect(expectRecord(await readJson(appDraftUploadResponse))["error"]).toMatchObject({
+        code: "not_found",
+      });
+
+      const appDraftCompleteResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/files/${appDraftFileId}/complete`, {
+          body: JSON.stringify({}),
+          headers: {
+            Authorization: bearer(TOKENS.owner),
+            "Content-Type": "application/json",
+          },
+          method: "POST",
+        }),
+      );
+      expect(appDraftCompleteResponse.status).toBe(404);
+      expect(expectRecord(await readJson(appDraftCompleteResponse))["error"]).toMatchObject({
+        code: "not_found",
       });
     });
   });

--- a/pkgs/contracts/src/http/public-api-openapi.contract.ts
+++ b/pkgs/contracts/src/http/public-api-openapi.contract.ts
@@ -1,7 +1,12 @@
 import { PLATFORM_ID_INPUT_PATTERN } from "@mosoo/id";
 
 import { AGENT_KIND_VALUES } from "../agent/agent.contract.ts";
-import { FILE_UPLOAD_STATUSES, FILE_UPLOAD_STRATEGIES } from "../file/file.contract";
+import {
+  FILE_SESSION_KINDS,
+  FILE_STATUSES,
+  FILE_UPLOAD_STATUSES,
+  FILE_UPLOAD_STRATEGIES,
+} from "../file/file.contract";
 import {
   PUBLIC_API_ERROR_CODES,
   PUBLIC_THREAD_CLIENT_EXTERNAL_REF_MAX_LENGTH,
@@ -228,6 +233,135 @@ export const PUBLIC_API_OPENAPI_SCHEMAS = {
       "status",
       "strategy",
     ],
+    type: "object",
+  },
+  CompleteFileUploadPart: {
+    additionalProperties: false,
+    description:
+      "A completed multipart upload part. Public Thread MVP uploads use single PUT and do not send parts.",
+    properties: {
+      etag: {
+        description: "ETag returned by the uploaded multipart part.",
+        minLength: 1,
+        type: "string",
+      },
+      partNumber: {
+        description: "One-based multipart part number for completion ordering.",
+        minimum: 1,
+        type: "integer",
+      },
+    },
+    required: ["etag", "partNumber"],
+    type: "object",
+  },
+  CompleteFileUploadRequest: {
+    additionalProperties: false,
+    description:
+      "Request body for completing a files API upload session. Public Thread MVP single PUT uploads send an empty object.",
+    properties: {
+      parts: {
+        description:
+          "Multipart completion parts. Omit this field for public MVP single PUT uploads.",
+        items: { $ref: "#/components/schemas/CompleteFileUploadPart" },
+        type: "array",
+      },
+    },
+    required: [],
+    type: "object",
+  },
+  FileEntry: {
+    additionalProperties: false,
+    description: "Files API file entry returned after an upload completes.",
+    properties: {
+      createdAt: {
+        description: "Timestamp (RFC 3339) at which the file record was created.",
+        format: "date-time",
+        type: "string",
+      },
+      createdBy: {
+        ...PLATFORM_ID_SCHEMA,
+        description: "Account ID (bare ULID) that created the file record.",
+      },
+      etag: {
+        description: "Storage ETag for the finalized object, or null when unavailable.",
+        type: ["string", "null"],
+      },
+      expiresAt: {
+        description: "Expiration timestamp for temporary files, or null for durable Thread files.",
+        format: "date-time",
+        type: ["string", "null"],
+      },
+      id: {
+        ...createPublicApiPlatformIdSchema({
+          maxLength: PUBLIC_THREAD_FILE_ID_MAX_LENGTH,
+          minLength: 1,
+        }),
+        description: "File ID (bare ULID) for the finalized file.",
+      },
+      mimeType: {
+        description: "Stored MIME type for the file bytes, or null when unknown.",
+        type: ["string", "null"],
+      },
+      name: {
+        description: "Original file name recorded for this file.",
+        type: "string",
+      },
+      path: {
+        description: "Files API record path for the finalized file.",
+        minLength: 1,
+        type: "string",
+      },
+      sessionKind: {
+        description: "Session file kind for Thread-scoped files, or null for non-session files.",
+        enum: [...FILE_SESSION_KINDS, null],
+      },
+      size: {
+        description: "Finalized file size in bytes.",
+        minimum: 0,
+        type: "integer",
+      },
+      status: {
+        description: "Current files API file lifecycle status.",
+        enum: FILE_STATUSES,
+      },
+      updatedAt: {
+        description: "Timestamp (RFC 3339) at which the file record was last updated.",
+        format: "date-time",
+        type: "string",
+      },
+      version: {
+        description: "Monotonic file version number within its path.",
+        minimum: 1,
+        type: "integer",
+      },
+    },
+    required: [
+      "createdAt",
+      "createdBy",
+      "etag",
+      "expiresAt",
+      "id",
+      "mimeType",
+      "name",
+      "path",
+      "sessionKind",
+      "size",
+      "status",
+      "updatedAt",
+      "version",
+    ],
+    type: "object",
+  },
+  CompleteFileUploadResponse: {
+    additionalProperties: false,
+    description: "Result of completing a files API upload session.",
+    properties: {
+      file: {
+        $ref: "#/components/schemas/FileEntry",
+        description: "Completed files API file entry.",
+      },
+    },
+    required: ["file"],
     type: "object",
   },
   ErrorResponse: {


### PR DESCRIPTION
## Summary

- Add Public API data-plane routes for Thread file upload content and completion.
- Gate both fileId-based routes through session attachment checks and public Thread admission before reusing `fileStore.putContent` / `fileStore.completeUpload`.
- Extend Public OpenAPI schemas and focused tests for the files API upload/complete contract.

## Validation

- `vp exec bun test apps/api/tests/api-web-boundary.test.ts apps/api/tests/public-thread-api.e2e.test.ts`
- `vp run --filter @mosoo/api tc`
- `vp fmt --check apps/api/src/adapters/http/routes/public-api-route.ts apps/api/src/modules/public-api/public-thread-file-api.service.ts apps/api/src/adapters/http/routes/public-api-openapi.ts pkgs/contracts/src/http/public-api-openapi.contract.ts apps/api/tests/api-web-boundary-fixtures.ts apps/api/tests/api-web-boundary.test.ts apps/api/tests/public-thread-api.e2e.test.ts`
- `git diff --check`

## Notes

- No generated files included.
- No GraphQL codegen included.
- No DB baseline updates included.
- Existing `apps/driver` submodule dirty marker was left out of this PR.
