### PR TITLE
fix(auth): consume cli oauth device code atomically

### DIFF
--- a/apps/api/src/modules/auth/application/cli-oauth-device.service.ts
+++ b/apps/api/src/modules/auth/application/cli-oauth-device.service.ts
@@ -10,7 +10,7 @@ import type {
 import { accountsTable, cliOAuthFlowsTable } from "@mosoo/db";
 import { createPlatformId } from "@mosoo/id";
 import type { AccountId, CliOAuthFlowId } from "@mosoo/id";
-import { eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { getAppDatabase } from "../../../platform/db/drizzle";
 import { currentTimestampMs } from "../../../time";
@@ -108,7 +108,7 @@ export async function pollCliOAuthDeviceToken(
 
   const now = currentTimestampMs();
   if (flow.expiresAt.getTime() <= now) {
-    await markCliOAuthFlowStatus(database, flow.id, "expired", now);
+    await markCliOAuthFlowStatus(database, flow.id, "expired", now, ["pending", "authorized"]);
     return { status: "expired" };
   }
 
@@ -129,10 +129,14 @@ export async function pollCliOAuthDeviceToken(
     throw new CliOAuthDeviceError(500, "invalid_flow", "CLI OAuth account no longer exists.");
   }
 
+  const consumed = await markCliOAuthFlowStatus(database, flow.id, "consumed", now, ["authorized"]);
+  if (!consumed) {
+    return { status: (await readCliOAuthFlowStatus(database, flow.id)) ?? "expired" };
+  }
+
   const token = await createPersonalAccessToken(database, viewer, {
     label: `CLI OAuth (${flow.provider})`,
   });
-  await markCliOAuthFlowStatus(database, flow.id, "consumed", now);
 
   return {
     access_token: token.value,
@@ -169,7 +173,7 @@ export async function confirmCliOAuthDeviceFlow(
 
   const now = currentTimestampMs();
   if (flow.expiresAt.getTime() <= now) {
-    await markCliOAuthFlowStatus(database, flow.id, "expired", now);
+    await markCliOAuthFlowStatus(database, flow.id, "expired", now, ["pending"]);
     return { status: "expired", user_code: userCode };
   }
 
@@ -177,16 +181,25 @@ export async function confirmCliOAuthDeviceFlow(
     return { status: flow.status, user_code: userCode };
   }
 
-  await getAppDatabase(database)
-    .update(cliOAuthFlowsTable)
-    .set({
-      accountId: viewer.id,
-      authorizedAt: new Date(now),
-      status: "authorized",
-      updatedAt: new Date(now),
-    })
-    .where(eq(cliOAuthFlowsTable.id, flow.id))
-    .run();
+  const authorized =
+    (await getAppDatabase(database)
+      .update(cliOAuthFlowsTable)
+      .set({
+        accountId: viewer.id,
+        authorizedAt: new Date(now),
+        status: "authorized",
+        updatedAt: new Date(now),
+      })
+      .where(and(eq(cliOAuthFlowsTable.id, flow.id), eq(cliOAuthFlowsTable.status, "pending")))
+      .returning({ id: cliOAuthFlowsTable.id })
+      .get()) ?? null;
+
+  if (!authorized) {
+    return {
+      status: (await readCliOAuthFlowStatus(database, flow.id)) ?? "expired",
+      user_code: userCode,
+    };
+  }
 
   return { status: "authorized", user_code: userCode };
 }
@@ -273,18 +286,43 @@ async function markCliOAuthFlowStatus(
   flowId: CliOAuthFlowId,
   status: CliOAuthDeviceStatus,
   timestampMs: number,
-): Promise<void> {
+  expectedStatuses?: CliOAuthDeviceStatus[],
+): Promise<boolean> {
   const timestamp = new Date(timestampMs);
-  await getAppDatabase(database)
-    .update(cliOAuthFlowsTable)
-    .set({
-      completedAt:
-        status === "expired" || status === "consumed" || status === "denied" ? timestamp : null,
-      status,
-      updatedAt: timestamp,
-    })
-    .where(eq(cliOAuthFlowsTable.id, flowId))
-    .run();
+  const predicates = [eq(cliOAuthFlowsTable.id, flowId)];
+  if (expectedStatuses && expectedStatuses.length > 0) {
+    predicates.push(inArray(cliOAuthFlowsTable.status, expectedStatuses));
+  }
+
+  const updated =
+    (await getAppDatabase(database)
+      .update(cliOAuthFlowsTable)
+      .set({
+        completedAt:
+          status === "expired" || status === "consumed" || status === "denied" ? timestamp : null,
+        status,
+        updatedAt: timestamp,
+      })
+      .where(and(...predicates))
+      .returning({ id: cliOAuthFlowsTable.id })
+      .get()) ?? null;
+
+  return updated !== null;
+}
+
+async function readCliOAuthFlowStatus(
+  database: D1Database,
+  flowId: CliOAuthFlowId,
+): Promise<CliOAuthDeviceStatus | null> {
+  const row =
+    (await getAppDatabase(database)
+      .select({ status: cliOAuthFlowsTable.status })
+      .from(cliOAuthFlowsTable)
+      .where(eq(cliOAuthFlowsTable.id, flowId))
+      .limit(1)
+      .get()) ?? null;
+
+  return row?.status ?? null;
 }
 
 async function getViewerByAccountId(

--- a/apps/api/tests/cli-oauth-device.test.ts
+++ b/apps/api/tests/cli-oauth-device.test.ts
@@ -124,6 +124,31 @@ describe("CLI OAuth device flow", () => {
     expect(consumed).toEqual({ status: "consumed" });
   });
 
+  test("consumes an authorized device code only once under concurrent polling", async () => {
+    const database = createCliOAuthDatabase();
+    const start = await startCliOAuthDeviceFlow(database, {
+      provider: "google",
+      webOrigin: "http://localhost:5173",
+    });
+
+    await confirmCliOAuthDeviceFlow(database, VIEWER, {
+      user_code: start.user_code,
+    });
+
+    const results = await Promise.all([
+      pollCliOAuthDeviceToken(database, { device_code: start.device_code }),
+      pollCliOAuthDeviceToken(database, { device_code: start.device_code }),
+    ]);
+
+    expect(results.filter((result) => result.status === "authorized")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "consumed")).toHaveLength(1);
+
+    const tokenCount = await database
+      .prepare("SELECT COUNT(*) AS count FROM personal_access_token")
+      .first<{ count: number }>();
+    expect(tokenCount?.count).toBe(1);
+  });
+
   test("rejects unsupported providers", async () => {
     const database = createCliOAuthDatabase();
 


### PR DESCRIPTION
## Summary

- Harden CLI OAuth device-token polling with a conditional authorized-to-consumed claim before PAT issuance.
- Add a regression test for simultaneous token polls so only one poll receives a bearer token and only one PAT row is created.

## Why

- PR 155 already implements the browser confirmation plus polling flow that avoids SSH localhost callback pain.
- The remaining lifecycle gap was concurrent polling after browser authorization: two token requests could both observe the authorized flow and mint separate personal access tokens.

## Verification

- Commands:
  - just test-file apps/api/tests/cli-oauth-device.test.ts
  - bun run fmt:check:path -- apps/api/src/modules/auth/application/cli-oauth-device.service.ts apps/api/tests/cli-oauth-device.test.ts
  - bun run --filter @mosoo/api tc
  - bun run --filter @mosoo/api test
  - just commit-check
- Manual steps: Not run; API lifecycle hardening only.

## Risk And Blast Radius

- Affected packages: @mosoo/api
- Affected user flows or APIs: /auth/cli/token and /auth/cli/confirm state transitions for CLI OAuth device authorization.
- Rollback: Revert this PR.

## Evidence

- UI/UX: N/A
- API or behavior: Concurrent token polling now has one authorized response, one consumed response, and one persisted PAT.
- Logs, recordings, or test output: @mosoo/api test passed with 697 tests, 0 failures.

## Compatibility

- Public contract changes: None.
- Env or config changes: None.
- Deployment or migration: None.

## Reviewer Focus

- Closest review areas: conditional status transitions around CLI OAuth confirm and token consumption.
- Known trade-offs: The flow is marked consumed before PAT creation to prevent duplicate issuance under concurrent polling; a token insert failure after claim would require starting a fresh CLI auth flow.

## Required Checks

- [x] PR title: type(scope): subject
- [x] Type: fix
- [x] Subject starts lowercase
- [x] Branch follows type/scope-subject when maintained in this repository
- [x] Commits: type(scope): subject, English only
- [ ] CLA: if prompted by CLA Assistant
- [x] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A
- GraphQL codegen: N/A
- DB baseline: N/A
- Lockfile: N/A
- Confirm no hand-edits to generated paths: No generated paths touched.

Closes YEF-760
