### PR TITLE
fix(runtime): satisfy lint rules in session output handling

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/events.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/events.ts
@@ -133,8 +133,7 @@ function getRuntimeOutputFileName(path: string): string {
     .trim()
     .replaceAll("\\", "/")
     .split("/")
-    .filter((segment) => segment.length > 0)
-    .at(-1);
+    .findLast((segment) => segment.length > 0);
 
   if (name === undefined) {
     throw new Error("Runtime output path must include a file name.");

--- a/apps/api/tests/runtime-session-outputs.test.ts
+++ b/apps/api/tests/runtime-session-outputs.test.ts
@@ -46,7 +46,7 @@ function createSandboxHandle(files: ReadonlyMap<string, string>): SandboxHandle 
       const output = [...files.keys()]
         .filter((path) => path.startsWith(outputDir))
         .map((path) => path.slice(outputDir.length))
-        .sort()
+        .toSorted()
         .join("\n");
 
       return {


### PR DESCRIPTION
## Summary

- Replace `filter((segment) => segment.length > 0).at(-1)` with `Array#findLast` in `getRuntimeOutputFileName`.
- Replace `Array#sort()` with `Array#toSorted()` in the session output listing test fixture.

## Why

- PR #101 was merged into `main` while the **Repository check** lint job was failing, so these two lint errors now live on `main` and break the check for every subsequent PR:
  - `unicorn/prefer-array-find`: Prefer `find` over filtering and accessing the first result.
  - `unicorn/no-array-sort`: Use `Array#toSorted()` instead of `Array#sort()`.
- Both fixes are behavior-preserving (`findLast` returns the same last non-empty segment; `toSorted` returns the same sorted listing).

## Verification

- Commands: ran `oxlint` with `unicorn/prefer-array-find` and `unicorn/no-array-sort` enabled on the two touched files — exit 0, no findings.
- Manual steps: N/A

## Risk And Blast Radius

- Affected packages: `@mosoo/api`
- Affected user flows or APIs: none — internal runtime output file-name resolution and a test fixture only.
- Rollback: revert this commit.

## Evidence

- UI/UX: N/A
- API or behavior: no behavior change.
- Logs, recordings, or test output: lint passes on the edited files.

## Compatibility

- Public contract changes: none
- Env or config changes: none
- Deployment or migration: none

## Reviewer Focus

- Closest review areas: `apps/api/src/modules/runtime/infrastructure/driver-instance/events.ts`, `apps/api/tests/runtime-session-outputs.test.ts`
- Known trade-offs: none

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `fix`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A

## Generated Files, Schema, And Lockfile

- N/A
