### PR TITLE
perf(web): defer shell dialogs out of the initial bundle

### DIFF
--- a/apps/web/src/features/files/upload-recovery/upload-recovery-dialog-content.tsx
+++ b/apps/web/src/features/files/upload-recovery/upload-recovery-dialog-content.tsx
@@ -1,0 +1,154 @@
+import { useState } from "react";
+
+import type {
+  FileUploadRecoveryCandidate,
+  FileUploadResumeResult,
+} from "@/shared/lib/file-api-error";
+import { Button } from "@/shared/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
+
+import {
+  discardStoredFileUploads,
+  resumeStoredFileUpload,
+} from "../../../domains/file/api/file-upload-recovery";
+import { toFileId, toFileIds } from "../../../routes/typed-id";
+import { isTruthy } from "../../../shared/lib/truthiness";
+
+// Rendered only after the recovery scan finds at least one resumable upload.
+// Splitting the dialog body out of the always-mounted gate keeps the Radix
+// dialog primitive and the resume/discard upload paths out of the entry bundle
+// that loads on every page.
+export function UploadRecoveryDialogContent({
+  initialCandidates,
+}: {
+  initialCandidates: FileUploadRecoveryCandidate[];
+}) {
+  const [open, setOpen] = useState(true);
+  const [candidates, setCandidates] = useState<FileUploadRecoveryCandidate[]>(initialCandidates);
+  const [recovering, setRecovering] = useState(false);
+  const [summary, setSummary] = useState<string | null>(null);
+
+  async function handleContinueAll() {
+    setRecovering(true);
+    setSummary(null);
+
+    let completedCount = 0;
+    let terminalCount = 0;
+    const retryableResults: {
+      candidate: FileUploadRecoveryCandidate;
+      result: FileUploadResumeResult;
+    }[] = [];
+
+    try {
+      const settled = await Promise.all(
+        candidates.map(async (candidate) => ({
+          candidate,
+          result: await resumeStoredFileUpload(toFileId(candidate.fileId)),
+        })),
+      );
+
+      for (const { candidate, result } of settled) {
+        if (result.status === "completed") {
+          completedCount += 1;
+          continue;
+        }
+
+        if (result.status === "removed_terminal") {
+          terminalCount += 1;
+          continue;
+        }
+
+        retryableResults.push({
+          candidate,
+          result,
+        });
+      }
+
+      const nextCandidates = retryableResults.map((entry) => entry.candidate);
+      setCandidates(nextCandidates);
+
+      if (nextCandidates.length === 0) {
+        setOpen(false);
+      }
+
+      const retryableCount = retryableResults.length;
+      const summaryParts = [
+        completedCount > 0
+          ? `Recovered ${completedCount} upload${completedCount === 1 ? "" : "s"}`
+          : null,
+        terminalCount > 0 ? `${terminalCount} terminated` : null,
+        retryableCount > 0 ? `${retryableCount} can still be retried` : null,
+      ].filter(Boolean);
+
+      setSummary(
+        summaryParts.length > 0 ? `${summaryParts.join(", ")}.` : "No uploads need recovery.",
+      );
+    } finally {
+      setRecovering(false);
+    }
+  }
+
+  async function handleDiscardAll() {
+    setRecovering(true);
+
+    try {
+      await discardStoredFileUploads(toFileIds(candidates.map((candidate) => candidate.fileId)));
+      setCandidates([]);
+      setSummary(null);
+      setOpen(false);
+    } finally {
+      setRecovering(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-[460px]" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>Resume unfinished uploads</DialogTitle>
+          <DialogDescription>
+            Found {candidates.length} unfinished upload{candidates.length === 1 ? "" : "s"}. If you
+            continue, they will resume one by one while each upload keeps chunk-level concurrency.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="border-border-subtle bg-secondary/30 text-muted-foreground rounded-lg border px-3 py-2 text-sm">
+          {candidates.length === 0
+            ? "There are no uploads to recover right now."
+            : candidates
+                .slice(0, 5)
+                .map((candidate) => candidate.fileName)
+                .join(", ")}
+          {candidates.length > 5 ? ` and ${candidates.length} files total` : ""}
+        </div>
+        {isTruthy(summary) ? <div className="text-muted-foreground text-sm">{summary}</div> : null}
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => {
+              setOpen(false);
+            }}
+            disabled={recovering}
+          >
+            Later
+          </Button>
+          <Button variant="outline" onClick={() => void handleDiscardAll()} disabled={recovering}>
+            Discard all
+          </Button>
+          <Button
+            onClick={() => void handleContinueAll()}
+            disabled={recovering || candidates.length === 0}
+          >
+            {recovering ? "Resuming..." : "Resume all"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/files/upload-recovery/upload-recovery-dialog.tsx
+++ b/apps/web/src/features/files/upload-recovery/upload-recovery-dialog.tsx
@@ -1,33 +1,22 @@
 import { ignorePromiseRejection } from "@mosoo/effects";
-import { useEffect, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useRef, useState } from "react";
 
-import type {
-  FileUploadRecoveryCandidate,
-  FileUploadResumeResult,
-} from "@/shared/lib/file-api-error";
-import { Button } from "@/shared/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/shared/ui/dialog";
+import type { FileUploadRecoveryCandidate } from "@/shared/lib/file-api-error";
 
-import {
-  discardStoredFileUploads,
-  inspectRecoverableFileUploads,
-  resumeStoredFileUpload,
-} from "../../../domains/file/api/file-upload-recovery";
-import { toFileId, toFileIds } from "../../../routes/typed-id";
-import { isTruthy } from "../../../shared/lib/truthiness";
+import { inspectRecoverableFileUploads } from "../../../domains/file/api/file-upload-recovery";
+
+// The dialog body is only needed when the scan actually finds resumable
+// uploads, which is the uncommon case. Loading it lazily keeps the Radix dialog
+// primitive and the resume/discard upload paths out of the entry bundle that
+// loads on every page; the lightweight scan still runs eagerly on mount.
+const UploadRecoveryDialogContent = lazy(async () => {
+  const content = await import("./upload-recovery-dialog-content");
+  return { default: content.UploadRecoveryDialogContent };
+});
+
 export function UploadRecoveryDialog() {
   const scannedRef = useRef(false);
-  const [open, setOpen] = useState(false);
-  const [candidates, setCandidates] = useState<FileUploadRecoveryCandidate[]>([]);
-  const [recovering, setRecovering] = useState(false);
-  const [summary, setSummary] = useState<string | null>(null);
+  const [candidates, setCandidates] = useState<FileUploadRecoveryCandidate[] | null>(null);
 
   useEffect(() => {
     if (scannedRef.current) {
@@ -40,126 +29,18 @@ export function UploadRecoveryDialog() {
       .then((result) => {
         if (result.candidates.length > 0) {
           setCandidates(result.candidates);
-          setOpen(true);
         }
       })
       .catch(ignorePromiseRejection);
   }, []);
 
-  async function handleContinueAll() {
-    setRecovering(true);
-    setSummary(null);
-
-    let completedCount = 0;
-    let terminalCount = 0;
-    const retryableResults: {
-      candidate: FileUploadRecoveryCandidate;
-      result: FileUploadResumeResult;
-    }[] = [];
-
-    try {
-      const settled = await Promise.all(
-        candidates.map(async (candidate) => ({
-          candidate,
-          result: await resumeStoredFileUpload(toFileId(candidate.fileId)),
-        })),
-      );
-
-      for (const { candidate, result } of settled) {
-        if (result.status === "completed") {
-          completedCount += 1;
-          continue;
-        }
-
-        if (result.status === "removed_terminal") {
-          terminalCount += 1;
-          continue;
-        }
-
-        retryableResults.push({
-          candidate,
-          result,
-        });
-      }
-
-      const nextCandidates = retryableResults.map((entry) => entry.candidate);
-      setCandidates(nextCandidates);
-
-      if (nextCandidates.length === 0) {
-        setOpen(false);
-      }
-
-      const retryableCount = retryableResults.length;
-      const summaryParts = [
-        completedCount > 0
-          ? `Recovered ${completedCount} upload${completedCount === 1 ? "" : "s"}`
-          : null,
-        terminalCount > 0 ? `${terminalCount} terminated` : null,
-        retryableCount > 0 ? `${retryableCount} can still be retried` : null,
-      ].filter(Boolean);
-
-      setSummary(
-        summaryParts.length > 0 ? `${summaryParts.join(", ")}.` : "No uploads need recovery.",
-      );
-    } finally {
-      setRecovering(false);
-    }
-  }
-
-  async function handleDiscardAll() {
-    setRecovering(true);
-
-    try {
-      await discardStoredFileUploads(toFileIds(candidates.map((candidate) => candidate.fileId)));
-      setCandidates([]);
-      setSummary(null);
-      setOpen(false);
-    } finally {
-      setRecovering(false);
-    }
+  if (candidates === null) {
+    return null;
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="sm:max-w-[460px]" showCloseButton={false}>
-        <DialogHeader>
-          <DialogTitle>Resume unfinished uploads</DialogTitle>
-          <DialogDescription>
-            Found {candidates.length} unfinished upload{candidates.length === 1 ? "" : "s"}. If you
-            continue, they will resume one by one while each upload keeps chunk-level concurrency.
-          </DialogDescription>
-        </DialogHeader>
-        <div className="border-border-subtle bg-secondary/30 text-muted-foreground rounded-lg border px-3 py-2 text-sm">
-          {candidates.length === 0
-            ? "There are no uploads to recover right now."
-            : candidates
-                .slice(0, 5)
-                .map((candidate) => candidate.fileName)
-                .join(", ")}
-          {candidates.length > 5 ? ` and ${candidates.length} files total` : ""}
-        </div>
-        {isTruthy(summary) ? <div className="text-muted-foreground text-sm">{summary}</div> : null}
-        <DialogFooter>
-          <Button
-            variant="outline"
-            onClick={() => {
-              setOpen(false);
-            }}
-            disabled={recovering}
-          >
-            Later
-          </Button>
-          <Button variant="outline" onClick={() => void handleDiscardAll()} disabled={recovering}>
-            Discard all
-          </Button>
-          <Button
-            onClick={() => void handleContinueAll()}
-            disabled={recovering || candidates.length === 0}
-          >
-            {recovering ? "Resuming..." : "Resume all"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <Suspense fallback={null}>
+      <UploadRecoveryDialogContent initialCandidates={candidates} />
+    </Suspense>
   );
 }

--- a/apps/web/src/features/help/help-menu.tsx
+++ b/apps/web/src/features/help/help-menu.tsx
@@ -1,10 +1,17 @@
 import { HelpCircle } from "lucide-react";
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 
 import { cn } from "@/shared/lib/class-names";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
-import { HelpDocsDialog } from "./help-docs-dialog";
+// Loaded on demand the first time Help is opened. The dialog drags in the Radix
+// dialog primitive and the help-docs search index, none of which the app shell
+// needs for its initial render, so it stays out of the entry bundle that loads
+// on every page.
+const HelpDocsDialog = lazy(async () => {
+  const helpDocsDialog = await import("./help-docs-dialog");
+  return { default: helpDocsDialog.HelpDocsDialog };
+});
 
 function isTypingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
@@ -17,6 +24,16 @@ function isTypingTarget(target: EventTarget | null): boolean {
 
 export function HelpMenu({ collapsed }: { collapsed: boolean }) {
   const [open, setOpen] = useState(false);
+  // Keep the dialog mounted once it has been opened so its close animation can
+  // still play, but never mount it before the first open so the chunk is not
+  // fetched on a normal page load.
+  const [hasOpened, setHasOpened] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setHasOpened(true);
+    }
+  }, [open]);
 
   // Press "?" anywhere outside a text field to open help, matching the common
   // shortcut used by other apps.
@@ -66,7 +83,11 @@ export function HelpMenu({ collapsed }: { collapsed: boolean }) {
       ) : (
         button
       )}
-      <HelpDocsDialog open={open} onOpenChange={setOpen} />
+      {hasOpened ? (
+        <Suspense fallback={null}>
+          <HelpDocsDialog open={open} onOpenChange={setOpen} />
+        </Suspense>
+      ) : null}
     </>
   );
 }


### PR DESCRIPTION
## Summary

- The Help docs dialog (`HelpMenu`) and the upload-recovery dialog (`route-guards`) were statically imported by the always-mounted app shell, so the Radix dialog primitive, the help-docs search index, and the resume/discard upload engine shipped in the entry chunk that loads on **every** page — even though all three are only needed on user action.
- Load `HelpDocsDialog` lazily on first open (kept mounted afterwards so the close animation still plays).
- Gate `UploadRecoveryDialog`: the lightweight recovery scan still runs eagerly on mount, but the dialog body is lazy-loaded only when the scan finds resumable uploads (the uncommon case).

## Why

- This continues the initial-load optimization line (route-level splitting, lazy unicorn engine, OpenAPI builder removal). The remaining shell still eagerly bundled two interaction-only dialogs.
- Result: initial **critical** transfer drops from ~188 KB to ~180 KB gzipped, and the Radix dialog primitive chunk (~11 KB gz) no longer loads on a normal page visit. Measured by summing the gzipped entry + modulepreload + CSS assets referenced from the built `dist/index.html`, before vs. after.

## Verification

- Commands: `tsc --noEmit` (web) ✅, `vp lint` on changed files ✅, `bun test tests` (web) — 97 pass / 0 fail ✅, production build ✅.
- Manual steps: rebuilt `dist` and confirmed `dialog-qa` (Radix dialog primitive) is no longer in `index.html`'s modulepreload set.

## Risk And Blast Radius

- Affected packages: `@mosoo/web`.
- Affected user flows: Help & docs dialog (sidebar button / `?` shortcut) and the unfinished-upload recovery prompt. Behavior is unchanged; only the load timing of the dialog code moves to first use.
- Rollback: revert this commit.

## Evidence

- UI/UX: no visual change — same dialogs, same triggers; only their JS now loads on demand. Behavior unchanged, so N/A for screenshots.
- Test output: `97 pass, 0 fail` (web suite).

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: `help-menu.tsx` lazy/Suspense mount; the new `upload-recovery-dialog-content.tsx` split and the gate in `upload-recovery-dialog.tsx`.
- Known trade-offs: the Help dialog and (when present) the upload-recovery dialog now incur a one-time chunk fetch on first use instead of being preloaded.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `perf`
- [x] Subject starts lowercase
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A (no visual change)
- [x] Generated files: none touched

## Generated Files, Schema, And Lockfile

- N/A — no generated files, schema, or lockfile changes.
