### PR TITLE
feat(runtime): centralize provider catalog metadata

### DIFF
--- a/apps/api/src/modules/agents/application/agent-runtime-capability-resolution.service.ts
+++ b/apps/api/src/modules/agents/application/agent-runtime-capability-resolution.service.ts
@@ -6,10 +6,12 @@ import type {
 import { vendorCredentialsTable } from "@mosoo/db";
 import type { AccountId, AppId } from "@mosoo/id";
 import {
+  VENDOR_DEEPSEEK,
   VENDOR_OPENAI,
   VENDOR_OPENAI_COMPATIBLE,
   VENDOR_OPENCODE,
   getRuntimeCatalogEntry,
+  getVendor,
 } from "@mosoo/runtime-catalog";
 import { and, asc, eq } from "drizzle-orm";
 
@@ -42,11 +44,21 @@ interface RuntimeCapabilityIssueInput {
 }
 
 const READINESS_PROVIDER_PROBE_TIMEOUT_MS = 10_000;
-const OPENAI_SHAPED_PROVIDER_IDS = new Set([
+const BUILT_IN_OPENAI_SHAPED_PROVIDER_IDS = new Set([
+  VENDOR_DEEPSEEK.vendorId,
   VENDOR_OPENAI.vendorId,
   VENDOR_OPENAI_COMPATIBLE.vendorId,
   VENDOR_OPENCODE.vendorId,
 ]);
+const OPENAI_COMPATIBLE_AI_SDK_PACKAGE = "@ai-sdk/openai-compatible";
+
+function allowsOpenAiChatCompletionProbe(providerId: string): boolean {
+  if (BUILT_IN_OPENAI_SHAPED_PROVIDER_IDS.has(providerId)) {
+    return true;
+  }
+
+  return getVendor(providerId)?.openCodeProvider?.npmPackage === OPENAI_COMPATIBLE_AI_SDK_PACKAGE;
+}
 
 async function hasAppCredential(
   database: D1Database,
@@ -156,7 +168,7 @@ async function collectProviderProbeIssues(
   }
 
   const result = await probeVendorCredential({
-    allowChatCompletionProbe: OPENAI_SHAPED_PROVIDER_IDS.has(input.selection.provider),
+    allowChatCompletionProbe: allowsOpenAiChatCompletionProbe(input.selection.provider),
     apiBase: credential.apiBase,
     apiKey: credential.apiKey,
     emitEvent: false,

--- a/apps/api/src/modules/cost/domain/cost-pricing.ts
+++ b/apps/api/src/modules/cost/domain/cost-pricing.ts
@@ -78,6 +78,12 @@ const MODEL_PRICING: readonly ModelPricing[] = [
     model: "gpt-5.2",
     outputUsdPerMillion: 14,
   }),
+  deepseekPricing({
+    cacheReadUsdPerMillion: 0.145,
+    inputUsdPerMillion: 1.74,
+    model: "deepseek-v4-pro",
+    outputUsdPerMillion: 3.48,
+  }),
   {
     cacheReadUsdPerMillion: 0.125,
     cacheWriteUsdPerMillion: 1.875,
@@ -159,6 +165,24 @@ function openAiPricing(input: {
     outputUsdPerMillion: input.outputUsdPerMillion,
     provider: "openai",
     vendor: "OpenAI",
+  };
+}
+
+function deepseekPricing(input: {
+  cacheReadUsdPerMillion: number;
+  cacheWriteUsdPerMillion?: number;
+  inputUsdPerMillion: number;
+  model: string;
+  outputUsdPerMillion: number;
+}): ModelPricing {
+  return {
+    cacheReadUsdPerMillion: input.cacheReadUsdPerMillion,
+    cacheWriteUsdPerMillion: input.cacheWriteUsdPerMillion ?? 0,
+    inputUsdPerMillion: input.inputUsdPerMillion,
+    model: input.model,
+    outputUsdPerMillion: input.outputUsdPerMillion,
+    provider: "deepseek",
+    vendor: "DeepSeek",
   };
 }
 

--- a/apps/api/src/modules/runtime/application/session-definition/hydrate-run-context.service.ts
+++ b/apps/api/src/modules/runtime/application/session-definition/hydrate-run-context.service.ts
@@ -68,6 +68,12 @@ const OPENCODE_CONFIG_CONTENT_ENV = "OPENCODE_CONFIG_CONTENT";
 const HYDRATED_RUN_CONTEXT_CACHE_TTL_MS = 20_000;
 const hydratedRunContextCache = new Map<string, HydratedRunContextCacheEntry>();
 
+interface OpenCodeProviderConfig {
+  readonly name?: string;
+  readonly npm?: string;
+  readonly options: Record<string, string>;
+}
+
 async function resolveRuntimeProfileIds(
   bindings: ApiBindings,
   input: {
@@ -183,32 +189,36 @@ function buildOpenCodeConfig(input: RuntimeVendorEnvironmentInput): string {
   });
 }
 
-function buildOpenCodeProviderConfig(
-  input: RuntimeVendorEnvironmentInput,
-): Record<string, unknown> {
+function buildOpenCodeProviderConfig(input: RuntimeVendorEnvironmentInput): OpenCodeProviderConfig {
   const options: Record<string, string> = {
     apiKey: `{env:${input.vendor.apiKeyEnvVar}}`,
   };
-  const openCodeProvider = input.vendor.openCodeProvider;
+  const provider = input.vendor.openCodeProvider;
 
-  if (openCodeProvider?.kind === "openai-compatible") {
-    const apiBase = input.credential.apiBase ?? input.vendor.defaultApiBase;
-
-    if (!isTruthy(apiBase)) {
-      throw new Error(`${input.vendor.label} requires a base URL for OpenCode.`);
-    }
-
-    enforceSafeApiBase(apiBase);
-    options[openCodeProvider.apiBaseOption] = apiBase;
-
-    return {
-      name: input.vendor.label,
-      npm: openCodeProvider.npmPackage,
-      options,
-    };
+  if (provider === undefined) {
+    return { options };
   }
 
-  return { options };
+  if (provider.apiBaseOption !== undefined) {
+    options[provider.apiBaseOption] = resolveOpenCodeProviderApiBase(input);
+  }
+
+  return {
+    name: provider.name,
+    npm: provider.npmPackage,
+    options,
+  };
+}
+
+function resolveOpenCodeProviderApiBase(input: RuntimeVendorEnvironmentInput): string {
+  const apiBase = input.credential.apiBase ?? input.vendor.defaultApiBase ?? null;
+
+  if (!isTruthy(apiBase)) {
+    throw new Error(`${input.vendor.label} requires a Base URL before it can be used by OpenCode.`);
+  }
+
+  enforceSafeApiBase(apiBase);
+  return apiBase;
 }
 
 async function hydrateRunContextFromSession(

--- a/apps/api/src/modules/runtime/application/session-definition/hydrate-run-context.service.ts
+++ b/apps/api/src/modules/runtime/application/session-definition/hydrate-run-context.service.ts
@@ -170,20 +170,45 @@ export function buildRuntimeVendorEnvVars(
 
 function buildOpenCodeConfig(input: RuntimeVendorEnvironmentInput): string {
   const model = input.model.includes("/") ? input.model : `${input.vendor.vendorId}/${input.model}`;
+  const providerConfig = buildOpenCodeProviderConfig(input);
 
   return JSON.stringify({
     $schema: "https://opencode.ai/config.json",
     enabled_providers: [input.vendor.vendorId],
     model,
     provider: {
-      [input.vendor.vendorId]: {
-        options: {
-          apiKey: `{env:${input.vendor.apiKeyEnvVar}}`,
-        },
-      },
+      [input.vendor.vendorId]: providerConfig,
     },
     small_model: model,
   });
+}
+
+function buildOpenCodeProviderConfig(
+  input: RuntimeVendorEnvironmentInput,
+): Record<string, unknown> {
+  const options: Record<string, string> = {
+    apiKey: `{env:${input.vendor.apiKeyEnvVar}}`,
+  };
+  const openCodeProvider = input.vendor.openCodeProvider;
+
+  if (openCodeProvider?.kind === "openai-compatible") {
+    const apiBase = input.credential.apiBase ?? input.vendor.defaultApiBase;
+
+    if (!isTruthy(apiBase)) {
+      throw new Error(`${input.vendor.label} requires a base URL for OpenCode.`);
+    }
+
+    enforceSafeApiBase(apiBase);
+    options[openCodeProvider.apiBaseOption] = apiBase;
+
+    return {
+      name: input.vendor.label,
+      npm: openCodeProvider.npmPackage,
+      options,
+    };
+  }
+
+  return { options };
 }
 
 async function hydrateRunContextFromSession(

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/rpc-event-ingestion-controller.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/rpc-event-ingestion-controller.ts
@@ -8,6 +8,7 @@ import type {
   DriverLogBatchOutput,
 } from "agent-driver/orpc";
 
+import { createErrorLogContext, logError } from "../../../../platform/cloudflare/logger";
 import type { SessionDeliveryEvent } from "../../../sessions/application/session-live-state.service";
 import { getSessionRuntimeEventSourceReceipts } from "../../../sessions/infrastructure/session-runtime-event-store.repository";
 import { EVENT_BATCH_MAX_SIZE, LOG_BATCH_MAX_SIZE } from "./connections";
@@ -23,6 +24,14 @@ import type { DriverInstanceRpcOperationContext } from "./rpc";
 import type { DriverInstanceRpcControllerDependencies } from "./rpc-controller-dependencies";
 import { RuntimeEventPersistenceCompactor } from "./runtime-event-persistence-compactor";
 import { filterDurablyAcceptedRuntimeStreamReplays } from "./runtime-event-replay-filter";
+
+function summarizeDriverEvents(events: readonly DriverEventEnvelope[]) {
+  return {
+    eventCount: events.length,
+    eventKinds: events.map((event) => event.event.kind).slice(0, 24),
+    sourceEventIds: events.map((event) => event.eventId).slice(0, 24),
+  };
+}
 
 export class DriverInstanceRpcEventIngestionController {
   readonly #dependencies: DriverInstanceRpcControllerDependencies;
@@ -79,24 +88,52 @@ export class DriverInstanceRpcEventIngestionController {
         return { accepted: replayedAccepted };
       }
 
-      const projection = await appRuntimeDriverEvents(env, {
-        assertCurrentConnection: () => context.assertActiveConnection(),
-        currentLiveState: viewCache.currentState,
-        driverInstanceId,
-        events,
-        link,
-      });
+      const projection = await (async () => {
+        try {
+          return await appRuntimeDriverEvents(env, {
+            assertCurrentConnection: () => context.assertActiveConnection(),
+            currentLiveState: viewCache.currentState,
+            driverInstanceId,
+            events,
+            link,
+          });
+        } catch (error) {
+          logError("runtime.driver.events.projection_failed", {
+            ...createErrorLogContext(error),
+            driverInstanceId,
+            ...summarizeDriverEvents(events),
+          });
+          throw error;
+        }
+      })();
       const persistenceRuntimeEvents = this.#runtimeEventPersistenceCompactor.compact(
         projection.runtimeEvents,
       );
 
-      const commit = await persistProjectedRuntimeDriverEvents(env, {
-        driverInstanceId,
-        projection: {
-          ...projection,
-          runtimeEvents: persistenceRuntimeEvents,
-        },
-      });
+      const commit = await (async () => {
+        try {
+          return await persistProjectedRuntimeDriverEvents(env, {
+            driverInstanceId,
+            projection: {
+              ...projection,
+              runtimeEvents: persistenceRuntimeEvents,
+            },
+          });
+        } catch (error) {
+          logError("runtime.driver.events.persistence_failed", {
+            ...createErrorLogContext(error),
+            driverInstanceId,
+            ...summarizeDriverEvents(events),
+            persistenceEventKinds: persistenceRuntimeEvents
+              .map((event) => event.event.kind)
+              .slice(0, 24),
+            persistenceEventSourceIds: persistenceRuntimeEvents
+              .map((event) => event.sourceEventId)
+              .slice(0, 24),
+          });
+          throw error;
+        }
+      })();
       context.assertActiveConnection();
 
       if (commit.liveState) {

--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-provisioning.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-provisioning.service.ts
@@ -121,6 +121,7 @@ export function toRuntimeProcessProxyEnv(bindings: RuntimeProxyBindings): Record
   const noProxy = mergeRuntimeNoProxy(readRuntimeProxyBinding(bindings, "MOSOO_RUNTIME_NO_PROXY"));
   env["NO_PROXY"] = noProxy;
   env["no_proxy"] = noProxy;
+  env["NODE_USE_ENV_PROXY"] = "1";
 
   return env;
 }

--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-socket-connection.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-socket-connection.ts
@@ -1,3 +1,4 @@
+import { sleepPromise } from "@mosoo/effects";
 import type { DriverInstanceId, SandboxId } from "@mosoo/id";
 
 import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
@@ -16,6 +17,10 @@ function isDriverSocketAlreadyConnectedError(error: unknown): boolean {
   return (
     error instanceof Error && error.message.includes("Driver control socket is already connected")
   );
+}
+
+function isTransientSandboxSocketConnectionError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("Container is not listening to port");
 }
 
 export async function waitForDriverControlPort(
@@ -39,14 +44,26 @@ export async function connectDriverSocketThroughSandbox(
     traceparent: string;
   },
 ): Promise<void> {
+  const deadlineMs = Date.now() + DRIVER_SOCKET_CONNECT_TIMEOUT_MS;
+
   try {
-    await connectDriverInstanceSandboxWebSocket(env, input.driverInstanceId, {
-      bootToken: input.bootToken,
-      port: input.driverControlPort,
-      sandboxId: input.sandboxId,
-      traceparent: input.traceparent,
-    });
-    return;
+    while (true) {
+      try {
+        await connectDriverInstanceSandboxWebSocket(env, input.driverInstanceId, {
+          bootToken: input.bootToken,
+          port: input.driverControlPort,
+          sandboxId: input.sandboxId,
+          traceparent: input.traceparent,
+        });
+        return;
+      } catch (error) {
+        if (!isTransientSandboxSocketConnectionError(error) || Date.now() >= deadlineMs) {
+          throw error;
+        }
+
+        await sleepPromise(DRIVER_SOCKET_CONNECT_RETRY_MS);
+      }
+    }
   } catch (error) {
     if (!isDriverSocketAlreadyConnectedError(error)) {
       throw error;

--- a/apps/api/src/modules/vendor-credentials/application/vendor-credential-probe.ts
+++ b/apps/api/src/modules/vendor-credentials/application/vendor-credential-probe.ts
@@ -8,7 +8,15 @@ export function toVendorProbeEndpointUrl(
   suffix: "chat/completions" | "models",
 ): string {
   const trimmed = apiBase.replace(/\/+$/u, "");
-  return trimmed.endsWith("/v1") ? `${trimmed}/${suffix}` : `${trimmed}/v1/${suffix}`;
+
+  try {
+    const url = new URL(trimmed);
+    const hasPathBase = url.pathname.replace(/\/+$/u, "").length > 0;
+
+    return hasPathBase ? `${trimmed}/${suffix}` : `${trimmed}/v1/${suffix}`;
+  } catch {
+    return trimmed.endsWith("/v1") ? `${trimmed}/${suffix}` : `${trimmed}/v1/${suffix}`;
+  }
 }
 
 export function toVendorProbeAuthHeaders(

--- a/apps/api/tests/available-models.test.ts
+++ b/apps/api/tests/available-models.test.ts
@@ -95,6 +95,15 @@ function createAvailableModelsDatabase(): SqliteD1Database {
       NULL
     ),
     (
+      'credential-gemini',
+      '${APP_ID}',
+      'gemini',
+      'Gemini default',
+      'secret-gemini',
+      NULL,
+      NULL
+    ),
+    (
       'credential-custom',
       '${APP_ID}',
       'openai-compatible',
@@ -171,6 +180,13 @@ describe("available models", () => {
       statusLabel: "Available",
     });
     expect(
+      entries.find((entry) => entry.vendorId === "gemini" && entry.modelId === "gemini-3.5-flash"),
+    ).toMatchObject({
+      available: true,
+      statusDetail: null,
+      statusLabel: "Available",
+    });
+    expect(
       entries.find((entry) => entry.vendorId === "opencode" && entry.modelId === "qwen3.6-plus"),
     ).toMatchObject({
       available: true,
@@ -197,6 +213,38 @@ describe("available models", () => {
       ),
     ).toMatchObject({
       available: true,
+      statusDetail: null,
+      statusLabel: "Available",
+    });
+    expect(
+      entries
+        .filter((entry) => entry.modelId === "gemini-3.5-flash")
+        .map((entry) => ({
+          available: entry.available,
+          vendorId: entry.vendorId,
+        })),
+    ).toContainEqual({
+      available: true,
+      vendorId: "gemini",
+    });
+    expect(
+      entries
+        .filter((entry) => entry.modelId === "gemini-3.5-flash")
+        .map((entry) => ({
+          available: entry.available,
+          vendorId: entry.vendorId,
+        })),
+    ).toContainEqual({
+      available: true,
+      vendorId: "opencode",
+    });
+    expect(
+      entries.find(
+        (entry) => entry.vendorId === "openai-compatible" && entry.modelId === "qwen-coder",
+      ),
+    ).toMatchObject({
+      available: true,
+      source: "custom",
       statusDetail: null,
       statusLabel: "Available",
     });

--- a/apps/api/tests/available-models.test.ts
+++ b/apps/api/tests/available-models.test.ts
@@ -86,6 +86,15 @@ function createAvailableModelsDatabase(): SqliteD1Database {
       NULL
     ),
     (
+      'credential-deepseek',
+      '${APP_ID}',
+      'deepseek',
+      'DeepSeek default',
+      'secret-deepseek',
+      NULL,
+      NULL
+    ),
+    (
       'credential-custom',
       '${APP_ID}',
       'openai-compatible',
@@ -148,14 +157,14 @@ describe("available models", () => {
     });
   });
 
-  test("makes OpenCode Zen models available for the OpenCode runtime", async () => {
+  test("makes OpenCode runtime models available through their owning providers", async () => {
     const entries = await resolveAvailableModels(createAvailableModelsDatabase(), {
       appId: APP_ID,
       runtimeId: "acp-fallback",
     });
 
     expect(
-      entries.find((entry) => entry.vendorId === "opencode" && entry.modelId === "deepseek-v4-pro"),
+      entries.find((entry) => entry.vendorId === "deepseek" && entry.modelId === "deepseek-v4-pro"),
     ).toMatchObject({
       available: true,
       statusDetail: null,

--- a/apps/api/tests/cost-pricing.test.ts
+++ b/apps/api/tests/cost-pricing.test.ts
@@ -4,9 +4,18 @@ import { PRESET_MODEL_CATALOG } from "@mosoo/runtime-catalog";
 
 import { findModelPricing } from "../src/modules/cost/domain/cost-pricing";
 
+const COST_PRICED_PROVIDER_IDS = new Set(["anthropic", "openai", "opencode"]);
+
+function requiresCostPricing(model: (typeof PRESET_MODEL_CATALOG)[number]): boolean {
+  return (
+    COST_PRICED_PROVIDER_IDS.has(model.vendorId) ||
+    (model.vendorId === "deepseek" && model.modelId === "deepseek-v4-pro")
+  );
+}
+
 describe("cost pricing", () => {
-  test("has pricing for every preset model", () => {
-    for (const model of PRESET_MODEL_CATALOG) {
+  test("has pricing for cost-managed preset models", () => {
+    for (const model of PRESET_MODEL_CATALOG.filter(requiresCostPricing)) {
       expect(
         findModelPricing({
           modelId: model.modelId,

--- a/apps/api/tests/runtime-driver-proxy-env.test.ts
+++ b/apps/api/tests/runtime-driver-proxy-env.test.ts
@@ -17,6 +17,7 @@ describe("runtime driver proxy env", () => {
     ).toEqual({
       ALL_PROXY: "http://host.docker.internal:1080",
       HTTPS_PROXY: "http://host.docker.internal:1080",
+      NODE_USE_ENV_PROXY: "1",
       NO_PROXY: "metadata.local,localhost,127.0.0.1,::1,host.docker.internal",
       all_proxy: "http://host.docker.internal:1080",
       https_proxy: "http://host.docker.internal:1080",

--- a/apps/api/tests/runtime-driver-socket-connection.test.ts
+++ b/apps/api/tests/runtime-driver-socket-connection.test.ts
@@ -77,4 +77,46 @@ describe("runtime driver socket connection", () => {
 
     expect(callCount).toBe(1);
   });
+
+  test("retries transient sandbox proxy port readiness failures", async () => {
+    let callCount = 0;
+    const bindings = {
+      DriverConnection: {
+        get() {
+          return {
+            async fetch() {
+              callCount += 1;
+
+              if (callCount === 1) {
+                return Response.json(
+                  {
+                    error:
+                      "Sandbox driver WebSocket rejected: Error proxying request to container: Container is not listening to port 50665",
+                  },
+                  { status: 500 },
+                );
+              }
+
+              return Response.json({ ok: true });
+            },
+          };
+        },
+        idFromName() {
+          return "driver-1";
+        },
+      },
+    } as unknown as ApiBindings;
+
+    await expect(
+      connectDriverSocketThroughSandbox(bindings, {
+        bootToken: "boot-token-1",
+        driverControlPort: 50_665,
+        driverInstanceId: "driver-1",
+        sandboxId: "01J0000000000000000000000D",
+        traceparent: "traceparent-1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(callCount).toBe(2);
+  });
 });

--- a/apps/api/tests/runtime-vendor-env-vars.test.ts
+++ b/apps/api/tests/runtime-vendor-env-vars.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { VENDOR_OPENCODE, VENDOR_OPENAI } from "@mosoo/runtime-catalog";
+import { VENDOR_DEEPSEEK, VENDOR_OPENCODE, VENDOR_OPENAI } from "@mosoo/runtime-catalog";
 
 import { buildRuntimeVendorEnvVars } from "../src/modules/runtime/application/session-definition/hydrate-run-context.service";
 
@@ -44,7 +44,7 @@ describe("runtime vendor env vars", () => {
         apiKey: "sk-opencode",
         credentialId: "01J000000000000000000000C5",
       },
-      model: "deepseek-v4-pro",
+      model: "qwen3.6-plus",
       runtimeId: "acp-fallback",
       vendor: VENDOR_OPENCODE,
     });
@@ -56,12 +56,46 @@ describe("runtime vendor env vars", () => {
     expect(envVars["OPENCODE_API_KEY"]).toBe("sk-opencode");
     expect(config).toMatchObject({
       enabled_providers: ["opencode"],
-      model: "opencode/deepseek-v4-pro",
-      small_model: "opencode/deepseek-v4-pro",
+      model: "opencode/qwen3.6-plus",
+      small_model: "opencode/qwen3.6-plus",
       provider: {
         opencode: {
           options: {
             apiKey: "{env:OPENCODE_API_KEY}",
+          },
+        },
+      },
+    });
+  });
+
+  test("generates OpenCode custom provider config for DeepSeek official API keys", () => {
+    const envVars = buildRuntimeVendorEnvVars({
+      credential: {
+        apiBase: null,
+        apiKey: "sk-deepseek",
+        credentialId: "01J000000000000000000000C6",
+      },
+      model: "deepseek-v4-pro",
+      runtimeId: "acp-fallback",
+      vendor: VENDOR_DEEPSEEK,
+    });
+    const config = JSON.parse(envVars["OPENCODE_CONFIG_CONTENT"] ?? "{}") as Record<
+      string,
+      unknown
+    >;
+
+    expect(envVars["DEEPSEEK_API_KEY"]).toBe("sk-deepseek");
+    expect(config).toMatchObject({
+      enabled_providers: ["deepseek"],
+      model: "deepseek/deepseek-v4-pro",
+      small_model: "deepseek/deepseek-v4-pro",
+      provider: {
+        deepseek: {
+          name: "DeepSeek",
+          npm: "@ai-sdk/openai-compatible",
+          options: {
+            apiKey: "{env:DEEPSEEK_API_KEY}",
+            baseURL: "https://api.deepseek.com",
           },
         },
       },

--- a/apps/api/tests/runtime-vendor-env-vars.test.ts
+++ b/apps/api/tests/runtime-vendor-env-vars.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, test } from "bun:test";
 
-import { VENDOR_DEEPSEEK, VENDOR_OPENCODE, VENDOR_OPENAI } from "@mosoo/runtime-catalog";
+import {
+  VENDOR_DEEPSEEK,
+  VENDOR_GEMINI,
+  VENDOR_KIMI,
+  VENDOR_MINIMAX,
+  VENDOR_OPENAI,
+  VENDOR_OPENAI_COMPATIBLE,
+  VENDOR_OPENCODE,
+  VENDOR_QWEN,
+  VENDOR_ZHIPU,
+} from "@mosoo/runtime-catalog";
+import type { RuntimeCatalogVendor } from "@mosoo/runtime-catalog";
 
 import { buildRuntimeVendorEnvVars } from "../src/modules/runtime/application/session-definition/hydrate-run-context.service";
 
@@ -68,7 +79,7 @@ describe("runtime vendor env vars", () => {
     });
   });
 
-  test("generates OpenCode custom provider config for DeepSeek official API keys", () => {
+  test("generates OpenCode native provider config for DeepSeek official API keys", () => {
     const envVars = buildRuntimeVendorEnvVars({
       credential: {
         apiBase: null,
@@ -91,11 +102,117 @@ describe("runtime vendor env vars", () => {
       small_model: "deepseek/deepseek-v4-pro",
       provider: {
         deepseek: {
-          name: "DeepSeek",
-          npm: "@ai-sdk/openai-compatible",
           options: {
             apiKey: "{env:DEEPSEEK_API_KEY}",
-            baseURL: "https://api.deepseek.com",
+          },
+        },
+      },
+    });
+  });
+
+  test.each([
+    {
+      baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
+      model: "gemini-3.5-flash",
+      name: "Gemini",
+      npm: "@ai-sdk/openai-compatible",
+      vendor: VENDOR_GEMINI,
+    },
+    {
+      baseURL: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+      model: "qwen3.7-plus",
+      name: "Qwen",
+      npm: "@ai-sdk/openai-compatible",
+      vendor: VENDOR_QWEN,
+    },
+    {
+      baseURL: "https://api.moonshot.ai/v1",
+      model: "kimi-k2.6",
+      name: "Kimi",
+      npm: "@ai-sdk/openai-compatible",
+      vendor: VENDOR_KIMI,
+    },
+    {
+      baseURL: "https://api.z.ai/api/paas/v4",
+      model: "glm-4.7",
+      name: "Zhipu",
+      npm: "@ai-sdk/openai-compatible",
+      vendor: VENDOR_ZHIPU,
+    },
+    {
+      baseURL: "https://api.minimax.io/anthropic/v1",
+      model: "MiniMax-M3",
+      name: "MiniMax",
+      npm: "@ai-sdk/anthropic",
+      vendor: VENDOR_MINIMAX,
+    },
+  ])(
+    "generates OpenCode adapter provider config for $name official API keys",
+    ({ baseURL, model, name, npm, vendor }) => {
+      const typedVendor: RuntimeCatalogVendor = vendor;
+      const envVars = buildRuntimeVendorEnvVars({
+        credential: {
+          apiBase: null,
+          apiKey: "sk-provider",
+          credentialId: "01J000000000000000000000C7",
+        },
+        model,
+        runtimeId: "acp-fallback",
+        vendor: typedVendor,
+      });
+      const config = JSON.parse(envVars["OPENCODE_CONFIG_CONTENT"] ?? "{}") as Record<
+        string,
+        unknown
+      >;
+
+      expect(envVars[typedVendor.apiKeyEnvVar]).toBe("sk-provider");
+      expect(config).toMatchObject({
+        enabled_providers: [typedVendor.vendorId],
+        model: `${typedVendor.vendorId}/${model}`,
+        small_model: `${typedVendor.vendorId}/${model}`,
+        provider: {
+          [typedVendor.vendorId]: {
+            name,
+            npm,
+            options: {
+              apiKey: `{env:${typedVendor.apiKeyEnvVar}}`,
+              baseURL,
+            },
+          },
+        },
+      });
+    },
+  );
+
+  test("generates OpenCode custom provider config from stored OpenAI-compatible Base URL", () => {
+    const envVars = buildRuntimeVendorEnvVars({
+      credential: {
+        apiBase: "https://models.example.com/v1",
+        apiKey: "sk-custom",
+        credentialId: "01J000000000000000000000C8",
+      },
+      model: "qwen-coder",
+      runtimeId: "acp-fallback",
+      vendor: VENDOR_OPENAI_COMPATIBLE,
+    });
+    const config = JSON.parse(envVars["OPENCODE_CONFIG_CONTENT"] ?? "{}") as Record<
+      string,
+      unknown
+    >;
+
+    expect(envVars["OPENAI_COMPATIBLE_API_KEY"]).toBe("sk-custom");
+    expect(envVars["OPENAI_COMPATIBLE_BASE_URL"]).toBe("https://models.example.com/v1");
+    expect(config).toMatchObject({
+      enabled_providers: ["openai-compatible"],
+      model: "openai-compatible/qwen-coder",
+      small_model: "openai-compatible/qwen-coder",
+      provider: {
+        "openai-compatible": {
+          name: "OpenAI Compatible",
+          npm: "@ai-sdk/openai-compatible",
+          options: {
+            apiKey: "{env:OPENAI_COMPATIBLE_API_KEY}",
+            baseURL: "https://models.example.com/v1",
           },
         },
       },

--- a/apps/api/tests/vendor-credential-probe.test.ts
+++ b/apps/api/tests/vendor-credential-probe.test.ts
@@ -16,6 +16,12 @@ describe("vendor credential probe", () => {
     expect(toVendorProbeEndpointUrl("https://api.example.com/v1/", "chat/completions")).toBe(
       "https://api.example.com/v1/chat/completions",
     );
+    expect(
+      toVendorProbeEndpointUrl("https://generativelanguage.googleapis.com/v1beta/openai", "models"),
+    ).toBe("https://generativelanguage.googleapis.com/v1beta/openai/models");
+    expect(toVendorProbeEndpointUrl("https://api.z.ai/api/paas/v4", "models")).toBe(
+      "https://api.z.ai/api/paas/v4/models",
+    );
   });
 
   test("rejects local and private API base URLs", () => {

--- a/apps/api/tests/vendor-credential-runtime-selection.test.ts
+++ b/apps/api/tests/vendor-credential-runtime-selection.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { parsePlatformId } from "@mosoo/id";
 import type { AccountId, OrganizationId, AppId, VendorCredentialId } from "@mosoo/id";
-import { VENDOR_OPENAI, VENDOR_OPENAI_COMPATIBLE } from "@mosoo/runtime-catalog";
+import { VENDOR_DEEPSEEK, VENDOR_OPENAI, VENDOR_OPENAI_COMPATIBLE } from "@mosoo/runtime-catalog";
 
 import { collectRuntimeCapabilityIssues } from "../src/modules/agents/application/agent-runtime-capability-resolution.service";
 import {
@@ -36,6 +36,10 @@ const CUSTOM_PRIMARY_CREDENTIAL_ID = parsePlatformId<VendorCredentialId>(
 const CUSTOM_SECONDARY_CREDENTIAL_ID = parsePlatformId<VendorCredentialId>(
   "01J00000000000000000000005",
   "secondary custom credential ID",
+);
+const DEEPSEEK_CREDENTIAL_ID = parsePlatformId<VendorCredentialId>(
+  "01J00000000000000000000006",
+  "DeepSeek credential ID",
 );
 
 function createCredentialRuntimeDatabase(): SqliteD1Database {
@@ -143,6 +147,18 @@ async function insertVendorCredential(
       input.vendorId,
     )
     .run();
+}
+
+function readFetchRequestUrl(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.href;
+  }
+
+  return input.url;
 }
 
 describe("vendor credential runtime selection", () => {
@@ -302,5 +318,70 @@ describe("vendor credential runtime selection", () => {
         targetLabel: VENDOR_OPENAI.vendorId,
       }),
     );
+  });
+
+  test("allows DeepSeek readiness to verify preset models through chat completions", async () => {
+    const database = createCredentialRuntimeDatabase();
+    const bindings = {
+      DB: database,
+      VAULT_ROOT_SECRET: "test-vault-root-secret",
+    } as ApiBindings;
+    const deepSeekSecretId = await storeVendorCredentialSecret(bindings, {
+      apiKey: "deepseek-key",
+      credentialId: DEEPSEEK_CREDENTIAL_ID,
+      appId: APP_ID,
+      providerId: VENDOR_DEEPSEEK.vendorId,
+      purpose: "credential_create_api_key",
+    });
+
+    await insertVendorCredential(database, {
+      apiBase: null,
+      credentialId: DEEPSEEK_CREDENTIAL_ID,
+      models: null,
+      name: "DeepSeek",
+      secretId: deepSeekSecretId,
+      vendorId: VENDOR_DEEPSEEK.vendorId,
+    });
+
+    const originalFetch = globalThis.fetch;
+    const requestedUrls: string[] = [];
+    globalThis.fetch = async (...args: Parameters<typeof fetch>): Promise<Response> => {
+      const requestUrl = readFetchRequestUrl(args[0]);
+      requestedUrls.push(requestUrl);
+
+      if (requestUrl.endsWith("/models")) {
+        return Response.json({ data: [] });
+      }
+
+      if (requestUrl.endsWith("/chat/completions")) {
+        return Response.json({ id: "probe-ok" });
+      }
+
+      return new Response("not found", { status: 404 });
+    };
+
+    try {
+      const issues = await collectRuntimeCapabilityIssues({
+        actorAccountId: APP_OWNER_ID,
+        bindings,
+        codePrefix: "agent.readiness",
+        database,
+        appId: APP_ID,
+        selection: {
+          model: "deepseek-v4-pro",
+          provider: VENDOR_DEEPSEEK.vendorId,
+          runtimeId: "acp-fallback",
+        },
+      });
+
+      expect(issues).not.toContainEqual(
+        expect.objectContaining({
+          code: "agent.readiness.provider.error",
+        }),
+      );
+      expect(requestedUrls.some((url) => url.endsWith("/chat/completions"))).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/apps/web/src/routes/agent/runtime-default.ts
+++ b/apps/web/src/routes/agent/runtime-default.ts
@@ -1,6 +1,7 @@
 import {
   PUBLIC_RUNTIME_CATALOG,
   VENDOR_OPENAI_COMPATIBLE,
+  getDefaultModelIdForVendor,
   listPresetModelsForVendor,
 } from "@mosoo/runtime-catalog";
 
@@ -25,6 +26,15 @@ function defaultModelForVendor(
   }
 
   const supportedModels = entry.supportedModelIds;
+  const defaultModel = getDefaultModelIdForVendor(vendorId);
+
+  if (
+    defaultModel !== null &&
+    (supportedModels === undefined || supportedModels.includes(defaultModel))
+  ) {
+    return defaultModel;
+  }
+
   const model = listPresetModelsForVendor(vendorId).find(
     (candidate) => supportedModels === undefined || supportedModels.includes(candidate.modelId),
   );

--- a/apps/web/src/routes/providers/providers-tab.tsx
+++ b/apps/web/src/routes/providers/providers-tab.tsx
@@ -1,4 +1,5 @@
 import { PUBLIC_VENDORS, getVendor } from "@mosoo/runtime-catalog";
+import type { RuntimeCatalogVendor } from "@mosoo/runtime-catalog";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Pencil, Plus, Trash2 } from "lucide-react";
 import type { ReactElement } from "react";
@@ -17,6 +18,7 @@ import { canUseCustomEndpoint } from "@/domains/vendor-credential/model/provider
 import { getErrorMessage } from "@/domains/vendor-credential/model/provider-credential-error";
 import { formatProviderErrorMessage } from "@/domains/vendor-credential/model/provider-readiness-copy";
 import { toAppId, toVendorCredentialId } from "@/routes/typed-id";
+import { VendorIcon, hasVendorIcon } from "@/shared/ui/brand-icons";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { PageHeader } from "@/shared/ui/page-header";
@@ -25,6 +27,11 @@ import { ProviderTestStatus } from "./provider-test-status";
 import { RuntimeAvailabilitySection } from "./runtime-availability-section";
 
 const CUSTOM_PROVIDER_VENDOR_ID = "openai-compatible";
+const CUSTOM_PROVIDER_DISPLAY: Pick<RuntimeCatalogVendor, "iconKey" | "label" | "vendorId"> = {
+  iconKey: "openai",
+  label: "Custom models",
+  vendorId: CUSTOM_PROVIDER_VENDOR_ID,
+};
 
 type TestState = "failure" | "idle" | "running" | "success";
 
@@ -60,8 +67,8 @@ const providerCredentialKeys = {
   list: (appId: string) => ["vendor-credentials", appId] as const,
 };
 
-// Preset providers (Anthropic, OpenAI) carry a default endpoint; pre-fill it so
-// the user does not have to look it up. OpenAI-compatible has no default.
+// Preset providers can carry a default endpoint; pre-fill it so the user does
+// not have to look it up. OpenAI-compatible has no default.
 function defaultApiBaseForVendor(vendorId: string): string {
   return getVendor(vendorId)?.defaultApiBase ?? "";
 }
@@ -271,7 +278,7 @@ export function ProvidersTab({ appId }: { appId: string }): ReactElement {
       >
         <Button onClick={() => startCreate(CUSTOM_PROVIDER_VENDOR_ID)} size="sm" variant="outline">
           <Plus className="size-3.5" />
-          Add OpenAI-compatible provider
+          Add custom model
         </Button>
       </PageHeader>
 
@@ -310,27 +317,30 @@ export function ProvidersTab({ appId }: { appId: string }): ReactElement {
                   setError(getErrorMessage(caughtError, "Failed to set default provider key."));
                 });
               }}
-              vendorId={vendor.vendorId}
+              vendor={vendor}
             />
           ))}
 
-          <ProviderCredentialSection
-            credentials={groupedCredentials.get(CUSTOM_PROVIDER_VENDOR_ID) ?? []}
-            formControls={formControls}
-            onCreate={() => startCreate(CUSTOM_PROVIDER_VENDOR_ID)}
-            onDelete={(credential) => {
-              void deleteMutation.mutateAsync(credential).catch((caughtError) => {
-                setError(getErrorMessage(caughtError, "Failed to delete provider key."));
-              });
-            }}
-            onEdit={startEdit}
-            onSetDefault={(credential) => {
-              void setDefaultMutation.mutateAsync(credential).catch((caughtError) => {
-                setError(getErrorMessage(caughtError, "Failed to set default provider key."));
-              });
-            }}
-            vendorId={CUSTOM_PROVIDER_VENDOR_ID}
-          />
+          {(groupedCredentials.get(CUSTOM_PROVIDER_VENDOR_ID)?.length ?? 0) > 0 ||
+          form.vendorId === CUSTOM_PROVIDER_VENDOR_ID ? (
+            <ProviderCredentialSection
+              credentials={groupedCredentials.get(CUSTOM_PROVIDER_VENDOR_ID) ?? []}
+              formControls={formControls}
+              onCreate={() => startCreate(CUSTOM_PROVIDER_VENDOR_ID)}
+              onDelete={(credential) => {
+                void deleteMutation.mutateAsync(credential).catch((caughtError) => {
+                  setError(getErrorMessage(caughtError, "Failed to delete provider key."));
+                });
+              }}
+              onEdit={startEdit}
+              onSetDefault={(credential) => {
+                void setDefaultMutation.mutateAsync(credential).catch((caughtError) => {
+                  setError(getErrorMessage(caughtError, "Failed to set default provider key."));
+                });
+              }}
+              vendor={CUSTOM_PROVIDER_DISPLAY}
+            />
+          ) : null}
         </div>
       </main>
     </div>
@@ -436,7 +446,7 @@ function ProviderCredentialSection({
   onDelete,
   onEdit,
   onSetDefault,
-  vendorId,
+  vendor,
 }: {
   credentials: readonly VendorCredential[];
   formControls: ProviderFormControls;
@@ -444,16 +454,25 @@ function ProviderCredentialSection({
   onDelete: (credential: VendorCredential) => void;
   onEdit: (credential: VendorCredential) => void;
   onSetDefault: (credential: VendorCredential) => void;
-  vendorId: string;
+  vendor: Pick<RuntimeCatalogVendor, "iconKey" | "label" | "vendorId">;
 }): ReactElement {
+  const { vendorId } = vendor;
   const isFormOpen = formControls.form.vendorId === vendorId;
 
   return (
     <section className="border-border bg-card space-y-3 rounded-lg border p-4">
       <div className="flex items-center justify-between gap-3">
-        <div>
-          <h2 className="text-fg-1 text-[15px] font-semibold">{vendorLabel(vendorId)}</h2>
-          <p className="text-muted-foreground text-[12px]">App-level provider keys</p>
+        <div className="flex min-w-0 items-center gap-3">
+          {hasVendorIcon(vendor.iconKey) ? (
+            <VendorIcon
+              className="size-7 shrink-0 rounded-md bg-white p-1"
+              iconKey={vendor.iconKey}
+            />
+          ) : null}
+          <div className="min-w-0">
+            <h2 className="text-fg-1 truncate text-[15px] font-semibold">{vendor.label}</h2>
+            <p className="text-muted-foreground text-[12px]">App-level provider keys</p>
+          </div>
         </div>
         {isFormOpen ? null : (
           <Button onClick={onCreate} size="sm" variant="outline">

--- a/apps/web/src/routes/providers/runtime-availability-model.ts
+++ b/apps/web/src/routes/providers/runtime-availability-model.ts
@@ -1,13 +1,26 @@
-import { PUBLIC_RUNTIME_CATALOG } from "@mosoo/runtime-catalog";
+import { PUBLIC_RUNTIME_CATALOG, VENDOR_OPENAI_COMPATIBLE } from "@mosoo/runtime-catalog";
 
 import type { VendorCredential } from "@/domains/vendor-credential/api/vendor-credential-client";
 
 export interface RuntimeAvailabilityRow {
   readonly label: string;
-  readonly provider: string;
   readonly runtimeId: string;
   readonly status: string;
   readonly tone: "muted" | "ready";
+}
+
+function formatJoin(items: readonly string[]): string {
+  if (items.length <= 2) {
+    return items.join(" or ");
+  }
+
+  const lastItem = items[items.length - 1];
+
+  if (lastItem === undefined) {
+    return "";
+  }
+
+  return `${items.slice(0, -1).join(", ")}, or ${lastItem}`;
 }
 
 export function listRuntimeAvailabilityRows(
@@ -16,14 +29,25 @@ export function listRuntimeAvailabilityRows(
   const configuredVendorIds = new Set(credentials.map((credential) => credential.vendorId));
 
   return PUBLIC_RUNTIME_CATALOG.map((runtime) => {
-    const [vendor] = runtime.vendors;
-    const ready = vendor !== undefined && configuredVendorIds.has(vendor.vendorId);
-    const provider = vendor?.label ?? runtime.defaultProvider;
-    const status = runtime.disabledReason ?? (ready ? "Ready" : `Add a ${provider} key`);
+    const configuredLabels = runtime.vendors
+      .filter((vendor) => configuredVendorIds.has(vendor.vendorId))
+      .map((vendor) => vendor.label);
+    const customProviderReady =
+      runtime.acceptsCustomProvider && configuredVendorIds.has(VENDOR_OPENAI_COMPATIBLE.vendorId);
+    const readyLabels = [...configuredLabels, ...(customProviderReady ? ["Custom model"] : [])];
+    const ready = readyLabels.length > 0;
+    const requiredLabels = [
+      ...runtime.vendors.map((vendor) => vendor.label),
+      ...(runtime.acceptsCustomProvider ? ["custom model"] : []),
+    ];
+    const status =
+      runtime.disabledReason ??
+      (ready
+        ? `Ready · ${readyLabels.join(" / ")} configured`
+        : `Needs key · Add ${formatJoin(requiredLabels)}`);
 
     return {
       label: runtime.label,
-      provider,
       runtimeId: runtime.runtimeId,
       status,
       tone: ready && runtime.disabledReason === undefined ? "ready" : "muted",

--- a/apps/web/src/routes/providers/runtime-availability-section.tsx
+++ b/apps/web/src/routes/providers/runtime-availability-section.tsx
@@ -8,13 +8,11 @@ import { listRuntimeAvailabilityRows } from "./runtime-availability-model";
 
 function RuntimeRow({
   label,
-  provider,
   runtimeId,
   status,
   tone,
 }: {
   label: string;
-  provider: string;
   runtimeId: string;
   status: string;
   tone: "muted" | "ready";
@@ -32,17 +30,21 @@ function RuntimeRow({
         ) : null}
         <div className="min-w-0">
           <div className="text-foreground truncate text-sm font-medium">{label}</div>
-          <div className="text-muted-foreground truncate text-xs">{provider}</div>
         </div>
       </div>
       <span
-        className={
-          tone === "ready"
-            ? "text-success-fg shrink-0 text-xs font-medium"
-            : "text-muted-foreground shrink-0 text-xs"
-        }
+        className={cn(
+          "flex min-w-0 shrink items-center gap-1.5 truncate text-xs font-medium",
+          tone === "ready" ? "text-success-fg" : "text-muted-foreground",
+        )}
       >
-        {status}
+        <span
+          className={cn(
+            "size-1.5 shrink-0 rounded-full",
+            tone === "ready" ? "bg-success-fg" : "bg-muted-foreground/60",
+          )}
+        />
+        <span className="truncate">{status}</span>
       </span>
     </div>
   );
@@ -71,7 +73,6 @@ export function RuntimeAvailabilitySection({
           <RuntimeRow
             key={runtime.runtimeId}
             label={runtime.label}
-            provider={runtime.provider}
             runtimeId={runtime.runtimeId}
             status={runtime.status}
             tone={runtime.tone}

--- a/apps/web/src/shared/ui/brand-icons/vendor-icon-data.ts
+++ b/apps/web/src/shared/ui/brand-icons/vendor-icon-data.ts
@@ -1,13 +1,25 @@
 import anthropicSvgUrl from "@lobehub/icons-static-svg/icons/anthropic.svg";
-import deepseekSvgUrl from "@lobehub/icons-static-svg/icons/deepseek.svg";
+import deepseekSvgUrl from "@lobehub/icons-static-svg/icons/deepseek-color.svg";
+import geminiSvgUrl from "@lobehub/icons-static-svg/icons/gemini-color.svg";
+import kimiSvgUrl from "@lobehub/icons-static-svg/icons/kimi-color.svg";
+import minimaxSvgUrl from "@lobehub/icons-static-svg/icons/minimax-color.svg";
 import openaiSvgUrl from "@lobehub/icons-static-svg/icons/openai.svg";
+import opencodeSvgUrl from "@lobehub/icons-static-svg/icons/opencode.svg";
+import qwenSvgUrl from "@lobehub/icons-static-svg/icons/qwen-color.svg";
+import zhipuSvgUrl from "@lobehub/icons-static-svg/icons/zhipu-color.svg";
 
 export const VENDOR_ICON_URL: Record<string, string> = {
   anthropic: anthropicSvgUrl,
   deepseek: deepseekSvgUrl,
+  gemini: geminiSvgUrl,
+  kimi: kimiSvgUrl,
+  minimax: minimaxSvgUrl,
   openai: openaiSvgUrl,
+  opencode: opencodeSvgUrl,
+  qwen: qwenSvgUrl,
+  zhipu: zhipuSvgUrl,
 };
 
-export function hasVendorIcon(vendorId: string): boolean {
-  return vendorId in VENDOR_ICON_URL;
+export function hasVendorIcon(iconKey: string): boolean {
+  return iconKey in VENDOR_ICON_URL;
 }

--- a/apps/web/src/shared/ui/brand-icons/vendor-icon-data.ts
+++ b/apps/web/src/shared/ui/brand-icons/vendor-icon-data.ts
@@ -1,8 +1,10 @@
 import anthropicSvgUrl from "@lobehub/icons-static-svg/icons/anthropic.svg";
+import deepseekSvgUrl from "@lobehub/icons-static-svg/icons/deepseek.svg";
 import openaiSvgUrl from "@lobehub/icons-static-svg/icons/openai.svg";
 
 export const VENDOR_ICON_URL: Record<string, string> = {
   anthropic: anthropicSvgUrl,
+  deepseek: deepseekSvgUrl,
   openai: openaiSvgUrl,
 };
 

--- a/apps/web/src/shared/ui/brand-icons/vendor-icon.tsx
+++ b/apps/web/src/shared/ui/brand-icons/vendor-icon.tsx
@@ -6,12 +6,12 @@ import { VENDOR_ICON_URL } from "./vendor-icon-data";
 
 export function VendorIcon({
   className,
-  vendorId,
+  iconKey,
 }: {
   className?: string;
-  vendorId: string;
+  iconKey: string;
 }): ReactElement | null {
-  const iconUrl = VENDOR_ICON_URL[vendorId];
+  const iconUrl = VENDOR_ICON_URL[iconKey];
 
   if (iconUrl === undefined) {
     return null;

--- a/apps/web/tests/provider-runtime-availability.test.ts
+++ b/apps/web/tests/provider-runtime-availability.test.ts
@@ -30,4 +30,29 @@ describe("provider runtime availability", () => {
     expect(listPlannedRuntimeDisplayEntries("provider-settings")).toEqual([]);
     expect(availabilityRuntimeIds).toEqual(publicRuntimeIds);
   });
+
+  test("marks OpenCode ready from any supported provider, not only the first vendor", () => {
+    const availabilityRows = listRuntimeAvailabilityRows([credential("gemini")]);
+    const openCodeRow = availabilityRows.find((runtime) => runtime.runtimeId === "acp-fallback");
+
+    expect(openCodeRow).toMatchObject({
+      status: "Ready · Gemini configured",
+      tone: "ready",
+    });
+  });
+
+  test("marks custom OpenAI-compatible credentials as runtime readiness for custom-capable runtimes", () => {
+    const availabilityRows = listRuntimeAvailabilityRows([credential("openai-compatible")]);
+    const openCodeRow = availabilityRows.find((runtime) => runtime.runtimeId === "acp-fallback");
+    const claudeRow = availabilityRows.find((runtime) => runtime.runtimeId === "claude-agent-sdk");
+
+    expect(openCodeRow).toMatchObject({
+      status: "Ready · Custom model configured",
+      tone: "ready",
+    });
+    expect(claudeRow).toMatchObject({
+      status: "Needs key · Add Anthropic",
+      tone: "muted",
+    });
+  });
 });

--- a/apps/web/tests/runtime-default.test.ts
+++ b/apps/web/tests/runtime-default.test.ts
@@ -17,9 +17,17 @@ function credential(vendorId: string): VendorCredential {
 }
 
 describe("default agent runtime", () => {
+  test("uses the official DeepSeek provider when only DeepSeek is configured", () => {
+    expect(resolveDefaultAgentRuntime([credential("deepseek")])).toEqual({
+      model: "deepseek-v4-pro",
+      provider: "deepseek",
+      runtimeId: "acp-fallback",
+    });
+  });
+
   test("uses an OpenCode Zen model when only OpenCode Zen is configured", () => {
     expect(resolveDefaultAgentRuntime([credential("opencode")])).toEqual({
-      model: "deepseek-v4-pro",
+      model: "qwen3.6-plus",
       provider: "opencode",
       runtimeId: "acp-fallback",
     });

--- a/apps/web/tests/runtime-default.test.ts
+++ b/apps/web/tests/runtime-default.test.ts
@@ -27,7 +27,7 @@ describe("default agent runtime", () => {
 
   test("uses an OpenCode Zen model when only OpenCode Zen is configured", () => {
     expect(resolveDefaultAgentRuntime([credential("opencode")])).toEqual({
-      model: "qwen3.6-plus",
+      model: "deepseek-v4-pro",
       provider: "opencode",
       runtimeId: "acp-fallback",
     });

--- a/docs/prd/runtime-catalog.md
+++ b/docs/prd/runtime-catalog.md
@@ -48,6 +48,7 @@ When a maintainer adds a runtime, they should be able to:
 | Runtime          | A launchable Agent driver choice shown to users, such as Claude Agent SDK, OpenAI Runtime, or OpenCode.                          |
 | Transport        | The control path Runtime uses to talk to the Driver backend, such as `claude-agent-sdk`, `openai-app-server`, or `acp-fallback`. |
 | Vendor           | A credential provider that can back one or more runtimes.                                                                        |
+| Adapter profile  | The provider-specific protocol shape a runtime backend must render, such as OpenAI Responses API or OpenAI-compatible base URL.  |
 | Preset model     | A known model option shipped by Mosoo for a preset vendor.                                                                       |
 | Public runtime   | A runtime visible and selectable in Agent creation.                                                                              |
 | Internal runtime | A cataloged runtime that is not user-selectable.                                                                                 |
@@ -77,6 +78,15 @@ Key decision: display-only planned runtimes sit beside public runtime display en
 5. Run `vp run --filter @mosoo/runtime-catalog catalog:generate`.
 6. Run `vp run --filter @mosoo/runtime-catalog test` and the affected API/Web type checks.
 7. Confirm the Driver transport path exists before making a runtime public.
+
+## 7.1 Provider And Adapter Decision Rule
+
+When adding a model source, first decide the identity boundary:
+
+- Add a new **Vendor** when credentials, billing, model ownership, or user-facing provider identity differ. DeepSeek is a vendor because it uses `DEEPSEEK_API_KEY`, DeepSeek-owned models, and a DeepSeek API base.
+- Add or reuse an **Adapter profile** when the same runtime transport must render a different protocol config for that vendor. DeepSeek on OpenCode reuses the OpenAI-compatible profile by emitting an OpenCode provider config with `npm: "@ai-sdk/openai-compatible"` and `baseURL`.
+- Do not encode a vendor as another vendor's model prefix. `opencode/deepseek-v4-pro` means OpenCode Zen owns the credential and endpoint; `deepseek/deepseek-v4-pro` means DeepSeek owns them, even if OpenCode launches the ACP process.
+- OpenAI can have multiple adapter profiles across runtimes: the OpenAI Runtime path uses the OpenAI runtime / Responses-style backend contract, while ACP fallback may use OpenCode-native or OpenAI-compatible config. The provider id remains `openai`; the adapter profile changes by runtime path.
 
 ## 8. Acceptance Criteria
 

--- a/docs/prd/runtime-catalog.md
+++ b/docs/prd/runtime-catalog.md
@@ -5,55 +5,60 @@
 
 ## One-Line Positioning
 
-Add or change an Agent runtime by editing one catalog source, regenerating the typed catalog, and letting API, Web, and Driver release checks consume the same runtime identity.
+Add or change an Agent runtime, Provider, model source, or display surface by editing one catalog source, regenerating the typed catalog, and letting API, Web, and Driver release checks consume the same runtime and provider identity.
 
 ## 1. User Problem
 
-Mosoo users see runtime availability in several places: Agent creation, model selection, Provider setup, and the landing page. Before this catalog boundary, those surfaces could drift because runtime/model allowlists, display names, icon mapping, and "coming soon" rows lived in separate handwritten code paths.
+Mosoo users see runtime and Provider availability in several places: Agent creation, model selection, Provider setup, and the landing page. Before this catalog boundary, those surfaces could drift because runtime/model allowlists, display names, icon mapping, Provider cards, custom model entry points, and "coming soon" rows lived in separate handwritten code paths.
 
 The person extending Mosoo needs a predictable answer to one question:
 
-> "What must change when we add a runtime, and how do we prove every surface saw the same change?"
+> "What must change when we add a runtime or Provider, and how do we prove every surface saw the same change?"
 
 ## 2. Goal
 
 When a maintainer adds a runtime, they should be able to:
 
 - Declare runtime identity, transport, visibility, providers, defaults, supported models, and display metadata in the runtime catalog source.
+- Declare first-class Provider identity, credential environment, default endpoint, auth shape, icon key, model source, and runtime adapter profile in the same source.
+- Keep Mosoo product-facing Provider ids under Mosoo control, even when upstream model metadata comes from another registry name such as `models.dev`.
 - Generate a typed catalog artifact consumed by API and Web code.
 - Keep planned display-only runtimes separate from public runtime release gates.
-- Validate that runtime admission, available model calculation, icon rendering, and coming-soon display do not drift.
+- Validate that runtime admission, available model calculation, Provider card rendering, icon rendering, custom model entry points, and coming-soon display do not drift.
 
 ## 3. In Scope
 
-- One canonical runtime catalog source for runtime, vendor, model, and display metadata.
+- One canonical runtime catalog source for runtime, Provider, model, model-source, adapter, and display metadata.
 - Generated TypeScript constants committed with the repository.
-- API model availability uses the generated preset model catalog plus runtime allowlists.
-- Web runtime options, default runtime selection, brand icon lookup, landing showcase, and Provider coming-soon rows consume runtime catalog exports.
+- API model availability uses the generated Provider model catalog plus runtime allowlists and App-level Provider credentials.
+- Web runtime options, default runtime selection, brand icon lookup, Provider cards, custom OpenAI-compatible entry point, landing showcase, and Provider coming-soon rows consume runtime catalog exports.
+- OpenCode model availability is the union of compatible models from configured first-class Providers, OpenCode Zen, and App-defined OpenAI-compatible custom credentials.
 - Planned runtimes may appear in display surfaces without becoming launchable runtimes.
 - A repeatable extension checklist for adding a new runtime.
 
 ## 4. Out Of Scope
 
 - Pricing catalog migration. Model pricing remains in the cost domain until cost reporting needs the same generator boundary.
-- Automatic import from external model databases such as `models.dev`.
+- Real-time model discovery from external model databases or Provider `/models` endpoints on every model picker render.
 - Remote runtime marketplace or user-installed runtime definitions.
 - Runtime-specific Driver implementation details. A catalog entry can expose a runtime only after the Driver path exists and is release-gated.
 - Per-App custom runtime definitions.
 
 ## 5. Concept Definitions
 
-| Concept          | Product definition                                                                                                               |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| Runtime          | A launchable Agent driver choice shown to users, such as Claude Agent SDK, OpenAI Runtime, or OpenCode.                          |
-| Transport        | The control path Runtime uses to talk to the Driver backend, such as `claude-agent-sdk`, `openai-app-server`, or `acp-fallback`. |
-| Vendor           | A credential provider that can back one or more runtimes.                                                                        |
-| Adapter profile  | The provider-specific protocol shape a runtime backend must render, such as OpenAI Responses API or OpenAI-compatible base URL.  |
-| Preset model     | A known model option shipped by Mosoo for a preset vendor.                                                                       |
-| Public runtime   | A runtime visible and selectable in Agent creation.                                                                              |
-| Internal runtime | A cataloged runtime that is not user-selectable.                                                                                 |
-| Planned runtime  | Display-only roadmap metadata. It must not affect runtime admission or launchability.                                            |
-| Icon key         | A catalog-owned symbolic key that Web maps to an imported brand asset.                                                           |
+| Concept                    | Product definition                                                                                                               |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime                    | A launchable Agent driver choice shown to users, such as Claude Agent SDK, OpenAI Runtime, or OpenCode.                          |
+| Transport                  | The control path Runtime uses to talk to the Driver backend, such as `claude-agent-sdk`, `openai-app-server`, or `acp-fallback`. |
+| Provider                   | A Mosoo product-facing credential provider that can back one or more runtimes. Its id is chosen by Mosoo, not by an upstream registry. |
+| Adapter profile            | The provider-specific protocol shape a runtime backend must render, such as OpenAI Responses API, Anthropic Messages, or OpenAI-compatible base URL. |
+| Provider model source      | Metadata describing where Mosoo can import or refresh a Provider's model list, such as a `models.dev` provider id or a Provider `/models` endpoint. |
+| Provider model             | A known model option shipped by Mosoo for a first-class Provider.                                                                |
+| Custom OpenAI-compatible   | App-defined credentials with user-provided Base URL and Model IDs. It is an action entry point, not a fixed Provider card.       |
+| Public runtime             | A runtime visible and selectable in Agent creation.                                                                              |
+| Internal runtime           | A cataloged runtime that is not user-selectable.                                                                                 |
+| Planned runtime            | Display-only roadmap metadata. It must not affect runtime admission or launchability.                                            |
+| Icon key                   | A catalog-owned symbolic key that Web maps to an imported brand asset.                                                           |
 
 ## 6. Relationship Lock
 
@@ -61,41 +66,98 @@ When a maintainer adds a runtime, they should be able to:
 flowchart LR
   Source["runtime-catalog.jsonc<br/>human-maintained source"] --> Generate["catalog generator<br/>validate + emit TS"]
   Generate --> TS["catalog.generated.ts<br/>committed typed artifact"]
-  TS --> RuntimeCatalog["runtime-catalog package<br/>admission + display exports"]
-  RuntimeCatalog --> API["API<br/>available models"]
-  RuntimeCatalog --> Web["Web<br/>runtime options + display"]
-  RuntimeCatalog --> DriverGate["Driver release gate<br/>transport readiness"]
+  TS --> RuntimeCatalog["runtime-catalog package<br/>provider + runtime admission + display exports"]
+  RuntimeCatalog --> API["API<br/>available models + credential hydration"]
+  RuntimeCatalog --> Web["Web<br/>provider cards + runtime options + display"]
+  RuntimeCatalog --> DriverGate["Driver release gate<br/>transport readiness + adapter coverage"]
 ```
 
-Key decision: display-only planned runtimes sit beside public runtime display entries, but they do not enter runtime admission.
+Key decisions:
+
+- Display-only planned runtimes sit beside public runtime display entries, but they do not enter runtime admission.
+- Mosoo Provider ids are product identities. For example, Mosoo may use `gemini`, `qwen`, `kimi`, `zhipu`, and `minimax` even when an upstream registry uses `google`, `alibaba`, `moonshotai`, `zai`, or regional variants as source ids.
+- Upstream source names belong in catalog metadata such as `modelSource`, not in API/Web/Driver branching logic.
 
 ## 7. Extension Flow
 
 1. Add or edit vendors, models, runtime entries, and planned display entries in `pkgs/runtime-catalog/catalog/runtime-catalog.jsonc`.
-2. If the runtime is launchable, set `visibility` to `public`, choose a supported `transport`, declare `vendorIds`, `defaultIdentity`, and `supportedModels`.
-3. If the runtime is only roadmap display, add it to `plannedRuntimes` with explicit `surfaces`.
-4. Add an icon asset only if the catalog `iconKey` is new.
-5. Run `vp run --filter @mosoo/runtime-catalog catalog:generate`.
-6. Run `vp run --filter @mosoo/runtime-catalog test` and the affected API/Web type checks.
-7. Confirm the Driver transport path exists before making a runtime public.
+2. If adding a Provider, choose the Mosoo product-facing `vendorId`, set the Provider card label/icon, declare credential env vars, default endpoint, auth header shape, optional `modelSource`, and any runtime-specific adapter profile.
+3. If the runtime is launchable, set `visibility` to `public`, choose a supported `transport`, declare `vendorIds`, `defaultIdentity`, `supportedModels`, and whether App-defined OpenAI-compatible custom credentials are admitted.
+4. If the runtime is only roadmap display, add it to `plannedRuntimes` with explicit `surfaces`.
+5. Add an icon asset only if the catalog `iconKey` is new. Prefer existing `@lobehub/icons-static-svg` assets before adding local SVGs.
+6. Run `vp run --filter @mosoo/runtime-catalog catalog:generate`.
+7. Run `vp run --filter @mosoo/runtime-catalog test` and the affected API/Web type checks.
+8. Confirm the Driver transport and adapter profile path exists before making a runtime/provider combination public.
+
+## 7.1 Provider Identity And Model Source Rule
+
+Provider ids are Mosoo product ids. They should be stable, readable, and aligned with what users expect to see in Provider setup. Mosoo does not need to mirror an upstream registry's provider id when that id is more implementation-oriented than product-oriented.
+
+Examples:
+
+| Mosoo Provider id | User-facing label | Possible upstream model source |
+| ----------------- | ----------------- | ------------------------------ |
+| `gemini`          | Gemini            | `models.dev` provider `google` |
+| `qwen`            | Qwen              | `models.dev` provider `alibaba` or regional Alibaba variants |
+| `kimi`            | Kimi              | `models.dev` provider `moonshotai` |
+| `zhipu`           | Zhipu             | `models.dev` provider `zai` or `zhipuai` |
+| `minimax`         | MiniMax           | `models.dev` provider `minimax` or regional MiniMax variants |
+
+This is not a runtime mapping layer. The catalog generator may use `modelSource` to import or refresh Provider model metadata, but generated Mosoo artifacts should expose Mosoo Provider ids to API, Web, and Driver code.
+
+## 7.2 Provider Cards And Custom Provider Entry
+
+First-class Provider cards should be rendered from catalog metadata and treated equally in the Providers page. The initial public set is expected to include Anthropic, OpenAI, DeepSeek, Gemini, Qwen, Kimi, Zhipu, MiniMax, and OpenCode Zen, each with an icon key and Provider credential affordance.
+
+OpenAI-compatible custom credentials are different:
+
+- They are created from a top-level action such as "Add custom model" or "Add OpenAI-compatible provider".
+- They require Name, API key, Base URL, and at least one Model ID.
+- They should not appear as a fixed `openai-compatible` Provider card.
+- Their models are App-defined and should be included only for runtimes that explicitly accept custom OpenAI-compatible credentials.
+
+## 7.3 Runtime Model Availability Rule
+
+Available models are computed by runtime, not by Web UI components. The Web model picker asks the API for `availableAgentModels`; the API resolves that list from:
+
+1. Generated Provider model catalog entries.
+2. App-level Provider credentials.
+3. Runtime provider/model admission rules.
+4. App-defined OpenAI-compatible custom credential model IDs when the runtime accepts them.
+
+The availability key is `(providerId, modelId)`, not only `modelId`, because the same upstream model id may be reachable through multiple credentials, billing paths, or endpoints.
+
+For OpenCode (`acp-fallback`), the model list should be the union of:
+
+- Compatible models from configured first-class Providers.
+- Models from configured OpenCode Zen.
+- Models from configured custom OpenAI-compatible credentials.
+
+OpenCode must therefore declare `acceptsCustomProvider: true` only when API hydration can render custom OpenAI-compatible credentials into a valid OpenCode provider config, including package and Base URL settings such as `@ai-sdk/openai-compatible` and `baseURL`.
 
 ## 7.1 Provider And Adapter Decision Rule
 
 When adding a model source, first decide the identity boundary:
 
 - Add a new **Vendor** when credentials, billing, model ownership, or user-facing provider identity differ. DeepSeek is a vendor because it uses `DEEPSEEK_API_KEY`, DeepSeek-owned models, and a DeepSeek API base.
-- Add or reuse an **Adapter profile** when the same runtime transport must render a different protocol config for that vendor. DeepSeek on OpenCode reuses the OpenAI-compatible profile by emitting an OpenCode provider config with `npm: "@ai-sdk/openai-compatible"` and `baseURL`.
+- Add or reuse an **Adapter profile** when the same runtime transport must render a different protocol config for that vendor. If OpenCode already ships a native provider such as DeepSeek, Mosoo should use the native provider shape and avoid an adapter shim.
 - Do not encode a vendor as another vendor's model prefix. `opencode/deepseek-v4-pro` means OpenCode Zen owns the credential and endpoint; `deepseek/deepseek-v4-pro` means DeepSeek owns them, even if OpenCode launches the ACP process.
 - OpenAI can have multiple adapter profiles across runtimes: the OpenAI Runtime path uses the OpenAI runtime / Responses-style backend contract, while ACP fallback may use OpenCode-native or OpenAI-compatible config. The provider id remains `openai`; the adapter profile changes by runtime path.
 
 ## 8. Acceptance Criteria
 
-- Changing a runtime label, icon key, planned surface, default model, or supported model list requires one source edit plus regeneration.
+- Changing a runtime label, Provider card label, icon key, planned surface, default model, Provider model source, adapter profile, or supported model list requires one source edit plus regeneration.
 - A planned runtime can appear on landing or Provider settings without becoming selectable in Agent creation.
 - A public runtime appears in Agent runtime options and API available-model calculations from the same catalog entry.
+- First-class Provider cards render from catalog metadata, with icons, without Web-only hard-coded Provider lists.
+- The fixed `openai-compatible` Provider card is absent; custom OpenAI-compatible credentials are reachable from a top-level custom model/provider action.
+- OpenCode availability reflects all configured compatible Provider credentials, not only the first Provider listed on the runtime.
+- OpenCode model picker entries include the union of compatible first-class Provider models, OpenCode Zen models, and custom OpenAI-compatible model IDs.
 - OpenCode is represented as the public runtime `acp-fallback`, not as a separate planned `opencode` runtime id.
 - Generated catalog checks fail when the committed artifact is stale.
 
 ## 9. Reasoning Review
 
-The deleted assumption is that each surface can safely hard-code runtime metadata because the list is small. That did not hold once OpenCode became partially public while roadmap displays still existed. The MVP deliberately avoids syncing a full external model database; Mosoo only needs the models and providers it can actually admit, price, and run. Pricing migration is deferred because cost semantics have separate accounting risks and should move only when the cost domain is ready to consume the same source boundary.
+The deleted assumption is that each surface can safely hard-code runtime or Provider metadata because the list is small. That did not hold once OpenCode became partially public while roadmap displays still existed and Provider cards expanded beyond OpenAI and Anthropic.
+
+The MVP should not perform live external model discovery during normal UI rendering. It can, however, use external sources such as `models.dev` or Provider `/models` endpoints as catalog import inputs. Mosoo only needs the models and providers it can actually admit, credential, price, and run. Pricing migration is deferred because cost semantics have separate accounting risks and should move only when the cost domain is ready to consume the same source boundary.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -45,24 +45,28 @@ Live provider cases require one of:
 MOSOO_E2E_PROVIDER_API_KEY=...
 MOSOO_E2E_OPENAI_API_KEY=...
 MOSOO_E2E_ANTHROPIC_API_KEY=...
+MOSOO_E2E_OPENCODE_API_KEY=...
 MOSOO_E2E_DEEPSEEK_API_KEY=...
 ```
 
-Use `MOSOO_E2E_PROVIDER=openai|anthropic|deepseek` to choose the runtime provider.
+Use `MOSOO_E2E_PROVIDER=openai|anthropic|opencode|deepseek` to choose the runtime provider.
 Optional environment can live in `.env`, `MOSOO_ENV_FILE`, or
 `MOSOO_E2E_ENV_FILE`.
 
 `MOSOO_E2E_PROVIDER=deepseek` is supported by the `public-api runtime` case. It creates an
-OpenAI-Compatible credential with:
+official DeepSeek credential and runs the DeepSeek preset through the OpenCode ACP fallback
+runtime:
 
 ```bash
+MOSOO_E2E_RUNTIME_ID=acp-fallback
+MOSOO_E2E_DEEPSEEK_API_KEY=...
 MOSOO_E2E_DEEPSEEK_BASE_URL=https://api.deepseek.com
 MOSOO_E2E_DEEPSEEK_MODEL=deepseek-v4-pro
 ```
 
-By default it runs through `openai-runtime`. Set `MOSOO_E2E_RUNTIME_ID` to target another
-public runtime; the target must accept OpenAI-Compatible custom providers. Planned display-only
-runtimes such as OpenClaw are rejected until they become public launchable runtimes.
+Use `MOSOO_E2E_OPENCODE_API_KEY` only for the OpenCode Zen provider. DeepSeek official keys must use
+`MOSOO_E2E_DEEPSEEK_API_KEY` or the generic `MOSOO_E2E_PROVIDER_API_KEY` with
+`MOSOO_E2E_PROVIDER=deepseek`.
 
 Common optional values:
 

--- a/e2e/cases.ts
+++ b/e2e/cases.ts
@@ -84,7 +84,7 @@ export const e2eCases: readonly E2ECase[] = [
     id: ["public-api", "runtime"],
     layer: "public-api",
     requiresEnv: [
-      "MOSOO_E2E_PROVIDER_API_KEY|MOSOO_E2E_OPENAI_API_KEY|MOSOO_E2E_ANTHROPIC_API_KEY|MOSOO_E2E_DEEPSEEK_API_KEY",
+      "MOSOO_E2E_PROVIDER_API_KEY|MOSOO_E2E_OPENAI_API_KEY|MOSOO_E2E_ANTHROPIC_API_KEY|MOSOO_E2E_OPENCODE_API_KEY|MOSOO_E2E_DEEPSEEK_API_KEY",
     ],
   },
   {

--- a/e2e/cases/public-api/runtime.spec.ts
+++ b/e2e/cases/public-api/runtime.spec.ts
@@ -1,18 +1,13 @@
 import { PUBLIC_API_PREFIX } from "@mosoo/contracts/public-api";
-import {
-  PUBLIC_RUNTIME_CATALOG,
-  VENDOR_OPENAI_COMPATIBLE,
-  listPresetModelsForVendor,
-} from "@mosoo/runtime-catalog";
+import { PUBLIC_RUNTIME_CATALOG, listPresetModelsForVendor } from "@mosoo/runtime-catalog";
 import { expect, test } from "@playwright/test";
 import type { APIRequestContext } from "@playwright/test";
 
 import { createRuntimeSignalCollector } from "../../lib/runtime-progress";
 
-type ProviderId = "anthropic" | "deepseek" | "openai";
-type RuntimeCredentialVendorId = "anthropic" | "openai" | typeof VENDOR_OPENAI_COMPATIBLE.vendorId;
+type ProviderId = "anthropic" | "deepseek" | "openai" | "opencode";
+type RuntimeCredentialVendorId = "anthropic" | "deepseek" | "openai" | "opencode";
 
-const DEFAULT_DEEPSEEK_API_BASE = "https://api.deepseek.com";
 const DEFAULT_DEEPSEEK_MODEL = "deepseek-v4-pro";
 
 interface GraphQLResponse<TData> {
@@ -40,8 +35,8 @@ function readProviderId(): ProviderId {
     return "anthropic";
   }
 
-  if (provider === "deepseek") {
-    return "deepseek";
+  if (provider === "deepseek" || provider === "opencode") {
+    return provider;
   }
 
   throw new Error(`Unsupported MOSOO_E2E_PROVIDER=${provider}.`);
@@ -54,7 +49,9 @@ function requireProviderApiKey(providerId: ProviderId): string {
       ? process.env["MOSOO_E2E_ANTHROPIC_API_KEY"]?.trim()
       : providerId === "deepseek"
         ? process.env["MOSOO_E2E_DEEPSEEK_API_KEY"]?.trim()
-        : process.env["MOSOO_E2E_OPENAI_API_KEY"]?.trim()) ||
+        : providerId === "opencode"
+          ? process.env["MOSOO_E2E_OPENCODE_API_KEY"]?.trim()
+          : process.env["MOSOO_E2E_OPENAI_API_KEY"]?.trim()) ||
     "";
 
   if (apiKey.length === 0) {
@@ -118,35 +115,52 @@ function selectPresetRuntime(providerId: "anthropic" | "openai"): RuntimeSelecti
   };
 }
 
-function selectDeepSeekRuntime(): RuntimeSelection {
-  const runtimeId = readRuntimeIdOverride() ?? "openai-runtime";
+function selectAcpFallbackRuntime(providerId: "deepseek" | "opencode"): RuntimeSelection {
+  const runtimeId = readRuntimeIdOverride() ?? "acp-fallback";
   const runtime = findPublicRuntime(runtimeId);
 
   if (runtime === undefined) {
     throw new Error(`No public runtime catalog entry for MOSOO_E2E_RUNTIME_ID=${runtimeId}.`);
   }
 
-  if (!runtime.acceptsCustomProvider) {
+  if (!runtime.vendors.some((vendor) => vendor.vendorId === providerId)) {
+    throw new Error(`Runtime ${runtime.runtimeId} does not support provider ${providerId}.`);
+  }
+
+  const model =
+    providerId === "deepseek"
+      ? process.env["MOSOO_E2E_DEEPSEEK_MODEL"]?.trim() || DEFAULT_DEEPSEEK_MODEL
+      : process.env["MOSOO_E2E_OPENCODE_MODEL"]?.trim() ||
+        listPresetModelsForVendor("opencode").find((entry) =>
+          runtime.supportedModelIds?.includes(entry.modelId),
+        )?.modelId;
+
+  if (model === undefined) {
     throw new Error(
-      `Runtime ${runtime.runtimeId} does not accept OpenAI-compatible custom providers. Use a public runtime with acceptsCustomProvider=true before running DeepSeek live E2E.`,
+      `Runtime ${runtime.runtimeId} does not expose a model for provider ${providerId}.`,
     );
   }
 
-  const model = process.env["MOSOO_E2E_DEEPSEEK_MODEL"]?.trim() || DEFAULT_DEEPSEEK_MODEL;
+  const supportsModel = runtime.supportedModelIds?.includes(model) ?? true;
+
+  if (!supportsModel) {
+    throw new Error(`Runtime ${runtime.runtimeId} does not expose ${providerId} model ${model}.`);
+  }
 
   return {
-    apiBase: process.env["MOSOO_E2E_DEEPSEEK_BASE_URL"]?.trim() || DEFAULT_DEEPSEEK_API_BASE,
-    credentialVendorId: VENDOR_OPENAI_COMPATIBLE.vendorId,
+    apiBase:
+      providerId === "deepseek" ? process.env["MOSOO_E2E_DEEPSEEK_BASE_URL"]?.trim() || null : null,
+    credentialVendorId: providerId,
     model,
-    providerId: "deepseek",
-    providerModelIds: [model],
+    providerId,
+    providerModelIds: [],
     runtimeId: runtime.runtimeId,
   };
 }
 
 function getRuntimeSelection(providerId: ProviderId): RuntimeSelection {
-  if (providerId === "deepseek") {
-    return selectDeepSeekRuntime();
+  if (providerId === "deepseek" || providerId === "opencode") {
+    return selectAcpFallbackRuntime(providerId);
   }
 
   return selectPresetRuntime(providerId);

--- a/pkgs/runtime-catalog/catalog/runtime-catalog.jsonc
+++ b/pkgs/runtime-catalog/catalog/runtime-catalog.jsonc
@@ -4,15 +4,25 @@
   "modelDefaults": {
     "anthropic": "claude-sonnet-4-5",
     "deepseek": "deepseek-v4-pro",
+    "gemini": "gemini-3.5-flash",
+    "kimi": "kimi-k2.6",
+    "minimax": "MiniMax-M3",
+    "opencode": "deepseek-v4-pro",
     "openai": "gpt-5.4",
+    "qwen": "qwen3.7-plus",
+    "zhipu": "glm-4.7",
   },
   "vendors": [
     {
       "vendorId": "anthropic",
       "label": "Anthropic",
+      "iconKey": "anthropic",
       "apiKeyEnvVar": "ANTHROPIC_API_KEY",
       "apiBaseEnvVar": "ANTHROPIC_BASE_URL",
       "defaultApiBase": "https://api.anthropic.com",
+      "modelSource": {
+        "kind": "manual",
+      },
       "authHeader": {
         "scheme": "api-key",
         "apiKeyHeader": "x-api-key",
@@ -24,9 +34,13 @@
     {
       "vendorId": "openai",
       "label": "OpenAI",
+      "iconKey": "openai",
       "apiKeyEnvVar": "OPENAI_API_KEY",
       "apiBaseEnvVar": "OPENAI_BASE_URL",
       "defaultApiBase": "https://api.openai.com/v1",
+      "modelSource": {
+        "kind": "manual",
+      },
       "authHeader": {
         "scheme": "bearer",
         "apiKeyHeader": "Authorization",
@@ -35,8 +49,17 @@
     {
       "vendorId": "openai-compatible",
       "label": "OpenAI-Compatible",
+      "iconKey": "openai",
       "apiKeyEnvVar": "OPENAI_COMPATIBLE_API_KEY",
       "apiBaseEnvVar": "OPENAI_COMPATIBLE_BASE_URL",
+      "modelSource": {
+        "kind": "manual",
+      },
+      "openCodeProvider": {
+        "name": "OpenAI Compatible",
+        "npmPackage": "@ai-sdk/openai-compatible",
+        "apiBaseOption": "baseURL",
+      },
       "authHeader": {
         "scheme": "bearer",
         "apiKeyHeader": "Authorization",
@@ -45,24 +68,136 @@
     {
       "vendorId": "deepseek",
       "label": "DeepSeek",
+      "iconKey": "deepseek",
       "apiKeyEnvVar": "DEEPSEEK_API_KEY",
       "apiBaseEnvVar": "DEEPSEEK_BASE_URL",
       "defaultApiBase": "https://api.deepseek.com",
+      "modelSource": {
+        "kind": "models.dev",
+        "providerId": "deepseek",
+      },
       "authHeader": {
         "scheme": "bearer",
         "apiKeyHeader": "Authorization",
       },
+    },
+    {
+      "vendorId": "gemini",
+      "label": "Gemini",
+      "iconKey": "gemini",
+      "apiKeyEnvVar": "GEMINI_API_KEY",
+      "apiBaseEnvVar": "GEMINI_BASE_URL",
+      "defaultApiBase": "https://generativelanguage.googleapis.com/v1beta/openai",
+      "modelSource": {
+        "kind": "models.dev",
+        "providerId": "google",
+      },
       "openCodeProvider": {
-        "kind": "openai-compatible",
+        "name": "Gemini",
         "npmPackage": "@ai-sdk/openai-compatible",
         "apiBaseOption": "baseURL",
+      },
+      "authHeader": {
+        "scheme": "bearer",
+        "apiKeyHeader": "Authorization",
+      },
+    },
+    {
+      "vendorId": "qwen",
+      "label": "Qwen",
+      "iconKey": "qwen",
+      "apiKeyEnvVar": "QWEN_API_KEY",
+      "apiBaseEnvVar": "QWEN_BASE_URL",
+      "defaultApiBase": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+      "modelSource": {
+        "kind": "models.dev",
+        "providerId": "alibaba",
+      },
+      "openCodeProvider": {
+        "name": "Qwen",
+        "npmPackage": "@ai-sdk/openai-compatible",
+        "apiBaseOption": "baseURL",
+      },
+      "authHeader": {
+        "scheme": "bearer",
+        "apiKeyHeader": "Authorization",
+      },
+    },
+    {
+      "vendorId": "kimi",
+      "label": "Kimi",
+      "iconKey": "kimi",
+      "apiKeyEnvVar": "KIMI_API_KEY",
+      "apiBaseEnvVar": "KIMI_BASE_URL",
+      "defaultApiBase": "https://api.moonshot.ai/v1",
+      "modelSource": {
+        "kind": "models.dev",
+        "providerId": "moonshotai",
+      },
+      "openCodeProvider": {
+        "name": "Kimi",
+        "npmPackage": "@ai-sdk/openai-compatible",
+        "apiBaseOption": "baseURL",
+      },
+      "authHeader": {
+        "scheme": "bearer",
+        "apiKeyHeader": "Authorization",
+      },
+    },
+    {
+      "vendorId": "zhipu",
+      "label": "Zhipu",
+      "iconKey": "zhipu",
+      "apiKeyEnvVar": "ZHIPU_API_KEY",
+      "apiBaseEnvVar": "ZHIPU_BASE_URL",
+      "defaultApiBase": "https://api.z.ai/api/paas/v4",
+      "modelSource": {
+        "kind": "models.dev",
+        "providerId": "zai",
+      },
+      "openCodeProvider": {
+        "name": "Zhipu",
+        "npmPackage": "@ai-sdk/openai-compatible",
+        "apiBaseOption": "baseURL",
+      },
+      "authHeader": {
+        "scheme": "bearer",
+        "apiKeyHeader": "Authorization",
+      },
+    },
+    {
+      "vendorId": "minimax",
+      "label": "MiniMax",
+      "iconKey": "minimax",
+      "apiKeyEnvVar": "MINIMAX_API_KEY",
+      "apiBaseEnvVar": "MINIMAX_BASE_URL",
+      "defaultApiBase": "https://api.minimax.io/anthropic/v1",
+      "modelSource": {
+        "kind": "models.dev",
+        "providerId": "minimax",
+      },
+      "openCodeProvider": {
+        "name": "MiniMax",
+        "npmPackage": "@ai-sdk/anthropic",
+        "apiBaseOption": "baseURL",
+      },
+      "authHeader": {
+        "scheme": "api-key",
+        "apiKeyHeader": "x-api-key",
+        "extraHeaders": {
+          "anthropic-version": "2023-06-01",
+        },
       },
     },
     {
       "vendorId": "opencode",
       "label": "OpenCode Zen",
+      "iconKey": "opencode",
       "apiKeyEnvVar": "OPENCODE_API_KEY",
       "defaultApiBase": "https://opencode.ai/zen/v1",
+      "modelSource": {
+        "kind": "manual",
+      },
       "authHeader": {
         "scheme": "bearer",
         "apiKeyHeader": "Authorization",
@@ -141,6 +276,72 @@
       "modelId": "deepseek-v4-pro",
       "protocol": "openai-chat-completions",
       "vendorId": "deepseek",
+    },
+    {
+      "displayName": "DeepSeek V4 Flash",
+      "modelId": "deepseek-v4-flash",
+      "protocol": "openai-chat-completions",
+      "vendorId": "deepseek",
+    },
+    {
+      "displayName": "Gemini 3.5 Flash",
+      "modelId": "gemini-3.5-flash",
+      "protocol": "openai-chat-completions",
+      "vendorId": "gemini",
+    },
+    {
+      "displayName": "Qwen3.7 Plus",
+      "modelId": "qwen3.7-plus",
+      "protocol": "openai-chat-completions",
+      "vendorId": "qwen",
+    },
+    {
+      "displayName": "Qwen3.6 Plus",
+      "modelId": "qwen3.6-plus",
+      "protocol": "openai-chat-completions",
+      "vendorId": "qwen",
+    },
+    {
+      "displayName": "Kimi K2.6",
+      "modelId": "kimi-k2.6",
+      "protocol": "openai-chat-completions",
+      "vendorId": "kimi",
+    },
+    {
+      "displayName": "Kimi K2.7 Code",
+      "modelId": "kimi-k2.7-code",
+      "protocol": "openai-chat-completions",
+      "vendorId": "kimi",
+    },
+    {
+      "displayName": "GLM-4.7",
+      "modelId": "glm-4.7",
+      "protocol": "openai-chat-completions",
+      "vendorId": "zhipu",
+    },
+    {
+      "displayName": "GLM-4.6",
+      "modelId": "glm-4.6",
+      "protocol": "openai-chat-completions",
+      "vendorId": "zhipu",
+    },
+    {
+      "displayName": "MiniMax M3",
+      "modelId": "MiniMax-M3",
+      "protocol": "anthropic-messages",
+      "vendorId": "minimax",
+    },
+    {
+      "displayName": "MiniMax M2.7",
+      "modelId": "MiniMax-M2.7",
+      "protocol": "anthropic-messages",
+      "vendorId": "minimax",
+    },
+    {
+      "displayName": "DeepSeek V4 Pro",
+      "modelId": "deepseek-v4-pro",
+      "protocol": "openai-chat-completions",
+      "vendorId": "opencode",
     },
     {
       "displayName": "Qwen3.6 Plus",
@@ -254,15 +455,35 @@
       "label": "OpenCode",
       "visibility": "public",
       "transport": "acp-fallback",
-      "acceptsCustomProvider": false,
+      "acceptsCustomProvider": true,
       "capabilityProfile": "standard",
       "defaultIdentity": {
         "providerId": "openai",
         "modelId": "gpt-5.4",
       },
-      "vendorIds": ["openai", "anthropic", "deepseek", "opencode"],
+      "vendorIds": [
+        "openai",
+        "anthropic",
+        "deepseek",
+        "gemini",
+        "qwen",
+        "kimi",
+        "zhipu",
+        "minimax",
+        "opencode",
+      ],
       "supportedModels": {
-        "vendorIds": ["anthropic", "openai", "deepseek", "opencode"],
+        "vendorIds": [
+          "anthropic",
+          "openai",
+          "deepseek",
+          "gemini",
+          "qwen",
+          "kimi",
+          "zhipu",
+          "minimax",
+          "opencode",
+        ],
       },
       "display": {
         "iconKey": "opencode",

--- a/pkgs/runtime-catalog/catalog/runtime-catalog.jsonc
+++ b/pkgs/runtime-catalog/catalog/runtime-catalog.jsonc
@@ -3,6 +3,7 @@
   // metadata. Do not edit src/catalog.generated.ts directly; regenerate it from this file.
   "modelDefaults": {
     "anthropic": "claude-sonnet-4-5",
+    "deepseek": "deepseek-v4-pro",
     "openai": "gpt-5.4",
   },
   "vendors": [
@@ -39,6 +40,22 @@
       "authHeader": {
         "scheme": "bearer",
         "apiKeyHeader": "Authorization",
+      },
+    },
+    {
+      "vendorId": "deepseek",
+      "label": "DeepSeek",
+      "apiKeyEnvVar": "DEEPSEEK_API_KEY",
+      "apiBaseEnvVar": "DEEPSEEK_BASE_URL",
+      "defaultApiBase": "https://api.deepseek.com",
+      "authHeader": {
+        "scheme": "bearer",
+        "apiKeyHeader": "Authorization",
+      },
+      "openCodeProvider": {
+        "kind": "openai-compatible",
+        "npmPackage": "@ai-sdk/openai-compatible",
+        "apiBaseOption": "baseURL",
       },
     },
     {
@@ -123,7 +140,7 @@
       "displayName": "DeepSeek V4 Pro",
       "modelId": "deepseek-v4-pro",
       "protocol": "openai-chat-completions",
-      "vendorId": "opencode",
+      "vendorId": "deepseek",
     },
     {
       "displayName": "Qwen3.6 Plus",
@@ -243,13 +260,13 @@
         "providerId": "openai",
         "modelId": "gpt-5.4",
       },
-      "vendorIds": ["openai", "anthropic", "opencode"],
+      "vendorIds": ["openai", "anthropic", "deepseek", "opencode"],
       "supportedModels": {
-        "vendorIds": ["anthropic", "openai", "opencode"],
+        "vendorIds": ["anthropic", "openai", "deepseek", "opencode"],
       },
       "display": {
         "iconKey": "opencode",
-        "providerLabel": "OpenCode Zen",
+        "providerLabel": "OpenCode",
       },
     },
   ],

--- a/pkgs/runtime-catalog/scripts/generate-runtime-catalog.ts
+++ b/pkgs/runtime-catalog/scripts/generate-runtime-catalog.ts
@@ -57,7 +57,14 @@ interface RawVendor {
   authHeader: unknown;
   defaultApiBase?: string;
   label: string;
+  openCodeProvider?: RawOpenCodeProvider;
   vendorId: string;
+}
+
+interface RawOpenCodeProvider {
+  apiBaseOption: string;
+  kind: string;
+  npmPackage: string;
 }
 
 interface RawModel {
@@ -228,6 +235,30 @@ function readAuthHeader(value: unknown, label: string): RawVendor["authHeader"] 
   fail(`${label}.scheme must be bearer or api-key.`);
 }
 
+function readOpenCodeProvider(value: unknown, label: string): RawOpenCodeProvider | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const record = readRecord(value, label);
+  const kind = readString(record["kind"], `${label}.kind`);
+  const apiBaseOption = readString(record["apiBaseOption"], `${label}.apiBaseOption`);
+
+  if (kind !== "openai-compatible") {
+    fail(`${label}.kind must be openai-compatible.`);
+  }
+
+  if (apiBaseOption !== "baseURL") {
+    fail(`${label}.apiBaseOption must be baseURL.`);
+  }
+
+  return {
+    apiBaseOption,
+    kind,
+    npmPackage: readString(record["npmPackage"], `${label}.npmPackage`),
+  };
+}
+
 function parseSource(): RawCatalog {
   const errors: ParseError[] = [];
   const value = parseJsonc(readFileSync(SOURCE_PATH, "utf8"), errors, {
@@ -313,6 +344,10 @@ function readVendors(value: unknown): RawVendor[] {
         `vendors[${index}].defaultApiBase`,
       ),
       label: readString(vendor["label"], `vendors[${index}].label`),
+      openCodeProvider: readOpenCodeProvider(
+        vendor["openCodeProvider"],
+        `vendors[${index}].openCodeProvider`,
+      ),
       vendorId: readString(vendor["vendorId"], `vendors[${index}].vendorId`),
     };
   });

--- a/pkgs/runtime-catalog/scripts/generate-runtime-catalog.ts
+++ b/pkgs/runtime-catalog/scripts/generate-runtime-catalog.ts
@@ -56,14 +56,25 @@ interface RawVendor {
   apiKeyEnvVar: string;
   authHeader: unknown;
   defaultApiBase?: string;
+  iconKey: string;
   label: string;
+  modelSource?: RawVendorModelSource;
   openCodeProvider?: RawOpenCodeProvider;
   vendorId: string;
 }
 
+type RawVendorModelSource =
+  | {
+      kind: "manual";
+    }
+  | {
+      kind: "models.dev";
+      providerId: string;
+    };
+
 interface RawOpenCodeProvider {
-  apiBaseOption: string;
-  kind: string;
+  apiBaseOption?: "baseURL";
+  name: string;
   npmPackage: string;
 }
 
@@ -235,27 +246,47 @@ function readAuthHeader(value: unknown, label: string): RawVendor["authHeader"] 
   fail(`${label}.scheme must be bearer or api-key.`);
 }
 
+function readVendorModelSource(value: unknown, label: string): RawVendorModelSource | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const source = readRecord(value, label);
+  const kind = readString(source["kind"], `${label}.kind`);
+
+  if (kind === "manual") {
+    return { kind };
+  }
+
+  if (kind === "models.dev") {
+    return {
+      kind,
+      providerId: readString(source["providerId"], `${label}.providerId`),
+    };
+  }
+
+  fail(`${label}.kind must be manual or models.dev.`);
+}
+
 function readOpenCodeProvider(value: unknown, label: string): RawOpenCodeProvider | undefined {
   if (value === undefined) {
     return undefined;
   }
 
-  const record = readRecord(value, label);
-  const kind = readString(record["kind"], `${label}.kind`);
-  const apiBaseOption = readString(record["apiBaseOption"], `${label}.apiBaseOption`);
+  const provider = readRecord(value, label);
+  const apiBaseOption =
+    provider["apiBaseOption"] === undefined
+      ? undefined
+      : readString(provider["apiBaseOption"], `${label}.apiBaseOption`);
 
-  if (kind !== "openai-compatible") {
-    fail(`${label}.kind must be openai-compatible.`);
-  }
-
-  if (apiBaseOption !== "baseURL") {
+  if (apiBaseOption !== undefined && apiBaseOption !== "baseURL") {
     fail(`${label}.apiBaseOption must be baseURL.`);
   }
 
   return {
-    apiBaseOption,
-    kind,
-    npmPackage: readString(record["npmPackage"], `${label}.npmPackage`),
+    ...(apiBaseOption === undefined ? {} : { apiBaseOption }),
+    name: readString(provider["name"], `${label}.name`),
+    npmPackage: readString(provider["npmPackage"], `${label}.npmPackage`),
   };
 }
 
@@ -334,21 +365,36 @@ function readCapabilityProfiles(value: unknown): Record<string, RawCapability[]>
 function readVendors(value: unknown): RawVendor[] {
   return readArray(value, "catalog.vendors").map((item, index) => {
     const vendor = readRecord(item, `vendors[${index}]`);
+    const defaultApiBase = readOptionalString(
+      vendor["defaultApiBase"],
+      `vendors[${index}].defaultApiBase`,
+    );
+    const openCodeProvider = readOpenCodeProvider(
+      vendor["openCodeProvider"],
+      `vendors[${index}].openCodeProvider`,
+    );
+    const vendorId = readString(vendor["vendorId"], `vendors[${index}].vendorId`);
+
+    if (
+      openCodeProvider?.apiBaseOption === "baseURL" &&
+      defaultApiBase === undefined &&
+      vendorId !== "openai-compatible"
+    ) {
+      fail(
+        `vendors[${index}].openCodeProvider.apiBaseOption requires defaultApiBase unless the vendor is openai-compatible.`,
+      );
+    }
 
     return {
       apiBaseEnvVar: readOptionalString(vendor["apiBaseEnvVar"], `vendors[${index}].apiBaseEnvVar`),
       apiKeyEnvVar: readString(vendor["apiKeyEnvVar"], `vendors[${index}].apiKeyEnvVar`),
       authHeader: readAuthHeader(vendor["authHeader"], `vendors[${index}].authHeader`),
-      defaultApiBase: readOptionalString(
-        vendor["defaultApiBase"],
-        `vendors[${index}].defaultApiBase`,
-      ),
+      defaultApiBase,
+      iconKey: readString(vendor["iconKey"], `vendors[${index}].iconKey`),
       label: readString(vendor["label"], `vendors[${index}].label`),
-      openCodeProvider: readOpenCodeProvider(
-        vendor["openCodeProvider"],
-        `vendors[${index}].openCodeProvider`,
-      ),
-      vendorId: readString(vendor["vendorId"], `vendors[${index}].vendorId`),
+      modelSource: readVendorModelSource(vendor["modelSource"], `vendors[${index}].modelSource`),
+      openCodeProvider,
+      vendorId,
     };
   });
 }
@@ -631,7 +677,7 @@ function arrayLiteral(items: readonly unknown[], depth: number): string {
   if (items.every(isPrimitiveLiteral)) {
     const inline = `[${items.map((item) => literal(item, depth)).join(", ")}]`;
 
-    if (inline.length + indentation(depth).length <= 100) {
+    if (inline.length + indentation(depth).length <= 80) {
       return inline;
     }
   }

--- a/pkgs/runtime-catalog/src/catalog.generated.ts
+++ b/pkgs/runtime-catalog/src/catalog.generated.ts
@@ -4,6 +4,7 @@
 
 export const GENERATED_MODEL_DEFAULT_IDS = {
   anthropic: "claude-sonnet-4-5",
+  deepseek: "deepseek-v4-pro",
   openai: "gpt-5.4",
 } as const;
 
@@ -42,6 +43,22 @@ export const GENERATED_VENDOR_CATALOG = [
     },
     label: "OpenAI-Compatible",
     vendorId: "openai-compatible",
+  },
+  {
+    apiBaseEnvVar: "DEEPSEEK_BASE_URL",
+    apiKeyEnvVar: "DEEPSEEK_API_KEY",
+    authHeader: {
+      apiKeyHeader: "Authorization",
+      scheme: "bearer",
+    },
+    defaultApiBase: "https://api.deepseek.com",
+    label: "DeepSeek",
+    openCodeProvider: {
+      apiBaseOption: "baseURL",
+      kind: "openai-compatible",
+      npmPackage: "@ai-sdk/openai-compatible",
+    },
+    vendorId: "deepseek",
   },
   {
     apiKeyEnvVar: "OPENCODE_API_KEY",
@@ -137,8 +154,8 @@ export const GENERATED_PRESET_MODEL_CATALOG = [
     displayName: "DeepSeek V4 Pro",
     modelId: "deepseek-v4-pro",
     protocol: "openai-chat-completions",
-    vendorId: "opencode",
-    vendorLabel: "OpenCode Zen",
+    vendorId: "deepseek",
+    vendorLabel: "DeepSeek",
   },
   {
     displayName: "Qwen3.6 Plus",
@@ -366,12 +383,12 @@ export const GENERATED_RUNTIME_CATALOG = [
     },
     display: {
       iconKey: "opencode",
-      providerLabel: "OpenCode Zen",
+      providerLabel: "OpenCode",
     },
     label: "OpenCode",
     runtimeId: "acp-fallback",
     transport: "acp-fallback",
-    vendorIds: ["openai", "anthropic", "opencode"],
+    vendorIds: ["openai", "anthropic", "deepseek", "opencode"],
     visibility: "public",
     capabilities: [
       {

--- a/pkgs/runtime-catalog/src/catalog.generated.ts
+++ b/pkgs/runtime-catalog/src/catalog.generated.ts
@@ -5,7 +5,13 @@
 export const GENERATED_MODEL_DEFAULT_IDS = {
   anthropic: "claude-sonnet-4-5",
   deepseek: "deepseek-v4-pro",
+  gemini: "gemini-3.5-flash",
+  kimi: "kimi-k2.6",
+  minimax: "MiniMax-M3",
+  opencode: "deepseek-v4-pro",
   openai: "gpt-5.4",
+  qwen: "qwen3.7-plus",
+  zhipu: "glm-4.7",
 } as const;
 
 export const GENERATED_VENDOR_CATALOG = [
@@ -20,7 +26,11 @@ export const GENERATED_VENDOR_CATALOG = [
       scheme: "api-key",
     },
     defaultApiBase: "https://api.anthropic.com",
+    iconKey: "anthropic",
     label: "Anthropic",
+    modelSource: {
+      kind: "manual",
+    },
     vendorId: "anthropic",
   },
   {
@@ -31,7 +41,11 @@ export const GENERATED_VENDOR_CATALOG = [
       scheme: "bearer",
     },
     defaultApiBase: "https://api.openai.com/v1",
+    iconKey: "openai",
     label: "OpenAI",
+    modelSource: {
+      kind: "manual",
+    },
     vendorId: "openai",
   },
   {
@@ -41,7 +55,16 @@ export const GENERATED_VENDOR_CATALOG = [
       apiKeyHeader: "Authorization",
       scheme: "bearer",
     },
+    iconKey: "openai",
     label: "OpenAI-Compatible",
+    modelSource: {
+      kind: "manual",
+    },
+    openCodeProvider: {
+      apiBaseOption: "baseURL",
+      name: "OpenAI Compatible",
+      npmPackage: "@ai-sdk/openai-compatible",
+    },
     vendorId: "openai-compatible",
   },
   {
@@ -52,13 +75,121 @@ export const GENERATED_VENDOR_CATALOG = [
       scheme: "bearer",
     },
     defaultApiBase: "https://api.deepseek.com",
+    iconKey: "deepseek",
     label: "DeepSeek",
-    openCodeProvider: {
-      apiBaseOption: "baseURL",
-      kind: "openai-compatible",
-      npmPackage: "@ai-sdk/openai-compatible",
+    modelSource: {
+      kind: "models.dev",
+      providerId: "deepseek",
     },
     vendorId: "deepseek",
+  },
+  {
+    apiBaseEnvVar: "GEMINI_BASE_URL",
+    apiKeyEnvVar: "GEMINI_API_KEY",
+    authHeader: {
+      apiKeyHeader: "Authorization",
+      scheme: "bearer",
+    },
+    defaultApiBase: "https://generativelanguage.googleapis.com/v1beta/openai",
+    iconKey: "gemini",
+    label: "Gemini",
+    modelSource: {
+      kind: "models.dev",
+      providerId: "google",
+    },
+    openCodeProvider: {
+      apiBaseOption: "baseURL",
+      name: "Gemini",
+      npmPackage: "@ai-sdk/openai-compatible",
+    },
+    vendorId: "gemini",
+  },
+  {
+    apiBaseEnvVar: "QWEN_BASE_URL",
+    apiKeyEnvVar: "QWEN_API_KEY",
+    authHeader: {
+      apiKeyHeader: "Authorization",
+      scheme: "bearer",
+    },
+    defaultApiBase: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    iconKey: "qwen",
+    label: "Qwen",
+    modelSource: {
+      kind: "models.dev",
+      providerId: "alibaba",
+    },
+    openCodeProvider: {
+      apiBaseOption: "baseURL",
+      name: "Qwen",
+      npmPackage: "@ai-sdk/openai-compatible",
+    },
+    vendorId: "qwen",
+  },
+  {
+    apiBaseEnvVar: "KIMI_BASE_URL",
+    apiKeyEnvVar: "KIMI_API_KEY",
+    authHeader: {
+      apiKeyHeader: "Authorization",
+      scheme: "bearer",
+    },
+    defaultApiBase: "https://api.moonshot.ai/v1",
+    iconKey: "kimi",
+    label: "Kimi",
+    modelSource: {
+      kind: "models.dev",
+      providerId: "moonshotai",
+    },
+    openCodeProvider: {
+      apiBaseOption: "baseURL",
+      name: "Kimi",
+      npmPackage: "@ai-sdk/openai-compatible",
+    },
+    vendorId: "kimi",
+  },
+  {
+    apiBaseEnvVar: "ZHIPU_BASE_URL",
+    apiKeyEnvVar: "ZHIPU_API_KEY",
+    authHeader: {
+      apiKeyHeader: "Authorization",
+      scheme: "bearer",
+    },
+    defaultApiBase: "https://api.z.ai/api/paas/v4",
+    iconKey: "zhipu",
+    label: "Zhipu",
+    modelSource: {
+      kind: "models.dev",
+      providerId: "zai",
+    },
+    openCodeProvider: {
+      apiBaseOption: "baseURL",
+      name: "Zhipu",
+      npmPackage: "@ai-sdk/openai-compatible",
+    },
+    vendorId: "zhipu",
+  },
+  {
+    apiBaseEnvVar: "MINIMAX_BASE_URL",
+    apiKeyEnvVar: "MINIMAX_API_KEY",
+    authHeader: {
+      apiKeyHeader: "x-api-key",
+      extraHeaders: {
+        "anthropic-version": "2023-06-01",
+      },
+      scheme: "api-key",
+    },
+    defaultApiBase: "https://api.minimax.io/anthropic/v1",
+    iconKey: "minimax",
+    label: "MiniMax",
+    modelSource: {
+      kind: "models.dev",
+      providerId: "minimax",
+    },
+    openCodeProvider: {
+      apiBaseOption: "baseURL",
+      name: "MiniMax",
+      npmPackage: "@ai-sdk/anthropic",
+    },
+    vendorId: "minimax",
   },
   {
     apiKeyEnvVar: "OPENCODE_API_KEY",
@@ -67,7 +198,11 @@ export const GENERATED_VENDOR_CATALOG = [
       scheme: "bearer",
     },
     defaultApiBase: "https://opencode.ai/zen/v1",
+    iconKey: "opencode",
     label: "OpenCode Zen",
+    modelSource: {
+      kind: "manual",
+    },
     vendorId: "opencode",
   },
 ] as const;
@@ -156,6 +291,83 @@ export const GENERATED_PRESET_MODEL_CATALOG = [
     protocol: "openai-chat-completions",
     vendorId: "deepseek",
     vendorLabel: "DeepSeek",
+  },
+  {
+    displayName: "DeepSeek V4 Flash",
+    modelId: "deepseek-v4-flash",
+    protocol: "openai-chat-completions",
+    vendorId: "deepseek",
+    vendorLabel: "DeepSeek",
+  },
+  {
+    displayName: "Gemini 3.5 Flash",
+    modelId: "gemini-3.5-flash",
+    protocol: "openai-chat-completions",
+    vendorId: "gemini",
+    vendorLabel: "Gemini",
+  },
+  {
+    displayName: "Qwen3.7 Plus",
+    modelId: "qwen3.7-plus",
+    protocol: "openai-chat-completions",
+    vendorId: "qwen",
+    vendorLabel: "Qwen",
+  },
+  {
+    displayName: "Qwen3.6 Plus",
+    modelId: "qwen3.6-plus",
+    protocol: "openai-chat-completions",
+    vendorId: "qwen",
+    vendorLabel: "Qwen",
+  },
+  {
+    displayName: "Kimi K2.6",
+    modelId: "kimi-k2.6",
+    protocol: "openai-chat-completions",
+    vendorId: "kimi",
+    vendorLabel: "Kimi",
+  },
+  {
+    displayName: "Kimi K2.7 Code",
+    modelId: "kimi-k2.7-code",
+    protocol: "openai-chat-completions",
+    vendorId: "kimi",
+    vendorLabel: "Kimi",
+  },
+  {
+    displayName: "GLM-4.7",
+    modelId: "glm-4.7",
+    protocol: "openai-chat-completions",
+    vendorId: "zhipu",
+    vendorLabel: "Zhipu",
+  },
+  {
+    displayName: "GLM-4.6",
+    modelId: "glm-4.6",
+    protocol: "openai-chat-completions",
+    vendorId: "zhipu",
+    vendorLabel: "Zhipu",
+  },
+  {
+    displayName: "MiniMax M3",
+    modelId: "MiniMax-M3",
+    protocol: "anthropic-messages",
+    vendorId: "minimax",
+    vendorLabel: "MiniMax",
+  },
+  {
+    displayName: "MiniMax M2.7",
+    modelId: "MiniMax-M2.7",
+    protocol: "anthropic-messages",
+    vendorId: "minimax",
+    vendorLabel: "MiniMax",
+  },
+  {
+    displayName: "DeepSeek V4 Pro",
+    modelId: "deepseek-v4-pro",
+    protocol: "openai-chat-completions",
+    vendorId: "opencode",
+    vendorLabel: "OpenCode Zen",
   },
   {
     displayName: "Qwen3.6 Plus",
@@ -376,7 +588,7 @@ export const GENERATED_RUNTIME_CATALOG = [
     supportedModelIds: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3", "gpt-5.2"],
   },
   {
-    acceptsCustomProvider: false,
+    acceptsCustomProvider: true,
     defaultIdentity: {
       modelId: "gpt-5.4",
       providerId: "openai",
@@ -388,7 +600,17 @@ export const GENERATED_RUNTIME_CATALOG = [
     label: "OpenCode",
     runtimeId: "acp-fallback",
     transport: "acp-fallback",
-    vendorIds: ["openai", "anthropic", "deepseek", "opencode"],
+    vendorIds: [
+      "openai",
+      "anthropic",
+      "deepseek",
+      "gemini",
+      "qwen",
+      "kimi",
+      "zhipu",
+      "minimax",
+      "opencode",
+    ],
     visibility: "public",
     capabilities: [
       {
@@ -465,10 +687,18 @@ export const GENERATED_RUNTIME_CATALOG = [
       "gpt-5.3",
       "gpt-5.2",
       "deepseek-v4-pro",
+      "deepseek-v4-flash",
+      "gemini-3.5-flash",
+      "qwen3.7-plus",
       "qwen3.6-plus",
+      "kimi-k2.6",
+      "kimi-k2.7-code",
+      "glm-4.7",
+      "glm-4.6",
+      "MiniMax-M3",
+      "MiniMax-M2.7",
       "glm-5.2",
       "minimax-m2.7",
-      "gemini-3.5-flash",
     ],
   },
 ] as const;

--- a/pkgs/runtime-catalog/src/runtime-catalog.ts
+++ b/pkgs/runtime-catalog/src/runtime-catalog.ts
@@ -55,6 +55,12 @@ export type RuntimeCatalogVendorAuthHeader =
       readonly scheme: "api-key";
     };
 
+export interface RuntimeCatalogVendorOpenCodeProvider {
+  readonly apiBaseOption: "baseURL";
+  readonly kind: "openai-compatible";
+  readonly npmPackage: string;
+}
+
 /**
  * Describes the vendor whose API key is required to power a runtime,
  * and the env var names used to inject credentials into the agent process.
@@ -72,6 +78,7 @@ export interface RuntimeCatalogVendor {
   readonly defaultApiBase?: string;
   readonly apiKeyEnvVar: string;
   readonly label: string;
+  readonly openCodeProvider?: RuntimeCatalogVendorOpenCodeProvider;
   readonly vendorId: string;
 }
 
@@ -171,6 +178,7 @@ function runtimeCatalogVendor(
 ): RuntimeCatalogVendor {
   const apiBaseEnvVar = "apiBaseEnvVar" in input ? input.apiBaseEnvVar : undefined;
   const defaultApiBase = "defaultApiBase" in input ? input.defaultApiBase : undefined;
+  const openCodeProvider = "openCodeProvider" in input ? input.openCodeProvider : undefined;
 
   return {
     ...(apiBaseEnvVar !== undefined ? { apiBaseEnvVar } : {}),
@@ -178,6 +186,15 @@ function runtimeCatalogVendor(
     apiKeyEnvVar: input.apiKeyEnvVar,
     authHeader: runtimeCatalogVendorAuthHeader(input.authHeader),
     label: input.label,
+    ...(openCodeProvider !== undefined
+      ? {
+          openCodeProvider: {
+            apiBaseOption: openCodeProvider.apiBaseOption,
+            kind: openCodeProvider.kind,
+            npmPackage: openCodeProvider.npmPackage,
+          },
+        }
+      : {}),
     vendorId: admitProviderId(input.vendorId),
   };
 }
@@ -298,12 +315,14 @@ export const PRESET_MODEL_CATALOG: readonly PresetModelEntry[] =
   GENERATED_PRESET_MODEL_CATALOG.map(presetModel);
 
 export const ANTHROPIC_DEFAULT_MODEL_ID = admitModelId(GENERATED_MODEL_DEFAULT_IDS.anthropic);
+export const DEEPSEEK_DEFAULT_MODEL_ID = admitModelId(GENERATED_MODEL_DEFAULT_IDS.deepseek);
 export const OPENAI_DEFAULT_MODEL_ID = admitModelId(GENERATED_MODEL_DEFAULT_IDS.openai);
 
 export const ALL_VENDORS: readonly RuntimeCatalogVendor[] =
   GENERATED_VENDOR_CATALOG.map(runtimeCatalogVendor);
 
 export const VENDOR_ANTHROPIC = requireVendor("anthropic");
+export const VENDOR_DEEPSEEK = requireVendor("deepseek");
 export const VENDOR_OPENAI = requireVendor("openai");
 export const VENDOR_OPENAI_COMPATIBLE = requireVendor("openai-compatible");
 export const VENDOR_OPENCODE = requireVendor("opencode");

--- a/pkgs/runtime-catalog/src/runtime-catalog.ts
+++ b/pkgs/runtime-catalog/src/runtime-catalog.ts
@@ -55,9 +55,18 @@ export type RuntimeCatalogVendorAuthHeader =
       readonly scheme: "api-key";
     };
 
-export interface RuntimeCatalogVendorOpenCodeProvider {
-  readonly apiBaseOption: "baseURL";
-  readonly kind: "openai-compatible";
+export type RuntimeCatalogVendorModelSource =
+  | {
+      readonly kind: "manual";
+    }
+  | {
+      readonly kind: "models.dev";
+      readonly providerId: string;
+    };
+
+export interface RuntimeCatalogOpenCodeProvider {
+  readonly apiBaseOption?: "baseURL";
+  readonly name: string;
   readonly npmPackage: string;
 }
 
@@ -77,8 +86,10 @@ export interface RuntimeCatalogVendor {
   readonly authHeader: RuntimeCatalogVendorAuthHeader;
   readonly defaultApiBase?: string;
   readonly apiKeyEnvVar: string;
+  readonly iconKey: string;
   readonly label: string;
-  readonly openCodeProvider?: RuntimeCatalogVendorOpenCodeProvider;
+  readonly modelSource?: RuntimeCatalogVendorModelSource;
+  readonly openCodeProvider?: RuntimeCatalogOpenCodeProvider;
   readonly vendorId: string;
 }
 
@@ -178,19 +189,24 @@ function runtimeCatalogVendor(
 ): RuntimeCatalogVendor {
   const apiBaseEnvVar = "apiBaseEnvVar" in input ? input.apiBaseEnvVar : undefined;
   const defaultApiBase = "defaultApiBase" in input ? input.defaultApiBase : undefined;
+  const modelSource = "modelSource" in input ? input.modelSource : undefined;
   const openCodeProvider = "openCodeProvider" in input ? input.openCodeProvider : undefined;
 
   return {
     ...(apiBaseEnvVar !== undefined ? { apiBaseEnvVar } : {}),
     ...(defaultApiBase !== undefined ? { defaultApiBase } : {}),
+    ...(modelSource !== undefined ? { modelSource } : {}),
     apiKeyEnvVar: input.apiKeyEnvVar,
     authHeader: runtimeCatalogVendorAuthHeader(input.authHeader),
+    iconKey: input.iconKey,
     label: input.label,
     ...(openCodeProvider !== undefined
       ? {
           openCodeProvider: {
-            apiBaseOption: openCodeProvider.apiBaseOption,
-            kind: openCodeProvider.kind,
+            ...("apiBaseOption" in openCodeProvider
+              ? { apiBaseOption: openCodeProvider.apiBaseOption }
+              : {}),
+            name: openCodeProvider.name,
             npmPackage: openCodeProvider.npmPackage,
           },
         }
@@ -323,9 +339,14 @@ export const ALL_VENDORS: readonly RuntimeCatalogVendor[] =
 
 export const VENDOR_ANTHROPIC = requireVendor("anthropic");
 export const VENDOR_DEEPSEEK = requireVendor("deepseek");
+export const VENDOR_GEMINI = requireVendor("gemini");
+export const VENDOR_KIMI = requireVendor("kimi");
+export const VENDOR_MINIMAX = requireVendor("minimax");
 export const VENDOR_OPENAI = requireVendor("openai");
 export const VENDOR_OPENAI_COMPATIBLE = requireVendor("openai-compatible");
 export const VENDOR_OPENCODE = requireVendor("opencode");
+export const VENDOR_QWEN = requireVendor("qwen");
+export const VENDOR_ZHIPU = requireVendor("zhipu");
 
 export const SYSTEM_AGENT_RUNTIME_ID = "system-agent";
 
@@ -339,6 +360,11 @@ export function listPresetModelsForProvider(provider: RuntimeModelProviderRef): 
 
 export function listPresetModelsForVendor(vendorId: string): PresetModelEntry[] {
   return PRESET_MODEL_CATALOG.filter((entry) => entry.vendorId === vendorId);
+}
+
+export function getDefaultModelIdForVendor(vendorId: string): ModelId | null {
+  const modelId = (GENERATED_MODEL_DEFAULT_IDS as Readonly<Record<string, string>>)[vendorId];
+  return modelId === undefined ? null : admitModelId(modelId);
 }
 
 export function getPresetModelForIdentity(identity: RuntimeModelIdentity): PresetModelEntry | null {

--- a/pkgs/runtime-catalog/tests/runtime-model-identity-admission.test.ts
+++ b/pkgs/runtime-catalog/tests/runtime-model-identity-admission.test.ts
@@ -8,7 +8,7 @@ import {
   RUNTIME_CATALOG,
   SYSTEM_AGENT_RUNTIME_ID,
   VENDOR_ANTHROPIC,
-  VENDOR_OPENCODE,
+  VENDOR_DEEPSEEK,
   VENDOR_OPENAI,
   VENDOR_OPENAI_COMPATIBLE,
   admitRuntimeModelIdentity,
@@ -143,12 +143,12 @@ describe("runtime catalog identity admission", () => {
         runtimeId: "openai-runtime",
       }),
     );
-    const opencodePreset = admitRuntimeModelIdentity(
+    const deepseekPreset = admitRuntimeModelIdentity(
       createRuntimeModelIdentity({
         modelId: "deepseek-v4-pro",
         provider: {
           kind: "preset",
-          providerId: VENDOR_OPENCODE.vendorId,
+          providerId: VENDOR_DEEPSEEK.vendorId,
         },
         runtimeId: "acp-fallback",
       }),
@@ -171,14 +171,14 @@ describe("runtime catalog identity admission", () => {
         vendorId: VENDOR_OPENAI_COMPATIBLE.vendorId,
       },
     });
-    expect(opencodePreset).toMatchObject({
+    expect(deepseekPreset).toMatchObject({
       ok: true,
       model: {
         modelId: "deepseek-v4-pro",
-        vendorId: VENDOR_OPENCODE.vendorId,
+        vendorId: VENDOR_DEEPSEEK.vendorId,
       },
       vendor: {
-        vendorId: VENDOR_OPENCODE.vendorId,
+        vendorId: VENDOR_DEEPSEEK.vendorId,
       },
     });
   });


### PR DESCRIPTION
## Summary
- centralize runtime/provider/model/display metadata in the runtime catalog source and generated exports
- add first-class Provider cards/model metadata for DeepSeek, Gemini, Qwen, Kimi, Zhipu, MiniMax, and OpenCode Zen
- make OpenCode availability/hydration support first-class providers, OpenCode Zen, and custom OpenAI-compatible credentials
- update Providers UI to remove the fixed openai-compatible card and use the top-level Add custom model flow
- document the runtime/provider extension workflow in docs/prd/runtime-catalog.md

## Validation
- bash ./init.sh development
- vp run --filter @mosoo/runtime-catalog test
- bun test apps/api/tests/runtime-vendor-env-vars.test.ts apps/api/tests/available-models.test.ts apps/api/tests/vendor-credential-probe.test.ts apps/api/tests/vendor-credential-runtime-selection.test.ts apps/api/tests/cost-pricing.test.ts apps/api/tests/runtime-openai-compatible-models.test.ts
- bun test apps/web/tests/runtime-default.test.ts apps/web/tests/model-picker-availability.test.ts apps/web/tests/provider-runtime-availability.test.ts
- just tc
- just test
- bun test apps/driver/tests/opencode-acp-live.test.ts

## Merge note
Merge langgenius/mosoo-agent-driver#24 first because this PR points apps/driver at its head commit.