### PR TITLE
docs(api): fix auth and app deployment API surface drift

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,6 +165,7 @@ Except for runtime boundaries such as Session Durable Objects and Sandbox instan
 7. **Auth Service**
    - Authentication is built on Better Auth. Supported authentication methods are **Google OAuth** and **Email OTP**. Both support registration, recovery, and cross-device fallback. Passkey (WebAuthn) is a planned future option but is not enabled in the current build.
    - The same verified email across providers maps to the same Account.
+   - CLI and other programmatic clients authenticate through a device authorization flow, not a separate login method. `POST /api/auth/cli/start` returns a `device_code`, a short `user_code`, and a `/cli-auth` verification URI; the user confirms inside an authenticated web session via `POST /api/auth/cli/confirm`, and the client polls `POST /api/auth/cli/token` until it receives a one-time `Bearer` token. The issued token is a Personal Access Token, so CLI access reuses the Account identity already established by Google OAuth or Email OTP rather than introducing a new credential type.
    - The current version does not support passwords, magic links, federated identity, directory sync, domain-based routing, or invite/request flows. Post-auth resolver logic outside the single-owner App path is not part of V1.
 
 8. **Session Service**

--- a/docs/prd/app-deployment.md
+++ b/docs/prd/app-deployment.md
@@ -332,7 +332,7 @@ camelCase names, and mutation inputs with explicit `appId`.
 
 First-cut fields:
 
-- `appDeployment(appId: ULID!): AppDeployment`
+- `appOverview(appId: ULID!): AppOverview!` exposes `deployment: AppDeployment` (the App's configured Deployment, or null).
 - `deployApp(input: DeployAppInput!): AppDeploymentRun!`
 - `appDeploymentStatus(appId: ULID!): AppDeploymentRun`
 - `deleteAppDeployment(input: DeleteAppDeploymentInput!): OperationResult!`
@@ -354,7 +354,7 @@ input DeleteAppDeploymentInput {
 `appId` is required. Do not infer the App from the current account or repository.
 First-cut status always targets the latest DeploymentRun for the App. `configPath`
 is optional and must be absent or `.mosoo.toml` in the first cut.
-`appDeployment` returns null when the App has no configured Deployment.
+`AppOverview.deployment` returns null when the App has no configured Deployment.
 `appDeploymentStatus` returns null when the App has no DeploymentRun.
 Deployment always uses the GitHub repository's current default branch; explicit
 branch selection is not part of the first cut.


### PR DESCRIPTION
## Summary

- Doc-gardening pass over `docs/` anchored on the last-24h commit diffs (#154, #155). Corrects two API-surface drifts where shipped code no longer matches the documentation.
- `docs(architecture)`: document the CLI OAuth device authorization flow shipped in #155 under the Auth Service section (`/api/auth/cli/start|confirm|token`), clarifying it issues a Personal Access Token rather than a new account login method.
- `docs(prd)`: the App Deployment PRD listed a top-level `appDeployment(appId): AppDeployment` query that was never implemented; #154 exposes the Deployment via `AppOverview.deployment`. Corrected the first-cut field list and the null-result note.

## Why

- #155 added a complete CLI OAuth device flow (route, service, DB schema, web `/cli-auth` route, tests) with no documentation; the Auth Service section was the canonical place to record the new surface (code-leads-docs drift).
- #154 updated the App Deployment PRD but left the GraphQL read field describing a `appDeployment` query that does not exist in `schema.generated.graphql`; the implemented resolvers are `appDeploymentStatus`, `deployApp`, `deleteAppDeployment`, plus `AppOverview.deployment`.

## Verification

- Commands: none (docs-only change).
- Manual steps: cross-checked every documented field against `apps/api/src/adapters/graphql/schema.generated.graphql`, `apps/api/src/modules/apps/graphql/app-graphql.ts`, `pkgs/contracts/src/auth/auth.contract.ts`, and `apps/api/src/modules/auth/application/cli-oauth-device.service.ts`. `DeployAppInput`/`DeleteAppDeploymentInput` already matched and were left unchanged.

## Risk And Blast Radius

- Affected packages: `docs` only.
- Affected user flows or APIs: none (documentation accuracy only).
- Rollback: revert this PR.

## Evidence

- UI/UX: N/A.
- API or behavior: no code changed; docs now reflect the implemented GraphQL/auth surfaces.

## Compatibility

- Public contract changes: none (doc correction of an already-shipped contract).
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Confirm the CLI OAuth flow description matches `cli-oauth-device.service.ts`.
- Confirm `AppOverview.deployment` is the intended read surface for an App's Deployment.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A
- [x] Generated files, codegen, DB baseline, lockfile: none hand-edited

## Generated Files, Schema, And Lockfile

- N/A — no generated artifacts touched.
