### PR TITLE
perf(web): defer below-the-fold landing sections on login route

### DIFF
--- a/apps/web/src/routes/login/landing/landing-below-fold.tsx
+++ b/apps/web/src/routes/login/landing/landing-below-fold.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement } from "react";
+
+import { CostSection } from "./cost-section";
+import { CtaBand } from "./cta-band";
+import { DeploySection } from "./deploy-section";
+import { FaqSection } from "./faq-section";
+import { InvokeSection } from "./invoke-section";
+import { RuntimeShowcase } from "./runtime-showcase";
+import { SandboxSection } from "./sandbox-section";
+
+// Everything below the hero. Split into its own chunk and loaded lazily so the
+// login route's critical path only ships the hero and auth card — the marketing
+// sections (and their heavier deps, e.g. the avatar set in the cost section)
+// stream in as the visitor scrolls past the first viewport.
+export function LandingBelowFold({ onContinue }: { onContinue: () => void }): ReactElement {
+  return (
+    <>
+      <DeploySection />
+      <RuntimeShowcase />
+      <SandboxSection />
+      <InvokeSection />
+      <CostSection />
+      <FaqSection />
+      <CtaBand onContinue={onContinue} />
+    </>
+  );
+}

--- a/apps/web/src/routes/login/landing/landing.tsx
+++ b/apps/web/src/routes/login/landing/landing.tsx
@@ -1,13 +1,16 @@
+import { lazy, Suspense } from "react";
 import type { ReactElement } from "react";
 
-import { CostSection } from "./cost-section";
-import { CtaBand } from "./cta-band";
-import { DeploySection } from "./deploy-section";
-import { FaqSection } from "./faq-section";
 import { Hero } from "./hero";
-import { InvokeSection } from "./invoke-section";
-import { RuntimeShowcase } from "./runtime-showcase";
-import { SandboxSection } from "./sandbox-section";
+
+// The marketing sections below the hero are not part of the first viewport, so
+// they load as a separate chunk once the route has painted. Keeping them out of
+// the login route's initial bundle shrinks the first thing every unauthenticated
+// visitor downloads.
+const LandingBelowFold = lazy(async () => {
+  const mod = await import("./landing-below-fold");
+  return { default: mod.LandingBelowFold };
+});
 
 export function LoginLanding({ onContinue }: { onContinue: () => void }): ReactElement {
   return (
@@ -16,13 +19,9 @@ export function LoginLanding({ onContinue }: { onContinue: () => void }): ReactE
           height (the "wireframe"); sections are split by horizontal dividers. */}
       <div className="border-border-strong divide-border-strong mx-auto w-full max-w-[1280px] divide-y border-x">
         <Hero onContinue={onContinue} />
-        <DeploySection />
-        <RuntimeShowcase />
-        <SandboxSection />
-        <InvokeSection />
-        <CostSection />
-        <FaqSection />
-        <CtaBand onContinue={onContinue} />
+        <Suspense fallback={null}>
+          <LandingBelowFold onContinue={onContinue} />
+        </Suspense>
       </div>
     </div>
   );

--- a/apps/web/tests/login-landing-boundary.test.ts
+++ b/apps/web/tests/login-landing-boundary.test.ts
@@ -7,7 +7,7 @@ function readSource(path: string): string {
 
 describe("Login landing boundary", () => {
   test("keeps Invoke copy aligned with exported App reuse and Agent-owned delivery", () => {
-    const landingSource = readSource("../src/routes/login/landing/landing.tsx");
+    const landingSource = readSource("../src/routes/login/landing/landing-below-fold.tsx");
     const invokeSource = readSource("../src/routes/login/landing/invoke-section.tsx");
 
     expect(landingSource).toContain("InvokeSection");


### PR DESCRIPTION
## Summary

- The login route is the first page every unauthenticated visitor loads. Its chunk eagerly bundled the hero **plus seven below-the-fold marketing sections** (Deploy, Runtime, Sandbox, Invoke, Cost, FAQ, CTA) and their dependencies.
- Extracted the below-the-fold sections into `landing-below-fold.tsx` and load it with `React.lazy` + `Suspense` so first paint ships only the hero and auth card; the marketing sections stream in as a separate chunk afterward.

## Why

- First-paint weight on the most-visited unauthenticated page directly drives login/landing load experience (YEF-720, 前端加载体验优化).
- Measured impact (production build, gzip):
  - **Login route first-paint JS: 64.85 kB -> 23.79 kB (-63%, ~41 kB)**
  - Below-the-fold content moved to a separate `landing-below-fold` chunk (29.31 kB gzip) fetched after the route paints.
- No change to total bytes for the full landing, no change to layout or copy — purely a load-order improvement.

## Verification

- Commands: `bun run tc` (clean), `bun run lint` (clean), `bun run test` (132 pass / 0 fail), `bun run vp build` (chunk sizes confirmed).
- Manual steps: N/A — DOM output and styling are unchanged; only the load timing of below-the-fold sections differs.

## Risk And Blast Radius

- Affected packages: `@mosoo/web` (login landing only).
- Affected user flows or APIs: login/landing page first render. Below-the-fold sections appear after a short async load (fallback is `null`, below the initial viewport).
- Rollback: revert this commit.

## Evidence

- UI/UX: no visual change — same sections, layout, and copy; only split into a deferred chunk. No before/after screenshot needed (rendered result is identical).
- Test output: `132 pass, 0 fail` across 35 files.
- Build: `login.route` 198.87 kB -> 65.16 kB raw (gzip 64.85 -> 23.79 kB); new `landing-below-fold` 95.60 kB / 29.31 kB gzip.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: `apps/web/src/routes/login/landing/landing.tsx`, `landing-below-fold.tsx`.
- Known trade-offs: below-the-fold sections now load just after first paint; the landing-shell `ResizeObserver` already re-measures scroll height as content arrives, so the footer-reveal effect is unaffected.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `perf`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: no visual change (N/A)
- [x] No generated files hand-edited

## Generated Files, Schema, And Lockfile

- N/A — no generated artifacts touched.
