### PR TITLE
fix(web): show Base URL field for OpenAI-Compatible provider edit

### DIFF
--- a/apps/web/src/domains/vendor-credential/model/provider-credential-endpoint.ts
+++ b/apps/web/src/domains/vendor-credential/model/provider-credential-endpoint.ts
@@ -1,7 +1,9 @@
-import { PUBLIC_VENDORS } from "@mosoo/runtime-catalog";
+import { getVendor } from "@mosoo/runtime-catalog";
 
+// A vendor supports a custom Base URL when it declares an apiBaseEnvVar. This
+// must consult the full vendor catalog (getVendor), not PUBLIC_VENDORS, because
+// the OpenAI-Compatible custom provider is excluded from the public list yet
+// always requires a Base URL.
 export function canUseCustomEndpoint(providerId: string): boolean {
-  return PUBLIC_VENDORS.some(
-    (vendor) => vendor.vendorId === providerId && Boolean(vendor.apiBaseEnvVar),
-  );
+  return Boolean(getVendor(providerId)?.apiBaseEnvVar);
 }


### PR DESCRIPTION
## Summary

- Fix the OpenAI-Compatible (Custom Provider) credential editor so it renders the **Base URL** field. Previously the field was hidden, yet saving still required a baseURL — making the form impossible to satisfy (alert: `Custom Provider requires baseURL and at least 1 model id`).

## Why

- `canUseCustomEndpoint(providerId)` consulted `PUBLIC_VENDORS`, which **explicitly excludes** `VENDOR_OPENAI_COMPATIBLE`. So for the custom provider it returned `false`, gating off the Base URL input in `ProviderCredentialForm`. The save/validation path (`enforceCredentialModelShape`) requires a baseURL for `openai-compatible`, so the user could never enter/edit the value the validator demanded.
- The custom provider does declare an `apiBaseEnvVar` (`OPENAI_COMPATIBLE_BASE_URL`), so it genuinely supports a custom endpoint. The check should use the full vendor catalog (`getVendor`) instead of the public-only list.

## Verification

- Commands:
  - `vp run --filter @mosoo/web tc` → pass
  - `vp lint` on changed + consuming files → pass
  - `vp fmt --check` → pass
  - `vp run --filter @mosoo/web test` → 90 pass / 0 fail
- Manual steps: N/A (no running env in sandbox); logic traced — `canUseCustomEndpoint("openai-compatible")` now returns `true`, so the Base URL field renders in both Add and Edit flows, and the save path forwards `apiBase` as before for preset and custom providers alike.

## Risk And Blast Radius

- Affected packages: `@mosoo/web`
- Affected user flows or APIs: Providers tab — Add/Edit OpenAI-Compatible provider key. Preset providers (Anthropic, OpenAI) are unaffected: both already declared `apiBaseEnvVar`, so `canUseCustomEndpoint` returns the same `true` for them as before.
- Rollback: revert this commit.

## Evidence

- UI/UX: Before (from the bug report) — the "Edit openai-compatible key" form shows only Name / API key / Models, with no Base URL field despite the existing key pointing at `https://api.deepseek.com/v1`. After the fix, a Base URL input is rendered (pre-filled from the existing credential's `apiBase`). A live after-screenshot is not attached as the sandbox has no running web app; the change is a single-condition fix verified by typecheck/lint/tests.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: `apps/web/src/domains/vendor-credential/model/provider-credential-endpoint.ts`.
- Known trade-offs: `canUseCustomEndpoint` now returns `true` for any vendor with `apiBaseEnvVar` (anthropic, openai, openai-compatible). This matches intent — preset providers already exposed the Base URL field via the same predicate.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `fix`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: sign if prompted by CLA Assistant
- [x] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: before screenshot referenced in Evidence
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A — no generated artifacts touched.
