### PR TITLE
fix(web): restore solid avatar fill color

### DIFF
--- a/apps/web/src/shared/lib/avatar.ts
+++ b/apps/web/src/shared/lib/avatar.ts
@@ -1,14 +1,21 @@
-// Solid, on-brand background colors for the default (no-image) avatar. A single
-// color is picked deterministically from a seed so a given account always renders
-// the same avatar, while different accounts get some variety. All colors are dark
+// Solid background colors for the default (no-image) avatar. A single color is
+// picked deterministically from a seed so a given account always renders the same
+// avatar, while different accounts get some variety. These are literal hex values
+// (not theme tokens) so the fill always renders regardless of which stylesheets are
+// loaded — earlier the palette referenced CSS variables that were undefined in the
+// web app, leaving the avatar with no background color at all. All colors are dark
 // enough to keep white initials legible.
 const AVATAR_BACKGROUNDS = [
-  "var(--green-600)",
-  "var(--green-700)",
-  "var(--green-800)",
-  "var(--forest-600)",
-  "var(--forest-700)",
-  "var(--forest-800)",
+  "#2563eb", // blue
+  "#7c3aed", // violet
+  "#db2777", // pink
+  "#dc2626", // red
+  "#ea580c", // orange
+  "#0d9488", // teal
+  "#0891b2", // cyan
+  "#4f46e5", // indigo
+  "#16a34a", // green
+  "#ca8a04", // amber
 ] as const;
 
 function hashSeed(seed: string): number {


### PR DESCRIPTION
## Summary

- The default (no-image) avatar lost all background color: it rendered as initials on a transparent circle.
- Root cause: `getAvatarBackground` picked from a 6-entry palette where half the entries referenced CSS variables `--forest-600/700/800`. Those variables are only defined in `pkgs/design-tokens/mosoo.css`, which the web app does not import, so `background: var(--forest-600)` resolved to nothing. Any account whose seed hashed to a forest entry showed no fill (e.g. `22@mosoo.ai`, reported in the issue).
- Fix: replace the palette with literal solid hex colors (10 hues) that always render regardless of which stylesheets are loaded. Each account still gets a deterministic, stable color via the existing seed hash, and all colors are dark enough to keep the white initials legible.

## Why

- Restores the intended "solid color avatar" behavior. Literal hex values remove the hidden dependency on un-imported theme tokens, so the fill can never silently disappear again.

## Verification

- Commands: change is a self-contained constant swap in `apps/web/src/shared/lib/avatar.ts` (no type/API change).
- Manual: rendered the avatar with the exact `getAvatarBackground`/`getAvatarInitial` logic and the same flex/rounded styling for several accounts. Before: forest-seeded accounts render with no background (reproduces the report). After: every account renders a distinct, legible solid fill. Before/after screenshot attached on the tracking issue.

## Risk And Blast Radius

- Affected packages: `@mosoo/web` only.
- Affected user flows or APIs: default avatar rendering in the account menu, profile settings tab, and thread user avatar. No API/contract change.
- Rollback: revert this commit.

## Evidence

- UI/UX: before/after screenshot posted on the tracking issue.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: `apps/web/src/shared/lib/avatar.ts` palette and the contrast of white initials on each hue.
- Known trade-offs: avatar colors are no longer green/forest brand shades — now a multi-hue set — which is the requested behavior (random solid color per account).

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `fix`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: N/A
- [x] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence
- [x] Generated files: none touched

## Generated Files, Schema, And Lockfile

- N/A
