### PR TITLE
fix(threads): pad New thread composer textarea

### DIFF
--- a/apps/web/src/routes/threads/compose/new-dialog.tsx
+++ b/apps/web/src/routes/threads/compose/new-dialog.tsx
@@ -384,23 +384,25 @@ export function NewThreadDialog({
             selectedAgentId={selectedAgentId}
           />
 
-          <Textarea
-            value={body}
-            onChange={(event) => {
-              dispatch({ body: event.target.value, type: "changeBody" });
-            }}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-                event.preventDefault();
-                void submit();
-              }
-            }}
-            className={cn(
-              "resize-none border-0 bg-transparent p-0 text-[14px] leading-relaxed shadow-none focus-visible:ring-0",
-              expanded ? "min-h-[420px]" : "min-h-[280px]",
-            )}
-            placeholder="Describe the goal, context, and success criteria for this task..."
-          />
+          <div className="border-border-subtle bg-card focus-within:border-ring focus-within:ring-ring/50 rounded-lg border px-3.5 py-3 shadow-[var(--shadow-sm)] transition-[color,box-shadow] focus-within:ring-[3px]">
+            <Textarea
+              value={body}
+              onChange={(event) => {
+                dispatch({ body: event.target.value, type: "changeBody" });
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                  event.preventDefault();
+                  void submit();
+                }
+              }}
+              className={cn(
+                "resize-none border-0 bg-transparent p-0 text-[14px] leading-relaxed shadow-none focus-visible:ring-0",
+                expanded ? "min-h-[420px]" : "min-h-[280px]",
+              )}
+              placeholder="Describe the goal, context, and success criteria for this task..."
+            />
+          </div>
 
           {files.length > 0 ? (
             <div className="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## Summary

- Fix the **New thread** composer textarea, where the typed text and placeholder sat flush in the top-left corner with no padding.
- Wrap the textarea in the same bordered card surface (`bg-card rounded-lg border px-3.5 py-3`) already used by the thread reply composer, so the writing area is properly defined and the text gets comfortable inset padding plus a focus ring.

## Why

The textarea used `border-0 bg-transparent p-0` but, unlike the thread reply composer, had **no wrapping surface** to provide padding. As a result the input text was anchored to the top-left corner of the writing area with no margin, which looked broken (reported in YEF-739).

## Verification

- Commands: `vp fmt --check`, `vp lint`, `tsc --noEmit` — all pass.
- Manual: rendered the dialog in isolation and confirmed the text now sits inset within a defined card. Before/after screenshots below.

## Risk And Blast Radius

- Affected packages: `apps/web` (`routes/threads/compose/new-dialog.tsx`)
- Affected user flows: New thread composer dialog only.
- Rollback: revert this commit.

## Evidence

- UI/UX before/after:

**Before** — text flush in the top-left corner, no surface/padding:

**After** — defined card surface with inset padding:

(Screenshots attached on the tracking issue.)

## Compatibility

- Public contract changes: none
- Env or config changes: none
- Deployment or migration: none

## Reviewer Focus

- Closest review areas: the new wrapper `div` around `<Textarea>` and its classes.
- Known trade-offs: none — mirrors the existing reply-composer pattern.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `fix`
- [x] Subject starts lowercase
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence
- [x] Generated files / lockfile: none touched

## Generated Files, Schema, And Lockfile

- N/A — no generated files, codegen, DB baseline, or lockfile changes.
