### PR TITLE
fix(agent): consolidate readiness alerts

### DIFF
--- a/apps/web/src/features/session-chat/session-composer.tsx
+++ b/apps/web/src/features/session-chat/session-composer.tsx
@@ -21,6 +21,7 @@ interface SessionComposerProps {
   onSend: () => void;
   pendingSessionFiles: PendingSessionFileChip[];
   sendDisabledReason?: string | null;
+  showSendDisabledReason?: boolean;
   sending: boolean;
   sessionResourceMentions: SessionResourceMention[];
   setInput: (value: string) => void;
@@ -89,6 +90,7 @@ export function SessionComposer({
   onSend,
   pendingSessionFiles,
   sendDisabledReason,
+  showSendDisabledReason = true,
   sending,
   sessionResourceMentions,
   setInput,
@@ -116,7 +118,7 @@ export function SessionComposer({
         </div>
       ) : null}
 
-      {isTruthy(sendDisabledReason) ? (
+      {showSendDisabledReason && isTruthy(sendDisabledReason) ? (
         <div className="border-border bg-muted/40 text-fg-2 mx-3 mt-3 rounded-md border px-3 py-2 text-[13px]">
           {sendDisabledReason}
         </div>

--- a/apps/web/src/routes/agent/components/agent-readiness-blockers-banner.tsx
+++ b/apps/web/src/routes/agent/components/agent-readiness-blockers-banner.tsx
@@ -30,10 +30,11 @@ export function AgentReadinessBlockersBanner({
   const providerPresentation = getPrimaryProviderReadinessPresentation(readiness.issues);
   const isRetrying = retrying === true;
   const hasSummary = summary !== null && summary !== "";
+  const visibleMessages = hasSummary ? [] : messages;
 
   return (
     <div
-      className="border-destructive/25 bg-destructive/[0.05] border-b px-4 py-3"
+      className="border-destructive/25 bg-destructive/[0.05] mb-3 rounded-lg border px-3 py-2.5"
       data-testid="agent-readiness-blockers"
       role="alert"
     >
@@ -67,9 +68,9 @@ export function AgentReadinessBlockersBanner({
           </Button>
         ) : null}
       </div>
-      {messages.length > 0 ? (
+      {visibleMessages.length > 0 ? (
         <ul className="text-fg-2 mt-2 space-y-1 text-[12px] leading-relaxed">
-          {messages.map((message) => (
+          {visibleMessages.map((message) => (
             <li key={message} className="flex gap-2">
               <span aria-hidden className="bg-destructive mt-[0.55em] size-1 rounded-full" />
               <span>{message}</span>

--- a/apps/web/src/routes/agent/components/agent-session-panel-rules.ts
+++ b/apps/web/src/routes/agent/components/agent-session-panel-rules.ts
@@ -28,6 +28,36 @@ export interface RuntimeReadyWaitInput {
   waitForRuntimeReadyOnNewSession: boolean;
 }
 
+export interface SessionPanelReadinessInput {
+  agentReadiness: AgentReadiness | null;
+  streamReadiness: AgentReadiness | null;
+}
+
+export function selectSessionPanelReadiness(
+  input: SessionPanelReadinessInput,
+): AgentReadiness | null {
+  if (input.streamReadiness === null) {
+    return input.agentReadiness;
+  }
+
+  if (input.agentReadiness === null) {
+    return input.streamReadiness;
+  }
+
+  const agentCheckedAtMs = parseTimestampMs(input.agentReadiness.checkedAt);
+  const streamCheckedAtMs = parseTimestampMs(input.streamReadiness.checkedAt);
+
+  if (
+    agentCheckedAtMs !== null &&
+    streamCheckedAtMs !== null &&
+    agentCheckedAtMs >= streamCheckedAtMs
+  ) {
+    return input.agentReadiness;
+  }
+
+  return input.streamReadiness;
+}
+
 export function getReadinessBlockMessage(readiness: AgentReadiness | null): string | null {
   if (readiness === null || readiness.issues.length === 0 || readiness.ready) {
     return null;

--- a/apps/web/src/routes/agent/components/agent-session-panel.tsx
+++ b/apps/web/src/routes/agent/components/agent-session-panel.tsx
@@ -175,15 +175,6 @@ export function AgentSessionPanel({
           </div>
         ) : null}
 
-        {setupBlocked && model.readiness ? (
-          <AgentReadinessBlockersBanner
-            onRetryProviderCheck={() => void model.retryProviderCheck()}
-            readiness={model.readiness}
-            retrying={model.sending}
-            summary={setupSummary}
-          />
-        ) : null}
-
         {model.configurationRefreshRequired ? (
           <div className="border-amber/30 bg-amber-bg border-b px-4 py-2.5">
             <div className="flex items-center justify-between gap-3">
@@ -287,6 +278,15 @@ export function AgentSessionPanel({
             </div>
           ) : null}
 
+          {setupBlocked && model.readiness ? (
+            <AgentReadinessBlockersBanner
+              onRetryProviderCheck={() => void model.retryProviderCheck()}
+              readiness={model.readiness}
+              retrying={model.sending}
+              summary={setupSummary}
+            />
+          ) : null}
+
           <SessionComposer
             composerError={model.composerError}
             fileInputRef={model.fileInputRef}
@@ -299,6 +299,7 @@ export function AgentSessionPanel({
             sending={model.sending}
             sessionResourceMentions={sessionResourceMentions}
             setInput={model.setInput}
+            showSendDisabledReason={!setupBlocked}
             streaming={model.streaming}
             sendDisabledReason={sendDisabledReason}
           />

--- a/apps/web/src/routes/agent/components/editor/form-sections.tsx
+++ b/apps/web/src/routes/agent/components/editor/form-sections.tsx
@@ -1,6 +1,5 @@
 import { AlertTriangle } from "lucide-react";
 
-import { getPrimaryProviderReadinessPresentation } from "@/domains/vendor-credential/model/provider-readiness-copy";
 import { cn } from "@/shared/lib/class-names";
 import { Input } from "@/shared/ui/input";
 import { Label } from "@/shared/ui/label";
@@ -17,54 +16,6 @@ import { RequiredMark } from "./required-mark";
 import { SectionHeader } from "./section-header";
 import { AgentSkillsField } from "./skills-field";
 import type { AgentEditorModel } from "./use-model";
-
-function ReadinessBanner({ agent }: { agent: Agent }) {
-  if (!agent.readiness || agent.readiness.ready || agent.readiness.issues.length === 0) {
-    return null;
-  }
-
-  const errors = agent.readiness.issues.filter((issue) => issue.severity === "error");
-
-  if (errors.length === 0) {
-    return null;
-  }
-
-  const primary = errors[0];
-  const providerPresentation = getPrimaryProviderReadinessPresentation(errors);
-
-  if (providerPresentation?.action === "add-provider-key") {
-    return null;
-  }
-
-  const message =
-    providerPresentation?.message ??
-    primary?.message ??
-    "Resolve configuration before preview or publish.";
-
-  return (
-    <div
-      className="border-amber/30 bg-amber-bg text-amber-fg rounded-lg border px-3 py-2.5"
-      role="alert"
-    >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2 text-[13px] font-semibold">
-            <AlertTriangle className="size-4 shrink-0" />
-            {providerPresentation?.title ?? "Configuration required"}
-          </div>
-          <div className="mt-1 text-[12px] leading-relaxed">{message}</div>
-          {providerPresentation?.originalMessage !== undefined &&
-          providerPresentation.originalMessage !== null &&
-          providerPresentation.originalMessage !== message ? (
-            <div className="text-amber-fg/80 mt-1 text-[11px] leading-relaxed">
-              {providerPresentation.originalMessage}
-            </div>
-          ) : null}
-        </div>
-      </div>
-    </div>
-  );
-}
 
 function PackageResolutionBanner({ agent }: { agent: Agent }) {
   const resolution = agent.packageResolution;
@@ -118,7 +69,6 @@ export function BasicsSection({
 }) {
   return (
     <div className="space-y-5">
-      <ReadinessBanner agent={agent} />
       {agent.packageResolution ? <PackageResolutionBanner agent={agent} /> : null}
 
       <div>

--- a/apps/web/src/routes/agent/components/editor/model-picker-field.tsx
+++ b/apps/web/src/routes/agent/components/editor/model-picker-field.tsx
@@ -20,12 +20,7 @@ import {
   listLockedVendorLabels,
   listModelPickerEntries,
 } from "./model-picker-availability";
-import {
-  ModelPickerEmptyItem,
-  ModelPickerEmptyState,
-  ModelPickerItem,
-  ModelProviderLink,
-} from "./model-picker-ui";
+import { ModelPickerEmptyItem, ModelPickerItem, ModelProviderLink } from "./model-picker-ui";
 import type { AgentEditorModel } from "./use-model";
 
 export function ModelPickerField({
@@ -56,7 +51,7 @@ export function ModelPickerField({
   const currentEntry = findCurrentModelEntry(entries, currentModelId, currentVendorId);
   const hasAvailable = entries.some((entry) => entry.available);
   const triggerLabel = currentEntry?.displayName ?? "Pick an available model";
-  const showInvalidHint = currentEntry?.available === false;
+  const showInvalidHint = currentEntry?.available === false && currentEntry.reason !== "needs-key";
   const isEmpty = !loading && !hasAvailable;
   const menuIsEmpty = !loading && pickerEntries.length === 0;
   const lockedVendors = listLockedVendorLabels(entries);
@@ -111,8 +106,6 @@ export function ModelPickerField({
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-
-      {isEmpty ? <ModelPickerEmptyState /> : null}
 
       {showInvalidHint && currentEntry !== null ? (
         <p className="text-destructive text-[11px]">

--- a/apps/web/src/routes/agent/components/editor/model-picker-ui.tsx
+++ b/apps/web/src/routes/agent/components/editor/model-picker-ui.tsx
@@ -8,7 +8,6 @@ import {
 } from "@/domains/vendor-credential/model/provider-readiness-copy";
 import { cn } from "@/shared/lib/class-names";
 import { Badge } from "@/shared/ui/badge";
-import { Button } from "@/shared/ui/button";
 import { DropdownMenuItem } from "@/shared/ui/dropdown-menu";
 
 import type { ResolvedModelEntry } from "../../../../domains/vendor-credential/api/vendor-credential-client";
@@ -36,25 +35,6 @@ export function ModelPickerEmptyItem(): ReactElement {
   return (
     <div className="text-muted-foreground px-3 py-6 text-center text-[12px]">
       No matching models. Configure a Provider to unlock models.
-    </div>
-  );
-}
-
-export function ModelPickerEmptyState(): ReactElement {
-  return (
-    <div className="border-amber/30 bg-amber-bg/60 flex items-start justify-between gap-3 rounded-md border border-dashed px-3 py-2.5">
-      <div className="space-y-0.5">
-        <div className="text-amber-fg text-[12px] font-medium">No models available</div>
-        <div className="text-amber-fg/80 text-[11px]">
-          Configure a Provider key (or add an OpenAI-compatible Provider) to unlock models.
-        </div>
-      </div>
-      <Button asChild size="xs" variant="outline">
-        <Link to="/providers">
-          {ADD_PROVIDER_KEY_TEXT}
-          <ExternalLink className="size-3" />
-        </Link>
-      </Button>
     </div>
   );
 }

--- a/apps/web/src/routes/agent/components/use-agent-session-panel-model.ts
+++ b/apps/web/src/routes/agent/components/use-agent-session-panel-model.ts
@@ -23,6 +23,7 @@ import {
   getReadinessBlockMessage,
   hasStaleSessionConfiguration,
   isComposerSendBlocked,
+  selectSessionPanelReadiness,
   shouldWaitForRuntimeReadyOnNewSession,
 } from "./agent-session-panel-rules";
 import {
@@ -119,7 +120,10 @@ export function useAgentSessionPanelModel(
     requireFreshConfiguration: input.requireFreshConfiguration,
   });
   const stream = useSessionStream(input.appId, activeSessionId);
-  const readiness = stream.readiness ?? input.readiness;
+  const readiness = selectSessionPanelReadiness({
+    agentReadiness: input.readiness,
+    streamReadiness: stream.readiness,
+  });
   const readinessBlockMessage = getReadinessBlockMessage(readiness);
   const permissionScrollSignal = useMemo(
     () => stream.permissionRequests.map((request) => request.requestId).join("|"),

--- a/apps/web/tests/agent-session-panel-boundary.test.ts
+++ b/apps/web/tests/agent-session-panel-boundary.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AgentReadiness } from "@mosoo/contracts/agent";
+
 import {
   getSessionControlMode,
+  selectSessionPanelReadiness,
   shouldWaitForRuntimeReadyOnNewSession,
 } from "../src/routes/agent/components/agent-session-panel-rules";
 import {
@@ -9,7 +12,41 @@ import {
   removeSessionConfigurationRevisionKeys,
 } from "../src/routes/agent/components/use-agent-session-panel-model";
 
+function readiness(overrides: Partial<AgentReadiness>): AgentReadiness {
+  return {
+    checkedAt: "2026-06-23T00:00:00.000Z",
+    issues: [],
+    ready: true,
+    ...overrides,
+  };
+}
+
 describe("agent session panel boundary", () => {
+  test("uses latest ready agent readiness over a stale blocking stream snapshot", () => {
+    const staleStreamReadiness = readiness({
+      checkedAt: "2026-06-23T00:00:00.000Z",
+      issues: [
+        {
+          code: "agent.readiness.provider_credential.missing",
+          message: "Provider key required.",
+          severity: "error",
+        },
+      ],
+      ready: false,
+    });
+    const latestAgentReadiness = readiness({
+      checkedAt: "2026-06-23T00:01:00.000Z",
+      ready: true,
+    });
+
+    expect(
+      selectSessionPanelReadiness({
+        agentReadiness: latestAgentReadiness,
+        streamReadiness: staleStreamReadiness,
+      }),
+    ).toBe(latestAgentReadiness);
+  });
+
   test("only Preview New Session opts into runtime readiness wait", () => {
     expect(
       shouldWaitForRuntimeReadyOnNewSession({


### PR DESCRIPTION
Closes YEF-727

## Summary

- Consolidates provider/readiness setup warnings into the single chat-composer alert above the user input, with the Providers quick link there.
- Removes duplicate provider-key alerts from the editor/model picker surfaces.
- Uses the newest readiness snapshot by `checkedAt` so refreshed ready agent state clears stale stream blockers after provider configuration completes.

## Why

- The agent editor was showing the same provider setup blocker in multiple places, and stale session-stream readiness could keep the alert visible after configuration was fixed.

## Verification

- Commands (`just check`, `just test-file <path>`, `just graphql-codegen`, etc.):
  - `bun test apps/web/tests/agent-session-panel-boundary.test.ts`
  - `bun run --filter @mosoo/web tc`
  - `bun run --filter @mosoo/web lint`
  - `bun run --filter @mosoo/web test`
  - `bun run commit:check`
- Manual steps:
  - Started `bun run --filter @mosoo/web dev --host 127.0.0.1` and captured the local public landing render at `http://127.0.0.1:5173/`.
  - Tried `bun run dev` for full editor-route browser verification; local API startup is blocked because Wrangler needs Docker to build the configured container image and Docker CLI is unavailable in this environment.

## Risk And Blast Radius

- Affected packages: `apps/web`
- Affected user flows or APIs: Agent preview/editor readiness and provider-key setup messaging only.
- Rollback: Revert `fix(agent): consolidate readiness alerts`.

## Evidence

- UI/UX: Local authenticated editor screenshot unavailable here because API dev startup is blocked by missing Docker. The visible alert consolidation is covered by the component diff and web verification commands above.
- API or behavior: Added unit coverage for stale stream readiness yielding to newer ready agent readiness.
- Logs, recordings, or test output: Web typecheck, lint, tests, focused boundary test, and commit policy all passed locally.

## Compatibility

- Public contract changes: None.
- Env or config changes: None.
- Deployment or migration: None.

## Reviewer Focus

- Closest review areas: Agent readiness precedence and the single-alert placement around the session composer.
- Known trade-offs: The right-side model field no longer duplicates the provider-key empty-state alert; users reach Providers through the composer-adjacent setup alert.

## Required Checks

- [x] PR title: `type(scope): subject` (e.g. `fix(fmt): restore pre-commit checks`)
- [x] Type: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`, `build`, `ci`, `style`, or `revert`
- [x] Subject starts lowercase; `!` only for intentional breaking changes (e.g. `feat(api)!: remove legacy session field`)
- [x] Branch follows `type/scope-subject` when maintained in this repository; fork branch names may vary
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: if prompted by CLA Assistant, every human contributor has signed by posting the exact required PR comment
- [x] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence, or N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A, or list touched artifacts: N/A
- GraphQL codegen (`just graphql-codegen`): N/A
- DB baseline (`just db-regen`): N/A
- Lockfile (`bun.lock`): N/A
- Confirm no hand-edits to generated paths (`schema.generated.graphql`, `apps/web/src/gql/**`, `pkgs/db/drizzle/**`): Confirmed
