### PR TITLE
fix(runtime): skip missing artifact manifest reads

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/events.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/events.ts
@@ -37,6 +37,7 @@ import { upsertNativeResumeRef } from "../native-resume-ref.repository";
 import { getRuntimeSubjectKeepAliveHandle } from "../runtime-subject-lifecycle/runtime-subject-lifecycle.service";
 import { getRuntimeConversationSession } from "../runtime-subject-lifecycle/runtime-subject-store";
 import { readSandboxFileBytes } from "../sandbox-file-bytes";
+import type { ExecutionSessionHandle } from "../sandbox-handles";
 import {
   assertRuntimeEventMatchesDriverEnvelope,
   assertRuntimeEventMatchesDriverLink,
@@ -74,6 +75,20 @@ export {
   recordDriverInstanceCompletion,
   recordDriverInstanceFailure,
 } from "./terminal-driver-events";
+
+function quoteShellArg(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+async function sandboxRegularFileExists(
+  handle: ExecutionSessionHandle,
+  path: string,
+): Promise<boolean> {
+  const command = `if [ -f ${quoteShellArg(path)} ]; then printf 1; fi`;
+  const result = await handle.exec(`sh -lc ${quoteShellArg(command)}`);
+
+  return result.success && result.exitCode === 0 && result.stdout.trim() === "1";
+}
 
 function resolveRuntimeOutputCreator(link: RuntimeSessionLink): AccountId | null {
   const actorId = link.executionOwnerId ?? link.callerId ?? link.creatorId;
@@ -263,6 +278,10 @@ async function recordRuntimeArtifactManifest(input: {
           RUNTIME_ARTIFACT_MANIFEST_PATH,
         );
         let manifestBytes: Uint8Array;
+
+        if (!(await sandboxRegularFileExists(sandboxSession, manifestPath))) {
+          return;
+        }
 
         try {
           manifestBytes = await readSandboxFileBytes(sandboxSession, manifestPath);

--- a/apps/api/tests/runtime-artifact-manifest.test.ts
+++ b/apps/api/tests/runtime-artifact-manifest.test.ts
@@ -44,10 +44,10 @@ function createSandboxHandle(files: ReadonlyMap<string, string>): SandboxHandle 
   const unavailable = async () => {
     throw new Error("Unexpected sandbox test method call.");
   };
-  const successfulCommand = async () => ({
+  const successfulCommand: SandboxHandle["exec"] = async (command) => ({
     exitCode: 0,
     stderr: "",
-    stdout: "",
+    stdout: [...files.keys()].some((path) => command.includes(path)) ? "1" : "",
     success: true,
   });
   const readFile: SandboxHandle["readFile"] = async (path) => {
@@ -88,6 +88,71 @@ function createSandboxHandle(files: ReadonlyMap<string, string>): SandboxHandle 
     writeFile: unavailable,
     wsConnect: unavailable,
   };
+}
+
+async function insertActiveSandboxSession(database: D1Database): Promise<void> {
+  await database
+    .prepare(
+      `
+        INSERT INTO sandbox_session (
+          cloudflare_session_id,
+          created_at,
+          cwd,
+          origin_json,
+          sandbox_id,
+          session_id,
+          status,
+          updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    )
+    .bind(
+      API_DRIVER_BOUNDARY_IDS.sandboxSession,
+      nowMsForTest(),
+      "/workspace/session",
+      "{}",
+      PUBLIC_API_TEST_IDS.sandbox,
+      PUBLIC_API_TEST_IDS.ownerSession,
+      "active",
+      nowMsForTest(),
+    )
+    .run();
+}
+
+function createArtifactManifestRuntimeLink(): RuntimeSessionLink {
+  return {
+    agentId: PUBLIC_API_TEST_IDS.agent,
+    callerId: PUBLIC_API_TEST_IDS.ownerAccount,
+    creatorId: PUBLIC_API_TEST_IDS.ownerAccount,
+    executionOwnerId: PUBLIC_API_TEST_IDS.ownerAccount,
+    sandboxId: PUBLIC_API_TEST_IDS.sandbox,
+    sandboxKind: "cattle",
+    sandboxSubjectKind: "session",
+    sessionId: PUBLIC_API_TEST_IDS.ownerSession,
+    sessionRunId: PUBLIC_API_TEST_IDS.run,
+    sessionRunStatus: "running",
+    traceId: "trace-artifact-manifest",
+  };
+}
+
+function createCompletedRunEvent() {
+  return createRuntimeEvent({
+    driverInstanceId: PUBLIC_API_TEST_IDS.driverOwner,
+    id: API_DRIVER_BOUNDARY_IDS.runtimeEvent,
+    kind: "run.completed",
+    occurredAt: "2026-06-22T00:00:00.000Z",
+    payload: {
+      run: {
+        completedAt: "2026-06-22T00:00:00.000Z",
+        error: null,
+        startedAt: null,
+        status: "completed",
+      },
+    },
+    runId: PUBLIC_API_TEST_IDS.run,
+    sessionId: PUBLIC_API_TEST_IDS.ownerSession,
+  });
 }
 
 describe("runtime artifact manifest", () => {
@@ -158,34 +223,7 @@ describe("runtime artifact manifest", () => {
   test("records declared sandbox outputs as session artifacts on run completion", async () => {
     const database = await createPublicHttpContractDatabase();
     await insertOwnerSession(database);
-
-    await database
-      .prepare(
-        `
-          INSERT INTO sandbox_session (
-            cloudflare_session_id,
-            created_at,
-            cwd,
-            origin_json,
-            sandbox_id,
-            session_id,
-            status,
-            updated_at
-          )
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        `,
-      )
-      .bind(
-        API_DRIVER_BOUNDARY_IDS.sandboxSession,
-        nowMsForTest(),
-        "/workspace/session",
-        "{}",
-        PUBLIC_API_TEST_IDS.sandbox,
-        PUBLIC_API_TEST_IDS.ownerSession,
-        "active",
-        nowMsForTest(),
-      )
-      .run();
+    await insertActiveSandboxSession(database);
 
     const bucket = new PublicApiMemoryFileBucket();
     const sandbox = createSandboxHandle(
@@ -210,35 +248,8 @@ describe("runtime artifact manifest", () => {
       }),
       runtimeSubjectHandleFactory: () => sandbox,
     } as ApiBindings;
-    const link: RuntimeSessionLink = {
-      agentId: PUBLIC_API_TEST_IDS.agent,
-      callerId: PUBLIC_API_TEST_IDS.ownerAccount,
-      creatorId: PUBLIC_API_TEST_IDS.ownerAccount,
-      executionOwnerId: PUBLIC_API_TEST_IDS.ownerAccount,
-      sandboxId: PUBLIC_API_TEST_IDS.sandbox,
-      sandboxKind: "cattle",
-      sandboxSubjectKind: "session",
-      sessionId: PUBLIC_API_TEST_IDS.ownerSession,
-      sessionRunId: PUBLIC_API_TEST_IDS.run,
-      sessionRunStatus: "running",
-      traceId: "trace-artifact-manifest",
-    };
-    const event = createRuntimeEvent({
-      driverInstanceId: PUBLIC_API_TEST_IDS.driverOwner,
-      id: API_DRIVER_BOUNDARY_IDS.runtimeEvent,
-      kind: "run.completed",
-      occurredAt: "2026-06-22T00:00:00.000Z",
-      payload: {
-        run: {
-          completedAt: "2026-06-22T00:00:00.000Z",
-          error: null,
-          startedAt: null,
-          status: "completed",
-        },
-      },
-      runId: PUBLIC_API_TEST_IDS.run,
-      sessionId: PUBLIC_API_TEST_IDS.ownerSession,
-    });
+    const link = createArtifactManifestRuntimeLink();
+    const event = createCompletedRunEvent();
 
     await appRuntimeDriverEvents(bindings, {
       currentLiveState: createBaseLiveState({
@@ -295,5 +306,47 @@ describe("runtime artifact manifest", () => {
         contentType: "text/plain",
       }),
     ]);
+  });
+
+  test("skips optional sandbox artifact manifest when it does not exist", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertOwnerSession(database);
+    await insertActiveSandboxSession(database);
+
+    const bucket = new PublicApiMemoryFileBucket();
+    const sandbox = createSandboxHandle(new Map());
+    const bindings = {
+      ...createPublicHttpTestBindings(database, {
+        fileBucket: bucket as unknown as R2Bucket,
+      }),
+      runtimeSubjectHandleFactory: () => sandbox,
+    } as ApiBindings;
+    const link = createArtifactManifestRuntimeLink();
+    const event = createCompletedRunEvent();
+
+    await appRuntimeDriverEvents(bindings, {
+      currentLiveState: createBaseLiveState({
+        callerId: link.callerId,
+        creatorId: link.creatorId,
+        driverInstanceId: PUBLIC_API_TEST_IDS.driverOwner,
+        sessionId: link.sessionId,
+      }),
+      driverInstanceId: PUBLIC_API_TEST_IDS.driverOwner,
+      events: [
+        {
+          event,
+          eventId: "source-run-completed-without-artifacts",
+          occurredAt: 1,
+        },
+      ],
+      link,
+    });
+
+    const row = await database
+      .prepare("SELECT count(*) AS count FROM file_record")
+      .first<{ count: number }>();
+
+    expect(row?.count).toBe(0);
+    expect([...bucket.objects.values()]).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- probe for optional .mosoo/artifacts.json before reading it from the sandbox
- keep missing runtime artifact manifests as no-op instead of producing noisy sandbox file-read errors
- add coverage for the missing-manifest path

## Verification
- bash ./init.sh development
- bun test apps/api/tests/runtime-artifact-manifest.test.ts
- bun run --filter @mosoo/api tc
- local /api/health on http://localhost:5173 and http://localhost:8788
- local Docker Desktop sandbox prewarm: sandbox active, driver ready, proxy container up
- Bash tool smoke in session 01KVQRZNQS9VW0T3APM83CAR63: run 01KVQVQME3B4W710FWW5HVZ9CE completed with tool_result output sandbox-health-ok
