### PR TITLE
feat(skills): import skills from GitHub and skills.sh URLs

### DIFF
--- a/apps/api/src/modules/skills/application/skill-package-github.service.ts
+++ b/apps/api/src/modules/skills/application/skill-package-github.service.ts
@@ -72,8 +72,9 @@ function parseGithubContentEntries(value: unknown, path: string): GithubContentE
 
 export async function loadSkillPackageFromGithub(
   githubUrl: string,
+  skillName?: string,
 ): Promise<NormalizedSkillPackage> {
-  const target = await resolveGithubSkillTarget(githubUrl);
+  const target = await resolveGithubSkillTarget(githubUrl, skillName);
 
   if (target.kind === "blob") {
     const body = await downloadGithubFile(target.owner, target.repo, target.ref, target.path);
@@ -182,7 +183,10 @@ async function walkGithubContents(
   }
 }
 
-async function resolveGithubSkillTarget(url: string): Promise<GithubSkillTarget> {
+async function resolveGithubSkillTarget(
+  url: string,
+  skillName?: string,
+): Promise<GithubSkillTarget> {
   let parsed: URL;
 
   try {
@@ -205,11 +209,24 @@ async function resolveGithubSkillTarget(url: string): Promise<GithubSkillTarget>
   const repo = stripDotGit(segments[1]!);
 
   if (segments.length === 2) {
+    const ref = await getDefaultBranch(owner, repo);
+
+    if (isTruthy(skillName)) {
+      return {
+        kind: "tree",
+        owner,
+        path: await resolveSkillSubdirectory(owner, repo, ref, skillName, ""),
+        ref,
+        relativePath: "",
+        repo,
+      };
+    }
+
     return {
       kind: "repository",
       owner,
       path: "",
-      ref: await getDefaultBranch(owner, repo),
+      ref,
       relativePath: "",
       repo,
     };
@@ -235,6 +252,17 @@ async function resolveGithubSkillTarget(url: string): Promise<GithubSkillTarget>
   const rawPathSegments = refAndPathSegments.slice(refSegmentCount);
   const path = rawPathSegments.join("/");
 
+  if (mode === "tree" && isTruthy(skillName)) {
+    return {
+      kind: "tree",
+      owner,
+      path: await resolveSkillSubdirectory(owner, repo, ref, skillName, path),
+      ref,
+      relativePath: "",
+      repo,
+    };
+  }
+
   if (mode === "blob" && !path) {
     throw new SkillRequestError(
       mode === "blob"
@@ -251,6 +279,73 @@ async function resolveGithubSkillTarget(url: string): Promise<GithubSkillTarget>
     relativePath: mode === "blob" ? (rawPathSegments.at(-1) ?? "SKILL.md") : "",
     repo,
   };
+}
+
+/**
+ * Resolves a `--skill <name>` selector (as used by skills.sh / `npx skills add`) to a concrete
+ * directory inside the repository. Skills live under a `skills/` folder by convention
+ * (e.g. vercel-labs/skills → skills/find-skills), but we also accept a top-level directory or a
+ * `.claude/skills/<name>` layout so single-skill repos and Claude-style repos work too.
+ */
+async function resolveSkillSubdirectory(
+  owner: string,
+  repo: string,
+  ref: string,
+  skillName: string,
+  basePath: string,
+): Promise<string> {
+  const base = basePath.replace(/^\/+|\/+$/g, "");
+  const candidates = [
+    joinGithubPath(base, "skills", skillName),
+    joinGithubPath(base, skillName),
+    joinGithubPath(base, ".claude", "skills", skillName),
+  ];
+
+  for (const candidate of candidates) {
+    if (await githubPathIsDirectory(owner, repo, ref, candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new SkillRequestError(
+    `Skill "${skillName}" was not found in ${owner}/${repo}. Looked in: ${candidates.join(", ")}.`,
+  );
+}
+
+function joinGithubPath(...parts: string[]): string {
+  return parts.filter((part) => part.length > 0).join("/");
+}
+
+async function githubPathIsDirectory(
+  owner: string,
+  repo: string,
+  ref: string,
+  path: string,
+): Promise<boolean> {
+  const normalizedPath = path.split("/").filter(Boolean).map(encodeURIComponent).join("/");
+  const response = await fetch(
+    `${GITHUB_API}/repos/${owner}/${repo}/contents/${normalizedPath}?ref=${encodeURIComponent(ref)}`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+      },
+    },
+  );
+
+  if (response.status === 404) {
+    return false;
+  }
+
+  if (response.status === 403) {
+    throw new SkillRequestError("GitHub API rate limited the request or requires authentication.");
+  }
+
+  if (!response.ok) {
+    throw new SkillRequestError(`GitHub API returned ${response.status}.`);
+  }
+
+  const payload: unknown = await response.json();
+  return Array.isArray(payload);
 }
 
 async function listGithubBranches(owner: string, repo: string): Promise<string[]> {

--- a/apps/api/src/modules/skills/application/skill-package-source.service.ts
+++ b/apps/api/src/modules/skills/application/skill-package-source.service.ts
@@ -19,6 +19,7 @@ import {
   SkillRequestError,
 } from "./skill-package.shared";
 import type { InspectSkillInput, UploadSkillFile } from "./skill-package.shared";
+import { parseSkillSourceUrl } from "./skill-source-url.service";
 export async function inspectSkillInput(input: InspectSkillInput): Promise<SkillInspectResult> {
   const normalized = await loadNormalizedSkillPackage(input);
 
@@ -53,7 +54,8 @@ export async function loadNormalizedSkillPackage(
     }
 
     if (isTruthy(input.githubUrl)) {
-      return await loadSkillPackageFromGithub(input.githubUrl);
+      const { githubUrl, skillName } = parseSkillSourceUrl(input.githubUrl);
+      return await loadSkillPackageFromGithub(githubUrl, skillName);
     }
   } catch (error) {
     if (error instanceof SkillRequestError) {

--- a/apps/api/src/modules/skills/application/skill-source-url.service.ts
+++ b/apps/api/src/modules/skills/application/skill-source-url.service.ts
@@ -1,0 +1,117 @@
+import { isTruthy } from "../../../shared/truthiness";
+import { SkillRequestError } from "./skill-package.shared";
+
+export interface ParsedSkillSource {
+  /** A canonical github.com URL the GitHub loader understands. */
+  githubUrl: string;
+  /** Optional skill selector (the `--skill <name>` value or a skills.sh slug segment). */
+  skillName?: string;
+}
+
+const GITHUB_HOSTS = new Set(["github.com", "www.github.com"]);
+const SKILLS_SH_HOSTS = new Set(["skills.sh", "www.skills.sh"]);
+
+/**
+ * Normalizes the many shapes a user can paste into the "import from URL" field into a
+ * canonical github.com URL (plus an optional skill selector):
+ *   - a github.com repo / directory / SKILL.md URL (passed through unchanged)
+ *   - a skills.sh skill URL, e.g. https://www.skills.sh/<owner>/<repo>/<skill>
+ *   - the full install command copied from skills.sh,
+ *     e.g. `npx skills add https://github.com/owner/repo --skill find-skills`
+ */
+export function parseSkillSourceUrl(raw: string): ParsedSkillSource {
+  const trimmed = raw.trim();
+
+  if (!trimmed) {
+    throw new SkillRequestError("A skill URL or install command is required.");
+  }
+
+  if (!/^https?:\/\//i.test(trimmed)) {
+    return parseInstallCommand(trimmed);
+  }
+
+  return fromUrl(trimmed);
+}
+
+function parseInstallCommand(command: string): ParsedSkillSource {
+  const tokens = command.split(/\s+/).filter(Boolean);
+  const urlToken = tokens.find((token) => /^https?:\/\//i.test(token));
+
+  if (!isTruthy(urlToken)) {
+    throw new SkillRequestError(
+      "Could not find a repository URL in the install command. Expected something like " +
+        "`npx skills add https://github.com/owner/repo --skill name`.",
+    );
+  }
+
+  const commandSkillName = readSkillFlag(tokens);
+  const parsed = fromUrl(urlToken);
+
+  return {
+    githubUrl: parsed.githubUrl,
+    ...(isTruthy(commandSkillName)
+      ? { skillName: commandSkillName }
+      : isTruthy(parsed.skillName)
+        ? { skillName: parsed.skillName }
+        : {}),
+  };
+}
+
+function readSkillFlag(tokens: string[]): string | undefined {
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index]!;
+
+    if (token === "--skill" || token === "-s") {
+      const value = tokens[index + 1];
+      return isTruthy(value) && !value.startsWith("-") ? value : undefined;
+    }
+
+    if (token.startsWith("--skill=")) {
+      const value = token.slice("--skill=".length);
+      return isTruthy(value) ? value : undefined;
+    }
+  }
+
+  return undefined;
+}
+
+function fromUrl(rawUrl: string): ParsedSkillSource {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new SkillRequestError("Invalid URL format.");
+  }
+
+  const host = parsed.hostname.toLowerCase();
+
+  if (GITHUB_HOSTS.has(host)) {
+    return { githubUrl: `https://github.com${parsed.pathname}` };
+  }
+
+  if (SKILLS_SH_HOSTS.has(host)) {
+    return fromSkillsShUrl(parsed);
+  }
+
+  throw new SkillRequestError("Only github.com and skills.sh URLs are supported.");
+}
+
+function fromSkillsShUrl(parsed: URL): ParsedSkillSource {
+  const segments = parsed.pathname.split("/").filter(Boolean);
+
+  if (segments.length < 2) {
+    throw new SkillRequestError(
+      "skills.sh URL is missing owner/repo. Expected https://skills.sh/<owner>/<repo>/<skill>.",
+    );
+  }
+
+  const owner = segments[0]!;
+  const repo = segments[1]!;
+  const skillName = segments[2];
+
+  return {
+    githubUrl: `https://github.com/${owner}/${repo}`,
+    ...(isTruthy(skillName) ? { skillName } : {}),
+  };
+}

--- a/apps/api/tests/skill-package-github-boundary.test.ts
+++ b/apps/api/tests/skill-package-github-boundary.test.ts
@@ -97,4 +97,61 @@ describe("GitHub skill package boundary", () => {
     ]);
     expect(downloads).toEqual(new Map([...fileBodies.keys()].map((url) => [url, 1] as const)));
   });
+
+  test("resolves a --skill selector to the skills/<name> directory", async () => {
+    globalThis.fetch = async (input) => {
+      const url = typeof input === "string" ? input : input.url;
+
+      if (url === "https://api.github.com/repos/acme/repo") {
+        return Response.json({ default_branch: "main" });
+      }
+
+      // Probe order: skills/find-skills exists, so it is selected.
+      if (url === "https://api.github.com/repos/acme/repo/contents/skills/find-skills?ref=main") {
+        return Response.json([
+          {
+            download_url:
+              "https://raw.githubusercontent.com/acme/repo/main/skills/find-skills/SKILL.md",
+            path: "skills/find-skills/SKILL.md",
+            type: "file",
+          },
+        ]);
+      }
+
+      if (url === "https://raw.githubusercontent.com/acme/repo/main/skills/find-skills/SKILL.md") {
+        const body = "---\nname: find-skills\ndescription: find skills\n---\n# Find\n";
+        return new Response(body, {
+          headers: {
+            "content-length": String(new TextEncoder().encode(body).byteLength),
+          },
+        });
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    };
+
+    const normalized = await loadSkillPackageFromGithub(
+      "https://github.com/acme/repo",
+      "find-skills",
+    );
+
+    expect(normalized.entries.map((entry) => entry.path)).toEqual(["SKILL.md"]);
+    expect(normalized.frontmatter.name).toBe("find-skills");
+  });
+
+  test("reports a clear error when the --skill selector is not found", async () => {
+    globalThis.fetch = async (input) => {
+      const url = typeof input === "string" ? input : input.url;
+
+      if (url === "https://api.github.com/repos/acme/repo") {
+        return Response.json({ default_branch: "main" });
+      }
+
+      return new Response("Not Found", { status: 404 });
+    };
+
+    await expect(
+      loadSkillPackageFromGithub("https://github.com/acme/repo", "missing"),
+    ).rejects.toThrow('Skill "missing" was not found in acme/repo');
+  });
 });

--- a/apps/api/tests/skill-source-url.test.ts
+++ b/apps/api/tests/skill-source-url.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseSkillSourceUrl } from "../src/modules/skills/application/skill-source-url.service";
+
+describe("parseSkillSourceUrl", () => {
+  test("passes through a github.com repo URL", () => {
+    expect(parseSkillSourceUrl("https://github.com/acme/repo")).toEqual({
+      githubUrl: "https://github.com/acme/repo",
+    });
+  });
+
+  test("passes through a github.com directory URL unchanged", () => {
+    expect(parseSkillSourceUrl("https://github.com/acme/repo/tree/main/skills/find")).toEqual({
+      githubUrl: "https://github.com/acme/repo/tree/main/skills/find",
+    });
+  });
+
+  test("maps a skills.sh skill page URL to a github repo plus skill selector", () => {
+    expect(parseSkillSourceUrl("https://www.skills.sh/vercel-labs/skills/find-skills")).toEqual({
+      githubUrl: "https://github.com/vercel-labs/skills",
+      skillName: "find-skills",
+    });
+  });
+
+  test("maps a skills.sh owner/repo URL without a skill selector", () => {
+    expect(parseSkillSourceUrl("https://skills.sh/vercel-labs/skills")).toEqual({
+      githubUrl: "https://github.com/vercel-labs/skills",
+    });
+  });
+
+  test("parses the npx skills add install command", () => {
+    expect(
+      parseSkillSourceUrl(
+        "npx skills add https://github.com/vercel-labs/skills --skill find-skills",
+      ),
+    ).toEqual({
+      githubUrl: "https://github.com/vercel-labs/skills",
+      skillName: "find-skills",
+    });
+  });
+
+  test("parses the --skill=name form and other runners", () => {
+    expect(
+      parseSkillSourceUrl("pnpm dlx skills add https://github.com/acme/repo --skill=my-skill"),
+    ).toEqual({
+      githubUrl: "https://github.com/acme/repo",
+      skillName: "my-skill",
+    });
+  });
+
+  test("command --skill flag overrides a skills.sh slug skill", () => {
+    expect(
+      parseSkillSourceUrl(
+        "npx skills add https://www.skills.sh/acme/repo/from-slug --skill from-flag",
+      ),
+    ).toEqual({
+      githubUrl: "https://github.com/acme/repo",
+      skillName: "from-flag",
+    });
+  });
+
+  test("rejects unsupported hosts", () => {
+    expect(() => parseSkillSourceUrl("https://example.com/acme/repo")).toThrow(
+      "Only github.com and skills.sh URLs are supported.",
+    );
+  });
+
+  test("rejects an empty value", () => {
+    expect(() => parseSkillSourceUrl("   ")).toThrow("A skill URL or install command is required.");
+  });
+
+  test("rejects a command without a URL", () => {
+    expect(() => parseSkillSourceUrl("npx skills add --skill find-skills")).toThrow(
+      "Could not find a repository URL",
+    );
+  });
+});

--- a/apps/web/src/routes/integrations/skills/skills-tab.tsx
+++ b/apps/web/src/routes/integrations/skills/skills-tab.tsx
@@ -40,6 +40,13 @@ export function SkillsTab() {
     }
   }
 
+  async function handleImportUrl(url: string) {
+    const created = await registry.publishFromGithub(url);
+    if (created) {
+      setDetailSkillId(created.id);
+    }
+  }
+
   return (
     <div className="flex h-full flex-col">
       <PageHeader title="Skills" description="Reusable capabilities you can attach to Agents.">
@@ -50,7 +57,7 @@ export function SkillsTab() {
           size="sm"
         >
           <Upload className="size-3.5" />
-          Upload skill
+          Add skill
         </Button>
       </PageHeader>
 
@@ -104,6 +111,7 @@ export function SkillsTab() {
         open={uploadOpen}
         onOpenChange={setUploadOpen}
         onUpload={handleUpload}
+        onImportUrl={handleImportUrl}
         registry={registry}
       />
       {detailSkill ? (
@@ -137,11 +145,11 @@ function SkillsEmptyState({ onUpload, searching }: { onUpload: () => void; searc
     <EmptyState
       icon={Sparkles}
       title="No skills yet"
-      description="Upload a `SKILL.md` file to get started, or fork an existing skill."
+      description="Upload a `SKILL.md` file, import from GitHub or skills.sh, or fork an existing skill."
     >
       <Button onClick={onUpload} size="sm">
         <Upload className="size-3.5" />
-        Upload skill
+        Add skill
       </Button>
     </EmptyState>
   );

--- a/apps/web/src/routes/integrations/skills/upload-skill-dialog.tsx
+++ b/apps/web/src/routes/integrations/skills/upload-skill-dialog.tsx
@@ -11,30 +11,42 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/shared/ui/dialog";
+import { Input } from "@/shared/ui/input";
 
 import { isTruthy } from "../../../shared/lib/truthiness";
 import type { useSkillRegistry } from "./use-skill-registry";
+type Mode = "file" | "url";
+
+type Prepared =
+  | { kind: "file"; file: File; preview: SkillInspectResult }
+  | { kind: "url"; url: string; preview: SkillInspectResult };
+
 interface Props {
   onOpenChange: (open: boolean) => void;
   onUpload: (file: File) => Promise<void> | void;
+  onImportUrl: (url: string) => Promise<void> | void;
   open: boolean;
   registry?: ReturnType<typeof useSkillRegistry>;
 }
 
-export function UploadSkillDialog({ onOpenChange, onUpload, open, registry }: Props) {
+export function UploadSkillDialog({ onImportUrl, onOpenChange, onUpload, open, registry }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const [mode, setMode] = useState<Mode>("file");
+  const [url, setUrl] = useState("");
   const [dragOver, setDragOver] = useState(false);
-  const [prepared, setPrepared] = useState<{ file: File; preview: SkillInspectResult } | null>(
-    null,
-  );
+  const [prepared, setPrepared] = useState<Prepared | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [inspecting, setInspecting] = useState(false);
 
   function reset() {
+    setMode("file");
+    setUrl("");
     setPrepared(null);
     setError(null);
     setDragOver(false);
     setSubmitting(false);
+    setInspecting(false);
     if (inputRef.current) {
       inputRef.current.value = "";
     }
@@ -60,12 +72,37 @@ export function UploadSkillDialog({ onOpenChange, onUpload, open, registry }: Pr
         throw new Error("Skill inspect service is unavailable.");
       }
 
-      setPrepared({ file, preview });
+      setPrepared({ kind: "file", file, preview });
     } catch (caughtError) {
       setError(
         "Failed to inspect: " +
           (caughtError instanceof Error ? caughtError.message : String(caughtError)),
       );
+    }
+  }
+
+  async function handleInspectUrl() {
+    const trimmed = url.trim();
+    setError(null);
+    if (!trimmed) {
+      return;
+    }
+    setInspecting(true);
+    try {
+      const preview = registry ? await registry.inspectGithub(trimmed) : null;
+
+      if (!preview) {
+        throw new Error("Skill inspect service is unavailable.");
+      }
+
+      setPrepared({ kind: "url", url: trimmed, preview });
+    } catch (caughtError) {
+      setError(
+        "Failed to inspect: " +
+          (caughtError instanceof Error ? caughtError.message : String(caughtError)),
+      );
+    } finally {
+      setInspecting(false);
     }
   }
 
@@ -75,11 +112,15 @@ export function UploadSkillDialog({ onOpenChange, onUpload, open, registry }: Pr
     }
     setSubmitting(true);
     try {
-      await onUpload(prepared.file);
+      if (prepared.kind === "file") {
+        await onUpload(prepared.file);
+      } else {
+        await onImportUrl(prepared.url);
+      }
       handleOpenChange(false);
     } catch (caughtError) {
       setError(
-        "Failed to upload: " +
+        "Failed to add skill: " +
           (caughtError instanceof Error ? caughtError.message : String(caughtError)),
       );
       setSubmitting(false);
@@ -90,9 +131,9 @@ export function UploadSkillDialog({ onOpenChange, onUpload, open, registry }: Pr
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Upload skill</DialogTitle>
+          <DialogTitle>Add skill</DialogTitle>
           <DialogDescription className="sr-only">
-            Upload a .md, .zip, or .skill file to your personal skills.
+            Upload a .md, .zip, or .skill file, or import a skill from a GitHub or skills.sh URL.
           </DialogDescription>
         </DialogHeader>
 
@@ -107,10 +148,34 @@ export function UploadSkillDialog({ onOpenChange, onUpload, open, registry }: Pr
           }}
         />
 
+        {!prepared ? (
+          <div className="border-border-strong bg-card inline-flex w-fit items-center overflow-hidden rounded-md border">
+            <ModeButton
+              active={mode === "file"}
+              label="Upload file"
+              onClick={() => {
+                setError(null);
+                setMode("file");
+              }}
+            />
+            <span className="bg-border-strong h-5 w-px" />
+            <ModeButton
+              active={mode === "url"}
+              label="From URL"
+              onClick={() => {
+                setError(null);
+                setMode("url");
+              }}
+            />
+          </div>
+        ) : null}
+
         {prepared ? (
           <div className="border-border bg-muted/30 flex flex-col gap-3 rounded-lg border p-4">
             <div className="flex items-center gap-2 text-sm">
-              <span className="text-muted-foreground font-mono text-xs">{prepared.file.name}</span>
+              <span className="text-muted-foreground font-mono text-xs">
+                {prepared.kind === "file" ? prepared.file.name : prepared.url}
+              </span>
             </div>
             <div>
               <div className="text-muted-foreground text-[11px] tracking-wider uppercase">Name</div>
@@ -130,7 +195,7 @@ export function UploadSkillDialog({ onOpenChange, onUpload, open, registry }: Pr
               </div>
             ) : null}
           </div>
-        ) : (
+        ) : mode === "file" ? (
           <button
             className={cn(
               "group flex cursor-pointer flex-col items-center justify-center gap-3 rounded-lg border border-dashed py-14 transition-colors",
@@ -157,6 +222,34 @@ export function UploadSkillDialog({ onOpenChange, onUpload, open, registry }: Pr
               Drag and drop or click to upload
             </div>
           </button>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <Input
+                value={url}
+                placeholder="https://github.com/owner/repo or npx skills add … --skill name"
+                aria-label="Skill source URL or install command"
+                onChange={(e) => {
+                  setUrl(e.target.value);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    void handleInspectUrl();
+                  }
+                }}
+              />
+              <Button
+                variant="outline"
+                onClick={() => {
+                  void handleInspectUrl();
+                }}
+                disabled={inspecting || url.trim().length === 0}
+              >
+                {inspecting ? "Checking…" : "Preview"}
+              </Button>
+            </div>
+          </div>
         )}
 
         {isTruthy(error) ? (
@@ -165,12 +258,37 @@ export function UploadSkillDialog({ onOpenChange, onUpload, open, registry }: Pr
           </div>
         ) : null}
 
-        {!prepared ? (
+        {!prepared && mode === "file" ? (
           <div className="space-y-2">
             <div className="text-foreground text-[13px] font-medium">File requirements</div>
             <ul className="text-muted-foreground marker:text-muted-foreground/60 list-disc space-y-1 pl-4 text-[12.5px]">
               <li>.md file must contain skill name and description formatted in YAML</li>
               <li>.zip or .skill file must include a SKILL.md file</li>
+            </ul>
+          </div>
+        ) : null}
+
+        {!prepared && mode === "url" ? (
+          <div className="space-y-2">
+            <div className="text-foreground text-[13px] font-medium">Supported sources</div>
+            <ul className="text-muted-foreground marker:text-muted-foreground/60 list-disc space-y-1 pl-4 text-[12.5px]">
+              <li>A GitHub repo, directory, or SKILL.md link</li>
+              <li>
+                A{" "}
+                <a
+                  href="https://www.skills.sh/"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-primary underline-offset-2 hover:underline"
+                >
+                  skills.sh
+                </a>{" "}
+                skill page URL
+              </li>
+              <li>
+                The install command copied from skills.sh, e.g.{" "}
+                <code className="font-mono text-[11.5px]">npx skills add …&nbsp;--skill name</code>
+              </li>
             </ul>
           </div>
         ) : null}
@@ -187,14 +305,38 @@ export function UploadSkillDialog({ onOpenChange, onUpload, open, registry }: Pr
           </Button>
           {prepared ? (
             <Button variant="outline" onClick={reset} disabled={submitting}>
-              Change file
+              Change
             </Button>
           ) : null}
           <Button disabled={!prepared || submitting} onClick={handleConfirm}>
-            {submitting ? "Uploading…" : "Upload"}
+            {submitting ? "Adding…" : "Add skill"}
           </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function ModeButton({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "h-8 px-3 text-[13px] font-medium transition-colors",
+        active ? "bg-paper-200 text-fg-1" : "text-fg-3 hover:bg-paper-200/50",
+      )}
+    >
+      {label}
+    </button>
   );
 }


### PR DESCRIPTION
## Summary

- Skill import now accepts a **GitHub URL, a skills.sh skill-page URL, or a pasted `npx skills add … --skill <name>` install command**, and the UI exposes it.
- Backend already accepted a `github.com` URL via the `githubUrl` field; this PR keeps that field (backward compatible) and broadens what it accepts.
- New `From URL` mode in the **Add skill** dialog (previously file-upload only) lets you preview and install a skill from a URL or install command.

### What changed

- **`skill-source-url.service.ts` (new)** — `parseSkillSourceUrl()` normalizes any of:
  - a `github.com` repo / directory / `SKILL.md` URL (passed through),
  - a `skills.sh` skill page, e.g. `https://www.skills.sh/<owner>/<repo>/<skill>`,
  - the install command copied from skills.sh, e.g. `npx skills add https://github.com/owner/repo --skill find-skills`
  
  …into a canonical `github.com` URL plus an optional skill selector. `--skill`/`-s`/`--skill=` and alternative runners (`pnpm dlx`, `bunx`) are handled.
- **`skill-package-github.service.ts`** — `loadSkillPackageFromGithub(url, skillName?)` resolves a `--skill <name>` selector to the matching directory, probing `skills/<name>`, `<name>`, then `.claude/skills/<name>` (matches the skills.sh / `npx skills` convention — e.g. `vercel-labs/skills` → `skills/find-skills`). Clear error when the skill is not found.
- **`upload-skill-dialog.tsx`** — adds an `Upload file` / `From URL` toggle; URL mode previews via the existing inspect endpoint then installs.
- The wire field stays `githubUrl` for backward compatibility.

## Why

The import backend supported GitHub already, but the UI only exposed file upload, and there was no way to install a skills.sh skill — whose canonical install is `npx skills add <repo> --skill <name>`. This makes the skills.sh ecosystem (and any GitHub-hosted skill) installable from the UI with a single paste.

## Verification

- Commands:
  - `vp run --filter @mosoo/api test` → **657 pass / 0 fail** (incl. new `skill-source-url.test.ts` and added `--skill` resolution cases in `skill-package-github-boundary.test.ts`)
  - `vp run --filter @mosoo/api tc` and `vp run --filter @mosoo/web tc` → clean
  - `vp lint` + `vp fmt --check` on touched files → clean
- Manual: the new dialog mode is built from existing inspect/publish endpoints (`registry.inspectGithub` / `registry.publishFromGithub`) that were already wired but unexposed.

## Risk And Blast Radius

- Affected packages: `@mosoo/api` (skills module), `@mosoo/web` (skills route).
- Affected user flows or APIs: skill import / `Add skill` dialog. `/skill/inspect` and `/skill/package` are unchanged on the wire (the `githubUrl` field just accepts more source shapes); existing GitHub-URL behavior is preserved.
- Rollback: revert this commit; no schema, migration, or env changes.

## Evidence

- UI/UX: the visible change is a new `Upload file` / `From URL` segmented toggle in the **Add skill** dialog; URL mode shows a text input (placeholder `https://github.com/owner/repo or npx skills add … --skill name`), a `Preview` button, and the same skill preview card before confirming. Bringing up the local Cloudflare/Docker-backed stack to screenshot was not feasible in the agent sandbox; happy to attach screenshots if a reviewer can run `just dev`.
- Test output: 657 pass / 0 fail (api suite).

## Compatibility

- Public contract changes: none (form field name unchanged).
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- `skill-source-url.service.ts` parsing rules and the `--skill` directory probe order in `skill-package-github.service.ts`.
- Known trade-off: skills.sh content is GitHub-hosted, so this resolves skills.sh URLs to GitHub rather than calling a skills.sh API — no new external dependency, and it reuses the existing GitHub fetch/limits path.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] Generated files / lockfile: none hand-edited

## Generated Files, Schema, And Lockfile

- N/A — no generated files, schema, or lockfile changes.
