### PR TITLE
refactor(web): remove unreachable non-owner agent consume path

### DIFF
--- a/apps/web/src/routes/agent/agent-detail.route.tsx
+++ b/apps/web/src/routes/agent/agent-detail.route.tsx
@@ -34,10 +34,10 @@ const TerminalMode = lazy(async () => {
 
 type DetailMode = AgentMode | "cost" | "logs" | "terminal";
 
-const MODE_TABS: { id: DetailMode; label: string; ownerOnly?: boolean }[] = [
+const MODE_TABS: { id: DetailMode; label: string }[] = [
   { id: "preview", label: "Preview" },
-  { id: "logs", label: "Logs", ownerOnly: true },
-  { id: "cost", label: "Cost", ownerOnly: true },
+  { id: "logs", label: "Logs" },
+  { id: "cost", label: "Cost" },
 ];
 
 interface DebugModeItem {
@@ -64,7 +64,6 @@ function AgentDetailHeader({
   agent,
   debugItems,
   headerActionTargetRef,
-  isOwner,
   mode,
   onBack,
   onOpenSettings,
@@ -75,7 +74,6 @@ function AgentDetailHeader({
   agent: Agent;
   debugItems: DebugModeItem[];
   headerActionTargetRef: (node: HTMLDivElement | null) => void;
-  isOwner: boolean;
   mode: DetailMode;
   onBack: () => void;
   onOpenSettings: () => void;
@@ -114,27 +112,21 @@ function AgentDetailHeader({
       </div>
 
       <div className="absolute left-1/2 flex -translate-x-1/2 items-center gap-1">
-        {MODE_TABS.flatMap((tab) =>
-          tab.ownerOnly === true && !isOwner
-            ? []
-            : [
-                <button
-                  key={tab.id}
-                  type="button"
-                  onClick={() => {
-                    onSelectMode(tab.id);
-                  }}
-                  className={cn(
-                    "px-3.5 py-1.5 rounded-lg text-[13px] font-medium transition-all",
-                    mode === tab.id
-                      ? "bg-ink-100 text-fg-1"
-                      : "text-muted-foreground hover:bg-accent",
-                  )}
-                >
-                  {tab.label}
-                </button>,
-              ],
-        )}
+        {MODE_TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => {
+              onSelectMode(tab.id);
+            }}
+            className={cn(
+              "px-3.5 py-1.5 rounded-lg text-[13px] font-medium transition-all",
+              mode === tab.id ? "bg-ink-100 text-fg-1" : "text-muted-foreground hover:bg-accent",
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
         {debugItems.map((item) => {
           const Icon = item.icon;
           return (
@@ -196,7 +188,6 @@ export function AgentDetailPage() {
 
   const basePath = globalThis.location.pathname.startsWith("/demo") ? "/demo/agent" : "/agent";
   const runtime = useMemo(() => (agent ? getRuntimeInfo(agent.runtime) : null), [agent]);
-  const isOwner = agent?.role === "owner";
   const canManageAgentAccess = detailQuery.data?.viewerRole === "owner";
   const canUseTerminal = canShowAgentDebugMenuItem({
     agentKind: agent?.kind ?? null,
@@ -242,18 +233,12 @@ export function AgentDetailPage() {
     );
   }, [settingsParam, setSearchParams]);
 
-  // Default mode: Owner → Preview (config + test chat), others → Consume.
-  // Owners can still reach Consume via `?tab=consume` (e.g. the
-  // post-publish success modal's "Open Chat" CTA) or the Preview tab for
-  // an in-context test chat.
-  const defaultMode: DetailMode = isOwner ? "preview" : "consume";
+  // Default mode is Preview (config + test chat). Consume is still reachable
+  // via `?tab=consume` (e.g. the post-publish success modal's "Open Chat" CTA),
+  // and the Preview tab offers an in-context test chat.
+  const defaultMode: DetailMode = "preview";
   const requestedMode = selectedMode ?? urlMode ?? defaultMode;
-  const mode =
-    !isOwner && requestedMode !== "consume"
-      ? "consume"
-      : requestedMode === "terminal" && !canUseTerminal
-        ? defaultMode
-        : requestedMode;
+  const mode = requestedMode === "terminal" && !canUseTerminal ? defaultMode : requestedMode;
 
   if (!isTruthy(agentId)) {
     return (
@@ -309,12 +294,7 @@ export function AgentDetailPage() {
     );
   }
 
-  // Non-owner consume mode.
-  if (!isOwner) {
-    return <ConsumeMode agent={agent} />;
-  }
-
-  // Owner consume mode keeps a config entry point.
+  // Consume mode keeps a config entry point back into the editor.
   if (mode === "consume") {
     return (
       <ConsumeMode
@@ -333,7 +313,6 @@ export function AgentDetailPage() {
         agent={agent}
         debugItems={debugItems}
         headerActionTargetRef={setHeaderActionTarget}
-        isOwner={isOwner}
         mode={mode}
         onBack={() => {
           void navigate(basePath);

--- a/apps/web/src/routes/agent/agent-view.mapper.ts
+++ b/apps/web/src/routes/agent/agent-view.mapper.ts
@@ -4,7 +4,6 @@ import type {
   AgentEnvironmentConfig,
   AgentSkillReference,
   AgentSummary,
-  AgentViewerRole,
 } from "@mosoo/contracts/agent";
 import { createDefaultAgentBuiltInTools } from "@mosoo/contracts/agent";
 import { getRuntimeCatalogEntry } from "@mosoo/runtime-catalog";
@@ -13,7 +12,6 @@ import type { AuthUser } from "@/domains/auth/use-auth";
 
 import type {
   Agent,
-  AgentRole,
   AgentStatus,
   McpServer,
   RuntimeId,
@@ -38,13 +36,6 @@ function toAgentStatus(status: string | null | undefined): AgentStatus {
     return "published";
   }
   return "draft";
-}
-
-function toAgentRole(viewerRole: AgentViewerRole): AgentRole {
-  if (viewerRole === "owner") {
-    return "owner";
-  }
-  return "none";
 }
 
 function toSkillInfo(skill: AgentSkillReference): SkillInfo {
@@ -158,7 +149,7 @@ export function mapAgentSummaryToListView(
     packageResolution: null,
     provider: "",
     readiness: null,
-    role: toAgentRole(profile.viewerRole),
+    role: "owner",
     runtime: parseKnownRuntimeId(profile.runtimeId),
     status: toAgentStatus(profile.status),
     tools: toEnabledToolInfos(profile.tools),
@@ -196,7 +187,7 @@ export function mapAgentDetailToView(
     packageResolution: editorDetail?.packageResolution ?? null,
     provider: profile.provider,
     readiness: editorDetail?.readiness ?? null,
-    role: toAgentRole(profile.viewerRole),
+    role: "owner",
     runtime: parseKnownRuntimeId(profile.runtimeId),
     status: toAgentStatus(profile.status),
     tools: toEnabledToolInfos(profile.tools),

--- a/apps/web/src/routes/agent/agent.types.ts
+++ b/apps/web/src/routes/agent/agent.types.ts
@@ -10,7 +10,10 @@ import type { AgentPackageResolutionState } from "@mosoo/contracts/agent-manifes
 import type { McpAuthorizationState, McpCredentialStatus } from "@mosoo/contracts/mcp";
 
 export type AgentStatus = "draft" | "published";
-export type AgentRole = "owner" | "none";
+// The web console only ever loads agents the viewer owns — the API returns
+// `viewerRole: "owner"` and 403s every other caller — so the view model role
+// is always "owner". Non-owner consumption is a separate (future) surface.
+export type AgentRole = "owner";
 export type AgentMode = "create" | "preview" | "consume";
 export type { AgentKind };
 

--- a/apps/web/tests/agent-runtime-lock-boundary.test.ts
+++ b/apps/web/tests/agent-runtime-lock-boundary.test.ts
@@ -24,8 +24,9 @@ describe("Agent runtime lock boundary", () => {
     expect(combinedSource).toContain("Locked after publishing. Fork to switch type.");
     expect(combinedSource).toContain("Agent type is locked after publishing.");
     expect(combinedSource).toContain("Runtime changes are not allowed in-place after publishing.");
-    expect(combinedSource).toContain("Non-owner consume mode.");
-    expect(combinedSource).toContain("Owner consume mode keeps a config entry point.");
+    expect(combinedSource).toContain(
+      "Consume mode keeps a config entry point back into the editor.",
+    );
 
     expect(combinedSource.toLowerCase()).not.toContain("published agent");
     expect(combinedSource).not.toContain("Fork Agent to change type or runtime");


### PR DESCRIPTION
## Summary

- Remove the unreachable non-owner code paths from the agent detail route. The web console can only ever load agents the viewer owns, so the non-owner full-screen `ConsumeMode` branch, the `!isOwner` mode coercion, the `ownerOnly` tab gating, and the view-model `AgentRole = "none"` member were all dead code.

## Why

- Legacy agent sharing was removed in `7aa6b616` (`feat(app-boundary): remove legacy agent sharing surfaces`). Since then `apps/api/src/modules/agents/application/agent-access.service.ts` always returns `viewerRole: "owner"` and `forbiddenError()`s every other caller — nothing produces `viewerRole: "none"`. The `isOwner` / non-owner branches in `agent-detail.route.tsx` could therefore never execute, and the "full-screen consumer chat" they rendered was orphaned. Tracked in YEF-523.

## Verification

- Commands: `vp exec tsc --noEmit` (web), `vp lint .` (web), `vp exec bun test tests` (web → 97 pass / 0 fail), `vp fmt --check` on changed files.
- Manual steps: none — removed paths were unreachable; owner flows (Preview / Logs / Cost / Terminal / `?tab=consume`) unchanged.

## Risk And Blast Radius

- Affected packages: `@mosoo/web`.
- Affected user flows or APIs: agent detail route rendering only. No API/contract change.
- Rollback: revert this commit.

## Evidence

- UI/UX: N/A — no visible change for owners; the removed branch had no reachable trigger.
- Test output: `97 pass, 0 fail` (apps/web).

## Compatibility

- Public contract changes: none. The transport `AgentViewerRole = "owner" | "none"` contract and `agent-debug-menu-policy` (which still tests the `"none"` case) are intentionally left untouched.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: `apps/web/src/routes/agent/agent-detail.route.tsx`, `agent-view.mapper.ts`, `agent.types.ts`.
- Known trade-offs: `AgentRole` is narrowed to the single literal `"owner"`; the remaining `agent.role === "owner"` gates in other components stay as defensive owner-checks rather than being ripped out, to keep this diff scoped.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `refactor`
- [x] Subject starts lowercase; no breaking `!`
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: if prompted by CLA Assistant, sign per instructions
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A
- [x] Generated files: none touched

## Generated Files, Schema, And Lockfile

- N/A — no generated artifacts, schema, or lockfile changes.
