### PR TITLE
feat(web): trial hugeicons navigation icons

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,8 @@
     "@base-ui/react": "^1.5.0",
     "@cloudflare/ai-chat": "^0.8.6",
     "@cloudflare/sandbox": "0.12.1",
+    "@hugeicons/core-free-icons": "^4.2.1",
+    "@hugeicons/react": "^1.1.9",
     "@lobehub/icons-static-svg": "^1.90.0",
     "@monaco-editor/react": "^4.7.0",
     "@mosoo/ag-ui-session": "workspace:*",

--- a/apps/web/src/app/account-menu.tsx
+++ b/apps/web/src/app/account-menu.tsx
@@ -1,4 +1,7 @@
-import { ChevronsUpDown, LayoutGrid, LogOut, Settings } from "lucide-react";
+import ChevronsDownUpIcon from "@hugeicons/core-free-icons/ChevronsDownUpIcon";
+import GridViewIcon from "@hugeicons/core-free-icons/GridViewIcon";
+import Logout01Icon from "@hugeicons/core-free-icons/Logout01Icon";
+import Settings02Icon from "@hugeicons/core-free-icons/Settings02Icon";
 import { Link } from "react-router-dom";
 
 import { cn } from "@/shared/lib/class-names";
@@ -16,6 +19,13 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { authClient } from "../domains/auth/api/auth-client";
 import { getAvatarBackground, getAvatarInitial } from "../shared/lib/avatar";
 import { isTruthy } from "../shared/lib/truthiness";
+import { createHugeicon } from "./hugeicon";
+
+const AccountMenuChevronIcon = createHugeicon(ChevronsDownUpIcon, "AccountMenuChevronIcon");
+const AccountMenuSettingsIcon = createHugeicon(Settings02Icon, "AccountMenuSettingsIcon");
+const AccountMenuSignOutIcon = createHugeicon(Logout01Icon, "AccountMenuSignOutIcon");
+const AccountMenuAppsIcon = createHugeicon(GridViewIcon, "AccountMenuAppsIcon");
+
 interface AccountMenuUser {
   email: string;
   id: string;
@@ -88,7 +98,7 @@ export function AccountMenu({
         <div className="text-fg-1 truncate text-[13px] font-bold">{user?.name}</div>
         <div className="text-fg-3 truncate text-[11.5px]">{user?.email}</div>
       </div>
-      <ChevronsUpDown className="text-fg-3 size-3.5 shrink-0" />
+      <AccountMenuChevronIcon className="text-fg-3 size-3.5 shrink-0" />
     </Button>
   );
 
@@ -105,13 +115,13 @@ export function AccountMenu({
           <DropdownMenuSeparator />
           <DropdownMenuItem asChild className="cursor-pointer rounded-md">
             <Link to="/apps">
-              <LayoutGrid className="size-4" />
+              <AccountMenuAppsIcon className="size-4" />
               Apps
             </Link>
           </DropdownMenuItem>
           <DropdownMenuItem asChild className="cursor-pointer rounded-md">
             <Link to="/settings">
-              <Settings className="size-4" />
+              <AccountMenuSettingsIcon className="size-4" />
               Settings
             </Link>
           </DropdownMenuItem>
@@ -124,7 +134,7 @@ export function AccountMenu({
               })();
             }}
           >
-            <LogOut className="size-4" />
+            <AccountMenuSignOutIcon className="size-4" />
             Sign out
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -1,15 +1,13 @@
+import AppWindowIcon from "@hugeicons/core-free-icons/AppWindowIcon";
+import CheckIcon from "@hugeicons/core-free-icons/CheckIcon";
+import ChevronLeftIcon from "@hugeicons/core-free-icons/ChevronLeftIcon";
+import ChevronsDownUpIcon from "@hugeicons/core-free-icons/ChevronsDownUpIcon";
+import GridViewIcon from "@hugeicons/core-free-icons/GridViewIcon";
+import PanelLeftCloseIcon from "@hugeicons/core-free-icons/PanelLeftCloseIcon";
+import PanelLeftOpenIcon from "@hugeicons/core-free-icons/PanelLeftOpenIcon";
+import PlusSignIcon from "@hugeicons/core-free-icons/PlusSignIcon";
+import Settings02Icon from "@hugeicons/core-free-icons/Settings02Icon";
 import type { AppSummary } from "@mosoo/contracts/app";
-import {
-  Box,
-  Check,
-  ChevronLeft,
-  ChevronsUpDown,
-  LayoutGrid,
-  PanelLeftClose,
-  PanelLeftOpen,
-  Plus,
-  Settings,
-} from "lucide-react";
 import type { ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
@@ -28,10 +26,21 @@ import { Separator } from "@/shared/ui/separator";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 import { AccountMenu } from "./account-menu";
+import { createHugeicon } from "./hugeicon";
 import { AppNavigation } from "./navigation";
 import { OrgNavigation } from "./org-navigation";
 import { useAppSession } from "./session-provider";
 import { useSidebarCollapsed } from "./use-sidebar-collapsed";
+
+const AppSwitcherIcon = createHugeicon(AppWindowIcon, "AppSwitcherIcon");
+const BackIcon = createHugeicon(ChevronLeftIcon, "BackIcon");
+const CheckmarkIcon = createHugeicon(CheckIcon, "CheckmarkIcon");
+const CollapseSidebarIcon = createHugeicon(PanelLeftCloseIcon, "CollapseSidebarIcon");
+const ExpandSidebarIcon = createHugeicon(PanelLeftOpenIcon, "ExpandSidebarIcon");
+const ManageAppsIcon = createHugeicon(GridViewIcon, "ManageAppsIcon");
+const NewAgentIcon = createHugeicon(PlusSignIcon, "NewAgentIcon");
+const SettingsIcon = createHugeicon(Settings02Icon, "SettingsIcon");
+const SwitcherChevronIcon = createHugeicon(ChevronsDownUpIcon, "SwitcherChevronIcon");
 
 // One-click return to the parent Org layer (the Apps list).
 function BackToOrgLink({ collapsed, orgName }: { collapsed: boolean; orgName: string | null }) {
@@ -47,7 +56,7 @@ function BackToOrgLink({ collapsed, orgName }: { collapsed: boolean; orgName: st
           : "mx-0.5 mb-1.5 px-1.5 py-1 text-[12px] font-medium",
       )}
     >
-      <ChevronLeft className="size-3.5 shrink-0" />
+      <BackIcon className="size-3.5 shrink-0" />
       {collapsed ? null : <span className="truncate">{label}</span>}
     </Link>
   );
@@ -90,7 +99,7 @@ function AppSwitcher({
         collapsed ? "mx-auto mb-3 size-9 justify-center" : "mx-0.5 mb-4 gap-2 px-2.5 py-2",
       )}
     >
-      <Box className="size-4 shrink-0" />
+      <AppSwitcherIcon className="size-4 shrink-0" />
       {collapsed ? null : (
         <>
           <div className="min-w-0 flex-1 text-left">
@@ -99,7 +108,7 @@ function AppSwitcher({
             </div>
             <div className="truncate">{displayLabel}</div>
           </div>
-          <ChevronsUpDown className="text-fg-3 size-3.5 shrink-0" />
+          <SwitcherChevronIcon className="text-fg-3 size-3.5 shrink-0" />
         </>
       )}
     </button>
@@ -122,23 +131,23 @@ function AppSwitcher({
             className="cursor-pointer gap-2 rounded-md"
             onSelect={() => onSwitch(app.id)}
           >
-            <Box className="text-fg-3 size-4 shrink-0" />
+            <AppSwitcherIcon className="text-fg-3 size-4 shrink-0" />
             <span className="min-w-0 flex-1 truncate">{app.name}</span>
             {activeApp !== null && app.id === activeApp.id ? (
-              <Check className="text-accent-press size-4 shrink-0" />
+              <CheckmarkIcon className="text-fg-1 size-4 shrink-0" />
             ) : null}
           </DropdownMenuItem>
         ))}
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild className="cursor-pointer rounded-md">
           <Link to="/apps">
-            <LayoutGrid className="size-4" />
+            <ManageAppsIcon className="size-4" />
             Manage apps
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild className="cursor-pointer rounded-md">
           <Link to="/settings/app">
-            <Settings className="size-4" />
+            <SettingsIcon className="size-4" />
             App settings
           </Link>
         </DropdownMenuItem>
@@ -154,7 +163,7 @@ function NewAgentCta({ collapsed, disabled }: { collapsed: boolean; disabled: bo
   if (disabled) {
     return (
       <Button disabled aria-label={label} className={className}>
-        <Plus className="size-4" />
+        <NewAgentIcon className="size-4" />
         {collapsed ? null : label}
       </Button>
     );
@@ -163,7 +172,7 @@ function NewAgentCta({ collapsed, disabled }: { collapsed: boolean; disabled: bo
   const cta = (
     <Button asChild aria-label={label} className={className}>
       <Link to="/agent?create=1">
-        <Plus className="size-4" />
+        <NewAgentIcon className="size-4" />
         {collapsed ? null : label}
       </Link>
     </Button>
@@ -220,7 +229,7 @@ function ConsoleShell({
   onToggleCollapsed: () => void;
   sidebar: ReactNode;
 }) {
-  const ToggleIcon = collapsed ? PanelLeftOpen : PanelLeftClose;
+  const ToggleIcon = collapsed ? ExpandSidebarIcon : CollapseSidebarIcon;
   const toggleLabel = collapsed ? "Expand sidebar" : "Collapse sidebar";
 
   return (

--- a/apps/web/src/app/hugeicon.tsx
+++ b/apps/web/src/app/hugeicon.tsx
@@ -1,0 +1,23 @@
+import { HugeiconsIcon } from "@hugeicons/react";
+import type { HugeiconsIconProps, IconSvgElement } from "@hugeicons/react";
+import { forwardRef } from "react";
+import type { ForwardRefExoticComponent, RefAttributes } from "react";
+
+type HugeiconProps = Omit<HugeiconsIconProps, "altIcon" | "icon">;
+
+export type AppIcon = ForwardRefExoticComponent<HugeiconProps & RefAttributes<SVGSVGElement>>;
+
+export function createHugeicon(icon: IconSvgElement, displayName: string): AppIcon {
+  const Component = forwardRef<SVGSVGElement, HugeiconProps>(function AppHugeicon(
+    { color = "currentColor", strokeWidth = 1.5, ...props },
+    ref,
+  ) {
+    return (
+      <HugeiconsIcon ref={ref} icon={icon} color={color} strokeWidth={strokeWidth} {...props} />
+    );
+  });
+
+  Component.displayName = displayName;
+
+  return Component;
+}

--- a/apps/web/src/app/navigation.tsx
+++ b/apps/web/src/app/navigation.tsx
@@ -1,20 +1,20 @@
-import type { LucideIcon } from "lucide-react";
-import {
-  Bot,
-  Box,
-  ChevronRight,
-  Files,
-  Inbox,
-  KeyRound,
-  LayoutDashboard,
-  Puzzle,
-} from "lucide-react";
+import BotIcon from "@hugeicons/core-free-icons/BotIcon";
+import ChevronRightIcon from "@hugeicons/core-free-icons/ChevronRightIcon";
+import DashboardSquare01Icon from "@hugeicons/core-free-icons/DashboardSquare01Icon";
+import Files02Icon from "@hugeicons/core-free-icons/Files02Icon";
+import InboxIcon from "@hugeicons/core-free-icons/InboxIcon";
+import Key01Icon from "@hugeicons/core-free-icons/Key01Icon";
+import PackageIcon from "@hugeicons/core-free-icons/PackageIcon";
+import PuzzleIcon from "@hugeicons/core-free-icons/PuzzleIcon";
 import type { MouseEvent } from "react";
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import { cn } from "@/shared/lib/class-names";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+
+import type { AppIcon } from "./hugeicon";
+import { createHugeicon } from "./hugeicon";
 
 interface AppNavChild {
   label: string;
@@ -23,7 +23,7 @@ interface AppNavChild {
 
 interface AppNavItem {
   children?: AppNavChild[];
-  icon: LucideIcon;
+  icon: AppIcon;
   label: string;
   path: string;
 }
@@ -36,11 +36,15 @@ interface AppNavSection {
 const NAV_SECTIONS: AppNavSection[] = [
   {
     items: [
-      { icon: LayoutDashboard, label: "Install", path: "/" },
-      { icon: Inbox, label: "Threads", path: "/threads" },
-      { icon: Bot, label: "Agents", path: "/agent" },
-      { icon: Files, label: "Files", path: "/files" },
-      { icon: Box, label: "Environments", path: "/environment" },
+      { icon: createHugeicon(DashboardSquare01Icon, "InstallIcon"), label: "Install", path: "/" },
+      { icon: createHugeicon(InboxIcon, "ThreadsIcon"), label: "Threads", path: "/threads" },
+      { icon: createHugeicon(BotIcon, "AgentsIcon"), label: "Agents", path: "/agent" },
+      { icon: createHugeicon(Files02Icon, "FilesIcon"), label: "Files", path: "/files" },
+      {
+        icon: createHugeicon(PackageIcon, "EnvironmentsIcon"),
+        label: "Environments",
+        path: "/environment",
+      },
     ],
   },
   {
@@ -50,14 +54,16 @@ const NAV_SECTIONS: AppNavSection[] = [
           { label: "Skills", path: "/integrations/skills" },
           { label: "MCP servers", path: "/integrations/mcp" },
         ],
-        icon: Puzzle,
+        icon: createHugeicon(PuzzleIcon, "IntegrationsIcon"),
         label: "Integrations",
         path: "/integrations",
       },
-      { icon: KeyRound, label: "Providers", path: "/providers" },
+      { icon: createHugeicon(Key01Icon, "ProvidersIcon"), label: "Providers", path: "/providers" },
     ],
   },
 ];
+
+const ExpandIcon = createHugeicon(ChevronRightIcon, "ExpandIcon");
 
 function isNavItemActive(pathname: string, path: string): boolean {
   return pathname === path || pathname.startsWith(`${path}/`);
@@ -71,7 +77,7 @@ function NavLink({
   path,
 }: {
   collapsed: boolean;
-  icon: LucideIcon;
+  icon: AppIcon;
   isActive: boolean;
   label: string;
   path: string;
@@ -181,7 +187,7 @@ function NavGroup({
             onClick={toggleExpansion}
             className="text-fg-3 hover:text-fg-1 flex w-7 shrink-0 items-center justify-center rounded-md transition-colors"
           >
-            <ChevronRight
+            <ExpandIcon
               className={cn(
                 "size-3.5 transition-transform duration-150 ease-out",
                 expanded ? "rotate-90" : "rotate-0",

--- a/apps/web/src/app/org-navigation.tsx
+++ b/apps/web/src/app/org-navigation.tsx
@@ -1,12 +1,17 @@
-import type { LucideIcon } from "lucide-react";
-import { BarChart3, LayoutGrid, Settings, Wallet } from "lucide-react";
+import ChartLineData01Icon from "@hugeicons/core-free-icons/ChartLineData01Icon";
+import GridViewIcon from "@hugeicons/core-free-icons/GridViewIcon";
+import Settings02Icon from "@hugeicons/core-free-icons/Settings02Icon";
+import Wallet02Icon from "@hugeicons/core-free-icons/Wallet02Icon";
 import { Link } from "react-router-dom";
 
 import { cn } from "@/shared/lib/class-names";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
+import type { AppIcon } from "./hugeicon";
+import { createHugeicon } from "./hugeicon";
+
 interface OrgNavItem {
-  icon: LucideIcon;
+  icon: AppIcon;
   label: string;
   path: string | null;
   soon?: boolean;
@@ -15,10 +20,19 @@ interface OrgNavItem {
 // Org layer = the account/billing shell. Usage and Billing are not built yet, so
 // they render as inert "coming soon" entries.
 const ORG_NAV_ITEMS: OrgNavItem[] = [
-  { icon: LayoutGrid, label: "Apps", path: "/apps" },
-  { icon: BarChart3, label: "Usage", path: null, soon: true },
-  { icon: Wallet, label: "Billing", path: null, soon: true },
-  { icon: Settings, label: "Org settings", path: "/org/settings" },
+  { icon: createHugeicon(GridViewIcon, "AppsIcon"), label: "Apps", path: "/apps" },
+  {
+    icon: createHugeicon(ChartLineData01Icon, "UsageIcon"),
+    label: "Usage",
+    path: null,
+    soon: true,
+  },
+  { icon: createHugeicon(Wallet02Icon, "BillingIcon"), label: "Billing", path: null, soon: true },
+  {
+    icon: createHugeicon(Settings02Icon, "OrgSettingsIcon"),
+    label: "Org settings",
+    path: "/org/settings",
+  },
 ];
 
 function isOrgNavItemActive(pathname: string, path: string): boolean {
@@ -31,7 +45,7 @@ function ComingSoonItem({
   label,
 }: {
   collapsed: boolean;
-  icon: LucideIcon;
+  icon: AppIcon;
   label: string;
 }) {
   const content = (
@@ -74,7 +88,7 @@ function OrgNavLink({
   path,
 }: {
   collapsed: boolean;
-  icon: LucideIcon;
+  icon: AppIcon;
   isActive: boolean;
   label: string;
   path: string;

--- a/apps/web/src/hugeicons-core-free-icons.d.ts
+++ b/apps/web/src/hugeicons-core-free-icons.d.ts
@@ -1,0 +1,6 @@
+declare module "@hugeicons/core-free-icons/*" {
+  import type { IconSvgElement } from "@hugeicons/react";
+
+  const icon: IconSvgElement;
+  export default icon;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -102,6 +102,8 @@
         "@base-ui/react": "^1.5.0",
         "@cloudflare/ai-chat": "^0.8.6",
         "@cloudflare/sandbox": "0.12.1",
+        "@hugeicons/core-free-icons": "^4.2.1",
+        "@hugeicons/react": "^1.1.9",
         "@lobehub/icons-static-svg": "^1.90.0",
         "@monaco-editor/react": "^4.7.0",
         "@mosoo/ag-ui-session": "workspace:*",
@@ -696,6 +698,10 @@
     "@graphql-yoga/typed-event-target": ["@graphql-yoga/typed-event-target@3.0.2", "", { "dependencies": { "@repeaterjs/repeater": "^3.0.4", "tslib": "^2.8.1" } }, "sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@hugeicons/core-free-icons": ["@hugeicons/core-free-icons@4.2.1", "", {}, "sha512-75jYZKYyA9VwS35YRmmGUGzFedbY+Fl0Vxx5FzXR2CGDlIhNRumFeVqaaKoClf2MeYEJwPAVMEL9RwCYtOgnSw=="],
+
+    "@hugeicons/react": ["@hugeicons/react@1.1.9", "", { "peerDependencies": { "react": ">=16.0.0" } }, "sha512-O+lWSWjbijoAvMCxn4K2bQWCGN5+mP1y5j+X99j23mXMj+s0X25fs71T6t9YJLaBodwmZdaewD27dzS/PiboQw=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 


### PR DESCRIPTION
## Summary
- Add Hugeicons Free React packages to the web app.
- Route App shell, App navigation, Org navigation, and account menu icons through a typed Hugeicons adapter.
- Keep the trial on Hugeicons Stroke with neutral currentColor styling after confirming the free package does not provide usable duotone coverage for the migrated shell icons.

## Verification
- `just check`
- `bun run --filter @mosoo/web build` (passes; Hugeicons package emits non-blocking Rolldown INVALID_ANNOTATION warnings from imported icon files)
- Playwright app-shell smoke on `http://127.0.0.1:5173/` with development backdoor login
- `bash ./init.sh development`

## Generated Files
- GraphQL codegen: not changed; `just check` ran `graphql:codegen:check` successfully.
- DB baseline/migrations: not changed.