### PR TITLE
feat(account): add default avatar and image upload for email-login users

### DIFF
--- a/apps/api/src/adapters/graphql/schema.generated.graphql
+++ b/apps/api/src/adapters/graphql/schema.generated.graphql
@@ -950,6 +950,7 @@ enum FileOwnerKind {
 }
 
 enum FilePurpose {
+  account_avatar
   agent_asset
   agent_package
   app_draft
@@ -983,6 +984,7 @@ type FileScope {
 }
 
 enum FileScopeKind {
+  account
   agent_package
   app_draft
   library

--- a/apps/api/src/modules/files/infrastructure/file-paths.ts
+++ b/apps/api/src/modules/files/infrastructure/file-paths.ts
@@ -1,4 +1,5 @@
 import {
+  createAccountAvatarPath as createContractAccountAvatarPath,
   createAttachmentPath as createContractAttachmentPath,
   createFileObjectKey as createContractFileObjectKey,
   createFileRecordObjectKey,
@@ -44,6 +45,10 @@ function translatePathAdmission<T>(read: () => T): T {
 
 export function createAttachmentPath(fileId: FileId, fileName: string): string {
   return translatePathAdmission(() => createContractAttachmentPath(fileId, fileName));
+}
+
+export function createAccountAvatarPath(fileId: FileId, fileName: string): string {
+  return translatePathAdmission(() => createContractAccountAvatarPath(fileId, fileName));
 }
 
 export function createSessionArtifactPath(fileId: FileId, fileName: string): string {

--- a/apps/api/src/modules/files/infrastructure/file-record-access.ts
+++ b/apps/api/src/modules/files/infrastructure/file-record-access.ts
@@ -57,6 +57,18 @@ async function ensureLibraryFileAccess(
   await ensureAppOwnership(database, viewerId, appId);
 }
 
+function ensureAccountFileAccess(
+  viewerId: AccountId,
+  file: FileRecordRow,
+  resourceKind: "file" | "upload",
+): void {
+  if (file.owner_kind !== "account" || file.owner_id !== viewerId) {
+    throw createFileNotFoundError(
+      resourceKind === "file" ? "File not found." : "Upload not found.",
+    );
+  }
+}
+
 export async function ensureUploadAccess({
   database,
   fileId,
@@ -69,7 +81,9 @@ export async function ensureUploadAccess({
     throw createFileNotFoundError("Upload not found.");
   }
 
-  if (context.upload.scope_kind === "library") {
+  if (context.upload.scope_kind === "account") {
+    ensureAccountFileAccess(viewerId, context.file, "upload");
+  } else if (context.upload.scope_kind === "library") {
     await ensureLibraryFileAccess(database, viewerId, context.file, "upload");
   } else if (context.upload.scope_kind === "session") {
     if (!context.sessionAccess) {
@@ -105,7 +119,9 @@ export async function ensureFileAccess({
     throw createFileNotFoundError("File not found.");
   }
 
-  if (file.scope_kind === "library") {
+  if (file.scope_kind === "account") {
+    ensureAccountFileAccess(viewerId, file, "file");
+  } else if (file.scope_kind === "library") {
     await ensureLibraryFileAccess(database, viewerId, file, "file");
   } else if (file.scope_kind === "session") {
     await ensureSessionFileAccess(

--- a/apps/api/src/modules/files/infrastructure/file-record-model.ts
+++ b/apps/api/src/modules/files/infrastructure/file-record-model.ts
@@ -127,6 +127,10 @@ function toFileScopeId(scopeKind: FileScopeKind, scopeId: PlatformId | null): Fi
     throw new Error(`${scopeKind} file scope ID is required.`);
   }
 
+  if (scopeKind === "account") {
+    return parsePlatformId<AccountId>(scopeId, "file account ID");
+  }
+
   if (scopeKind === "agent_package" || scopeKind === "app_draft" || scopeKind === "library") {
     return parsePlatformId<AppId>(scopeId, "file app ID");
   }

--- a/apps/api/src/modules/files/infrastructure/file-scope-descriptor.ts
+++ b/apps/api/src/modules/files/infrastructure/file-scope-descriptor.ts
@@ -16,6 +16,7 @@ import { ensureAppOwnership } from "../../apps/application/app.service";
 import type { AuthenticatedViewer } from "../../auth/application/viewer-auth.service";
 import { createFileInvalidRequestError } from "./file-errors";
 import {
+  createAccountAvatarPath,
   createAttachmentPath,
   ensureLibraryFilePathHasExtension,
   normalizeFileName,
@@ -99,6 +100,40 @@ function defineFileScopeDescriptor<Kind extends FileUploadTargetKind>(
     },
   };
 }
+
+const accountDescriptor = defineFileScopeDescriptor({
+  capabilities: {
+    moveRename: {
+      enabled: false,
+    },
+    pathLocks: false,
+    versioning: false,
+  },
+  kind: "account",
+  uploadPurpose: "account_avatar",
+  async resolveUploadTargetContext({ fileId, target, viewer }) {
+    const viewerId: AccountId = parsePlatformId(viewer.id, "viewer ID");
+    const targetId: AccountId = parsePlatformId(target.id, "upload account ID");
+
+    if (targetId !== viewerId) {
+      throw createFileInvalidRequestError("Avatars can only be uploaded for the current account.");
+    }
+
+    const name = normalizeFileName(target.name);
+    const logicalPath = createAccountAvatarPath(fileId, name);
+
+    return {
+      logicalPath,
+      name,
+      ownerId: viewerId,
+      ownerKind: "account",
+      parentPath: getParentPath(logicalPath),
+      scopeId: viewerId,
+      scopeKind: "account",
+      sessionKind: null,
+    };
+  },
+});
 
 const libraryDescriptor = defineFileScopeDescriptor({
   capabilities: {
@@ -230,6 +265,7 @@ const appDraftDescriptor = defineFileScopeDescriptor({
 });
 
 const fileScopeDescriptors = {
+  account: accountDescriptor,
   agent_package: agentPackageDescriptor,
   app_draft: appDraftDescriptor,
   library: libraryDescriptor,

--- a/apps/api/tests/file-upload-access.test.ts
+++ b/apps/api/tests/file-upload-access.test.ts
@@ -543,6 +543,101 @@ describe("file upload access", () => {
     ).rejects.toThrow();
   });
 
+  test("creates account avatar uploads as account-owned files", async () => {
+    const database = createFileUploadAccessDatabase();
+    const bindings = { DB: database } as ApiBindings;
+
+    const upload = await createFileUpload(bindings, VIEWER, {
+      file: {
+        contentType: "image/png",
+        name: "avatar.png",
+        size: 42,
+      },
+      purpose: "account_avatar",
+      target: {
+        id: VIEWER_ID,
+        kind: "account",
+        name: "avatar.png",
+      },
+    });
+
+    expect(upload.path).toBe(`avatar/${upload.fileId}/avatar.png`);
+
+    const row = await database
+      .prepare(
+        `SELECT object_key, owner_id, owner_kind, purpose, scope_id, scope_kind, session_kind
+           FROM file_record
+          WHERE id = ?`,
+      )
+      .bind(upload.fileId)
+      .first<{
+        object_key: string;
+        owner_id: string;
+        owner_kind: string;
+        purpose: string;
+        scope_id: string;
+        scope_kind: string;
+        session_kind: string | null;
+      }>();
+
+    expect(row).toEqual({
+      object_key: `staging/account/${VIEWER_ID}/${upload.fileId}`,
+      owner_id: VIEWER_ID,
+      owner_kind: "account",
+      purpose: "account_avatar",
+      scope_id: VIEWER_ID,
+      scope_kind: "account",
+      session_kind: null,
+    });
+
+    await expect(
+      ensureFileAccess({
+        database,
+        fileId: upload.fileId,
+        requiredIntent: "read",
+        viewer: VIEWER,
+      }),
+    ).resolves.toMatchObject({ owner_kind: "account" });
+
+    await expect(
+      ensureUploadAccess({
+        database,
+        fileId: upload.fileId,
+        requiredIntent: "write",
+        viewer: { ...VIEWER, id: OTHER_VIEWER_ID },
+      }),
+    ).rejects.toThrow();
+    await expect(
+      ensureFileAccess({
+        database,
+        fileId: upload.fileId,
+        requiredIntent: "read",
+        viewer: { ...VIEWER, id: OTHER_VIEWER_ID },
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("rejects account avatar uploads targeting another account", async () => {
+    const database = createFileUploadAccessDatabase();
+    const bindings = { DB: database } as ApiBindings;
+
+    await expect(
+      createFileUpload(bindings, VIEWER, {
+        file: {
+          contentType: "image/png",
+          name: "avatar.png",
+          size: 42,
+        },
+        purpose: "account_avatar",
+        target: {
+          id: OTHER_VIEWER_ID,
+          kind: "account",
+          name: "avatar.png",
+        },
+      }),
+    ).rejects.toThrow();
+  });
+
   test("requires matching App proof for raw session upload targets", async () => {
     const fixture = await createApiTestFixture();
     await fixture.client.loginAsMosooAiTestAccount();

--- a/apps/web/src/app/account-menu.tsx
+++ b/apps/web/src/app/account-menu.tsx
@@ -14,6 +14,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 import { authClient } from "../domains/auth/api/auth-client";
+import { getAvatarBackground, getAvatarInitial } from "../shared/lib/avatar";
 import { isTruthy } from "../shared/lib/truthiness";
 interface AccountMenuUser {
   email: string;
@@ -27,7 +28,7 @@ function UserAvatar({
   user,
 }: {
   size?: number;
-  user: { image?: string | null; name: string } | null;
+  user: { email?: string | null; image?: string | null; name: string } | null;
 }) {
   if (isTruthy(user?.image)) {
     return (
@@ -45,13 +46,13 @@ function UserAvatar({
     <div
       className="flex shrink-0 items-center justify-center rounded-full font-bold tracking-[0.02em] text-white"
       style={{
-        background: "linear-gradient(135deg, var(--green-600), var(--green-800))",
+        background: getAvatarBackground(user?.email ?? user?.name),
         fontSize: size * 0.4,
         height: size,
         width: size,
       }}
     >
-      {user?.name?.charAt(0)?.toUpperCase() ?? "?"}
+      {getAvatarInitial(user?.name)}
     </div>
   );
 }

--- a/apps/web/src/domains/file/api/account-avatar-client.ts
+++ b/apps/web/src/domains/file/api/account-avatar-client.ts
@@ -1,0 +1,32 @@
+import type { AccountId } from "@mosoo/contracts/id";
+
+import { apiPath } from "@/platform/http/public-api";
+
+import { createAndRunFileUpload } from "./file-upload-client";
+
+/**
+ * Uploads an image for the current account's avatar and returns the internal
+ * file URL that can be stored as the account image. The returned path matches
+ * the internal-file pattern accepted by the profile update mutation.
+ */
+export async function uploadAccountAvatar(accountId: AccountId, file: File): Promise<string> {
+  const { fileId } = await createAndRunFileUpload(
+    {
+      file: {
+        contentType: file.type,
+        name: file.name,
+        size: file.size,
+      },
+      overwrite: true,
+      purpose: "account_avatar",
+      target: {
+        id: accountId,
+        kind: "account",
+        name: file.name,
+      },
+    },
+    file,
+  );
+
+  return apiPath(`/files/${fileId}/content?disposition=inline`);
+}

--- a/apps/web/src/gql/graphql.ts
+++ b/apps/web/src/gql/graphql.ts
@@ -345,6 +345,7 @@ export type FileListInput = {
 };
 
 export type FileScopeKind =
+  | 'account'
   | 'agent_package'
   | 'app_draft'
   | 'library'

--- a/apps/web/src/routes/settings/profile-tab.tsx
+++ b/apps/web/src/routes/settings/profile-tab.tsx
@@ -1,15 +1,27 @@
-import { Check, Loader2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { Check, Loader2, Upload } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/shared/ui/button";
 
 import { useAppSession } from "../../app/session-provider";
+import { uploadAccountAvatar } from "../../domains/file/api/account-avatar-client";
 import { updateProfile } from "../../domains/user/api/user-client";
+import { apiPath } from "../../platform/http/public-api";
+import { getAvatarBackground, getAvatarInitial } from "../../shared/lib/avatar";
 import { isTruthy } from "../../shared/lib/truthiness";
+import { toAccountId } from "../typed-id";
 
 const MAX_AVATAR_URL_LENGTH = 2048;
+const MAX_AVATAR_FILE_BYTES = 5 * 1024 * 1024;
+const INTERNAL_FILE_PATH_PATTERN = new RegExp(
+  `^${apiPath("/files")}/[A-Za-z0-9]+/content(?:\\?disposition=inline)?$`,
+);
 
-function isValidAvatarUrl(value: string): boolean {
+function isValidAvatarValue(value: string): boolean {
+  if (INTERNAL_FILE_PATH_PATTERN.test(value)) {
+    return true;
+  }
+
   try {
     const parsed = new URL(value);
     return parsed.protocol === "http:" || parsed.protocol === "https:";
@@ -24,7 +36,9 @@ export function ProfileTab() {
   const [avatarInput, setAvatarInput] = useState(user?.image ?? "");
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     setName(user?.name ?? "");
@@ -43,10 +57,11 @@ export function ProfileTab() {
   const nameValid = trimmedName.length > 0;
   const avatarValid =
     trimmedAvatar === "" ||
-    (trimmedAvatar.length <= MAX_AVATAR_URL_LENGTH && isValidAvatarUrl(trimmedAvatar));
+    (trimmedAvatar.length <= MAX_AVATAR_URL_LENGTH && isValidAvatarValue(trimmedAvatar));
   const avatarPreview = trimmedAvatar || currentAvatar;
-  const avatarPreviewValid = avatarPreview === "" || isValidAvatarUrl(avatarPreview);
-  const canSave = dirty && nameValid && avatarValid && !saving;
+  const avatarPreviewValid = avatarPreview === "" || isValidAvatarValue(avatarPreview);
+  const canSave = dirty && nameValid && avatarValid && !saving && !uploading;
+  const avatarBackground = getAvatarBackground(user?.email ?? user?.name);
 
   async function handleSave() {
     if (!canSave) {
@@ -73,6 +88,35 @@ export function ProfileTab() {
     }
   }
 
+  async function handleFileSelected(file: File) {
+    if (!file.type.startsWith("image/")) {
+      setError("Please choose an image file.");
+      return;
+    }
+
+    if (file.size > MAX_AVATAR_FILE_BYTES) {
+      setError("Image must be 5 MB or smaller.");
+      return;
+    }
+
+    if (!isTruthy(user?.id)) {
+      setError("Unable to upload right now. Please try again.");
+      return;
+    }
+
+    setUploading(true);
+    setError(null);
+
+    try {
+      const imageUrl = await uploadAccountAvatar(toAccountId(user.id), file);
+      setAvatarInput(imageUrl);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Failed to upload image.");
+    } finally {
+      setUploading(false);
+    }
+  }
+
   return (
     <>
       <header className="border-border-subtle flex h-12 shrink-0 items-center border-b px-5">
@@ -91,29 +135,60 @@ export function ProfileTab() {
             ) : (
               <div
                 className="flex size-16 items-center justify-center rounded-full text-xl font-semibold text-white"
-                style={{
-                  background:
-                    "linear-gradient(135deg, rgba(255,255,255,0.12), rgba(255,255,255,0.08)), rgb(21, 90, 239)",
-                }}
+                style={{ background: avatarBackground }}
               >
-                {user?.name?.charAt(0)?.toUpperCase() ?? "?"}
+                {getAvatarInitial(user?.name)}
               </div>
             )}
             <div className="min-w-0">
               <div className="text-foreground truncate text-lg font-semibold">{user?.name}</div>
               <div className="text-muted-foreground truncate text-sm">{user?.email}</div>
+              <div className="mt-2">
+                <input
+                  ref={fileInputRef}
+                  aria-label="Upload profile picture"
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    event.target.value = "";
+                    if (file) {
+                      void handleFileSelected(file);
+                    }
+                  }}
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={uploading || saving}
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  {uploading ? (
+                    <>
+                      <Loader2 className="mr-1 size-4 animate-spin" /> Uploading…
+                    </>
+                  ) : (
+                    <>
+                      <Upload className="mr-1 size-4" /> Upload image
+                    </>
+                  )}
+                </Button>
+              </div>
             </div>
           </div>
 
           <div className="space-y-2">
             <label className="text-foreground text-sm font-medium" htmlFor="profile-avatar-url">
-              Profile picture
+              Profile picture URL
             </label>
-            <p className="text-fg-2 text-[12px]">Paste an image URL to use as your avatar.</p>
+            <p className="text-fg-2 text-[12px]">
+              Upload an image above, or paste an image URL to use as your avatar.
+            </p>
             <input
               aria-label="Profile picture URL"
               id="profile-avatar-url"
-              type="url"
+              type="text"
               inputMode="url"
               placeholder="https://example.com/avatar.png"
               value={avatarInput}

--- a/apps/web/src/routes/threads/user-avatar.tsx
+++ b/apps/web/src/routes/threads/user-avatar.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 
+import { getAvatarBackground, getAvatarInitial } from "@/shared/lib/avatar";
 import { cn } from "@/shared/lib/class-names";
 
 export function UserAvatar({
@@ -28,11 +29,11 @@ export function UserAvatar({
     <span
       className={cn(
         "flex shrink-0 items-center justify-center overflow-hidden rounded-md font-bold text-white",
-        "bg-[linear-gradient(135deg,var(--green-600),var(--green-800))]",
         sizeClassName,
       )}
+      style={{ background: getAvatarBackground(name) }}
     >
-      {name.charAt(0).toUpperCase() || "?"}
+      {getAvatarInitial(name)}
     </span>
   );
 }

--- a/apps/web/src/shared/lib/avatar.ts
+++ b/apps/web/src/shared/lib/avatar.ts
@@ -1,0 +1,39 @@
+// Solid, on-brand background colors for the default (no-image) avatar. A single
+// color is picked deterministically from a seed so a given account always renders
+// the same avatar, while different accounts get some variety. All colors are dark
+// enough to keep white initials legible.
+const AVATAR_BACKGROUNDS = [
+  "var(--green-600)",
+  "var(--green-700)",
+  "var(--green-800)",
+  "var(--forest-600)",
+  "var(--forest-700)",
+  "var(--forest-800)",
+] as const;
+
+function hashSeed(seed: string): number {
+  let hash = 0;
+
+  for (let index = 0; index < seed.length; index += 1) {
+    hash = (Math.imul(hash, 31) + seed.charCodeAt(index)) | 0;
+  }
+
+  return Math.abs(hash);
+}
+
+/**
+ * Returns a deterministic solid background color for an account's default avatar.
+ * Seed with a stable identifier (email preferred, name as a fallback) so the same
+ * account renders the same color everywhere.
+ */
+export function getAvatarBackground(seed: string | null | undefined): string {
+  const normalized = (seed ?? "").trim().toLowerCase();
+  const index = normalized.length === 0 ? 0 : hashSeed(normalized) % AVATAR_BACKGROUNDS.length;
+
+  return AVATAR_BACKGROUNDS[index] ?? AVATAR_BACKGROUNDS[0];
+}
+
+/** Returns the uppercase initial to render inside a default avatar. */
+export function getAvatarInitial(name: string | null | undefined): string {
+  return (name ?? "").trim().charAt(0).toUpperCase() || "?";
+}

--- a/pkgs/contracts/src/file/file.contract.ts
+++ b/pkgs/contracts/src/file/file.contract.ts
@@ -2,7 +2,13 @@ import { parsePlatformId } from "@mosoo/id";
 
 import type { AccountId, FileId, AppId, SessionId } from "../id/id.contract";
 
-export const FILE_SCOPE_KINDS = ["agent_package", "app_draft", "library", "session"] as const;
+export const FILE_SCOPE_KINDS = [
+  "account",
+  "agent_package",
+  "app_draft",
+  "library",
+  "session",
+] as const;
 export type FileScopeKind = (typeof FILE_SCOPE_KINDS)[number];
 
 export const FILE_STATUSES = ["deleting", "failed", "pending", "ready"] as const;
@@ -22,6 +28,7 @@ export type FileUploadStatus = (typeof FILE_UPLOAD_STATUSES)[number];
 export const FILE_UPLOAD_STRATEGIES = ["multipart", "single_put"] as const;
 export type FileUploadStrategy = (typeof FILE_UPLOAD_STRATEGIES)[number];
 export const FILE_PURPOSES = [
+  "account_avatar",
   "agent_asset",
   "agent_package",
   "app_draft",
@@ -235,7 +242,7 @@ export function choosePartSize(size: number): number {
   return Math.max(basePartSize, MIN_MULTIPART_PART_SIZE_BYTES);
 }
 
-export type FileScopeId = AppId | SessionId | null;
+export type FileScopeId = AccountId | AppId | SessionId | null;
 export type FileOwnerId = AccountId | AppId | SessionId;
 
 export function createScope(scopeKind: FileScopeKind, scopeId: FileScopeId): FileScope {
@@ -249,9 +256,14 @@ export const SESSION_RESOURCE_RECORD_DIR = "attachment";
 export const SESSION_RESOURCE_MOUNT_DIR = "session-files";
 export const SESSION_ARTIFACT_RECORD_DIR = "artifact";
 export const SESSION_ARTIFACT_MATERIALIZED_DIR = "session-artifacts";
+export const ACCOUNT_AVATAR_RECORD_DIR = "avatar";
 
 export function createAttachmentPath(fileId: FileId, fileName: string): string {
   return `${SESSION_RESOURCE_RECORD_DIR}/${fileId}/${normalizeFileName(fileName)}`;
+}
+
+export function createAccountAvatarPath(fileId: FileId, fileName: string): string {
+  return `${ACCOUNT_AVATAR_RECORD_DIR}/${fileId}/${normalizeFileName(fileName)}`;
 }
 
 export function createSessionArtifactPath(fileId: FileId, fileName: string): string {
@@ -346,6 +358,10 @@ export function createFileObjectKey(file: FileObjectKeyInput): string {
   }
 
   const fileName = requireProjectionFileName(file.name);
+
+  if (file.scope.kind === "account") {
+    return `account/${file.scope.id}/${ACCOUNT_AVATAR_RECORD_DIR}/${file.id}/${fileName}`;
+  }
 
   if (file.scope.kind === "app_draft") {
     return `app-draft/${file.scope.id}/attachment/${file.id}/${fileName}`;
@@ -470,6 +486,12 @@ export interface FileEntryListing {
   files: FileEntry[];
 }
 
+export interface CreateAccountAvatarUploadTarget {
+  id: AccountId;
+  kind: "account";
+  name: string;
+}
+
 export interface CreateLibraryFileUploadTarget {
   id: AppId;
   kind: "library";
@@ -496,6 +518,7 @@ export interface CreateAgentPackageFileUploadTarget {
 }
 
 export type CreateFileUploadTarget =
+  | CreateAccountAvatarUploadTarget
   | CreateSessionFileUploadTarget
   | CreateLibraryFileUploadTarget
   | CreateAgentPackageFileUploadTarget

--- a/pkgs/contracts/tests/owner-boundaries.test.ts
+++ b/pkgs/contracts/tests/owner-boundaries.test.ts
@@ -17,6 +17,7 @@ import {
 } from "@mosoo/contracts/agent-manifest-parser";
 import {
   SESSION_RESOURCE_MOUNT_DIR,
+  createAccountAvatarPath,
   createAttachmentPath,
   createDownloadDisposition,
   createFileObjectKey,
@@ -29,7 +30,7 @@ import {
   normalizeLibraryFilePath,
   toSessionResourceMaterializedPath,
 } from "@mosoo/contracts/file";
-import type { FileId, SessionId } from "@mosoo/contracts/id";
+import type { AccountId, FileId, SessionId } from "@mosoo/contracts/id";
 import {
   createRuntimeModelIdentity,
   isCustomRuntimeModelProvider,
@@ -44,6 +45,7 @@ import {
 
 const FILE_ID = "01J00000000000000000000001" as FileId;
 const SESSION_ID = "01J00000000000000000000002" as SessionId;
+const ACCOUNT_ID = "01J00000000000000000000003" as AccountId;
 
 function readFixture(path: string): string {
   return readFileSync(new URL(path, import.meta.url), "utf8");
@@ -313,6 +315,16 @@ describe("contracts owner boundaries", () => {
         scope: createScope("session", SESSION_ID),
       }),
     ).toBe(`session/${SESSION_ID}/attachment/${FILE_ID}/notes.txt`);
+
+    expect(createAccountAvatarPath(FILE_ID, " avatar.png ")).toBe(`avatar/${FILE_ID}/avatar.png`);
+    expect(
+      createFileObjectKey({
+        id: FILE_ID,
+        name: "avatar.png",
+        path: `avatar/${FILE_ID}/avatar.png`,
+        scope: createScope("account", ACCOUNT_ID),
+      }),
+    ).toBe(`account/${ACCOUNT_ID}/avatar/${FILE_ID}/avatar.png`);
 
     expect(() =>
       createFileObjectKey({


### PR DESCRIPTION
## Summary

- Email-login accounts now render a deterministic, on-brand **solid-color default avatar** (seeded by email/name) instead of a generic gradient.
- Users can **upload an image file** to replace it in **Settings → Profile**, in addition to the existing paste-a-URL flow.
- Uploaded avatars are stored via the existing file subsystem under a new account-scoped file scope and referenced by their internal `/api/files/<id>/content` URL (already accepted by the profile-update mutation).

## Why

Closes YEF-734. Email (non-SSO) users had no avatar of their own and could only paste a URL — there was no way to upload an image, and the default was a fixed gradient rather than a solid color.

## Verification

- Commands: `bun run lint`, `@mosoo/contracts`/`@mosoo/api`/`@mosoo/web` `tc`, `bun run graphql:codegen` + `graphql:codegen:check`, package tests (`contracts` 11 pass, `api` 647 pass, `web` 90 pass).
- Manual steps: opened Settings → Profile, confirmed the default solid-color avatar, the new "Upload image" button, and that the pasted-URL field still validates http(s) URLs and the internal file path.

## Risk And Blast Radius

- Affected packages: `@mosoo/contracts`, `@mosoo/api` (files module), `@mosoo/web`.
- Affected user flows or APIs: account avatar display, profile update, file upload create/content access (new `account` scope only; existing scopes unchanged).
- Rollback: revert this PR; no data migration required (file columns are already generic text).

## Evidence

- UI/UX: representative render of the deterministic solid-color default avatars and the new upload control (exact design-token colors + the shipped avatar logic) attached on the issue.

## Compatibility

- Public contract changes: additive only — new `account` file scope kind, `account_avatar` purpose, and account avatar upload target.
- Env or config changes: none.
- Deployment or migration: none (no schema migration; `owner_kind=account` and text scope columns already exist).

## Reviewer Focus

- Closest review areas: `file-scope-descriptor.ts` (new account descriptor), `file-record-access.ts` (owner-scoped read/upload access), `pkgs/contracts/src/file/file.contract.ts` (scope/purpose/object-key).
- Known trade-offs: account avatars are private to the owning account (served with the viewer cookie); all current avatar render sites show the viewer's own image, so this is sufficient today.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshot in Evidence
- [x] Generated files only where required (`schema.generated.graphql`, `apps/web/src/gql/**` via `graphql-codegen`; not hand-edited)

## Generated Files, Schema, And Lockfile

- Touched artifacts: `apps/api/src/adapters/graphql/schema.generated.graphql`, `apps/web/src/gql/graphql.ts` — regenerated via `bun run graphql:codegen` (enums derive from the contract arrays).
- DB baseline: N/A.
- Lockfile: unchanged.
