### PR TITLE
feat(openapi): add thread file downloads

### DIFF
--- a/apps/api/src/adapters/http/routes/public-api-openapi.ts
+++ b/apps/api/src/adapters/http/routes/public-api-openapi.ts
@@ -147,6 +147,19 @@ const threadEventsLimitParameter = {
   },
 } satisfies OpenApiParameter;
 
+const fileContentDispositionParameter = {
+  description:
+    "Controls the Content-Disposition response header. Use attachment for downloads or inline for previewable content.",
+  example: "attachment",
+  in: "query",
+  name: "disposition",
+  schema: {
+    default: "attachment",
+    enum: ["attachment", "inline"],
+    type: "string",
+  },
+} satisfies OpenApiParameter;
+
 const standardResponses = {
   "400": {
     $ref: "#/components/responses/InvalidRequest",
@@ -211,6 +224,38 @@ function binaryRequestBody(description: string) {
     },
     description,
     required: true,
+  };
+}
+
+function binaryResponse(description: string) {
+  return {
+    content: {
+      "application/octet-stream": {
+        schema: {
+          format: "binary",
+          type: "string",
+        },
+      },
+    },
+    description,
+    headers: {
+      "Cache-Control": {
+        description: "Set to no-store for public API file downloads.",
+        schema: { type: "string" },
+      },
+      "Content-Disposition": {
+        description: "Download or inline content disposition for the returned file.",
+        schema: { type: "string" },
+      },
+      "Content-Length": {
+        description: "File size in bytes.",
+        schema: { minimum: 0, type: "integer" },
+      },
+      ETag: {
+        description: "Storage ETag for the returned object.",
+        schema: { type: "string" },
+      },
+    },
   };
 }
 
@@ -303,6 +348,16 @@ export function createPublicApiOpenApiDocument(origin: string): PublicApiOpenApi
       }),
     },
     "/files/{fileId}/content": {
+      get: operation({
+        description:
+          "Downloads bytes for a ready Thread attachment or Agent artifact. The file must belong to a public Thread visible to the Access Token caller.",
+        parameters: [fileIdParameter, fileContentDispositionParameter],
+        security: ACCESS_TOKEN_SECURITY,
+        success: {
+          "200": binaryResponse("Thread file content."),
+        },
+        summary: "Download Thread file content",
+      }),
       put: operation({
         description:
           "Uploads raw bytes for a pending single PUT Thread file upload. The file must have been created through POST /threads/{threadId}/files/uploads and belong to a public Thread visible to the Access Token caller.",

--- a/apps/api/src/adapters/http/routes/public-api-route-support.ts
+++ b/apps/api/src/adapters/http/routes/public-api-route-support.ts
@@ -317,6 +317,18 @@ export async function runPublicApiAuthenticatedJson<T>(
   }
 }
 
+export async function runPublicApiAuthenticatedResponse(
+  c: PublicApiRouteContext,
+  operation: (caller: PersonalAccessTokenCaller) => Promise<Response>,
+): Promise<Response> {
+  try {
+    const caller = await requireRateLimitedAccessTokenCaller(c);
+    return await operation(caller);
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}
+
 export async function runPublicApiSessionMutation<T, Prepared = undefined>(
   c: PublicApiRouteContext,
   input: {

--- a/apps/api/src/adapters/http/routes/public-api-route.ts
+++ b/apps/api/src/adapters/http/routes/public-api-route.ts
@@ -11,12 +11,14 @@ import type { ApiGatewayEnvironment } from "../../../platform/cloudflare/worker-
 import { createPublicApiOpenApiDocument } from "./public-api-openapi";
 import {
   runPublicApiAuthenticatedJson,
+  runPublicApiAuthenticatedResponse,
   runPublicApiSessionMutation,
   runPublicApiThreadMutation,
   runPublicApiThreadReadJson,
   runPublicApiThreadReadResponse,
 } from "./public-api-route-support";
 import {
+  parseFileContentDisposition,
   parseOptionalBoolean,
   parseAgentIdParam,
   parseFileIdParam,
@@ -166,6 +168,16 @@ export function registerPublicApiRoute(app: Hono<ApiGatewayEnvironment>) {
         archived: parseOptionalBoolean(c.req.query("archived")),
       }),
     ),
+  );
+
+  v1.get("/files/:fileId/content", async (c) =>
+    runPublicApiAuthenticatedResponse(c, async (caller) => {
+      const service = await loadPublicThreadFileService();
+      return service.downloadPublicThreadFileContent(c.env, caller.viewer, {
+        disposition: parseFileContentDisposition(c.req.query("disposition")),
+        fileId: parseFileIdParam(c.req.param("fileId")),
+      });
+    }),
   );
 
   v1.put("/files/:fileId/content", async (c) =>

--- a/apps/api/src/adapters/http/routes/public-thread-api-request.ts
+++ b/apps/api/src/adapters/http/routes/public-thread-api-request.ts
@@ -162,6 +162,22 @@ export function parseOptionalBoolean(value: string | undefined): boolean | null 
   });
 }
 
+export function parseFileContentDisposition(value: string | undefined): "attachment" | "inline" {
+  if (value === undefined) {
+    return "attachment";
+  }
+
+  if (value === "attachment" || value === "inline") {
+    return value;
+  }
+
+  throw new PublicApiError({
+    code: "invalid_request",
+    message: "File content disposition must be attachment or inline.",
+    status: 400,
+  });
+}
+
 export function parseThreadEventsLimit(value: string | undefined): number {
   if (value === undefined) {
     return PUBLIC_THREAD_EVENTS_DEFAULT_LIMIT;

--- a/apps/api/src/modules/public-api/public-thread-file-api.service.ts
+++ b/apps/api/src/modules/public-api/public-thread-file-api.service.ts
@@ -46,16 +46,24 @@ function assertPublicThreadFile(file: FileRecord, sessionId: SessionId): void {
   }
 }
 
-function requirePublicThreadAttachment(file: FileRecord): PublicThreadId {
+function requirePublicThreadFile(file: FileRecord): PublicThreadId {
   if (
     file.scope.kind !== "session" ||
     file.scope.id === null ||
-    file.sessionKind !== "attachment"
+    (file.sessionKind !== "attachment" && file.sessionKind !== "artifact")
   ) {
     throw new FileControlError(404, "file_not_found", `Thread file ${file.id} was not found.`);
   }
 
   return toPublicThreadId(parsePlatformId<SessionId>(file.scope.id, "File session ID"));
+}
+
+function requirePublicThreadAttachment(file: FileRecord): PublicThreadId {
+  if (file.sessionKind !== "attachment") {
+    throw new FileControlError(404, "file_not_found", `Thread file ${file.id} was not found.`);
+  }
+
+  return requirePublicThreadFile(file);
 }
 
 function toPublicThreadFile(file: FileEntry | FileRecord): PublicThreadFile {
@@ -132,6 +140,28 @@ export async function completePublicThreadFileUpload(
     fileId: input.fileId,
     input: input.request,
     viewer: caller,
+  });
+}
+
+export async function downloadPublicThreadFileContent(
+  bindings: ApiBindings,
+  caller: AuthenticatedViewer,
+  input: {
+    disposition: "attachment" | "inline";
+    fileId: FileId;
+  },
+): Promise<Response> {
+  const file = await fileStore.getRecord(bindings, caller, input.fileId);
+  const threadId = requirePublicThreadFile(file);
+
+  await admitPublicSessionCaller(bindings.DB, caller, threadId);
+  const response = await fileStore.streamContent(bindings, caller, input.fileId, input.disposition);
+  const headers = new Headers(response.headers);
+  headers.set("Cache-Control", "no-store");
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
   });
 }
 

--- a/apps/api/tests/api-web-boundary.test.ts
+++ b/apps/api/tests/api-web-boundary.test.ts
@@ -11,6 +11,7 @@ import { isEnumType, isInputObjectType, isObjectType } from "graphql";
 import { createGraphQLSchema } from "../src/adapters/graphql/create-graphql-schema";
 import { createPublicApiOpenApiDocument } from "../src/adapters/http/routes/public-api-openapi";
 import {
+  parseFileContentDisposition,
   parseOptionalBoolean,
   readCreateThreadRequest,
   readCreateThreadFileRequest,
@@ -296,6 +297,40 @@ describe("API to web boundary", () => {
       "/threads/{threadId}/files/{fileId}",
       "/threads/{threadId}/unarchive",
     ]);
+
+    const downloadContentOperation = document.paths["/files/{fileId}/content"]?.get;
+    expect(downloadContentOperation?.parameters?.map((parameter) => parameter.name)).toEqual([
+      "fileId",
+      "disposition",
+    ]);
+    const dispositionParameter = downloadContentOperation?.parameters?.find(
+      (parameter) => parameter.name === "disposition",
+    );
+    expect(dispositionParameter).toMatchObject({
+      in: "query",
+      schema: {
+        default: "attachment",
+        enum: ["attachment", "inline"],
+        type: "string",
+      },
+    });
+    expect(downloadContentOperation?.requestBody).toBeUndefined();
+    expect(downloadContentOperation?.responses["200"]).toMatchObject({
+      content: {
+        "application/octet-stream": {
+          schema: {
+            format: "binary",
+            type: "string",
+          },
+        },
+      },
+      headers: {
+        "Cache-Control": {},
+        "Content-Disposition": {},
+        "Content-Length": {},
+        ETag: {},
+      },
+    });
 
     const uploadContentOperation = document.paths["/files/{fileId}/content"]?.put;
     expect(uploadContentOperation?.parameters?.map((parameter) => parameter.name)).toContain(
@@ -916,10 +951,24 @@ describe("API to web boundary", () => {
     expect(parseOptionalBoolean(undefined)).toBeNull();
     expect(parseOptionalBoolean("true")).toBe(true);
     expect(parseOptionalBoolean("false")).toBe(false);
+    expect(parseFileContentDisposition(undefined)).toBe("attachment");
+    expect(parseFileContentDisposition("attachment")).toBe("attachment");
+    expect(parseFileContentDisposition("inline")).toBe("inline");
 
     try {
       parseOptionalBoolean("yes");
       throw new Error("Expected parseOptionalBoolean to reject.");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PublicApiError);
+      expect(error).toMatchObject({
+        code: "invalid_request",
+        status: 400,
+      });
+    }
+
+    try {
+      parseFileContentDisposition("download");
+      throw new Error("Expected parseFileContentDisposition to reject.");
     } catch (error) {
       expect(error).toBeInstanceOf(PublicApiError);
       expect(error).toMatchObject({

--- a/apps/api/tests/public-thread-api.e2e.test.ts
+++ b/apps/api/tests/public-thread-api.e2e.test.ts
@@ -982,6 +982,45 @@ describe("Public Thread API e2e", () => {
         size: 23,
       });
 
+      const downloadAttachmentResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/files/${fileId}/content`, {
+          headers: { Authorization: bearer(TOKENS.owner) },
+        }),
+      );
+      expect(downloadAttachmentResponse.status).toBe(200);
+      expect(downloadAttachmentResponse.headers.get("cache-control")).toBe("no-store");
+      expect(downloadAttachmentResponse.headers.get("content-type")).toBe("text/plain");
+      expect(downloadAttachmentResponse.headers.get("content-disposition")).toContain(
+        'attachment; filename="launch-note.txt"',
+      );
+      expect(await downloadAttachmentResponse.text()).toBe("Launch note.\n");
+
+      const downloadArtifactResponse = await requestThreadApi(
+        new Request(
+          `https://api.example.com/api/v1/files/${PUBLIC_API_TEST_IDS.fileAlt}/content?disposition=inline`,
+          {
+            headers: { Authorization: bearer(TOKENS.owner) },
+          },
+        ),
+      );
+      expect(downloadArtifactResponse.status).toBe(200);
+      expect(downloadArtifactResponse.headers.get("cache-control")).toBe("no-store");
+      expect(downloadArtifactResponse.headers.get("content-type")).toBe("text/markdown");
+      expect(downloadArtifactResponse.headers.get("content-disposition")).toContain(
+        'inline; filename="summary.md"',
+      );
+      expect(await downloadArtifactResponse.text()).toBe("runtime summary");
+
+      const nonOwnerDownloadResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/files/${fileId}/content`, {
+          headers: { Authorization: bearer(TOKENS.nonOwner) },
+        }),
+      );
+      expect(nonOwnerDownloadResponse.status).toBe(404);
+      expect(expectRecord(await readJson(nonOwnerDownloadResponse))["error"]).toMatchObject({
+        code: "not_found",
+      });
+
       const deleteFileResponse = await requestThreadApi(
         new Request(`https://api.example.com/api/v1/threads/${threadId}/files/${fileId}`, {
           headers: { Authorization: bearer(TOKENS.owner) },
@@ -1199,6 +1238,17 @@ describe("Public Thread API e2e", () => {
         .first<{ status: string }>();
       expect(uploadedRow).toEqual({ status: "uploading" });
 
+      const pendingDownloadResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/files/${fileId}/content`, {
+          headers: { Authorization: bearer(TOKENS.owner) },
+        }),
+      );
+      expect(pendingDownloadResponse.status).toBe(400);
+      expect(expectRecord(await readJson(pendingDownloadResponse))["error"]).toMatchObject({
+        code: "invalid_request",
+        message: "Only a ready file can be downloaded.",
+      });
+
       const nonOwnerUploadResponse = await requestThreadApi(
         new Request(`https://api.example.com/api/v1/files/${fileId}/content`, {
           body: "non-owner overwrite\n",
@@ -1264,6 +1314,31 @@ describe("Public Thread API e2e", () => {
       expect(await finalObject?.text()).toBe(fileBody);
       expect(await bucket.get(pendingFileRow.object_key)).toBeNull();
 
+      const downloadContentResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/files/${fileId}/content?disposition=inline`, {
+          headers: { Authorization: bearer(TOKENS.owner) },
+        }),
+      );
+      expect(downloadContentResponse.status).toBe(200);
+      expect(downloadContentResponse.headers.get("cache-control")).toBe("no-store");
+      expect(downloadContentResponse.headers.get("content-length")).toBe(String(fileSize));
+      expect(downloadContentResponse.headers.get("content-type")).toBe("text/plain");
+      expect(downloadContentResponse.headers.get("content-disposition")).toContain(
+        'inline; filename="launch-note.txt"',
+      );
+      expect(await downloadContentResponse.text()).toBe(fileBody);
+
+      const invalidDispositionResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/files/${fileId}/content?disposition=download`, {
+          headers: { Authorization: bearer(TOKENS.owner) },
+        }),
+      );
+      expect(invalidDispositionResponse.status).toBe(400);
+      expect(expectRecord(await readJson(invalidDispositionResponse))["error"]).toMatchObject({
+        code: "invalid_request",
+        message: "File content disposition must be attachment or inline.",
+      });
+
       const completedFileRow = await database
         .prepare(
           `SELECT committed, expires_at, object_key, status
@@ -1323,6 +1398,22 @@ describe("Public Thread API e2e", () => {
       );
       expect(appDraftCompleteResponse.status).toBe(404);
       expect(expectRecord(await readJson(appDraftCompleteResponse))["error"]).toMatchObject({
+        code: "not_found",
+      });
+
+      const readyAppDraftFileId = await createReadyAppDraftFile({
+        body: "Ready app draft.\n",
+        bucket,
+        database,
+        name: "ready-app-draft.txt",
+      });
+      const appDraftDownloadResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/files/${readyAppDraftFileId}/content`, {
+          headers: { Authorization: bearer(TOKENS.owner) },
+        }),
+      );
+      expect(appDraftDownloadResponse.status).toBe(404);
+      expect(expectRecord(await readJson(appDraftDownloadResponse))["error"]).toMatchObject({
         code: "not_found",
       });
     });


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/files/{fileId}/content` for downloading ready public Thread attachments and Agent artifacts.
- Reuse `fileStore.streamContent` for file bytes, headers, storage access, and ready-file enforcement while adding public Thread admission on top.
- Document the binary download response in the public OpenAPI document and cover attachment, artifact, non-ready, invalid disposition, and non-Thread file behavior in tests.

## Validation

- `just fmt-check-path apps/api/src/adapters/http/routes`
- `just fmt-check-path apps/api/src/modules/public-api`
- `just fmt-check-path apps/api/tests`
- `just tc-package @mosoo/contracts`
- `just tc-package @mosoo/api`
- `vp exec bun test apps/api/tests/api-web-boundary.test.ts apps/api/tests/public-thread-api.e2e.test.ts`
- `vp exec bun test apps/api/tests/public-thread-api.e2e.test.ts -t "creates a Thread file upload through the public files API contract"`
- `vp exec bun test apps/api/tests/public-thread-api.e2e.test.ts -t "archives, unarchives, and manages Thread files through the public routes"`
- `bun scripts/validate-commit-range.ts origin/main HEAD`

## Generated files / codegen / DB baseline

- Generated files: no
- GraphQL codegen: no
- DB baseline updates: no
