### PR TITLE
feat(web): collect name and runtime in New Agent dialog before creating

### DIFF
--- a/apps/web/src/routes/agent/components/create-agent-launcher.tsx
+++ b/apps/web/src/routes/agent/components/create-agent-launcher.tsx
@@ -1,17 +1,24 @@
 import type { AppId } from "@mosoo/contracts/id";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
-import type { ReactElement } from "react";
+import { useMemo, useState } from "react";
+import type { FormEvent, ReactElement } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useAppSession } from "@/app/session-provider";
 import { createAgent } from "@/domains/agent/api/agent-client";
 import { agentKeys } from "@/domains/agent/query/agent-queries";
 import { useVendorCredentialsQuery } from "@/domains/vendor-credential/model/provider-credential-query";
-import { Dialog, DialogContent, DialogTitle } from "@/shared/ui/dialog";
+import { cn } from "@/shared/lib/class-names";
+import { Button } from "@/shared/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/shared/ui/dialog";
+import { Input } from "@/shared/ui/input";
+import { Label } from "@/shared/ui/label";
 
+import type { RuntimeInfo } from "../agent.types";
+import { isRuntimeSelectable, listRuntimeOptions } from "../runtime-catalog";
 import { resolveDefaultAgentRuntime } from "../runtime-default";
+import { RuntimeIcon } from "./runtime-icon";
 
 const DEFAULT_AGENT_NAME = "Untitled agent";
 
@@ -26,10 +33,7 @@ export function CreateAgentLauncherDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        showCloseButton
-        className="gap-0 overflow-hidden rounded-lg p-0 sm:max-w-[420px]"
-      >
+      <DialogContent showCloseButton className="gap-0 overflow-hidden rounded-lg sm:max-w-[460px]">
         {activeOrganization === null ? (
           <LauncherStatus message="Finish App setup before creating agents." />
         ) : activeApp === null ? (
@@ -52,8 +56,24 @@ function CreateAgentLauncherBody({
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { credentials, loading: credentialsLoading } = useVendorCredentialsQuery(appId);
-  const createStartedRef = useRef(false);
-  const [localError, setLocalError] = useState<string | null>(null);
+
+  const [name, setName] = useState("");
+  const [selectedRuntimeId, setSelectedRuntimeId] = useState<string | null>(null);
+
+  const defaultRuntime = useMemo(
+    () => (credentialsLoading ? null : resolveDefaultAgentRuntime(credentials)),
+    [credentials, credentialsLoading],
+  );
+  const runtimeOptions = useMemo(
+    () =>
+      listRuntimeOptions(defaultRuntime?.runtimeId).filter((runtime) =>
+        isRuntimeSelectable(runtime.id),
+      ),
+    [defaultRuntime],
+  );
+
+  const activeRuntimeId = selectedRuntimeId ?? defaultRuntime?.runtimeId ?? null;
+
   const createAgentMutation = useMutation({
     mutationFn: createAgent,
     onSuccess: async () => {
@@ -61,67 +81,163 @@ function CreateAgentLauncherBody({
     },
   });
 
-  useEffect(() => {
-    if (credentialsLoading || createStartedRef.current) {
+  const trimmedName = name.trim();
+  const canSubmit =
+    !credentialsLoading &&
+    defaultRuntime !== null &&
+    activeRuntimeId !== null &&
+    trimmedName.length > 0 &&
+    !createAgentMutation.isPending;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+
+    if (defaultRuntime === null || activeRuntimeId === null || trimmedName.length === 0) {
       return;
     }
 
-    const runtime = resolveDefaultAgentRuntime(credentials);
+    const runtimeConfig = resolveRuntimeConfig(activeRuntimeId, defaultRuntime, runtimeOptions);
 
-    if (runtime === null) {
-      setLocalError("Configure a provider before creating agents.");
-      return;
+    try {
+      const createdAgent = await createAgentMutation.mutateAsync({
+        kind: "pet",
+        model: runtimeConfig.model,
+        name: trimmedName,
+        appId,
+        prompt: "",
+        provider: runtimeConfig.provider,
+        runtimeId: runtimeConfig.runtimeId,
+        skillIds: [],
+      });
+
+      onOpenChange(false);
+      void navigate(
+        globalThis.location.pathname.startsWith("/demo")
+          ? `/demo/agent/${createdAgent.id}?tab=preview`
+          : `/agent/${createdAgent.id}?tab=preview`,
+      );
+    } catch {
+      // Error state is rendered from the mutation object.
     }
+  }
 
-    const runtimeConfig = runtime;
-    createStartedRef.current = true;
-
-    async function createAndOpenPreview(): Promise<void> {
-      try {
-        const createdAgent = await createAgentMutation.mutateAsync({
-          kind: "pet",
-          model: runtimeConfig.model,
-          name: DEFAULT_AGENT_NAME,
-          appId,
-          prompt: "",
-          provider: runtimeConfig.provider,
-          runtimeId: runtimeConfig.runtimeId,
-          skillIds: [],
-        });
-
-        onOpenChange(false);
-        void navigate(
-          globalThis.location.pathname.startsWith("/demo")
-            ? `/demo/agent/${createdAgent.id}?tab=preview`
-            : `/agent/${createdAgent.id}?tab=preview`,
-        );
-      } catch {
-        // Error state is rendered from the mutation object.
-      }
-    }
-
-    void createAndOpenPreview();
-  }, [appId, createAgentMutation, credentials, credentialsLoading, navigate, onOpenChange]);
-
+  const noRuntimeAvailable = !credentialsLoading && defaultRuntime === null;
   const mutationError =
     createAgentMutation.error instanceof Error ? createAgentMutation.error.message : null;
-  const error = localError ?? mutationError;
+  const error = noRuntimeAvailable ? "Configure a provider before creating agents." : mutationError;
 
   return (
-    <div className="px-7 py-10 text-center">
-      <DialogTitle asChild>
-        <h2 className="text-foreground text-[16px] font-medium">Creating agent</h2>
-      </DialogTitle>
-      {error === null ? (
-        <div className="text-muted-foreground mt-3 flex items-center justify-center gap-2 text-[13px]">
-          <Loader2 className="size-4 animate-spin" />
-          Opening Preview…
+    <form onSubmit={handleSubmit}>
+      <DialogHeader className="px-6 pt-6">
+        <DialogTitle className="text-[16px]">New Agent</DialogTitle>
+      </DialogHeader>
+
+      <div className="space-y-5 px-6 py-5">
+        <div className="space-y-2">
+          <Label className="text-muted-foreground text-[12px]" htmlFor="new-agent-name">
+            Name
+          </Label>
+          <Input
+            id="new-agent-name"
+            onChange={(event) => {
+              setName(event.target.value);
+            }}
+            placeholder={DEFAULT_AGENT_NAME}
+            value={name}
+          />
         </div>
-      ) : (
-        <div className="text-destructive mt-3 text-[13px]">{error}</div>
-      )}
-    </div>
+
+        <div className="space-y-2">
+          <Label className="text-muted-foreground text-[12px]">Runtime</Label>
+          {credentialsLoading ? (
+            <div className="text-muted-foreground flex items-center gap-2 py-2 text-[13px]">
+              <Loader2 className="size-4 animate-spin" />
+              Loading runtimes…
+            </div>
+          ) : runtimeOptions.length === 0 ? (
+            <div className="text-muted-foreground text-[13px]">No runtimes available.</div>
+          ) : (
+            <div className="grid grid-cols-2 gap-3">
+              {runtimeOptions.map((runtime) => {
+                const selected = runtime.id === activeRuntimeId;
+
+                return (
+                  <button
+                    aria-pressed={selected}
+                    className={cn(
+                      "focus-visible:ring-brand-ring flex items-center gap-3 rounded-lg border px-3 py-3 text-left transition-colors focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none",
+                      selected
+                        ? "border-brand bg-brand-light"
+                        : "border-border hover:border-brand/30",
+                    )}
+                    key={runtime.id}
+                    onClick={() => {
+                      setSelectedRuntimeId(runtime.id);
+                    }}
+                    type="button"
+                  >
+                    <RuntimeIcon runtime={runtime} size={24} />
+                    <div className="min-w-0">
+                      <div className="text-foreground text-[13px] font-medium">{runtime.name}</div>
+                      <div className="text-muted-foreground text-[11px]">{runtime.vendor}</div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {error !== null ? <div className="text-destructive text-[13px]">{error}</div> : null}
+      </div>
+
+      <DialogFooter className="border-border-subtle border-t px-6 py-4">
+        <Button
+          onClick={() => {
+            onOpenChange(false);
+          }}
+          type="button"
+          variant="outline"
+        >
+          Cancel
+        </Button>
+        <Button disabled={!canSubmit} type="submit">
+          {createAgentMutation.isPending ? (
+            <>
+              <Loader2 className="size-4 animate-spin" />
+              Creating…
+            </>
+          ) : (
+            "Create"
+          )}
+        </Button>
+      </DialogFooter>
+    </form>
   );
+}
+
+function resolveRuntimeConfig(
+  runtimeId: string,
+  defaultRuntime: { model: string; provider: string; runtimeId: string },
+  runtimeOptions: readonly RuntimeInfo[],
+): { model: string; provider: string; runtimeId: string } {
+  // Keep the resolved provider/model when the user keeps the default runtime, so
+  // custom-provider credentials (e.g. OpenAI-compatible) stay wired correctly.
+  if (runtimeId === defaultRuntime.runtimeId) {
+    return defaultRuntime;
+  }
+
+  const runtime = runtimeOptions.find((candidate) => candidate.id === runtimeId);
+
+  if (runtime === undefined) {
+    return defaultRuntime;
+  }
+
+  return {
+    model: runtime.defaultModel,
+    provider: runtime.provider,
+    runtimeId: runtime.id,
+  };
 }
 
 function LauncherStatus({ message }: { message: string }): ReactElement {


### PR DESCRIPTION
## Summary

- Clicking **New Agent** now opens a dialog that collects an agent **name** and a **Runtime** selection, and the agent is created only after the user confirms with **Create**.
- Previously the launcher auto-created an "Untitled agent" with the default runtime the moment it opened; the new flow turns that one-click action into a small confirm form.

## Why

- Users had no chance to name the agent or choose a runtime before creation, producing throwaway "Untitled agent" records and forcing a runtime change afterward.

## Verification

- Commands: `tsc --noEmit` (web) ✅, `lint` on the changed file ✅, formatter ✅.
- Manual steps (local dev, `@mosoo.ai` development login): clicked **Create agent** → dialog shows Name + Runtime; filled a name, picked a runtime, clicked **Create**; the agent was created and the app navigated to `/agent/<id>?tab=preview`.

## Risk And Blast Radius

- Affected packages: `apps/web` only.
- Affected user flows: agent creation entry point (`CreateAgentLauncherDialog`).
- Rollback: revert this commit.

## Evidence

- UI/UX: dialog with Name field + Runtime selection (Claude Agent SDK / OpenAI Runtime) and Cancel/Create buttons. Screenshot attached on the tracking issue YEF-732.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- `apps/web/src/routes/agent/components/create-agent-launcher.tsx` — name/runtime state, default-runtime preselection, and `resolveRuntimeConfig` (keeps the resolved provider/model when the default runtime is kept so custom-provider credentials stay wired).

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Subject starts lowercase
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshot in Evidence (on tracking issue)

## Generated Files, Schema, And Lockfile

- N/A
