### PR TITLE
fix(auth): support PAT auth for REST routes

### DIFF
--- a/apps/api/src/adapters/graphql/create-graphql-gateway.ts
+++ b/apps/api/src/adapters/graphql/create-graphql-gateway.ts
@@ -1,13 +1,8 @@
 import { PUBLIC_API_PREFIX } from "@mosoo/contracts/public-api";
 import { createYoga } from "graphql-yoga";
 
-import {
-  authenticatePersonalAccessToken,
-  readBearerToken,
-} from "../../modules/auth/application/personal-access-token.service";
-import { getViewerFromRequest } from "../../modules/auth/application/viewer-auth.service";
+import { getAuthenticatedViewerFromRequest } from "../../modules/auth/application/viewer-auth.service";
 import type { ApiServerContext } from "../../platform/cloudflare/worker-types";
-import { isTruthy } from "../../shared/truthiness";
 import { createGraphQLSchema } from "./create-graphql-schema";
 import type { GraphQLContext } from "./graphql-context";
 const schema = createGraphQLSchema();
@@ -16,12 +11,7 @@ export function createGraphQLGateway() {
   return createYoga<ApiServerContext, GraphQLContext>({
     context: async ({ request, ...serverContext }) => {
       const { executionCtx: executionContext, ...bindings } = serverContext;
-      const sessionViewer = await getViewerFromRequest(bindings, request);
-      const token = sessionViewer ? null : readBearerToken(request);
-      const tokenCaller = isTruthy(token)
-        ? await authenticatePersonalAccessToken(bindings.DB, token)
-        : null;
-      const viewer = tokenCaller ? tokenCaller.viewer : sessionViewer;
+      const viewer = await getAuthenticatedViewerFromRequest(bindings, request);
 
       return {
         ...serverContext,

--- a/apps/api/src/adapters/http/routes/access-token-route.ts
+++ b/apps/api/src/adapters/http/routes/access-token-route.ts
@@ -8,7 +8,10 @@ import {
   listPersonalAccessTokens,
   revokePersonalAccessToken,
 } from "../../../modules/auth/application/personal-access-token.service";
-import { getViewerFromRequest } from "../../../modules/auth/application/viewer-auth.service";
+import {
+  getAuthenticatedViewerFromRequest,
+  getViewerFromRequest,
+} from "../../../modules/auth/application/viewer-auth.service";
 import { createErrorLogContext, logError } from "../../../platform/cloudflare/logger";
 import type { ApiGatewayEnvironment } from "../../../platform/cloudflare/worker-types";
 import {
@@ -69,7 +72,7 @@ async function readCreatePersonalAccessTokenRequest(
 export function registerAccessTokenRoute(app: Hono<ApiGatewayEnvironment>) {
   app.get("/access-tokens", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
       if (!viewer) {
         return unauthorized();
       }
@@ -100,7 +103,7 @@ export function registerAccessTokenRoute(app: Hono<ApiGatewayEnvironment>) {
 
   app.delete("/access-tokens/:tokenId", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
       if (!viewer) {
         return unauthorized();
       }

--- a/apps/api/src/adapters/http/routes/file-route.ts
+++ b/apps/api/src/adapters/http/routes/file-route.ts
@@ -12,7 +12,7 @@ import type { FileListQuery, FileSessionKind } from "@mosoo/contracts/file";
 import type { AppId, FileId, SessionId } from "@mosoo/id";
 import type { Hono } from "hono";
 
-import { getViewerFromRequest } from "../../../modules/auth/application/viewer-auth.service";
+import { getAuthenticatedViewerFromRequest } from "../../../modules/auth/application/viewer-auth.service";
 import {
   FileControlError,
   createFileErrorResponse,
@@ -137,7 +137,7 @@ function toFileEntry(file: FileRecord): FileEntry {
 export function registerFileRoute(app: Hono<ApiGatewayEnvironment>) {
   app.get("/files", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
 
       if (!viewer) {
         return Response.json(createFileErrorResponse(unauthorizedFileError()), { status: 401 });
@@ -159,7 +159,7 @@ export function registerFileRoute(app: Hono<ApiGatewayEnvironment>) {
 
   app.post("/files", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
 
       if (!viewer) {
         return Response.json(createFileErrorResponse(unauthorizedFileError()), { status: 401 });
@@ -175,7 +175,7 @@ export function registerFileRoute(app: Hono<ApiGatewayEnvironment>) {
 
   app.get("/files/:fileId/upload", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
 
       if (!viewer) {
         return Response.json(createFileErrorResponse(unauthorizedFileError()), { status: 401 });
@@ -195,7 +195,7 @@ export function registerFileRoute(app: Hono<ApiGatewayEnvironment>) {
 
   app.put("/files/:fileId/content", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
 
       if (!viewer) {
         return Response.json(createFileErrorResponse(unauthorizedFileError()), { status: 401 });
@@ -215,7 +215,7 @@ export function registerFileRoute(app: Hono<ApiGatewayEnvironment>) {
 
   app.put("/files/:fileId/parts/:partNumber", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
 
       if (!viewer) {
         return Response.json(createFileErrorResponse(unauthorizedFileError()), { status: 401 });
@@ -237,7 +237,7 @@ export function registerFileRoute(app: Hono<ApiGatewayEnvironment>) {
 
   app.post("/files/:fileId/complete", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
 
       if (!viewer) {
         return Response.json(createFileErrorResponse(unauthorizedFileError()), { status: 401 });
@@ -259,7 +259,7 @@ export function registerFileRoute(app: Hono<ApiGatewayEnvironment>) {
 
   app.delete("/files/:fileId/upload", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
 
       if (!viewer) {
         return Response.json(createFileErrorResponse(unauthorizedFileError()), { status: 401 });
@@ -278,7 +278,7 @@ export function registerFileRoute(app: Hono<ApiGatewayEnvironment>) {
 
   app.get("/files/:fileId/content", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
 
       if (!viewer) {
         return Response.json(createFileErrorResponse(unauthorizedFileError()), { status: 401 });
@@ -303,7 +303,7 @@ export function registerFileRoute(app: Hono<ApiGatewayEnvironment>) {
 
   app.patch("/files/:fileId", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
 
       if (!viewer) {
         return Response.json(createFileErrorResponse(unauthorizedFileError()), { status: 401 });
@@ -325,7 +325,7 @@ export function registerFileRoute(app: Hono<ApiGatewayEnvironment>) {
 
   app.delete("/files/:fileId", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
 
       if (!viewer) {
         return c.json(

--- a/apps/api/src/adapters/http/routes/skill-route.ts
+++ b/apps/api/src/adapters/http/routes/skill-route.ts
@@ -1,7 +1,7 @@
 import type { AppId, SkillId } from "@mosoo/id";
 import type { Hono } from "hono";
 
-import { getViewerFromRequest } from "../../../modules/auth/application/viewer-auth.service";
+import { getAuthenticatedViewerFromRequest } from "../../../modules/auth/application/viewer-auth.service";
 import { inspectSkillInput } from "../../../modules/skills/application/skill-package-source.service";
 import {
   createSkillFromUpload,
@@ -52,7 +52,7 @@ function errorResponse(error: unknown): Response {
 export function registerSkillRoute(app: Hono<ApiGatewayEnvironment>) {
   app.post("/skill/inspect", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
       if (!viewer) {
         return unauthorized();
       }
@@ -80,7 +80,7 @@ export function registerSkillRoute(app: Hono<ApiGatewayEnvironment>) {
 
   app.post("/skill/package", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
       if (!viewer) {
         return unauthorized();
       }
@@ -144,7 +144,7 @@ export function registerSkillRoute(app: Hono<ApiGatewayEnvironment>) {
 
   app.get("/skill/:skillId/source", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
       if (!viewer) {
         return unauthorized();
       }
@@ -169,7 +169,7 @@ export function registerSkillRoute(app: Hono<ApiGatewayEnvironment>) {
 
   app.get("/skill/:skillId/package", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
       if (!viewer) {
         return unauthorized();
       }

--- a/apps/api/src/modules/auth/application/viewer-auth.service.ts
+++ b/apps/api/src/modules/auth/application/viewer-auth.service.ts
@@ -1,5 +1,6 @@
 import type { ApiBindings } from "../../../platform/cloudflare/worker-types";
 import type { AuthenticatedViewer } from "../domain/authenticated-viewer";
+import { authenticatePersonalAccessToken, readBearerToken } from "./personal-access-token.service";
 
 export type { AuthenticatedViewer };
 
@@ -19,4 +20,22 @@ export async function getViewerFromRequest(
     await import("../infrastructure/session-auth");
 
   return readViewerFromRequest(bindings, request);
+}
+
+export async function getAuthenticatedViewerFromRequest(
+  bindings: ApiBindings,
+  request: Request,
+): Promise<AuthenticatedViewer | null> {
+  const sessionViewer = await getViewerFromRequest(bindings, request);
+  if (sessionViewer) {
+    return sessionViewer;
+  }
+
+  const token = readBearerToken(request);
+  if (!token) {
+    return null;
+  }
+
+  const tokenCaller = await authenticatePersonalAccessToken(bindings.DB, token);
+  return tokenCaller?.viewer ?? null;
 }


### PR DESCRIPTION
## Summary

- Add a shared session-or-PAT viewer resolver for API requests.
- Reuse that resolver in GraphQL and REST routes for `/api/files`, `/api/skill/*`, and GET/DELETE `/api/access-tokens`.
- Keep POST `/api/access-tokens` session-only so a PAT cannot mint replacement PATs.

## Why

- `mosoo auth login` issues PATs, but these REST routes still only accepted session cookies.
- This aligns the REST routes with GraphQL and the rest of the bearer-token API behavior without adding a route-specific workaround.

## Verification

- Commands:
  - `rtk just check`
  - `command codex review --commit HEAD`
  - `rtk just tc-package @mosoo/api`
  - `rtk just test-file apps/api/tests/personal-access-token.test.ts`
  - `rtk just test-file apps/api/tests/file-upload-access.test.ts`
  - `git diff HEAD^ HEAD --check`
- Manual steps: N/A

## Risk And Blast Radius

- Affected packages: `@mosoo/api`
- Affected user flows or APIs: GraphQL viewer auth internals; REST `/api/files`, `/api/skill/*`, and `/api/access-tokens`
- Rollback: revert this commit to restore session-cookie-only behavior on the touched REST routes.

## Evidence

- UI/UX: N/A
- API or behavior: focused route/code review confirmed GET/DELETE token routes accept session or PAT, while POST token creation stays session-only.
- Logs, recordings, or test output: local checks listed above passed.

## Compatibility

- Public contract changes: additive Bearer PAT support for existing REST routes; no OpenAPI/GraphQL schema shape changes.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: `viewer-auth.service.ts`, `access-token-route.ts`, `file-route.ts`, `skill-route.ts`.
- Known trade-offs: no new tests were added by request; existing focused and full gates were run.

## Required Checks

- [x] PR title: `type(scope): subject` (e.g. `fix(fmt): restore pre-commit checks`)
- [x] Type: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`, `build`, `ci`, `style`, or `revert`
- [x] Subject starts lowercase; `!` only for intentional breaking changes (e.g. `feat(api)!: remove legacy session field`)
- [x] Branch follows `type/scope-subject` when maintained in this repository; fork branch names may vary
- [x] Commits: `type(scope): subject`, English only
- [x] CLA: if prompted by CLA Assistant, every human contributor has signed by posting the exact required PR comment
- [x] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence, or N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- Touched artifacts: N/A
- GraphQL codegen (`just graphql-codegen`): N/A
- DB baseline (`just db-regen`): N/A
- Lockfile (`bun.lock`): N/A
- Confirm no hand-edits to generated paths (`schema.generated.graphql`, `apps/web/src/gql/**`, `pkgs/db/drizzle/**`): confirmed.
