### PR TITLE
fix(web): unify org settings header title

### DIFF
--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -195,7 +195,10 @@ function ConsoleSidebarFooter({ collapsed }: { collapsed: boolean }) {
   );
 }
 
-const ORG_HEADER_TITLES = [{ path: "/apps", title: "Apps" }] as const;
+const ORG_HEADER_TITLES = [
+  { path: "/apps", title: "Apps" },
+  { path: "/org/settings", title: "Org settings" },
+] as const;
 
 function getOrgHeaderTitle(pathname: string): string | null {
   return (

--- a/apps/web/src/routes/org/org-settings.route.tsx
+++ b/apps/web/src/routes/org/org-settings.route.tsx
@@ -1,5 +1,4 @@
 import { useAppSession } from "@/app/session-provider";
-import { PageHeader } from "@/shared/ui/page-header";
 
 function ReadonlyField({ label, value }: { label: string; value: string }) {
   return (
@@ -19,8 +18,6 @@ export function OrgSettingsPage() {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <PageHeader title="Org settings" description="General details for this account shell." />
-
       <main className="min-h-0 flex-1 overflow-y-auto px-8 py-6">
         <div className="max-w-[560px]">
           {activeOrganization === null ? (

--- a/apps/web/tests/app-two-layer-boundary.test.ts
+++ b/apps/web/tests/app-two-layer-boundary.test.ts
@@ -41,6 +41,15 @@ describe("Two-layer console boundary", () => {
     expect(appsList).not.toContain(">Apps</h1>");
   });
 
+  test("Org shell owns the Org settings title in the top band", () => {
+    const shell = readSource("../src/app/app-shell.tsx");
+    const orgSettings = readSource("../src/routes/org/org-settings.route.tsx");
+
+    expect(shell).toContain('path: "/org/settings", title: "Org settings"');
+    expect(orgSettings).not.toContain("<PageHeader");
+    expect(orgSettings).not.toContain('title="Org settings"');
+  });
+
   test("New app creation is wired to the createApp mutation", () => {
     const appsList = readSource("../src/routes/apps/apps-list.route.tsx");
 


### PR DESCRIPTION
## Summary

- Add `/org/settings` to the org shell header title map so it matches the Apps header treatment.
- Remove the in-page Org settings `PageHeader` so the body content starts consistently below the shared org chrome.
- Add boundary coverage that the org shell owns the Org settings title.

## Validation

- `bun run fmt:check:path -- apps/web/src/app/app-shell.tsx apps/web/src/routes/org/org-settings.route.tsx apps/web/tests/app-two-layer-boundary.test.ts`
- `git diff --check origin/main..HEAD`
- `vp run --filter @mosoo/web test`
- `vp run --filter @mosoo/web tc`
- `vp run --filter @mosoo/web lint`
- `bun run commit:check`
- Playwright visual QA for `/org/settings` with screenshot attached on the Multica issue.

## Generated Artifacts

- Generated files: none
- GraphQL codegen: not updated
- DB baseline or migrations: not updated

Follow-up to #108.
Related: #91
