### PR TITLE
perf(web): preload primary Geist UI font

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,6 +4,19 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <!-- Preload the primary UI font so it streams in parallel with the CSS/JS
+         instead of being discovered only after the stylesheet parses. Geist is
+         the body + heading face (--font-sans) painted on every page's first
+         view; the file is small (~29 KB) and self-hosted, so this shrinks the
+         font-swap window without competing for bandwidth on the critical path.
+         Only Geist is preloaded — Inter is a fallback and far larger. -->
+    <link
+      rel="preload"
+      href="/fonts/Geist-Variable.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin="anonymous"
+    />
     <title>Mosoo</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary

Preload the primary **Geist** variable UI font in `apps/web/index.html` so it streams in parallel with the CSS and JS instead of being discovered only after the stylesheet parses.

## Why

`--font-sans` (Geist) is the body + heading face painted on every page's first view. Without a preload, the browser can't request the font until it has downloaded and parsed `index-*.css`, which serializes behind the critical CSS/JS. That lengthens the `font-display: swap` window — first paint shows the fallback face, then reflows to Geist.

Geist-Variable.woff2 is small (~29 KB) and self-hosted, so preloading it costs almost nothing on the critical path while letting real text paint sooner with less font-swap shift. Only Geist is preloaded; Inter is a much larger fallback and stays lazily fetched.

## Verification

- Commands: `vp build` (clean), `vp exec tsc --noEmit` (0 errors), `vp lint .` (0 errors), `vp exec bun test tests` (98 pass / 0 fail).
- Confirmed `<link rel="preload" ... Geist-Variable.woff2>` is emitted into `dist/index.html` and the font asset is copied to `dist/fonts/` with a stable (non-hashed) path that matches the `@font-face` `src`.

## Risk And Blast Radius

- Affected packages: `@mosoo/web` only.
- Affected user flows or APIs: none — additive resource hint in `<head>`, no JS or runtime changes.
- Rollback: revert this one-file commit.

## Evidence

- UI/UX: no visual change to the design; effect is a shorter font-swap window on cold loads. No screenshot applicable (no layout/style change).
- Test output: `98 pass, 0 fail` across 28 files.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review area: `apps/web/index.html` preload hint (single font, `crossorigin`, `type="font/woff2"`).
- Known trade-offs: preloads exactly one font (the primary face). Inter and other faces remain CSS-discovered to avoid spending critical-path bandwidth on faces not guaranteed above the fold.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `perf`
- [x] Subject starts lowercase
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A (no visual change)

## Generated Files, Schema, And Lockfile

- N/A
