### PR TITLE
feat(org): show organization id in settings

### DIFF
--- a/apps/web/src/routes/org/org-settings.route.tsx
+++ b/apps/web/src/routes/org/org-settings.route.tsx
@@ -5,6 +5,7 @@ import { useAppSession } from "@/app/session-provider";
 import { renameOrganization } from "@/domains/organization/api/organization-client";
 import { isTruthy } from "@/shared/lib/truthiness";
 import { Button } from "@/shared/ui/button";
+import { CommandBlock } from "@/shared/ui/command-block";
 
 // Org-layer General settings — the account/billing shell's identity.
 export function OrgSettingsPage() {
@@ -86,6 +87,18 @@ export function OrgSettingsPage() {
                     "Save changes"
                   )}
                 </Button>
+              </div>
+
+              <div className="space-y-2">
+                <div className="text-foreground text-sm font-medium">Org ID</div>
+                <p className="text-fg-2 text-[12px]">
+                  This is the identifier for the active organization.
+                </p>
+                <CommandBlock
+                  command={activeOrganization.id}
+                  copyLabel="Copy org ID"
+                  prompt={null}
+                />
               </div>
             </div>
           )}

--- a/apps/web/src/shared/ui/command-block.tsx
+++ b/apps/web/src/shared/ui/command-block.tsx
@@ -22,10 +22,12 @@ async function writeClipboardText(value: string): Promise<boolean> {
 export function CommandBlock({
   className,
   command,
+  copyLabel = "Copy command",
   prompt = "$",
 }: {
   className?: string;
   command: string;
+  copyLabel?: string;
   prompt?: string | null;
 }): ReactElement {
   const [copied, setCopied] = useState(false);
@@ -56,7 +58,7 @@ export function CommandBlock({
       </code>
       <button
         type="button"
-        aria-label={copied ? "Copied" : "Copy command"}
+        aria-label={copied ? "Copied" : copyLabel}
         onClick={copy}
         className="text-fg-3 hover:bg-ink-900/[0.06] hover:text-fg-1 flex size-7 shrink-0 items-center justify-center rounded-md transition-colors"
       >


### PR DESCRIPTION
## Summary

- Show the active organization ID on the Org settings page.
- Reuse the existing copyable command block UI and allow a context-specific copy button label.

## Why

- Users need a read-only way to identify and copy the active organization ID from the settings surface.

## Verification

- Commands:
  - `just fmt-check-path apps/web/src/routes/org/org-settings.route.tsx`
  - `just fmt-check-path apps/web/src/shared/ui/command-block.tsx`
  - `just tc-package @mosoo/web`
  - `just check`
- Manual steps:
  - Logged in locally with the `@mosoo.ai` development login channel at `http://localhost:5174`.
  - Opened `/org/settings`, verified the Org ID block renders, clicked `Copy org ID`, and confirmed the browser clipboard matched the displayed organization ID.
  - Checked the 390px mobile viewport for the Org ID row and copy icon.

## Risk And Blast Radius

- Affected packages: `@mosoo/web`.
- Affected user flows or APIs: Org settings UI only; no API, schema, database, or generated contract changes.
- Rollback: Revert the single commit.

## Evidence

- UI/UX: Browser QA completed on desktop and 390px mobile viewports; local screenshots captured during verification.
- API or behavior: Existing viewer session already provides `activeOrganization.id`; no backend request changed.
- Logs, recordings, or test output: Browser console had no relevant warnings or errors during the Org settings copy check.

## Compatibility

- Public contract changes: None.
- Env or config changes: None.
- Deployment or migration: None.

## Reviewer Focus

- Closest review areas: Org settings layout and `CommandBlock` aria-label behavior.
- Known trade-offs: The copied-state label remains the generic `Copied`, matching existing copy controls.

## Required Checks

- [x] PR title: `type(scope): subject`.
- [x] Type: `feat`.
- [x] Subject starts lowercase; no breaking-change marker.
- [x] Branch follows `type/scope-subject`.
- [x] Commits: `type(scope): subject`, English only.
- [x] CLA: N/A for existing maintainer account unless CLA Assistant requests it.
- [x] Self-assigned.
- [x] Diff scoped; no unrelated cleanup.
- [x] UI/UX: Browser QA evidence listed above.
- [x] Generated files, codegen, DB baseline, and lockfile are not touched.

## Generated Files, Schema, And Lockfile

- N/A.
- GraphQL codegen: not run; no GraphQL changes.
- DB baseline: not run; no DB changes.
- Lockfile: not touched.
- Confirm no hand-edits to generated paths: no generated paths changed.