### PR TITLE
fix(apps): show copyable app ids

### DIFF
--- a/apps/web/src/routes/app-overview/app-overview.route.tsx
+++ b/apps/web/src/routes/app-overview/app-overview.route.tsx
@@ -2,6 +2,7 @@ import { Bot, Box, KeyRound } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { useAppSession } from "@/app/session-provider";
+import { AppIdBadge } from "@/shared/ui/app-id-badge";
 
 import { AppOverviewInstallGuide } from "./app-overview-install";
 
@@ -24,9 +25,12 @@ export function AppOverviewPage() {
             <Box className="size-3.5" />
             App
           </div>
-          <h1 className="text-foreground mt-1 truncate text-2xl font-semibold tracking-normal">
-            {activeApp.name}
-          </h1>
+          <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
+            <h1 className="text-foreground min-w-0 truncate text-2xl font-semibold tracking-normal">
+              {activeApp.name}
+            </h1>
+            <AppIdBadge appId={activeApp.id} />
+          </div>
         </div>
         <div className="flex items-center gap-2">
           <Link

--- a/apps/web/src/routes/apps/apps-list.route.tsx
+++ b/apps/web/src/routes/apps/apps-list.route.tsx
@@ -8,6 +8,7 @@ import { useAppSession } from "@/app/session-provider";
 import { useVisibleAgentsQuery } from "@/domains/agent/query/agent-queries";
 import { createApp } from "@/domains/app/api/app-client";
 import { appKeys } from "@/domains/app/query/app-queries";
+import { AppIdBadge } from "@/shared/ui/app-id-badge";
 import { Button } from "@/shared/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/shared/ui/dialog";
 import { Input } from "@/shared/ui/input";
@@ -27,12 +28,14 @@ function AppCard({
     agentCount === undefined ? "—" : `${agentCount} ${agentCount === 1 ? "agent" : "agents"}`;
 
   return (
-    <button
-      type="button"
-      onClick={onEnter}
-      className="border-border bg-card hover:border-border-strong group flex flex-col gap-2.5 rounded-md border p-4 text-left transition-colors"
-    >
-      <div className="flex items-center gap-2">
+    <div className="border-border bg-card hover:border-border-strong group relative flex min-h-[120px] flex-col gap-3 rounded-md border p-4 text-left transition-colors">
+      <button
+        type="button"
+        onClick={onEnter}
+        aria-label={`Open ${app.name}`}
+        className="focus-visible:border-ring focus-visible:ring-ring absolute inset-0 rounded-md outline-none focus-visible:ring-[2px]"
+      />
+      <div className="pointer-events-none relative z-10 flex items-center gap-2">
         <span className="text-foreground min-w-0 flex-1 truncate text-sm font-semibold">
           {app.name}
         </span>
@@ -43,8 +46,11 @@ function AppCard({
         ) : null}
         <ChevronRight className="text-fg-3 group-hover:text-fg-1 size-4 shrink-0 transition-colors" />
       </div>
-      <div className="text-muted-foreground text-xs">{agentLabel}</div>
-    </button>
+      <div className="pointer-events-none relative z-10 flex min-w-0 flex-col gap-2">
+        <AppIdBadge appId={app.id} className="pointer-events-auto w-fit" />
+        <div className="text-muted-foreground text-xs">{agentLabel}</div>
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/src/shared/ui/app-id-badge.tsx
+++ b/apps/web/src/shared/ui/app-id-badge.tsx
@@ -1,0 +1,70 @@
+import { Check, Copy } from "lucide-react";
+import type { MouseEvent, ReactElement } from "react";
+import { useState } from "react";
+
+import { cn } from "@/shared/lib/class-names";
+import { Button } from "@/shared/ui/button";
+
+async function writeClipboardText(text: string): Promise<boolean> {
+  if (typeof navigator === "undefined" || !navigator.clipboard) {
+    return false;
+  }
+
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function AppIdBadge({
+  appId,
+  className,
+}: {
+  appId: string;
+  className?: string;
+}): ReactElement {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy(event: MouseEvent<HTMLButtonElement>): Promise<void> {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const didCopy = await writeClipboardText(appId);
+    if (!didCopy) {
+      return;
+    }
+
+    setCopied(true);
+    globalThis.setTimeout(() => {
+      setCopied(false);
+    }, 1500);
+  }
+
+  return (
+    <div
+      className={cn(
+        "border-border-subtle text-muted-foreground inline-flex h-6 max-w-full min-w-0 items-center gap-1 rounded-md border bg-white py-0.5 pr-0.5 pl-1.5 text-[11px]",
+        className,
+      )}
+    >
+      <span title={appId} className="min-w-0 truncate font-mono">
+        App ID: {appId}
+      </span>
+      <Button
+        aria-label={copied ? "App ID copied" : "Copy app ID"}
+        className="text-muted-foreground hover:text-foreground size-5"
+        onClick={(event) => {
+          void handleCopy(event);
+        }}
+        size="icon-xs"
+        title={copied ? "Copied" : "Copy app ID"}
+        type="button"
+        variant="ghost"
+      >
+        {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/tests/app-overview-boundary.test.ts
+++ b/apps/web/tests/app-overview-boundary.test.ts
@@ -32,12 +32,15 @@ describe("App overview boundary", () => {
   test("hands the App to a coding agent with one CLI command on the console root", () => {
     const routeSource = readSource("../src/routes/app-overview/app-overview.route.tsx");
     const installSource = readSource("../src/routes/app-overview/app-overview-install.tsx");
+    const appIdBadgeSource = readSource("../src/shared/ui/app-id-badge.tsx");
 
     expect(routeSource).toContain("AppOverviewInstallGuide");
+    expect(routeSource).toContain("AppIdBadge");
     expect(installSource).toContain("Hand Mosoo to your agent");
     expect(installSource).toContain("npx mosoo login");
     expect(installSource).toContain("@mosoo skill");
     expect(installSource).toContain("Codex");
+    expect(appIdBadgeSource).toContain("Copy app ID");
     // The CLI token is minted on demand and only copied — never rendered.
     expect(installSource).toContain("createPersonalAccessToken");
     expect(installSource).toContain("MASKED_TOKEN");

--- a/apps/web/tests/app-two-layer-boundary.test.ts
+++ b/apps/web/tests/app-two-layer-boundary.test.ts
@@ -46,6 +46,7 @@ describe("Two-layer console boundary", () => {
 
     expect(appsList).toContain("createApp");
     expect(appsList).toContain("New app");
+    expect(appsList).toContain("AppIdBadge");
     expect(appsList).not.toContain("coming soon");
   });
 });


### PR DESCRIPTION
## Summary

- Add a reusable App ID badge with a copy action.
- Show the App ID on each Apps page card.
- Show the active App ID next to the App overview title.
- Extend boundary tests so both surfaces keep rendering the copyable App ID.

## Validation

- `bun run --filter @mosoo/web test`
- `bun run --filter @mosoo/web tc`
- `bun run --filter @mosoo/web lint`
- `bun run fmt:check:path apps/web/src/shared/ui/app-id-badge.tsx apps/web/src/routes/apps/apps-list.route.tsx apps/web/src/routes/app-overview/app-overview.route.tsx apps/web/tests/app-overview-boundary.test.ts apps/web/tests/app-two-layer-boundary.test.ts`
- `bun run commit:check`
- Local visual smoke on `http://localhost:5174`: confirmed the Apps list and App overview render the App ID badge, and confirmed the copy action writes the app ID to the clipboard.

## Notes

- Generated files: none.
- GraphQL codegen: not changed.
- DB baseline: not changed.

Closes YEF-722.
Related GitHub issue: https://github.com/langgenius/mosoo/issues/107
