### PR TITLE
perf(web): drop OpenAPI builder from initial bundle

### DIFF
--- a/apps/web/src/platform/http/public-api.ts
+++ b/apps/web/src/platform/http/public-api.ts
@@ -1,4 +1,4 @@
-import { PUBLIC_API_PREFIX } from "@mosoo/contracts/public-api";
+import { PUBLIC_API_PREFIX } from "@mosoo/contracts/public-api-core";
 
 export type ApiPath = `/${string}`;
 

--- a/apps/web/src/routes/agent/lifecycle/distribution-info.ts
+++ b/apps/web/src/routes/agent/lifecycle/distribution-info.ts
@@ -1,4 +1,4 @@
-import { PUBLIC_API_PREFIX, PUBLIC_API_VERSION_PREFIX } from "@mosoo/contracts/public-api";
+import { PUBLIC_API_PREFIX, PUBLIC_API_VERSION_PREFIX } from "@mosoo/contracts/public-api-core";
 
 import { MOSOO_API_REFERENCE_URL } from "@/shared/config/external-links";
 

--- a/pkgs/contracts/package.json
+++ b/pkgs/contracts/package.json
@@ -21,6 +21,7 @@
     "./operation-result": "./src/transport/operation-result.contract.ts",
     "./app": "./src/app/app.contract.ts",
     "./public-api": "./src/http/public-api.contract.ts",
+    "./public-api-core": "./src/http/public-api-core.contract.ts",
     "./id": "./src/id/id.contract.ts",
     "./runtime-command": "./src/runtime/runtime-command.contract.ts",
     "./sandbox": "./src/runtime/sandbox.contract.ts",


### PR DESCRIPTION
## Summary

- The web app imported only `PUBLIC_API_PREFIX` / `PUBLIC_API_VERSION_PREFIX` from the `@mosoo/contracts/public-api` barrel, which `export *`s `public-api-openapi.contract`. That module eagerly builds an OpenAPI document and pulls in the full agent contract plus `arktype`; its top-level side effects block tree-shaking, so ~154 KB (47 KB gzip) of OpenAPI/agent-contract code was `modulepreload`ed into **every page's** initial critical path.
- Added a focused `./public-api-core` package export and pointed the two web value-imports at it. The API keeps using the full `./public-api` barrel unchanged.

## Why

- The frontend never renders the OpenAPI spec, yet its byte cost was paid on first paint of every route. Trimming the eager graph is the highest-leverage frontend-load win available without a deeper refactor.

## Verification

- Commands: `vp build`, `vp exec tsc --noEmit` (web + contracts), `vp lint .` (web), `vp exec bun test tests` (web → 89 pass / 0 fail).
- Measured the initial critical path (entry script + `modulepreload` graph + CSS) from `dist/index.html` before/after:
  - **Before:** ~229 KB gzip — included `agent.contract` chunk at 46.9 KB gz / 154 KB raw.
  - **After:** ~182 KB gzip — `agent.contract` chunk shrinks to 2.5 KB and its bulk moves into a **lazy** chunk loaded on demand.
- Net: **~47 KB gzip / ~154 KB uncompressed removed from every page's first load.** Agent routes are unchanged (`agent-detail` 313.5 KB vs 312.8 KB; `terminal-mode` identical).

## Risk And Blast Radius

- Affected packages: `@mosoo/web`, `@mosoo/contracts` (additive export only).
- Affected user flows or APIs: none functional — same constants, different import path. The `@mosoo/api` consumers of the full barrel are untouched.
- Rollback: revert the commit; purely a build-graph change.

## Evidence

- API or behavior: no behavior change; constants are byte-identical.
- Test output: web suite 89 pass / 0 fail; web + contracts typecheck clean; web lint clean.

## Compatibility

- Public contract changes: none (new `./public-api-core` subpath is additive; existing `./public-api` barrel unchanged).
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: the two redirected imports and the new export map entry.
- Known trade-offs: the heavy OpenAPI/agent-contract code now co-locates into the lazy chunks that actually use it (e.g. providers route); initial load is strictly lighter, on-demand routes are byte-neutral.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `perf`
- [x] Subject starts lowercase
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A (no visible change)
- [x] Generated files: none hand-edited

## Generated Files, Schema, And Lockfile

- N/A — no generated artifacts touched.
