### PR TITLE
feat(settings): unify settings sub-tab layout alignment

### DIFF
--- a/apps/web/src/routes/cost/cost-page-header.tsx
+++ b/apps/web/src/routes/cost/cost-page-header.tsx
@@ -2,7 +2,6 @@ import { Download } from "lucide-react";
 
 import { cn } from "@/shared/lib/class-names";
 import { Button } from "@/shared/ui/button";
-import { PageHeader } from "@/shared/ui/page-header";
 
 import { downloadCsv } from "./cost-csv";
 import {
@@ -30,57 +29,61 @@ export function CostPageHeader({
   setRunPurpose: (value: CostRunPurpose | "all") => void;
 }) {
   return (
-    <PageHeader
-      className="border-border-subtle border-b"
-      title="App Usage"
-      description={`${card?.appName ?? "App"} · ${rangeLabel(range)} · ${formatCurrency(card?.totals.totalCostUsd ?? 0)}`}
-    >
-      <div className="border-border bg-card flex rounded-md border p-0.5">
-        {RUN_PURPOSE_FILTERS.map((item) => (
-          <button
-            key={item.value}
-            type="button"
-            onClick={() => {
-              setRunPurpose(item.value);
-            }}
-            className={cn(
-              "rounded px-2.5 py-1.5 text-xs font-semibold",
-              runPurpose === item.value ? "bg-ink-100 text-fg-1" : "text-muted-foreground",
-            )}
-          >
-            {item.label}
-          </button>
-        ))}
+    <header className="border-border-subtle flex h-12 shrink-0 items-center justify-between gap-3 border-b px-6">
+      <div className="flex min-w-0 items-baseline gap-2">
+        <span className="text-sm font-medium">App Usage</span>
+        <span className="text-fg-3 hidden truncate text-xs sm:inline">
+          {`${card?.appName ?? "App"} · ${rangeLabel(range)} · ${formatCurrency(card?.totals.totalCostUsd ?? 0)}`}
+        </span>
       </div>
-      <div className="border-border bg-card flex rounded-md border p-0.5">
-        {COST_RANGES.map((value) => (
-          <button
-            key={value}
-            type="button"
-            onClick={() => {
-              setRange(value);
-            }}
-            className={cn(
-              "rounded px-3 py-1.5 text-xs font-semibold uppercase",
-              range === value ? "bg-ink-100 text-fg-1" : "text-muted-foreground",
-            )}
-          >
-            {value}
-          </button>
-        ))}
+      <div className="flex shrink-0 items-center gap-2">
+        <div className="border-border bg-card flex rounded-md border p-0.5">
+          {RUN_PURPOSE_FILTERS.map((item) => (
+            <button
+              key={item.value}
+              type="button"
+              onClick={() => {
+                setRunPurpose(item.value);
+              }}
+              className={cn(
+                "rounded px-2.5 py-1 text-xs font-semibold",
+                runPurpose === item.value ? "bg-ink-100 text-fg-1" : "text-muted-foreground",
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+        <div className="border-border bg-card flex rounded-md border p-0.5">
+          {COST_RANGES.map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => {
+                setRange(value);
+              }}
+              className={cn(
+                "rounded px-3 py-1 text-xs font-semibold uppercase",
+                range === value ? "bg-ink-100 text-fg-1" : "text-muted-foreground",
+              )}
+            >
+              {value}
+            </button>
+          ))}
+        </div>
+        <Button
+          variant="outline"
+          size="xs"
+          onClick={() => {
+            exportCostCsv(effectiveTab, card);
+          }}
+          disabled={!card}
+        >
+          <Download className="size-3.5" />
+          Export CSV
+        </Button>
       </div>
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={() => {
-          exportCostCsv(effectiveTab, card);
-        }}
-        disabled={!card}
-      >
-        <Download className="size-3.5" />
-        Export CSV
-      </Button>
-    </PageHeader>
+    </header>
   );
 }
 

--- a/apps/web/src/routes/cost/cost-tab-bar.tsx
+++ b/apps/web/src/routes/cost/cost-tab-bar.tsx
@@ -11,7 +11,7 @@ export function CostTabBar({
   setActiveTab: (tab: CostTab) => void;
 }) {
   return (
-    <div className="border-border-subtle flex shrink-0 gap-1 border-b px-8 py-3">
+    <div className="border-border-subtle flex shrink-0 gap-1 border-b px-6 py-3">
       {COST_TABS.map((tab) => (
         <button
           key={tab.id}

--- a/apps/web/src/routes/cost/cost.route.tsx
+++ b/apps/web/src/routes/cost/cost.route.tsx
@@ -49,8 +49,8 @@ export function CostPage() {
       />
       <CostTabBar effectiveTab={activeTab} setActiveTab={setActiveTab} />
 
-      <main className="min-h-0 flex-1 overflow-y-auto px-8 py-6">
-        <div className="mx-auto max-w-6xl space-y-5">
+      <main className="min-h-0 flex-1 overflow-y-auto p-6">
+        <div className="max-w-6xl space-y-5">
           {costQuery.isLoading ? (
             <div className="border-border bg-card text-muted-foreground rounded-lg border px-4 py-10 text-center text-sm">
               Loading cost data…

--- a/apps/web/src/routes/settings/access-tokens-tab.tsx
+++ b/apps/web/src/routes/settings/access-tokens-tab.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 
 import { isTruthy } from "../../shared/lib/truthiness";
+import { SettingsTabBody, SettingsTabHeader } from "./settings-tab-layout";
 
 const ACCESS_TOKEN_QUERY_KEY = ["auth", "personal-access-tokens"] as const;
 
@@ -121,17 +122,19 @@ export function AccessTokensTab() {
 
   return (
     <>
-      <header className="border-border-subtle flex h-12 shrink-0 items-center justify-between gap-3 border-b px-5">
-        <span className="text-sm font-medium">API Tokens</span>
-        <Button asChild className="gap-1 text-[11.5px]" size="xs" variant="outline">
-          <a href={MOSOO_API_REFERENCE_URL} rel="noreferrer noopener" target="_blank">
-            <ExternalLink className="size-3" />
-            API reference
-          </a>
-        </Button>
-      </header>
-      <div className="flex-1 overflow-y-auto p-6">
-        <div className="mx-auto max-w-4xl space-y-5">
+      <SettingsTabHeader
+        title="API Tokens"
+        actions={
+          <Button asChild className="gap-1 text-[11.5px]" size="xs" variant="outline">
+            <a href={MOSOO_API_REFERENCE_URL} rel="noreferrer noopener" target="_blank">
+              <ExternalLink className="size-3" />
+              API reference
+            </a>
+          </Button>
+        }
+      />
+      <SettingsTabBody width="wide">
+        <div className="space-y-5">
           <PersonalTokenSection
             copied={copied}
             createError={createMutation.error}
@@ -154,7 +157,7 @@ export function AccessTokensTab() {
             tokens={tokensQuery.data?.tokens ?? null}
           />
         </div>
-      </div>
+      </SettingsTabBody>
     </>
   );
 }

--- a/apps/web/src/routes/settings/app-tab.tsx
+++ b/apps/web/src/routes/settings/app-tab.tsx
@@ -10,6 +10,8 @@ import { isTruthy } from "@/shared/lib/truthiness";
 import { Button } from "@/shared/ui/button";
 import { CommandBlock } from "@/shared/ui/command-block";
 
+import { SettingsTabBody, SettingsTabHeader } from "./settings-tab-layout";
+
 export function AppTab() {
   const { activeApp } = useAppSession();
   const queryClient = useQueryClient();
@@ -51,61 +53,57 @@ export function AppTab() {
 
   return (
     <>
-      <header className="border-border-subtle flex h-12 shrink-0 items-center border-b px-5">
-        <span className="text-sm font-medium">App</span>
-      </header>
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-[520px] p-6">
-          <div className="space-y-2">
-            <label className="text-foreground text-sm font-medium" htmlFor="app-name">
-              App name
-            </label>
-            <p className="text-fg-2 text-[12px]">
-              The App is your engineering and delivery boundary for Agents and resources.
-            </p>
-            <input
-              aria-label="App name"
-              id="app-name"
-              type="text"
-              value={name}
-              disabled={activeApp === null}
-              onChange={(event) => {
-                setName(event.target.value);
-              }}
-              className="border-border bg-background text-foreground focus:ring-primary/20 focus:border-primary disabled:bg-muted disabled:text-muted-foreground h-10 w-full rounded-lg border px-3 text-sm transition-colors focus:ring-2 focus:outline-none disabled:cursor-not-allowed"
-            />
-            {isTruthy(error) ? <p className="text-destructive text-[12px]">{error}</p> : null}
-          </div>
-
-          <div className="mt-6">
-            <Button onClick={() => void handleSave()} disabled={!canSave} size="sm">
-              {saving ? (
-                <>
-                  <Loader2 className="mr-1 size-4 animate-spin" /> Saving…
-                </>
-              ) : saved ? (
-                <>
-                  <Check className="mr-1 size-4" /> Saved
-                </>
-              ) : (
-                "Save changes"
-              )}
-            </Button>
-          </div>
-
-          {activeApp === null ? null : (
-            <div className="mt-8 space-y-6">
-              <div className="space-y-2">
-                <div className="text-foreground text-sm font-medium">App ID</div>
-                <p className="text-fg-2 text-[12px]">
-                  The CLI and API use this id to target this App.
-                </p>
-                <CommandBlock command={activeApp.id} prompt={null} />
-              </div>
-            </div>
-          )}
+      <SettingsTabHeader title="App" />
+      <SettingsTabBody>
+        <div className="space-y-2">
+          <label className="text-foreground text-sm font-medium" htmlFor="app-name">
+            App name
+          </label>
+          <p className="text-fg-2 text-[12px]">
+            The App is your engineering and delivery boundary for Agents and resources.
+          </p>
+          <input
+            aria-label="App name"
+            id="app-name"
+            type="text"
+            value={name}
+            disabled={activeApp === null}
+            onChange={(event) => {
+              setName(event.target.value);
+            }}
+            className="border-border bg-background text-foreground focus:ring-primary/20 focus:border-primary disabled:bg-muted disabled:text-muted-foreground h-10 w-full rounded-lg border px-3 text-sm transition-colors focus:ring-2 focus:outline-none disabled:cursor-not-allowed"
+          />
+          {isTruthy(error) ? <p className="text-destructive text-[12px]">{error}</p> : null}
         </div>
-      </div>
+
+        <div className="mt-6">
+          <Button onClick={() => void handleSave()} disabled={!canSave} size="sm">
+            {saving ? (
+              <>
+                <Loader2 className="mr-1 size-4 animate-spin" /> Saving…
+              </>
+            ) : saved ? (
+              <>
+                <Check className="mr-1 size-4" /> Saved
+              </>
+            ) : (
+              "Save changes"
+            )}
+          </Button>
+        </div>
+
+        {activeApp === null ? null : (
+          <div className="mt-8 space-y-6">
+            <div className="space-y-2">
+              <div className="text-foreground text-sm font-medium">App ID</div>
+              <p className="text-fg-2 text-[12px]">
+                The CLI and API use this id to target this App.
+              </p>
+              <CommandBlock command={activeApp.id} prompt={null} />
+            </div>
+          </div>
+        )}
+      </SettingsTabBody>
     </>
   );
 }

--- a/apps/web/src/routes/settings/profile-tab.tsx
+++ b/apps/web/src/routes/settings/profile-tab.tsx
@@ -10,6 +10,7 @@ import { apiPath } from "../../platform/http/public-api";
 import { getAvatarBackground, getAvatarInitial } from "../../shared/lib/avatar";
 import { isTruthy } from "../../shared/lib/truthiness";
 import { toAccountId } from "../typed-id";
+import { SettingsTabBody, SettingsTabHeader } from "./settings-tab-layout";
 
 const MAX_AVATAR_URL_LENGTH = 2048;
 const MAX_AVATAR_FILE_BYTES = 5 * 1024 * 1024;
@@ -28,6 +29,13 @@ function isValidAvatarValue(value: string): boolean {
   } catch {
     return false;
   }
+}
+
+// Only an http(s) URL or an internal file path may ever reach an <img src>.
+// Routing the value through this guard (rather than a separately computed
+// boolean) keeps the validation on the exact value that flows to the sink.
+function sanitizeAvatarSrc(value: string): string {
+  return isValidAvatarValue(value) ? value : "";
 }
 
 export function ProfileTab() {
@@ -59,7 +67,7 @@ export function ProfileTab() {
     trimmedAvatar === "" ||
     (trimmedAvatar.length <= MAX_AVATAR_URL_LENGTH && isValidAvatarValue(trimmedAvatar));
   const avatarPreview = trimmedAvatar || currentAvatar;
-  const avatarPreviewValid = avatarPreview === "" || isValidAvatarValue(avatarPreview);
+  const avatarPreviewSrc = sanitizeAvatarSrc(avatarPreview);
   const canSave = dirty && nameValid && avatarValid && !saving && !uploading;
   const avatarBackground = getAvatarBackground(user?.email ?? user?.name);
 
@@ -119,142 +127,138 @@ export function ProfileTab() {
 
   return (
     <>
-      <header className="border-border-subtle flex h-12 shrink-0 items-center border-b px-5">
-        <span className="text-sm font-medium">Profile</span>
-      </header>
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-[520px] p-6">
-          <div className="mb-8 flex items-center gap-5">
-            {isTruthy(avatarPreview) && avatarPreviewValid ? (
-              <img
-                src={avatarPreview}
-                alt={user?.name ?? ""}
-                className="size-16 rounded-full object-cover"
-                referrerPolicy="no-referrer"
+      <SettingsTabHeader title="Profile" />
+      <SettingsTabBody>
+        <div className="mb-8 flex items-center gap-5">
+          {isTruthy(avatarPreviewSrc) ? (
+            <img
+              src={avatarPreviewSrc}
+              alt={user?.name ?? ""}
+              className="size-16 rounded-full object-cover"
+              referrerPolicy="no-referrer"
+            />
+          ) : (
+            <div
+              className="flex size-16 items-center justify-center rounded-full text-xl font-semibold text-white"
+              style={{ background: avatarBackground }}
+            >
+              {getAvatarInitial(user?.name)}
+            </div>
+          )}
+          <div className="min-w-0">
+            <div className="text-foreground truncate text-lg font-semibold">{user?.name}</div>
+            <div className="text-muted-foreground truncate text-sm">{user?.email}</div>
+            <div className="mt-2">
+              <input
+                ref={fileInputRef}
+                aria-label="Upload profile picture"
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={(event) => {
+                  const file = event.target.files?.[0];
+                  event.target.value = "";
+                  if (file) {
+                    void handleFileSelected(file);
+                  }
+                }}
               />
-            ) : (
-              <div
-                className="flex size-16 items-center justify-center rounded-full text-xl font-semibold text-white"
-                style={{ background: avatarBackground }}
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={uploading || saving}
+                onClick={() => fileInputRef.current?.click()}
               >
-                {getAvatarInitial(user?.name)}
-              </div>
-            )}
-            <div className="min-w-0">
-              <div className="text-foreground truncate text-lg font-semibold">{user?.name}</div>
-              <div className="text-muted-foreground truncate text-sm">{user?.email}</div>
-              <div className="mt-2">
-                <input
-                  ref={fileInputRef}
-                  aria-label="Upload profile picture"
-                  type="file"
-                  accept="image/*"
-                  className="hidden"
-                  onChange={(event) => {
-                    const file = event.target.files?.[0];
-                    event.target.value = "";
-                    if (file) {
-                      void handleFileSelected(file);
-                    }
-                  }}
-                />
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={uploading || saving}
-                  onClick={() => fileInputRef.current?.click()}
-                >
-                  {uploading ? (
-                    <>
-                      <Loader2 className="mr-1 size-4 animate-spin" /> Uploading…
-                    </>
-                  ) : (
-                    <>
-                      <Upload className="mr-1 size-4" /> Upload image
-                    </>
-                  )}
-                </Button>
-              </div>
+                {uploading ? (
+                  <>
+                    <Loader2 className="mr-1 size-4 animate-spin" /> Uploading…
+                  </>
+                ) : (
+                  <>
+                    <Upload className="mr-1 size-4" /> Upload image
+                  </>
+                )}
+              </Button>
             </div>
-          </div>
-
-          <div className="space-y-2">
-            <label className="text-foreground text-sm font-medium" htmlFor="profile-avatar-url">
-              Profile picture URL
-            </label>
-            <p className="text-fg-2 text-[12px]">
-              Upload an image above, or paste an image URL to use as your avatar.
-            </p>
-            <input
-              aria-label="Profile picture URL"
-              id="profile-avatar-url"
-              type="text"
-              inputMode="url"
-              placeholder="https://example.com/avatar.png"
-              value={avatarInput}
-              onChange={(event) => {
-                setAvatarInput(event.target.value);
-              }}
-              className="border-border bg-background text-foreground focus:ring-primary/20 focus:border-primary h-10 w-full rounded-lg border px-3 text-sm transition-colors focus:ring-2 focus:outline-none"
-            />
-            {trimmedAvatar !== "" && !avatarValid ? (
-              <p className="text-destructive text-[12px]">Enter a valid http or https URL.</p>
-            ) : null}
-          </div>
-
-          <div className="mt-4 space-y-2">
-            <label className="text-foreground text-sm font-medium" htmlFor="profile-display-name">
-              Display name
-            </label>
-            <input
-              aria-label="Display name"
-              id="profile-display-name"
-              type="text"
-              value={name}
-              onChange={(event) => {
-                setName(event.target.value);
-              }}
-              className="border-border bg-background text-foreground focus:ring-primary/20 focus:border-primary h-10 w-full rounded-lg border px-3 text-sm transition-colors focus:ring-2 focus:outline-none"
-            />
-          </div>
-
-          <div className="mt-4 space-y-2">
-            <label className="text-foreground text-sm font-medium" htmlFor="profile-email">
-              Email
-            </label>
-            <input
-              aria-label="Email"
-              id="profile-email"
-              type="email"
-              value={user?.email ?? ""}
-              readOnly
-              className="border-border bg-muted text-muted-foreground h-10 w-full cursor-not-allowed rounded-lg border px-3 text-sm"
-            />
-          </div>
-
-          {isTruthy(error) ? (
-            <div className="bg-destructive/10 text-destructive mt-4 rounded-lg p-3 text-sm">
-              {error}
-            </div>
-          ) : null}
-
-          <div className="mt-6">
-            <Button onClick={() => void handleSave()} disabled={!canSave} size="sm">
-              {saving ? (
-                <>
-                  <Loader2 className="mr-1 size-4 animate-spin" /> Saving…
-                </>
-              ) : saved ? (
-                <>
-                  <Check className="mr-1 size-4" /> Saved
-                </>
-              ) : (
-                "Save changes"
-              )}
-            </Button>
           </div>
         </div>
-      </div>
+
+        <div className="space-y-2">
+          <label className="text-foreground text-sm font-medium" htmlFor="profile-avatar-url">
+            Profile picture URL
+          </label>
+          <p className="text-fg-2 text-[12px]">
+            Upload an image above, or paste an image URL to use as your avatar.
+          </p>
+          <input
+            aria-label="Profile picture URL"
+            id="profile-avatar-url"
+            type="text"
+            inputMode="url"
+            placeholder="https://example.com/avatar.png"
+            value={avatarInput}
+            onChange={(event) => {
+              setAvatarInput(event.target.value);
+            }}
+            className="border-border bg-background text-foreground focus:ring-primary/20 focus:border-primary h-10 w-full rounded-lg border px-3 text-sm transition-colors focus:ring-2 focus:outline-none"
+          />
+          {trimmedAvatar !== "" && !avatarValid ? (
+            <p className="text-destructive text-[12px]">Enter a valid http or https URL.</p>
+          ) : null}
+        </div>
+
+        <div className="mt-4 space-y-2">
+          <label className="text-foreground text-sm font-medium" htmlFor="profile-display-name">
+            Display name
+          </label>
+          <input
+            aria-label="Display name"
+            id="profile-display-name"
+            type="text"
+            value={name}
+            onChange={(event) => {
+              setName(event.target.value);
+            }}
+            className="border-border bg-background text-foreground focus:ring-primary/20 focus:border-primary h-10 w-full rounded-lg border px-3 text-sm transition-colors focus:ring-2 focus:outline-none"
+          />
+        </div>
+
+        <div className="mt-4 space-y-2">
+          <label className="text-foreground text-sm font-medium" htmlFor="profile-email">
+            Email
+          </label>
+          <input
+            aria-label="Email"
+            id="profile-email"
+            type="email"
+            value={user?.email ?? ""}
+            readOnly
+            className="border-border bg-muted text-muted-foreground h-10 w-full cursor-not-allowed rounded-lg border px-3 text-sm"
+          />
+        </div>
+
+        {isTruthy(error) ? (
+          <div className="bg-destructive/10 text-destructive mt-4 rounded-lg p-3 text-sm">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-6">
+          <Button onClick={() => void handleSave()} disabled={!canSave} size="sm">
+            {saving ? (
+              <>
+                <Loader2 className="mr-1 size-4 animate-spin" /> Saving…
+              </>
+            ) : saved ? (
+              <>
+                <Check className="mr-1 size-4" /> Saved
+              </>
+            ) : (
+              "Save changes"
+            )}
+          </Button>
+        </div>
+      </SettingsTabBody>
     </>
   );
 }

--- a/apps/web/src/routes/settings/settings-tab-layout.tsx
+++ b/apps/web/src/routes/settings/settings-tab-layout.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/shared/lib/class-names";
+
+// Shared chrome for every /settings/* sub-tab so they line up: a thin title
+// bar plus a left-aligned, consistently padded content column. Tabs only vary
+// the content width to fit their payload (narrow forms vs. wide data tables).
+const SETTINGS_TAB_WIDTHS = {
+  form: "max-w-[560px]",
+  full: "max-w-6xl",
+  wide: "max-w-3xl",
+} as const;
+
+export type SettingsTabWidth = keyof typeof SETTINGS_TAB_WIDTHS;
+
+export function SettingsTabHeader({ actions, title }: { actions?: ReactNode; title: ReactNode }) {
+  return (
+    <header className="border-border-subtle flex h-12 shrink-0 items-center justify-between gap-3 border-b px-6">
+      <span className="text-sm font-medium">{title}</span>
+      {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
+    </header>
+  );
+}
+
+export function SettingsTabBody({
+  children,
+  className,
+  width = "form",
+}: {
+  children: ReactNode;
+  className?: string;
+  width?: SettingsTabWidth;
+}) {
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className={cn("p-6", SETTINGS_TAB_WIDTHS[width], className)}>{children}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Unify the layout of every `/settings/*` sub-tab (Profile, API tokens, General, App usage) so they share one chrome pattern: a thin title bar plus a left-aligned, consistently padded content column.
- Add `SettingsTabHeader` / `SettingsTabBody` helpers so each tab only varies its content width (`form` / `wide` / `full`) instead of hand-rolling its own header and wrapper.
- API tokens: drop the centered (`mx-auto`) card layout for a left-aligned column matching Profile and General.
- App usage (cost): replace the tall `PageHeader` with the same thin header, left-align the content (`mx-auto` removed), and align the sub-tab bar to the shared left rail (`px-8` → `px-6`).

## Why

The settings sub-tabs were visually inconsistent: API tokens and App usage used centered layouts while Profile/General were left-aligned, and the cost tab additionally used a much taller page header. This unifies them on the left-aligned design.

## Verification

- Commands: `tsc --noEmit` (web) clean; `vp lint` on touched dirs clean; `vp fmt` applied.
- Manual: local `@mosoo.ai` dev login at `http://localhost:5173`, screenshotted all four sub-tabs (attached on the tracking issue).

## Risk And Blast Radius

- Affected packages: `@mosoo/web` only.
- Affected user flows: Settings sub-tabs (Profile, API tokens, General, App usage). Layout/markup only — no behavior, data, or API changes.
- Rollback: revert this commit.

## Evidence

- UI/UX: before/after screenshots attached to the tracking issue (YEF-744).

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- `apps/web/src/routes/settings/settings-tab-layout.tsx` (the shared helpers) and the cost header restyle in `cost-page-header.tsx`.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Subject starts lowercase
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence
- [x] Generated files: N/A
