### PR TITLE
fix(api): dedupe runtime outputs by path and content

### DIFF
--- a/apps/api/src/modules/files/application/file-store.ts
+++ b/apps/api/src/modules/files/application/file-store.ts
@@ -86,6 +86,7 @@ export interface CompleteFileUploadCommand {
 export interface RuntimeOutputFileInput {
   bindings: ApiBindings;
   body: Uint8Array;
+  contentSha256?: string;
   contentType?: string | null;
   createdBy: AccountId;
   path: string;
@@ -177,6 +178,7 @@ export interface FileStore {
     viewer: AuthenticatedViewer,
     query: FileListQuery,
   ): Promise<FileListing>;
+  listReadySessionArtifactKeys(database: D1Database, sessionId: SessionId): Promise<string[]>;
   listReadySessionFiles(database: D1Database, sessionId: SessionId): Promise<SessionFile[]>;
   listSessionResourcePathEntries(
     database: D1Database,
@@ -219,16 +221,43 @@ async function publishSessionResourceUpsert(
   await publishSessionResourceUpsertEvent(bindings, file);
 }
 
-function getRuntimeOutputName(path: string): string {
+function readRuntimeOutputPathSegments(path: string): string[] {
   const normalizedPath = path.trim().replaceAll("\\", "/");
-  const segments = normalizedPath.split("/").filter((segment) => segment.length > 0);
-  const name = segments.at(-1);
+  const segments = normalizedPath
+    .split("/")
+    .filter((segment) => segment.length > 0)
+    .map(normalizeFileName);
+
+  if (segments.length === 0) {
+    throw createFileInvalidRequestError("Runtime output path must include a file name.");
+  }
+
+  return segments;
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer instanceof ArrayBuffer
+    ? bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+    : Uint8Array.from(bytes).buffer;
+}
+
+export function getRuntimeOutputName(path: string): string {
+  const name = readRuntimeOutputPathSegments(path).at(-1);
 
   if (name === undefined) {
     throw createFileInvalidRequestError("Runtime output path must include a file name.");
   }
 
-  return normalizeFileName(name);
+  return name;
+}
+
+export async function createRuntimeOutputContentSha256(body: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", toArrayBuffer(body));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export function createRuntimeOutputParentPath(path: string, contentSha256: string): string {
+  return ["runtime-output", ...readRuntimeOutputPathSegments(path), contentSha256].join("/");
 }
 
 function toSessionResource(file: FileRecord): SessionResource {
@@ -587,6 +616,28 @@ async function listReadySessionFiles(
   return rows.map(toSessionFile);
 }
 
+async function listReadySessionArtifactKeys(
+  database: D1Database,
+  sessionId: SessionId,
+): Promise<string[]> {
+  const rows = await getAppDatabase(database)
+    .select({
+      parentPath: fileRecordsTable.parentPath,
+    })
+    .from(fileRecordsTable)
+    .where(
+      and(
+        eq(fileRecordsTable.scopeKind, "session"),
+        eq(fileRecordsTable.scopeId, sessionId),
+        eq(fileRecordsTable.status, "ready"),
+        eq(fileRecordsTable.sessionKind, "artifact"),
+      ),
+    )
+    .all();
+
+  return rows.map((row) => row.parentPath);
+}
+
 async function listSessionResources(
   database: D1Database,
   sessionId: SessionId,
@@ -774,6 +825,7 @@ async function recordRuntimeOutput(input: RuntimeOutputFileInput): Promise<FileR
   const fileId = createPlatformId<FileId>();
   const name = getRuntimeOutputName(input.path);
   const contentType = normalizeContentType(input.contentType ?? "application/octet-stream");
+  const contentSha256 = input.contentSha256 ?? (await createRuntimeOutputContentSha256(input.body));
   const path = createSessionArtifactPath(fileId, name);
   const timestampMs = currentTimestampMs();
   const objectKey = createFinalObjectKey({
@@ -806,7 +858,7 @@ async function recordRuntimeOutput(input: RuntimeOutputFileInput): Promise<FileR
       objectKey,
       ownerId: input.sessionId,
       ownerKind: "session",
-      parentPath: `artifact/${fileId}`,
+      parentPath: createRuntimeOutputParentPath(input.path, contentSha256),
       path,
       purpose: "session_artifact",
       scopeId: input.sessionId,
@@ -855,6 +907,7 @@ export const fileStore: FileStore = {
   getRecord,
   getUpload,
   list,
+  listReadySessionArtifactKeys,
   listReadySessionFiles,
   listSessionResourcePathEntries,
   listSessionResources,

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/events.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/events.ts
@@ -22,7 +22,11 @@ import { createErrorLogContext, logInfo, logWarn } from "../../../../platform/cl
 import { withDisposedRpcResource } from "../../../../platform/cloudflare/rpc-disposal";
 import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
 import { isTruthy } from "../../../../shared/truthiness";
-import { fileStore, normalizeFileName } from "../../../files/application/file-store";
+import {
+  createRuntimeOutputContentSha256,
+  createRuntimeOutputParentPath,
+  fileStore,
+} from "../../../files/application/file-store";
 import {
   applyAgUiEventToSessionLiveState,
   loadSessionViewerState,
@@ -128,61 +132,34 @@ async function listRuntimeSessionOutputFiles(
   return readRuntimeSessionOutputListing(result.stdout);
 }
 
-function getRuntimeOutputFileName(path: string): string {
-  const name = path
-    .trim()
-    .replaceAll("\\", "/")
-    .split("/")
-    .findLast((segment) => segment.length > 0);
-
-  if (name === undefined) {
-    throw new Error("Runtime output path must include a file name.");
-  }
-
-  return normalizeFileName(name);
-}
-
-function createRecordedArtifactKey(input: { name: string; size: number }): string {
-  return `${input.name}\0${input.size}`;
-}
-
-function createRecordedArtifactSet(
-  files: Awaited<ReturnType<typeof fileStore.listReadySessionFiles>>,
-): Set<string> {
-  return new Set(
-    files
-      .filter((file) => file.kind === "artifact")
-      .map((file) => createRecordedArtifactKey({ name: file.name, size: file.size })),
-  );
-}
-
 async function recordRuntimeSessionOutputFile(input: {
   bindings: ApiBindings;
   body: Uint8Array;
   contentType: string | null;
   createdBy: AccountId;
+  existingArtifacts: Set<string>;
   path: string;
   recordedArtifacts: Set<string>;
   sessionId: SessionId;
 }): Promise<void> {
-  const artifactKey = createRecordedArtifactKey({
-    name: getRuntimeOutputFileName(input.path),
-    size: input.body.byteLength,
-  });
+  const contentSha256 = await createRuntimeOutputContentSha256(input.body);
+  const artifactKey = createRuntimeOutputParentPath(input.path, contentSha256);
 
-  if (input.recordedArtifacts.has(artifactKey)) {
+  if (input.recordedArtifacts.has(artifactKey) || input.existingArtifacts.has(artifactKey)) {
     return;
   }
 
   await fileStore.recordRuntimeOutput({
     bindings: input.bindings,
     body: input.body,
+    contentSha256,
     contentType: input.contentType,
     createdBy: input.createdBy,
     path: input.path,
     sessionId: input.sessionId,
   });
   input.recordedArtifacts.add(artifactKey);
+  input.existingArtifacts.add(artifactKey);
 }
 
 function readTerminalPendingToolResult(event: RuntimeEventEnvelope): string | null {
@@ -288,9 +265,10 @@ async function recordRuntimeFileChanges(input: {
   }
 
   const parsedSessionId = parsePlatformId<SessionId>(sessionId, "runtime output session ID");
-  const recordedArtifacts = createRecordedArtifactSet(
-    await fileStore.listReadySessionFiles(input.bindings.DB, parsedSessionId),
+  const existingArtifacts = new Set(
+    await fileStore.listReadySessionArtifactKeys(input.bindings.DB, parsedSessionId),
   );
+  const recordedArtifacts = new Set<string>();
 
   await withDisposedRpcResource(
     await getRuntimeSubjectKeepAliveHandle(input.bindings, sandboxId),
@@ -304,6 +282,7 @@ async function recordRuntimeFileChanges(input: {
             body: await readSandboxFileBytes(sandboxSession, outputFile.readPath),
             contentType: outputFile.contentType,
             createdBy,
+            existingArtifacts,
             path: outputFile.artifactPath,
             recordedArtifacts,
             sessionId: parsedSessionId,
@@ -365,11 +344,10 @@ async function recordRuntimeSessionOutputDirectory(input: {
           return;
         }
 
-        const existingFiles = await fileStore.listReadySessionFiles(
-          input.bindings.DB,
-          parsedSessionId,
+        const existingArtifacts = new Set(
+          await fileStore.listReadySessionArtifactKeys(input.bindings.DB, parsedSessionId),
         );
-        const recordedArtifacts = createRecordedArtifactSet(existingFiles);
+        const recordedArtifacts = new Set<string>();
 
         for (const outputPath of outputPaths) {
           const artifactPath = toRuntimeSessionOutputArtifactPath(outputPath);
@@ -380,6 +358,7 @@ async function recordRuntimeSessionOutputDirectory(input: {
               body: await readSandboxFileBytes(sandboxSession, `${outputDir}/${outputPath}`),
               contentType: guessRuntimeSessionOutputContentType(outputPath),
               createdBy,
+              existingArtifacts,
               path: artifactPath,
               recordedArtifacts,
               sessionId: parsedSessionId,

--- a/apps/api/tests/runtime-session-outputs.test.ts
+++ b/apps/api/tests/runtime-session-outputs.test.ts
@@ -169,7 +169,7 @@ function createCompletedRunEvent() {
   });
 }
 
-function createFileChangedEvent() {
+function createFileChangedEvent(path = "outputs/live.txt") {
   return createRuntimeEvent({
     driverInstanceId: PUBLIC_API_TEST_IDS.driverOwner,
     id: API_DRIVER_BOUNDARY_IDS.runtimeEvent,
@@ -180,7 +180,7 @@ function createFileChangedEvent() {
         {
           change: "upsert",
           metadata: { contentType: "text/plain" },
-          path: "outputs/live.txt",
+          path,
         },
         {
           change: "upsert",
@@ -338,6 +338,55 @@ describe("runtime session outputs", () => {
       },
     ]);
     expect([...bucket.objects.values()]).toHaveLength(2);
+  });
+
+  test("deduplicates runtime outputs by source path and content", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertOwnerSession(database);
+    await insertActiveSandboxSession(database);
+
+    const files = new Map([
+      ["/workspace/session/outputs/one/report.txt", "alpha"],
+      ["/workspace/session/outputs/two/report.txt", "bravo"],
+    ]);
+    const { bindings } = await createBindings({
+      database,
+      files,
+    });
+    const link = createRuntimeLink();
+    const readReportCount = async () => {
+      const row = await database
+        .prepare(
+          "SELECT count(*) AS count FROM file_record WHERE session_kind = 'artifact' AND name = 'report.txt' AND size = 5",
+        )
+        .first<{ count: number }>();
+
+      return row?.count;
+    };
+
+    await dispatchRuntimeEvent({
+      bindings,
+      event: createFileChangedEvent("outputs/one/report.txt"),
+      link,
+    });
+
+    await dispatchRuntimeEvent({
+      bindings,
+      event: createCompletedRunEvent(),
+      link,
+    });
+
+    expect(await readReportCount()).toBe(2);
+
+    files.set("/workspace/session/outputs/one/report.txt", "gamma");
+
+    await dispatchRuntimeEvent({
+      bindings,
+      event: createFileChangedEvent("outputs/one/report.txt"),
+      link,
+    });
+
+    expect(await readReportCount()).toBe(3);
   });
 
   test("records file change events only when the path is under outputs", async () => {


### PR DESCRIPTION
## Summary

- Deduplicate runtime output artifacts by source output path and content hash instead of basename and byte length.
- Preserve distinct same-name same-size outputs from different paths and same-path rewrites with different content.
- Add one focused runtime output regression test covering both cases.

## Why

- Fixes #141.
- The old `name + size` key could silently drop valid runtime artifacts.

## Verification

- Commands:
  - `git diff HEAD~1..HEAD --check`
  - `just test-file apps/api/tests/runtime-session-outputs.test.ts`
  - `just tc-package @mosoo/api`
  - `pre-ship --committed` local scan: no MUST-FIX findings
- Manual steps: N/A

## Risk And Blast Radius

- Affected packages: `@mosoo/api`
- Affected user flows or APIs: runtime-produced session artifacts
- Rollback: revert this commit

## Evidence

- API or behavior: regression test records two same-name same-size artifacts from different paths, then records a same-path same-size content rewrite as a third artifact.

## Compatibility

- Public contract changes: none
- Env or config changes: none
- Deployment or migration: none

## Reviewer Focus

- Closest review areas: runtime artifact identity and file-store artifact lookup
- Known trade-offs: content hash is stored in internal `parent_path`; public session artifact paths remain unchanged.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `fix`
- [x] Subject starts lowercase; no breaking change marker
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [x] CLA: N/A for maintainer-owned branch
- [x] Self-assigned
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- Touched artifacts: N/A
- GraphQL codegen: N/A
- DB baseline: N/A
- Lockfile: N/A
- Confirm no hand-edits to generated paths: confirmed