### PR TITLE
docs(prd): document thread file upload data plane

### DIFF
--- a/docs/prd/public-thread-api-surface.md
+++ b/docs/prd/public-thread-api-surface.md
@@ -144,9 +144,16 @@ The current route family is:
 | Archive / unarchive Thread  | `POST /api/v1/threads/{threadId}/archive`      | Hide or restore a Thread for the caller.    |
 | Delete Thread               | `DELETE /api/v1/threads/{threadId}`            | Delete the Thread through the public API.   |
 | List Thread files           | `GET /api/v1/threads/{threadId}/files`         | List files attached to the Thread.          |
-| Attach Thread file          | `POST /api/v1/threads/{threadId}/files`        | Claim a draft file into the Thread.         |
+| Create Thread file upload   | `POST /api/v1/threads/{threadId}/files/uploads`| Open a Thread-scoped upload for raw bytes.  |
+| Upload Thread file bytes    | `PUT /api/v1/files/{fileId}/content`           | Send the file bytes for a pending upload.   |
+| Complete Thread file upload | `POST /api/v1/files/{fileId}/complete`         | Finalize a pending upload into a ready file. |
+| Attach Thread file          | `POST /api/v1/threads/{threadId}/files`        | Claim a ready file handle into the Thread.  |
 | Delete Thread file          | `DELETE /api/v1/threads/{threadId}/files/{id}` | Remove a file from the Thread.              |
 | Machine-readable API schema | `GET /api/v1/openapi.json`                     | Describe the Public Thread API for tooling. |
+
+Attaching a file is a two-stage flow: upload the bytes through the files data
+plane first (create upload → `PUT` content → complete), then claim the resulting
+`fileId` into the Thread. MVP public uploads are single `PUT` and size-capped.
 
 The public schema should keep runtime implementation details out of responses:
 driver ids, deployment internals, trace ids, vendor resume pointers, raw event


### PR DESCRIPTION
## Summary

- The Public Thread API human-facing surface (`docs/prd/public-thread-api-surface.md`) §5 route table listed only `POST /threads/{threadId}/files` for attaching a file, but the actual public file flow added in #96/#98 is a multi-step data plane: create upload → `PUT` bytes → complete → claim.
- Added the three missing rows (`POST /threads/{threadId}/files/uploads`, `PUT /files/{fileId}/content`, `POST /files/{fileId}/complete`), relabeled "Attach Thread file" as claiming a *ready* file handle, and added a short note describing the upload-then-claim flow.

## Why

- The doc claims to enumerate the "current route family," but it drifted behind the last-24h commits that shipped the public thread file data plane (#96 thread file upload endpoint, #98 public thread file data plane). The OpenAPI contract — which this doc defers to as the engineering source of truth — already documents these routes; the human narrative did not.

## Verification

- Cross-checked each route against the registered handlers in `apps/api/src/adapters/http/routes/public-api-route.ts` and the OpenAPI definitions in `public-api-openapi.ts`.
- Docs-only change; no code, codegen, or tests affected.

## Risk And Blast Radius

- Affected packages: docs only.
- Affected user flows or APIs: none (documentation accuracy only).
- Rollback: revert this commit.

## Compatibility

- Public contract changes: none — documents already-shipped routes.

## Reviewer Focus

- Confirm the route methods/paths in the new table rows match the OpenAPI contract.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Subject starts lowercase
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A
