### PR TITLE
fix(threads): give New thread description more breathing room

### DIFF
--- a/apps/web/src/routes/threads/compose/new-dialog.tsx
+++ b/apps/web/src/routes/threads/compose/new-dialog.tsx
@@ -365,7 +365,7 @@ export function NewThreadDialog({
           </div>
         </DialogHeader>
 
-        <div className="flex min-h-0 flex-col gap-3 px-5 py-4">
+        <div className="flex min-h-0 flex-col gap-4 px-5 py-4">
           <AgentAssignField
             agents={agents}
             locked={locked}


### PR DESCRIPTION
## Summary

- Adjust the spacing in the **New thread** composer so the description textarea is no longer cramped against the *Assign to* field. The body's inter-item gap is bumped from `gap-3` (12px) to `gap-4` (16px), matching the body's existing 16px (`py-4`) outer rhythm.

## Why

- Reported via issue YEF-725 (UI margin adjustment, see screenshot). The description input sits ~12px below the *Assign to* row, which reads as tight for the modal's primary input. Aligning the gap with the surrounding 16px rhythm gives it consistent breathing room.

## Verification

- Commands: N/A (single Tailwind class change; no logic touched).
- Manual steps: Open the **New thread** dialog; the description placeholder now has slightly more separation from the *Assign to* field.

## Risk And Blast Radius

- Affected packages: `@mosoo/web`
- Affected user flows or APIs: New thread composer dialog only (visual spacing).
- Rollback: revert the single-line class change.

## Evidence

- UI/UX: before/after comparison rendered from a faithful static replica of the composer top section (the change is a +4px vertical gap between *Assign to* and the description). Screenshots are attached on the Multica issue YEF-725.

## Compatibility

- Public contract changes: none
- Env or config changes: none
- Deployment or migration: none

## Reviewer Focus

- Closest review areas: `apps/web/src/routes/threads/compose/new-dialog.tsx` body container className.
- Known trade-offs: magnitude is intentionally conservative (+4px); easy to tune if a larger/smaller gap is preferred.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `fix`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence (attached on issue YEF-725)
- [x] Generated files: none

## Generated Files, Schema, And Lockfile

- N/A
