### PR TITLE
feat(auth): add cli oauth device authorization flow

### DIFF
--- a/apps/api/src/adapters/http/routes/auth-route.ts
+++ b/apps/api/src/adapters/http/routes/auth-route.ts
@@ -1,13 +1,114 @@
+import type {
+  CliOAuthDeviceConfirmRequest,
+  CliOAuthDeviceStartRequest,
+  CliOAuthDeviceTokenRequest,
+} from "@mosoo/contracts/auth";
 import { Hono } from "hono";
 
+import {
+  CliOAuthDeviceError,
+  confirmCliOAuthDeviceFlow,
+  pollCliOAuthDeviceToken,
+  startCliOAuthDeviceFlow,
+} from "../../../modules/auth/application/cli-oauth-device.service";
+import { getViewerFromRequest } from "../../../modules/auth/application/viewer-auth.service";
 import type { ApiGatewayEnvironment } from "../../../platform/cloudflare/worker-types";
 
 function isAuthConfigured(bindings: Pick<ApiGatewayEnvironment["Bindings"], "BETTER_AUTH_SECRET">) {
   return Boolean(bindings.BETTER_AUTH_SECRET?.trim());
 }
 
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readJsonRecord(request: Request): Promise<Record<string, unknown>> {
+  const body = await request.json().catch(() => null);
+  if (!isJsonRecord(body)) {
+    throw new CliOAuthDeviceError(400, "invalid_request", "JSON object body is required.");
+  }
+  return body;
+}
+
+function readOptionalString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function readRequiredString(record: Record<string, unknown>, key: string): string {
+  const value = readOptionalString(record, key);
+  if (value === undefined) {
+    throw new CliOAuthDeviceError(400, "invalid_request", `${key} is required.`);
+  }
+  return value;
+}
+
+function cliOAuthError(error: unknown): Response {
+  if (error instanceof CliOAuthDeviceError) {
+    return Response.json(
+      {
+        error: {
+          code: error.code,
+          message: error.message,
+        },
+      },
+      { status: error.status },
+    );
+  }
+  throw error;
+}
+
 export function registerAuthRoute(app: Hono<ApiGatewayEnvironment>) {
   const auth = new Hono<ApiGatewayEnvironment>();
+
+  auth.post("/cli/start", async (c) => {
+    try {
+      const body = await readJsonRecord(c.req.raw);
+      const request: CliOAuthDeviceStartRequest = {};
+      const hostname = readOptionalString(body, "hostname");
+      const provider = readOptionalString(body, "provider");
+      if (hostname !== undefined) {
+        request.hostname = hostname;
+      }
+      if (provider !== undefined) {
+        request.provider = provider;
+      }
+      return c.json(
+        await startCliOAuthDeviceFlow(c.env.DB, { ...request, webOrigin: c.env.WEB_ORIGIN }),
+      );
+    } catch (error) {
+      return cliOAuthError(error);
+    }
+  });
+
+  auth.post("/cli/token", async (c) => {
+    try {
+      const body = await readJsonRecord(c.req.raw);
+      const request: CliOAuthDeviceTokenRequest = {
+        device_code: readRequiredString(body, "device_code"),
+      };
+      return c.json(await pollCliOAuthDeviceToken(c.env.DB, request));
+    } catch (error) {
+      return cliOAuthError(error);
+    }
+  });
+
+  auth.post("/cli/confirm", async (c) => {
+    try {
+      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      if (!viewer) {
+        return Response.json({ error: "Unauthorized." }, { status: 401 });
+      }
+
+      const body = await readJsonRecord(c.req.raw);
+      const request: CliOAuthDeviceConfirmRequest = {
+        user_code: readRequiredString(body, "user_code"),
+      };
+      return c.json(await confirmCliOAuthDeviceFlow(c.env.DB, viewer, request));
+    } catch (error) {
+      return cliOAuthError(error);
+    }
+  });
 
   auth.on(["GET", "POST"], "/*", async (c) => {
     if (!isAuthConfigured(c.env)) {

--- a/apps/api/src/modules/auth/application/cli-oauth-device.service.ts
+++ b/apps/api/src/modules/auth/application/cli-oauth-device.service.ts
@@ -1,0 +1,319 @@
+import type {
+  CliOAuthDeviceConfirmRequest,
+  CliOAuthDeviceConfirmResponse,
+  CliOAuthDeviceStartRequest,
+  CliOAuthDeviceStartResponse,
+  CliOAuthDeviceStatus,
+  CliOAuthDeviceTokenRequest,
+  CliOAuthDeviceTokenResponse,
+} from "@mosoo/contracts/auth";
+import { accountsTable, cliOAuthFlowsTable } from "@mosoo/db";
+import { createPlatformId } from "@mosoo/id";
+import type { AccountId, CliOAuthFlowId } from "@mosoo/id";
+import { eq } from "drizzle-orm";
+
+import { getAppDatabase } from "../../../platform/db/drizzle";
+import { currentTimestampMs } from "../../../time";
+import { createPersonalAccessToken } from "./personal-access-token.service";
+import type { AuthenticatedViewer } from "./viewer-auth.service";
+
+const CLI_OAUTH_FLOW_TTL_MS = 10 * 60 * 1000;
+const CLI_OAUTH_POLL_INTERVAL_SECONDS = 2;
+const CLI_OAUTH_USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const CLI_OAUTH_DEVICE_CODE_BYTES = 32;
+const CLI_OAUTH_MAX_HOSTNAME_LENGTH = 512;
+
+export class CliOAuthDeviceError extends Error {
+  readonly code: string;
+  readonly status: number;
+
+  constructor(status: number, code: string, message: string) {
+    super(message);
+    this.name = "CliOAuthDeviceError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+interface StartCliOAuthDeviceFlowInput extends CliOAuthDeviceStartRequest {
+  webOrigin: string;
+}
+
+export async function startCliOAuthDeviceFlow(
+  database: D1Database,
+  input: StartCliOAuthDeviceFlowInput,
+): Promise<CliOAuthDeviceStartResponse> {
+  const provider = normalizeProvider(input.provider);
+  const webOrigin = normalizeWebOrigin(input.webOrigin);
+  const hostname = normalizeHostname(input.hostname);
+  const now = currentTimestampMs();
+  const expiresAt = now + CLI_OAUTH_FLOW_TTL_MS;
+  const nowDate = new Date(now);
+  const deviceCode = createDeviceCode();
+  const deviceCodeHash = await hashCliOAuthDeviceCode(deviceCode);
+  const userCode = createUserCode();
+  const verificationUri = new URL("/cli-auth", webOrigin);
+  const verificationUriComplete = new URL(verificationUri);
+  verificationUriComplete.searchParams.set("code", userCode);
+
+  await getAppDatabase(database)
+    .insert(cliOAuthFlowsTable)
+    .values({
+      accountId: null,
+      authorizedAt: null,
+      completedAt: null,
+      createdAt: nowDate,
+      deviceCodeHash,
+      expiresAt: new Date(expiresAt),
+      hostname,
+      id: createPlatformId<CliOAuthFlowId>(),
+      provider,
+      status: "pending",
+      updatedAt: nowDate,
+      userCode,
+    })
+    .run();
+
+  return {
+    device_code: deviceCode,
+    expires_in: Math.floor(CLI_OAUTH_FLOW_TTL_MS / 1000),
+    interval: CLI_OAUTH_POLL_INTERVAL_SECONDS,
+    user_code: userCode,
+    verification_uri: verificationUri.toString(),
+    verification_uri_complete: verificationUriComplete.toString(),
+  };
+}
+
+export async function pollCliOAuthDeviceToken(
+  database: D1Database,
+  input: CliOAuthDeviceTokenRequest,
+): Promise<CliOAuthDeviceTokenResponse> {
+  const deviceCode = typeof input.device_code === "string" ? input.device_code.trim() : "";
+  if (deviceCode === "") {
+    throw new CliOAuthDeviceError(400, "invalid_request", "Device code is required.");
+  }
+
+  const deviceCodeHash = await hashCliOAuthDeviceCode(deviceCode);
+  const flow =
+    (await getAppDatabase(database)
+      .select()
+      .from(cliOAuthFlowsTable)
+      .where(eq(cliOAuthFlowsTable.deviceCodeHash, deviceCodeHash))
+      .limit(1)
+      .get()) ?? null;
+
+  if (!flow) {
+    return { status: "expired" };
+  }
+
+  const now = currentTimestampMs();
+  if (flow.expiresAt.getTime() <= now) {
+    await markCliOAuthFlowStatus(database, flow.id, "expired", now);
+    return { status: "expired" };
+  }
+
+  if (flow.status === "pending" || flow.status === "denied" || flow.status === "consumed") {
+    return { status: flow.status };
+  }
+
+  if (flow.status === "expired") {
+    return { status: "expired" };
+  }
+
+  if (!flow.accountId) {
+    throw new CliOAuthDeviceError(500, "invalid_flow", "CLI OAuth flow is missing account.");
+  }
+
+  const viewer = await getViewerByAccountId(database, flow.accountId);
+  if (!viewer) {
+    throw new CliOAuthDeviceError(500, "invalid_flow", "CLI OAuth account no longer exists.");
+  }
+
+  const token = await createPersonalAccessToken(database, viewer, {
+    label: `CLI OAuth (${flow.provider})`,
+  });
+  await markCliOAuthFlowStatus(database, flow.id, "consumed", now);
+
+  return {
+    access_token: token.value,
+    status: "authorized",
+    token_type: "Bearer",
+    user: {
+      email: viewer.email,
+      name: viewer.name,
+    },
+  };
+}
+
+export async function confirmCliOAuthDeviceFlow(
+  database: D1Database,
+  viewer: AuthenticatedViewer,
+  input: CliOAuthDeviceConfirmRequest,
+): Promise<CliOAuthDeviceConfirmResponse> {
+  const userCode = normalizeCliOAuthUserCode(input.user_code);
+  if (!userCode) {
+    throw new CliOAuthDeviceError(400, "invalid_request", "User code is invalid.");
+  }
+
+  const flow =
+    (await getAppDatabase(database)
+      .select()
+      .from(cliOAuthFlowsTable)
+      .where(eq(cliOAuthFlowsTable.userCode, userCode))
+      .limit(1)
+      .get()) ?? null;
+
+  if (!flow) {
+    throw new CliOAuthDeviceError(404, "not_found", "CLI OAuth flow was not found.");
+  }
+
+  const now = currentTimestampMs();
+  if (flow.expiresAt.getTime() <= now) {
+    await markCliOAuthFlowStatus(database, flow.id, "expired", now);
+    return { status: "expired", user_code: userCode };
+  }
+
+  if (flow.status !== "pending") {
+    return { status: flow.status, user_code: userCode };
+  }
+
+  await getAppDatabase(database)
+    .update(cliOAuthFlowsTable)
+    .set({
+      accountId: viewer.id,
+      authorizedAt: new Date(now),
+      status: "authorized",
+      updatedAt: new Date(now),
+    })
+    .where(eq(cliOAuthFlowsTable.id, flow.id))
+    .run();
+
+  return { status: "authorized", user_code: userCode };
+}
+
+export async function hashCliOAuthDeviceCode(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return encodeBase64Url(new Uint8Array(digest));
+}
+
+export function normalizeCliOAuthUserCode(value: string): string | null {
+  const normalized = value
+    .trim()
+    .toUpperCase()
+    .replaceAll(/[^A-Z0-9]/g, "");
+  if (normalized.length !== 8) {
+    return null;
+  }
+
+  return `${normalized.slice(0, 4)}-${normalized.slice(4)}`;
+}
+
+function normalizeProvider(value: string | undefined): "google" {
+  const provider = value?.trim().toLowerCase() || "google";
+  if (provider !== "google") {
+    throw new CliOAuthDeviceError(
+      400,
+      "unsupported_provider",
+      "Mosoo CLI OAuth supports google only.",
+    );
+  }
+  return "google";
+}
+
+function normalizeWebOrigin(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new CliOAuthDeviceError(500, "invalid_config", "WEB_ORIGIN is invalid.");
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new CliOAuthDeviceError(500, "invalid_config", "WEB_ORIGIN must use http or https.");
+  }
+  return url.origin;
+}
+
+function normalizeHostname(value: string | undefined): string | null {
+  const hostname = value?.trim() ?? "";
+  if (hostname === "") {
+    return null;
+  }
+  if (hostname.length > CLI_OAUTH_MAX_HOSTNAME_LENGTH) {
+    throw new CliOAuthDeviceError(400, "invalid_request", "Hostname is too long.");
+  }
+  return hostname;
+}
+
+function createDeviceCode(): string {
+  const bytes = new Uint8Array(CLI_OAUTH_DEVICE_CODE_BYTES);
+  crypto.getRandomValues(bytes);
+  return `cli_${encodeBase64Url(bytes)}`;
+}
+
+function createUserCode(): string {
+  const bytes = new Uint8Array(8);
+  crypto.getRandomValues(bytes);
+  const chars = Array.from(bytes, (byte) => {
+    const index = byte % CLI_OAUTH_USER_CODE_ALPHABET.length;
+    return CLI_OAUTH_USER_CODE_ALPHABET[index] ?? "A";
+  }).join("");
+  return `${chars.slice(0, 4)}-${chars.slice(4)}`;
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+async function markCliOAuthFlowStatus(
+  database: D1Database,
+  flowId: CliOAuthFlowId,
+  status: CliOAuthDeviceStatus,
+  timestampMs: number,
+): Promise<void> {
+  const timestamp = new Date(timestampMs);
+  await getAppDatabase(database)
+    .update(cliOAuthFlowsTable)
+    .set({
+      completedAt:
+        status === "expired" || status === "consumed" || status === "denied" ? timestamp : null,
+      status,
+      updatedAt: timestamp,
+    })
+    .where(eq(cliOAuthFlowsTable.id, flowId))
+    .run();
+}
+
+async function getViewerByAccountId(
+  database: D1Database,
+  accountId: AccountId,
+): Promise<AuthenticatedViewer | null> {
+  const row =
+    (await getAppDatabase(database)
+      .select({
+        email: accountsTable.email,
+        emailVerified: accountsTable.emailVerified,
+        id: accountsTable.id,
+        imageUrl: accountsTable.image,
+        name: accountsTable.name,
+      })
+      .from(accountsTable)
+      .where(eq(accountsTable.id, accountId))
+      .limit(1)
+      .get()) ?? null;
+
+  if (!row) {
+    return null;
+  }
+
+  return {
+    email: row.email,
+    emailVerified: row.emailVerified,
+    id: row.id,
+    imageUrl: row.imageUrl,
+    name: row.name,
+  };
+}

--- a/apps/api/tests/cli-oauth-device.test.ts
+++ b/apps/api/tests/cli-oauth-device.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  confirmCliOAuthDeviceFlow,
+  pollCliOAuthDeviceToken,
+  startCliOAuthDeviceFlow,
+} from "../src/modules/auth/application/cli-oauth-device.service";
+import { authenticatePersonalAccessToken } from "../src/modules/auth/application/personal-access-token.service";
+import type { AuthenticatedViewer } from "../src/modules/auth/application/viewer-auth.service";
+import { SqliteD1Database } from "./helpers/sqlite-d1";
+
+const VIEWER: AuthenticatedViewer = {
+  email: "owner@example.com",
+  emailVerified: true,
+  id: "01J00000000000000000000001",
+  imageUrl: null,
+  name: "Owner",
+};
+
+function createCliOAuthDatabase(): SqliteD1Database {
+  const database = new SqliteD1Database();
+
+  database.execute(`
+    CREATE TABLE account (
+      id text PRIMARY KEY NOT NULL,
+      email text NOT NULL,
+      email_verified integer NOT NULL,
+      image_url text,
+      last_active_organization_id text,
+      name text NOT NULL,
+      system_agent_model text,
+      created_at integer NOT NULL,
+      updated_at integer NOT NULL
+    );
+
+    CREATE TABLE personal_access_token (
+      id text PRIMARY KEY NOT NULL,
+      account_id text NOT NULL,
+      label text NOT NULL,
+      token_hash text NOT NULL,
+      last_used_at integer,
+      revoked_at integer,
+      created_at integer NOT NULL,
+      updated_at integer NOT NULL
+    );
+
+    CREATE TABLE cli_oauth_flow (
+      id text PRIMARY KEY NOT NULL,
+      account_id text,
+      authorized_at integer,
+      completed_at integer,
+      created_at integer NOT NULL,
+      device_code_hash text NOT NULL,
+      expires_at integer NOT NULL,
+      hostname text,
+      provider text NOT NULL,
+      status text NOT NULL,
+      updated_at integer NOT NULL,
+      user_code text NOT NULL
+    );
+
+    CREATE UNIQUE INDEX cli_oauth_flow_device_code_hash_idx
+      ON cli_oauth_flow (device_code_hash);
+    CREATE UNIQUE INDEX cli_oauth_flow_user_code_idx
+      ON cli_oauth_flow (user_code);
+
+    INSERT INTO account (
+      id,
+      email,
+      email_verified,
+      image_url,
+      last_active_organization_id,
+      name,
+      system_agent_model,
+      created_at,
+      updated_at
+    )
+    VALUES ('01J00000000000000000000001', 'owner@example.com', 1, NULL, NULL, 'Owner', NULL, 1, 1);
+  `);
+
+  return database;
+}
+
+describe("CLI OAuth device flow", () => {
+  test("exchanges a confirmed browser session for a personal access token", async () => {
+    const database = createCliOAuthDatabase();
+    const start = await startCliOAuthDeviceFlow(database, {
+      hostname: "http://localhost:8787/api",
+      provider: "google",
+      webOrigin: "http://localhost:5173",
+    });
+
+    expect(start.device_code).toStartWith("cli_");
+    expect(start.user_code).toContain("-");
+    expect(start.verification_uri).toBe("http://localhost:5173/cli-auth");
+    expect(start.verification_uri_complete).toContain(
+      `/cli-auth?code=${encodeURIComponent(start.user_code)}`,
+    );
+
+    const pending = await pollCliOAuthDeviceToken(database, {
+      device_code: start.device_code,
+    });
+    expect(pending.status).toBe("pending");
+
+    const confirmed = await confirmCliOAuthDeviceFlow(database, VIEWER, {
+      user_code: start.user_code.replace("-", ""),
+    });
+    expect(confirmed.status).toBe("authorized");
+    expect(confirmed.user_code).toBe(start.user_code);
+
+    const token = await pollCliOAuthDeviceToken(database, {
+      device_code: start.device_code,
+    });
+    expect(token.status).toBe("authorized");
+    expect(token.access_token).toStartWith("mst_");
+    expect(token.user?.email).toBe("owner@example.com");
+
+    const caller = await authenticatePersonalAccessToken(database, token.access_token ?? "");
+    expect(caller?.viewer.id).toBe(VIEWER.id);
+
+    const consumed = await pollCliOAuthDeviceToken(database, {
+      device_code: start.device_code,
+    });
+    expect(consumed).toEqual({ status: "consumed" });
+  });
+
+  test("rejects unsupported providers", async () => {
+    const database = createCliOAuthDatabase();
+
+    await expect(
+      startCliOAuthDeviceFlow(database, {
+        provider: "github",
+        webOrigin: "http://localhost:5173",
+      }),
+    ).rejects.toThrow("supports google only");
+  });
+});

--- a/apps/web/src/app/route-registry.tsx
+++ b/apps/web/src/app/route-registry.tsx
@@ -55,6 +55,7 @@ const McpOAuthComplete = lazyNamed(
   async () => import("../routes/integrations/mcp/oauth-complete.route"),
   "McpOAuthCompletePage",
 );
+const CliAuth = lazyNamed(async () => import("../routes/cli-auth/cli-auth.route"), "CliAuthPage");
 const Providers = lazyNamed(
   async () => import("../routes/providers/providers.route"),
   "ProvidersPage",
@@ -110,6 +111,7 @@ const appRoutes = [
     path: "/onboarding",
   },
   { element: <McpOAuthComplete />, path: "/integrations/mcp/oauth-complete" },
+  { element: protectedRoute(<CliAuth />), path: "/cli-auth" },
   { element: protectedRoute(<AppOverview />), path: "/" },
   { element: orgProtectedRoute(<AppsList />), path: "/apps" },
   { element: orgProtectedRoute(<OrgSettings />), path: "/org/settings" },

--- a/apps/web/src/domains/auth/api/cli-oauth-client.ts
+++ b/apps/web/src/domains/auth/api/cli-oauth-client.ts
@@ -1,0 +1,60 @@
+import type { CliOAuthDeviceConfirmResponse } from "@mosoo/contracts/auth";
+
+import { apiFetch } from "@/platform/http/public-api";
+
+export async function confirmCliOAuthDeviceFlow(
+  userCode: string,
+): Promise<CliOAuthDeviceConfirmResponse> {
+  const response = await apiFetch("/auth/cli/confirm", {
+    body: JSON.stringify({ user_code: userCode }),
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new Error(readErrorMessage(payload) ?? "CLI authorization failed.");
+  }
+
+  return parseConfirmResponse(payload);
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  return response.json().catch(() => null);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readErrorMessage(value: unknown): string | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const error = value["error"];
+  if (typeof error === "string") {
+    return error;
+  }
+  if (isRecord(error) && typeof error["message"] === "string") {
+    return error["message"];
+  }
+  return null;
+}
+
+function parseConfirmResponse(value: unknown): CliOAuthDeviceConfirmResponse {
+  if (
+    !isRecord(value) ||
+    typeof value["status"] !== "string" ||
+    typeof value["user_code"] !== "string"
+  ) {
+    throw new Error("CLI authorization response is invalid.");
+  }
+
+  return {
+    status: value["status"] as CliOAuthDeviceConfirmResponse["status"],
+    user_code: value["user_code"],
+  };
+}

--- a/apps/web/src/routes/cli-auth/cli-auth.route.tsx
+++ b/apps/web/src/routes/cli-auth/cli-auth.route.tsx
@@ -1,0 +1,89 @@
+import { useMutation } from "@tanstack/react-query";
+import { AlertCircle, CheckCircle2, KeyRound, Loader2 } from "lucide-react";
+import { useSearchParams } from "react-router-dom";
+
+import { confirmCliOAuthDeviceFlow } from "@/domains/auth/api/cli-oauth-client";
+import { Button } from "@/shared/ui/button";
+
+export function CliAuthPage() {
+  const [searchParams] = useSearchParams();
+  const code = searchParams.get("code")?.trim() ?? "";
+  const confirmMutation = useMutation({
+    mutationFn: () => confirmCliOAuthDeviceFlow(code),
+  });
+  const status = confirmMutation.data?.status ?? null;
+  const canConfirm = code !== "" && !confirmMutation.isPending && status === null;
+
+  return (
+    <main className="mx-auto flex w-full max-w-xl flex-col gap-5 px-6 py-12">
+      <div className="border-border-default bg-bg-elevated rounded-lg border p-6 shadow-sm">
+        <div className="flex items-start gap-4">
+          <div className="bg-accent-soft text-accent flex size-10 shrink-0 items-center justify-center rounded-md">
+            <KeyRound className="size-5" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h1 className="text-fg-1 text-lg font-semibold">Authorize CLI access</h1>
+            <p className="text-fg-2 mt-2 text-sm leading-6">
+              Connect this browser session to the Mosoo CLI request below.
+            </p>
+            <div className="border-border-default bg-bg-sunken text-fg-1 mt-4 rounded-md border px-3 py-2 font-mono text-sm">
+              {code || "Missing code"}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+          <Button disabled={!canConfirm} onClick={() => confirmMutation.mutate()}>
+            {confirmMutation.isPending ? <Loader2 className="size-4 animate-spin" /> : null}
+            Authorize CLI
+          </Button>
+          <StatusMessage error={confirmMutation.error} status={status} />
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function StatusMessage({ error, status }: { error: Error | null; status: string | null }) {
+  if (error) {
+    return (
+      <p className="text-danger inline-flex items-center gap-2 text-sm">
+        <AlertCircle className="size-4" />
+        {error.message}
+      </p>
+    );
+  }
+
+  if (status === "authorized") {
+    return (
+      <p className="text-success inline-flex items-center gap-2 text-sm">
+        <CheckCircle2 className="size-4" />
+        CLI access authorized.
+      </p>
+    );
+  }
+
+  if (status === "expired") {
+    return (
+      <p className="text-danger inline-flex items-center gap-2 text-sm">
+        <AlertCircle className="size-4" />
+        This code has expired.
+      </p>
+    );
+  }
+
+  if (status === "consumed") {
+    return (
+      <p className="text-fg-2 inline-flex items-center gap-2 text-sm">
+        <CheckCircle2 className="size-4" />
+        This code has already been used.
+      </p>
+    );
+  }
+
+  if (status) {
+    return <p className="text-fg-2 text-sm">Status: {status}</p>;
+  }
+
+  return null;
+}

--- a/pkgs/contracts/src/auth/auth.contract.ts
+++ b/pkgs/contracts/src/auth/auth.contract.ts
@@ -24,3 +24,43 @@ export interface CreatePersonalAccessTokenResponse {
 export interface PersonalAccessTokenListResponse {
   tokens: PersonalAccessTokenSummary[];
 }
+
+export type CliOAuthDeviceStatus = "pending" | "authorized" | "consumed" | "denied" | "expired";
+
+export interface CliOAuthDeviceStartRequest {
+  hostname?: string;
+  provider?: string;
+}
+
+export interface CliOAuthDeviceStartResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete: string;
+  interval: number;
+  expires_in: number;
+}
+
+export interface CliOAuthDeviceTokenRequest {
+  device_code: string;
+}
+
+export interface CliOAuthDeviceTokenResponse {
+  status: CliOAuthDeviceStatus;
+  access_token?: string;
+  expires_in?: number;
+  token_type?: "Bearer";
+  user?: {
+    email: string;
+    name: string;
+  };
+}
+
+export interface CliOAuthDeviceConfirmRequest {
+  user_code: string;
+}
+
+export interface CliOAuthDeviceConfirmResponse {
+  status: CliOAuthDeviceStatus;
+  user_code: string;
+}

--- a/pkgs/contracts/src/id/id.contract.ts
+++ b/pkgs/contracts/src/id/id.contract.ts
@@ -6,6 +6,7 @@ export type {
   AppDeploymentId,
   AppDeploymentRunId,
   ChannelBindingId,
+  CliOAuthFlowId,
   CredentialId,
   DriverCommandId,
   DriverInstanceId,

--- a/pkgs/db/drizzle/0000_baseline.sql
+++ b/pkgs/db/drizzle/0000_baseline.sql
@@ -132,6 +132,24 @@ CREATE TABLE `auth_verification` (
 --> statement-breakpoint
 CREATE INDEX `auth_verification_expires_at_idx` ON `auth_verification` (`expires_at`);--> statement-breakpoint
 CREATE INDEX `auth_verification_identifier_idx` ON `auth_verification` (`identifier`);--> statement-breakpoint
+CREATE TABLE `cli_oauth_flow` (
+	`account_id` text CHECK ("account_id" = upper("account_id") AND length("account_id") = 26 AND substr("account_id", 1, 1) GLOB '[0-7]' AND "account_id" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*'),
+	`authorized_at` integer,
+	`completed_at` integer,
+	`created_at` integer NOT NULL,
+	`device_code_hash` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`hostname` text,
+	`id` text CHECK ("id" = upper("id") AND length("id") = 26 AND substr("id", 1, 1) GLOB '[0-7]' AND "id" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*') PRIMARY KEY NOT NULL,
+	`provider` text NOT NULL,
+	`status` text NOT NULL,
+	`updated_at` integer NOT NULL,
+	`user_code` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `cli_oauth_flow_status_expires_idx` ON `cli_oauth_flow` (`status`,`expires_at`);--> statement-breakpoint
+CREATE UNIQUE INDEX `cli_oauth_flow_device_code_hash_idx` ON `cli_oauth_flow` (`device_code_hash`);--> statement-breakpoint
+CREATE UNIQUE INDEX `cli_oauth_flow_user_code_idx` ON `cli_oauth_flow` (`user_code`);--> statement-breakpoint
 CREATE TABLE `personal_access_token` (
 	`account_id` text CHECK ("account_id" = upper("account_id") AND length("account_id") = 26 AND substr("account_id", 1, 1) GLOB '[0-7]' AND "account_id" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*') NOT NULL,
 	`created_at` integer NOT NULL,

--- a/pkgs/db/drizzle/meta/0000_snapshot.json
+++ b/pkgs/db/drizzle/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "e046a0fc-f0ee-57bb-8925-4cb04c5215cc",
+  "id": "38a2c3cf-7781-52b6-82e8-53906d6b66ac",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "agent_deployment_version": {
@@ -797,6 +797,116 @@
           "name": "auth_verification_identifier_idx",
           "columns": ["identifier"],
           "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cli_oauth_flow": {
+      "name": "cli_oauth_flow",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text CHECK (\"account_id\" = upper(\"account_id\") AND length(\"account_id\") = 26 AND substr(\"account_id\", 1, 1) GLOB '[0-7]' AND \"account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "authorized_at": {
+          "name": "authorized_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code_hash": {
+          "name": "device_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cli_oauth_flow_status_expires_idx": {
+          "name": "cli_oauth_flow_status_expires_idx",
+          "columns": ["status", "expires_at"],
+          "isUnique": false
+        },
+        "cli_oauth_flow_device_code_hash_idx": {
+          "name": "cli_oauth_flow_device_code_hash_idx",
+          "columns": ["device_code_hash"],
+          "isUnique": true
+        },
+        "cli_oauth_flow_user_code_idx": {
+          "name": "cli_oauth_flow_user_code_idx",
+          "columns": ["user_code"],
+          "isUnique": true
         }
       },
       "foreignKeys": {},

--- a/pkgs/db/src/schema/auth.schema.ts
+++ b/pkgs/db/src/schema/auth.schema.ts
@@ -1,7 +1,9 @@
-import type { AccountId, PersonalAccessTokenId } from "@mosoo/id";
+import type { AccountId, CliOAuthFlowId, PersonalAccessTokenId } from "@mosoo/id";
 import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 import { platformIdColumn } from "./id-column";
+
+type CliOAuthFlowStatus = "pending" | "authorized" | "consumed" | "denied" | "expired";
 
 export const authSessionsTable = sqliteTable(
   "auth_session",
@@ -88,3 +90,28 @@ export const personalAccessTokensTable = sqliteTable(
 );
 
 export type PersonalAccessTokenRow = typeof personalAccessTokensTable.$inferSelect;
+
+export const cliOAuthFlowsTable = sqliteTable(
+  "cli_oauth_flow",
+  {
+    accountId: platformIdColumn<AccountId>("account_id"),
+    authorizedAt: integer("authorized_at", { mode: "timestamp_ms" }),
+    completedAt: integer("completed_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+    deviceCodeHash: text("device_code_hash").notNull(),
+    expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+    hostname: text("hostname"),
+    id: platformIdColumn<CliOAuthFlowId>("id").primaryKey(),
+    provider: text("provider").notNull(),
+    status: text("status").$type<CliOAuthFlowStatus>().notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+    userCode: text("user_code").notNull(),
+  },
+  (table) => [
+    index("cli_oauth_flow_status_expires_idx").on(table.status, table.expiresAt),
+    uniqueIndex("cli_oauth_flow_device_code_hash_idx").on(table.deviceCodeHash),
+    uniqueIndex("cli_oauth_flow_user_code_idx").on(table.userCode),
+  ],
+);
+
+export type CliOAuthFlowRow = typeof cliOAuthFlowsTable.$inferSelect;

--- a/pkgs/id/src/index.ts
+++ b/pkgs/id/src/index.ts
@@ -15,6 +15,7 @@ export type AgentMcpBindingId = SemanticPlatformId<"AgentMcpBindingId">;
 export type AppDeploymentId = SemanticPlatformId<"AppDeploymentId">;
 export type AppDeploymentRunId = SemanticPlatformId<"AppDeploymentRunId">;
 export type ChannelBindingId = SemanticPlatformId<"ChannelBindingId">;
+export type CliOAuthFlowId = SemanticPlatformId<"CliOAuthFlowId">;
 export type CredentialId = SemanticPlatformId<"CredentialId">;
 export type DriverCommandId = SemanticPlatformId<"DriverCommandId">;
 export type DriverInstanceId = SemanticPlatformId<"DriverInstanceId">;


### PR DESCRIPTION
## Summary

- Add RFC 8628-style CLI OAuth device flow: `/auth/cli/start`, `/auth/cli/token`, and authenticated `/auth/cli/confirm` API endpoints backed by a new `cli_oauth_flow` table.
- Issue personal access tokens after the user confirms in the browser at `/cli-auth`.
- Add contracts, ID type, service layer, API tests, and a web confirmation page.

## Why

- CLI tools need a secure browser-based login bridge without embedding OAuth secrets in the terminal.

## Verification

- Commands: `just test-file apps/api/tests/cli-oauth-device.test.ts` (2 tests passed)
- Manual steps: not run (browser `/cli-auth` confirmation flow)

## Risk And Blast Radius

- Affected packages: `@mosoo/api`, `@mosoo/web`, `@mosoo/contracts`, `@mosoo/db`, `@mosoo/id`
- Affected user flows or APIs: new `/auth/cli/*` endpoints; new `/cli-auth` web route; DB baseline adds `cli_oauth_flow`
- Rollback: revert PR; no migration beyond baseline regen

## Evidence

- UI/UX: N/A (not manually verified in browser)
- API or behavior: `just test-file apps/api/tests/cli-oauth-device.test.ts` — full start → confirm → token → consume cycle passes
- Logs, recordings, or test output: 2 pass / 0 fail

## Compatibility

- Public contract changes: new auth contract types and `/auth/cli/*` routes
- Env or config changes: uses existing `WEB_ORIGIN` and `BETTER_AUTH_SECRET`
- Deployment or migration: `cli_oauth_flow` table in DB baseline

## Reviewer Focus

- Closest review areas: device-code hashing, token exchange lifecycle, confirm endpoint auth gate, DB schema/indexes
- Known trade-offs: confirm update is not atomic on `status = pending` (deferred — low-probability race on high-entropy user codes)

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `feat`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: English only
- [ ] CLA: if prompted by CLA Assistant
- [ ] Self-assigned
- [x] Diff scoped
- [x] UI/UX: N/A
- [x] Generated files: DB baseline updated for new schema

## Generated Files, Schema, And Lockfile

- DB baseline (`pkgs/db/drizzle/0000_baseline.sql`, `meta/0000_snapshot.json`) updated for `cli_oauth_flow`
- GraphQL codegen: N/A
- Lockfile: N/A
- Confirm no hand-edits to generated paths beyond required baseline regen for new table

## Considered and deferred

- cli-oauth-device.service.ts:180 [BOT-TASTE]: confirm update lacks atomic WHERE status=pending guard; user codes are high-entropy and concurrent confirm races are low probability — defer.