### PR TITLE
fix(web): align org shell chrome

### DIFF
--- a/apps/web/src/app/account-menu.tsx
+++ b/apps/web/src/app/account-menu.tsx
@@ -58,19 +58,12 @@ function UserAvatar({
 
 export function AccountMenu({
   collapsed,
-  placement = "sidebar",
   user,
 }: {
   collapsed: boolean;
-  placement?: "sidebar" | "topbar";
   user: AccountMenuUser | null;
 }) {
-  const wrapperClassName =
-    placement === "topbar"
-      ? ""
-      : cn(collapsed ? "flex justify-center pb-3 pt-2" : "px-2 pb-3 pt-2");
-  const menuSide = placement === "topbar" ? "bottom" : "top";
-  const menuAlign = placement === "topbar" ? "end" : "start";
+  const wrapperClassName = cn(collapsed ? "flex justify-center pb-3 pt-2" : "px-2 pb-3 pt-2");
   const trigger = collapsed ? (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -103,7 +96,7 @@ export function AccountMenu({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
 
-        <DropdownMenuContent align={menuAlign} side={menuSide} className="w-[220px] rounded-lg p-1">
+        <DropdownMenuContent align="start" side="top" className="w-[220px] rounded-lg p-1">
           <DropdownMenuLabel className="px-2 pb-1">
             <div className="text-fg-1 text-[13px] font-semibold">{user?.name}</div>
             <div className="text-fg-3 mt-0.5 text-[11.5px] font-normal">{user?.email}</div>

--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -195,6 +195,15 @@ function ConsoleSidebarFooter({ collapsed }: { collapsed: boolean }) {
   );
 }
 
+const ORG_HEADER_TITLES = [{ path: "/apps", title: "Apps" }] as const;
+
+function getOrgHeaderTitle(pathname: string): string | null {
+  return (
+    ORG_HEADER_TITLES.find((item) => pathname === item.path || pathname.startsWith(`${item.path}/`))
+      ?.title ?? null
+  );
+}
+
 // Shared console chrome (brand, collapse toggle, help, account, content area).
 // The middle `sidebar` slot is what differs between the App and Org layers.
 function ConsoleShell({
@@ -301,20 +310,30 @@ export function Layout({ children }: { children: ReactNode }) {
 export function OrgLayout({ children }: { children: ReactNode }) {
   const { activeOrganization } = useAppSession();
   const location = useLocation();
+  const headerTitle = getOrgHeaderTitle(location.pathname);
 
   return (
     <div className="bg-background flex h-screen flex-col">
-      <header className="border-border-soft flex h-14 shrink-0 items-center gap-2 border-b px-4">
-        <Link to="/apps" aria-label="Apps" className="flex items-center">
-          <img src="/brand/logo-mark.svg" alt="Mosoo" className="block size-6" />
-        </Link>
-        {activeOrganization === null ? null : (
-          <>
-            <span className="text-fg-muted text-base font-light">/</span>
-            <span className="text-foreground max-w-[240px] truncate text-sm font-semibold">
-              {activeOrganization.name}
-            </span>
-          </>
+      <header className="border-border-soft flex shrink-0 border-b">
+        <div className="flex min-h-[76px] w-[224px] shrink-0 items-center gap-2 px-4">
+          <Link to="/apps" aria-label="Apps" className="flex items-center">
+            <img src="/brand/logo-mark.svg" alt="Mosoo" className="block size-6" />
+          </Link>
+          {activeOrganization === null ? null : (
+            <>
+              <span className="text-fg-muted text-base font-light">/</span>
+              <span className="text-foreground max-w-[144px] truncate text-sm font-semibold">
+                {activeOrganization.name}
+              </span>
+            </>
+          )}
+        </div>
+        {headerTitle === null ? null : (
+          <div className="flex min-w-0 flex-1 items-center px-8">
+            <h1 className="text-foreground truncate text-2xl font-semibold tracking-normal">
+              {headerTitle}
+            </h1>
+          </div>
         )}
       </header>
       <div className="flex min-h-0 flex-1">

--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -14,7 +14,6 @@ import type { ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
 import { HelpMenu } from "@/features/help/help-menu";
-import { MOSOO_GITHUB_URL } from "@/shared/config/external-links";
 import { cn } from "@/shared/lib/class-names";
 import { Button } from "@/shared/ui/button";
 import {
@@ -148,23 +147,6 @@ function AppSwitcher({
   );
 }
 
-function GithubLink() {
-  return (
-    <a
-      href={MOSOO_GITHUB_URL}
-      target="_blank"
-      rel="noreferrer noopener"
-      aria-label="Mosoo on GitHub"
-      title="Mosoo on GitHub"
-      className="text-fg-2 hover:bg-ink-900/[0.04] hover:text-fg-1 flex size-9 items-center justify-center rounded-md transition-colors"
-    >
-      <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor" className="size-[18px]">
-        <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56 0-.28-.01-1.01-.02-1.99-3.2.7-3.87-1.54-3.87-1.54-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.74-1.55-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.51-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.79 0c2.21-1.49 3.18-1.18 3.18-1.18.62 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.39-5.25 5.68.41.36.78 1.06.78 2.14 0 1.55-.01 2.8-.01 3.18 0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
-      </svg>
-    </a>
-  );
-}
-
 function NewAgentCta({ collapsed, disabled }: { collapsed: boolean; disabled: boolean }) {
   const className = cn("mb-4", collapsed ? "mx-auto size-9 p-0" : "w-full justify-center");
   const label = "New agent";
@@ -199,6 +181,20 @@ function NewAgentCta({ collapsed, disabled }: { collapsed: boolean; disabled: bo
   );
 }
 
+function ConsoleSidebarFooter({ collapsed }: { collapsed: boolean }) {
+  const { user } = useAppSession();
+
+  return (
+    <>
+      <div className={cn("pb-2", collapsed ? "flex justify-center" : "px-0.5")}>
+        <HelpMenu collapsed={collapsed} />
+      </div>
+      <Separator className="bg-border-soft" />
+      <AccountMenu collapsed={collapsed} user={user} />
+    </>
+  );
+}
+
 // Shared console chrome (brand, collapse toggle, help, account, content area).
 // The middle `sidebar` slot is what differs between the App and Org layers.
 function ConsoleShell({
@@ -212,8 +208,6 @@ function ConsoleShell({
   onToggleCollapsed: () => void;
   sidebar: ReactNode;
 }) {
-  const { user } = useAppSession();
-
   const ToggleIcon = collapsed ? PanelLeftOpen : PanelLeftClose;
   const toggleLabel = collapsed ? "Expand sidebar" : "Collapse sidebar";
 
@@ -253,11 +247,7 @@ function ConsoleShell({
         {sidebar}
 
         <div className="flex-1" />
-        <div className={cn("pb-2", collapsed ? "flex justify-center" : "px-0.5")}>
-          <HelpMenu collapsed={collapsed} />
-        </div>
-        <Separator className="bg-border-soft" />
-        <AccountMenu collapsed={collapsed} user={user} />
+        <ConsoleSidebarFooter collapsed={collapsed} />
       </nav>
 
       <div className="flex min-w-0 flex-1 md:py-2 md:pr-2">
@@ -305,11 +295,11 @@ export function Layout({ children }: { children: ReactNode }) {
   );
 }
 
-// Org-layer shell: a horizontal top bar (logo + org switcher + account) over a
+// Org-layer shell: a horizontal top bar (logo + org name) over a
 // dedicated Org sidebar. Deliberately distinct from the App shell so the Apps
 // list / pre-App console reads as the account layer, not an App detail page.
 export function OrgLayout({ children }: { children: ReactNode }) {
-  const { activeOrganization, user } = useAppSession();
+  const { activeOrganization } = useAppSession();
   const location = useLocation();
 
   return (
@@ -326,14 +316,12 @@ export function OrgLayout({ children }: { children: ReactNode }) {
             </span>
           </>
         )}
-        <div className="flex-1" />
-        <GithubLink />
-        <HelpMenu collapsed />
-        <AccountMenu collapsed placement="topbar" user={user} />
       </header>
       <div className="flex min-h-0 flex-1">
-        <aside className="border-border-soft w-[224px] shrink-0 border-r px-3 py-4">
+        <aside className="border-border-soft flex w-[224px] shrink-0 flex-col border-r px-3 py-4">
           <OrgNavigation collapsed={false} pathname={location.pathname} />
+          <div className="flex-1" />
+          <ConsoleSidebarFooter collapsed={false} />
         </aside>
         <main className="min-w-0 flex-1 overflow-hidden">{children}</main>
       </div>

--- a/apps/web/src/routes/apps/apps-list.route.tsx
+++ b/apps/web/src/routes/apps/apps-list.route.tsx
@@ -101,10 +101,8 @@ export function AppsListPage() {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <main className="min-h-0 flex-1 overflow-y-auto px-8 pt-7 pb-8">
-        <h1 className="text-fg-1 text-[24px] font-semibold tracking-[-0.01em]">Apps</h1>
-
-        <div className="mt-6 flex flex-wrap items-center gap-3">
+      <main className="min-h-0 flex-1 overflow-y-auto px-8 pt-6 pb-8">
+        <div className="flex flex-wrap items-center gap-3">
           <div className="relative w-full max-w-[320px]">
             <Search className="text-fg-3 absolute top-1/2 left-3 size-3.5 -translate-y-1/2" />
             <Input

--- a/apps/web/tests/app-two-layer-boundary.test.ts
+++ b/apps/web/tests/app-two-layer-boundary.test.ts
@@ -32,6 +32,15 @@ describe("Two-layer console boundary", () => {
     expect(shell).not.toContain("<GithubLink />");
   });
 
+  test("Org shell owns the Apps title in the top band", () => {
+    const shell = readSource("../src/app/app-shell.tsx");
+    const appsList = readSource("../src/routes/apps/apps-list.route.tsx");
+
+    expect(shell).toContain('title: "Apps"');
+    expect(shell).toContain("getOrgHeaderTitle");
+    expect(appsList).not.toContain(">Apps</h1>");
+  });
+
   test("New app creation is wired to the createApp mutation", () => {
     const appsList = readSource("../src/routes/apps/apps-list.route.tsx");
 

--- a/apps/web/tests/app-two-layer-boundary.test.ts
+++ b/apps/web/tests/app-two-layer-boundary.test.ts
@@ -23,6 +23,15 @@ describe("Two-layer console boundary", () => {
     expect(shell).toContain("OrgNavigation");
   });
 
+  test("Org shell uses the shared lower-left account navigation", () => {
+    const shell = readSource("../src/app/app-shell.tsx");
+
+    expect(shell).toContain("ConsoleSidebarFooter");
+    expect(shell).toContain("<ConsoleSidebarFooter collapsed={false} />");
+    expect(shell).not.toContain('placement="topbar"');
+    expect(shell).not.toContain("<GithubLink />");
+  });
+
   test("New app creation is wired to the createApp mutation", () => {
     const appsList = readSource("../src/routes/apps/apps-list.route.tsx");
 


### PR DESCRIPTION
## Summary

- Move the shared account/help navigation into the lower-left org shell navigation so Apps matches the in-app avatar placement.
- Remove the duplicate top-right account placement from the org Apps surface.
- Move the Apps page H1 into the org header band and remove the duplicate content-area title.

## Validation

- `bun run fmt:check:path -- apps/web/src/app/app-shell.tsx apps/web/src/routes/apps/apps-list.route.tsx apps/web/tests/app-two-layer-boundary.test.ts`
- `git diff --check`
- `vp run --filter @mosoo/web test`
- `vp run --filter @mosoo/web tc`
- `vp run --filter @mosoo/web lint`
- `bun run commit:check`
- Playwright visual QA for `/apps` with screenshot attached on the Multica issue.

## Generated Artifacts

- Generated files: none
- GraphQL codegen: not updated
- DB baseline or migrations: not updated

Closes #91
