### PR TITLE
perf(web): drop redundant WebGL engine from landing critical path

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,7 +45,6 @@
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",
-    "unicornstudio-react": "^2.1.9",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/apps/web/src/routes/login/landing/unicorn.tsx
+++ b/apps/web/src/routes/login/landing/unicorn.tsx
@@ -1,23 +1,74 @@
-import { lazy, Suspense, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ReactElement } from "react";
 
-// `unicornstudio-react` bundles the full ~1.3 MB WebGL engine. The landing page
-// is the first thing every unauthenticated visitor loads, and this background is
-// purely decorative (aria-hidden, non-interactive, behind the content). Loading
-// it lazily keeps the engine out of the login route's critical path: the form and
-// copy paint immediately and the aurora streams in once its chunk arrives. The
-// runtime SDK is fetched separately from the CDN below, so deferring the wrapper
-// costs nothing visually.
-const UnicornScene = lazy(async () => {
-  const mod = await import("unicornstudio-react");
-  return { default: mod.UnicornScene };
-});
-
-// Shared Unicorn Studio WebGL background. A single SDK version is used across the
-// whole landing so the global runtime loads once and every scene renders on the
-// same build (the loader injects the SDK only on first mount).
+// The landing page is the first thing every unauthenticated visitor loads, and
+// this background is purely decorative (aria-hidden, non-interactive, behind the
+// content). The actual rendering is done by the Unicorn Studio runtime fetched
+// from the CDN below — we deliberately do NOT depend on `unicornstudio-react`,
+// whose single module inlines the full ~1.3 MB WebGL engine. Importing that
+// wrapper shipped the engine in our own bundle (a 252 KB gzip route chunk) on
+// top of the CDN script, so the landing route paid for the engine twice. This
+// thin wrapper drives the same CDN SDK directly via `window.UnicornStudio`, so
+// the only WebGL bytes on the critical path are the ones we already loaded.
 const UNICORN_SDK_URL =
   "https://cdn.jsdelivr.net/gh/hiunicornstudio/unicornstudio.js@v2.2.0/dist/unicornStudio.umd.js";
+
+interface UnicornScene {
+  destroy: () => void;
+}
+
+interface UnicornStudioSdk {
+  addScene: (config: {
+    element: HTMLElement;
+    projectId: string;
+    fps?: number;
+    scale?: number;
+    dpi?: number;
+    lazyLoad?: boolean;
+    production?: boolean;
+  }) => Promise<UnicornScene>;
+}
+
+declare global {
+  interface Window {
+    UnicornStudio?: UnicornStudioSdk;
+  }
+}
+
+// Inject the runtime SDK once and share the in-flight promise across every scene
+// on the page, so the hero and CTA backgrounds load the global engine a single
+// time instead of racing two identical <script> fetches.
+let sdkPromise: Promise<UnicornStudioSdk> | null = null;
+
+function loadUnicornSdk(): Promise<UnicornStudioSdk> {
+  if (window.UnicornStudio) {
+    return Promise.resolve(window.UnicornStudio);
+  }
+  if (sdkPromise) {
+    return sdkPromise;
+  }
+
+  sdkPromise = new Promise<UnicornStudioSdk>((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = UNICORN_SDK_URL;
+    script.async = true;
+    script.addEventListener("load", () => {
+      if (window.UnicornStudio) {
+        resolve(window.UnicornStudio);
+      } else {
+        reject(new Error("Unicorn Studio SDK loaded without exposing a runtime"));
+      }
+    });
+    script.addEventListener("error", () => {
+      // Let a later mount retry the fetch rather than caching the failure.
+      sdkPromise = null;
+      reject(new Error("Failed to load the Unicorn Studio SDK"));
+    });
+    document.head.append(script);
+  });
+
+  return sdkPromise;
+}
 
 /**
  * Full-bleed, non-interactive WebGL scene pinned behind a section's content.
@@ -26,7 +77,39 @@ const UNICORN_SDK_URL =
  * readable instead of sitting on a black canvas.
  */
 export function UnicornBackground({ sceneId }: { sceneId: string }): ReactElement | null {
+  const containerRef = useRef<HTMLDivElement>(null);
   const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (element === null) {
+      return;
+    }
+
+    let cancelled = false;
+    let scene: UnicornScene | null = null;
+
+    loadUnicornSdk()
+      .then(async (sdk) => sdk.addScene({ element, projectId: sceneId }))
+      .then((created) => {
+        if (cancelled) {
+          // Unmounted before the scene resolved — tear it down immediately.
+          created.destroy();
+          return;
+        }
+        scene = created;
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setFailed(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      scene?.destroy();
+    };
+  }, [sceneId]);
 
   if (failed) {
     return null;
@@ -34,18 +117,9 @@ export function UnicornBackground({ sceneId }: { sceneId: string }): ReactElemen
 
   return (
     <div
+      ref={containerRef}
       aria-hidden="true"
-      className="pointer-events-none absolute inset-0 z-0 [&>div]:!h-full [&>div]:!w-full"
-    >
-      <Suspense fallback={null}>
-        <UnicornScene
-          projectId={sceneId}
-          sdkUrl={UNICORN_SDK_URL}
-          width="100%"
-          height="100%"
-          onError={() => setFailed(true)}
-        />
-      </Suspense>
-    </div>
+      className="pointer-events-none absolute inset-0 z-0"
+    />
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,5 @@
 {
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -129,7 +129,6 @@
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.0",
         "tw-animate-css": "^1.4.0",
-        "unicornstudio-react": "^2.1.9",
         "yaml": "^2.9.0",
       },
       "devDependencies": {
@@ -2962,8 +2961,6 @@
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
-
-    "unicornstudio-react": ["unicornstudio-react@2.1.12", "", { "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-DoJMYEK/5Ecwp8Q/L8f4zQXtjSbb8enUHNeNP/VVrl3kZ6ULT6oyB+L3IjZTBFaUwMXxnlDkUWrhFULS26Rj1w=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 


### PR DESCRIPTION
## Summary

- Stop rendering the landing/login WebGL backgrounds through `unicornstudio-react`. That package's single module inlines the full ~1.3 MB Unicorn Studio engine, so importing it shipped a 1.25 MB (252 KB gzip) route chunk on the page every unauthenticated visitor loads first.
- Our scenes already pass `sdkUrl`, so the bundled engine was never executed — the actual rendering ran off the engine fetched from the CDN. The landing route effectively downloaded the engine twice.
- Replace the dependency with a thin in-house wrapper (`apps/web/src/routes/login/landing/unicorn.tsx`) that injects the same CDN SDK once (shared across the hero and CTA scenes) and drives it via `window.UnicornStudio.addScene`, tearing the scene down on unmount.

## Why

- Page-load optimization. The redundant 252 KB gzip chunk is removed from the landing critical path and total shipped JS drops by ~1.25 MB, with no change to what actually renders (same CDN SDK, same scenes).

## Verification

- Commands: `tsc --noEmit` (clean), `vite build` (succeeds; the 1.25 MB `dist-*.js` Unicorn engine chunk is gone), `bun test tests` (98 pass / 0 fail).
- Manual steps: confirmed via the production build that the engine chunk is no longer emitted and the landing chunks no longer reference it.

## Risk And Blast Radius

- Affected packages: `@mosoo/web` only.
- Affected user flows: the decorative WebGL backgrounds on the hero and CTA bands of the unauthenticated landing page. Behavior is intended to be identical.
- Rollback: revert this commit; restores the previous dependency-based wrapper.

## Evidence

- UI/UX: no intended visual change — the same CDN-hosted Unicorn Studio SDK renders the same scene IDs. Backgrounds are `aria-hidden`, non-interactive, and behind the content; on any SDK/CDN failure the wrapper removes itself so the section's own background shows through (unchanged fallback behavior).
- Test output: 98 web unit tests pass; `vite build` succeeds.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: `apps/web/src/routes/login/landing/unicorn.tsx` — the script-injection singleton and the `addScene`/`destroy` lifecycle in the effect.
- Known trade-offs: we now call the `window.UnicornStudio` runtime directly instead of through the package; the call shape mirrors what the package did internally when `sdkUrl` was provided.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `perf`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject` (fork branch)
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: no visible change (see Evidence)
- [x] Generated files: only `bun.lock`, updated by `bun install` after the dependency removal; not hand-edited

## Generated Files, Schema, And Lockfile

- Lockfile (`bun.lock`): updated by `bun install` after removing `unicornstudio-react` from `apps/web/package.json`.
- Confirm no hand-edits to generated paths: confirmed.
