### PR TITLE
fix(runtime-catalog): remove planned runtime promises

### DIFF
--- a/apps/web/src/routes/login/landing/runtime-showcase.tsx
+++ b/apps/web/src/routes/login/landing/runtime-showcase.tsx
@@ -1,5 +1,5 @@
 import { listRuntimeShowcaseDisplayEntries } from "@mosoo/runtime-catalog";
-import { Check, Clock } from "lucide-react";
+import { Check } from "lucide-react";
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { useState } from "react";
 import type { ReactElement } from "react";
@@ -33,8 +33,6 @@ function CheckDot(): ReactElement {
 }
 
 function RuntimeCard({ runtime }: { runtime: Runtime }): ReactElement {
-  const available = runtime.status === "available";
-
   return (
     <div className="border-border-soft bg-bg-elevated rounded-[18px] border p-5 shadow-sm">
       <div className="flex items-center gap-3">
@@ -45,17 +43,10 @@ function RuntimeCard({ runtime }: { runtime: Runtime }): ReactElement {
           <p className="text-fg-1 text-[15px] font-semibold tracking-[-0.01em]">{runtime.label}</p>
           <p className="text-fg-3 text-[12.5px]">{runtime.providerLabel}</p>
         </div>
-        {available ? (
-          <span className="inline-flex items-center gap-1.5 rounded-[6px] bg-green-50 px-2 py-1 text-[11px] font-semibold text-green-800">
-            <span className="size-1.5 rounded-full bg-green-600" />
-            Available
-          </span>
-        ) : (
-          <span className="bg-bg-sunken text-fg-3 inline-flex items-center gap-1.5 rounded-[6px] px-2 py-1 text-[11px] font-semibold">
-            <Clock className="size-3" />
-            Coming soon
-          </span>
-        )}
+        <span className="inline-flex items-center gap-1.5 rounded-[6px] bg-green-50 px-2 py-1 text-[11px] font-semibold text-green-800">
+          <span className="size-1.5 rounded-full bg-green-600" />
+          Available
+        </span>
       </div>
 
       <div className="border-border-soft text-fg-2 mt-4 flex items-center gap-2 border-t pt-4 text-[13px]">

--- a/apps/web/src/routes/providers/runtime-availability-model.ts
+++ b/apps/web/src/routes/providers/runtime-availability-model.ts
@@ -1,0 +1,32 @@
+import { PUBLIC_RUNTIME_CATALOG } from "@mosoo/runtime-catalog";
+
+import type { VendorCredential } from "@/domains/vendor-credential/api/vendor-credential-client";
+
+export interface RuntimeAvailabilityRow {
+  readonly label: string;
+  readonly provider: string;
+  readonly runtimeId: string;
+  readonly status: string;
+  readonly tone: "muted" | "ready";
+}
+
+export function listRuntimeAvailabilityRows(
+  credentials: readonly VendorCredential[],
+): RuntimeAvailabilityRow[] {
+  const configuredVendorIds = new Set(credentials.map((credential) => credential.vendorId));
+
+  return PUBLIC_RUNTIME_CATALOG.map((runtime) => {
+    const [vendor] = runtime.vendors;
+    const ready = vendor !== undefined && configuredVendorIds.has(vendor.vendorId);
+    const provider = vendor?.label ?? runtime.defaultProvider;
+    const status = runtime.disabledReason ?? (ready ? "Ready" : `Add a ${provider} key`);
+
+    return {
+      label: runtime.label,
+      provider,
+      runtimeId: runtime.runtimeId,
+      status,
+      tone: ready && runtime.disabledReason === undefined ? "ready" : "muted",
+    };
+  });
+}

--- a/apps/web/src/routes/providers/runtime-availability-section.tsx
+++ b/apps/web/src/routes/providers/runtime-availability-section.tsx
@@ -1,11 +1,10 @@
-import { PUBLIC_RUNTIME_CATALOG, listPlannedRuntimeDisplayEntries } from "@mosoo/runtime-catalog";
 import type { ReactElement } from "react";
 
 import type { VendorCredential } from "@/domains/vendor-credential/api/vendor-credential-client";
 import { cn } from "@/shared/lib/class-names";
 import { RuntimeIcon, hasRuntimeIcon } from "@/shared/ui/brand-icons";
 
-const COMING_SOON_RUNTIMES = listPlannedRuntimeDisplayEntries("provider-settings");
+import { listRuntimeAvailabilityRows } from "./runtime-availability-model";
 
 function RuntimeRow({
   label,
@@ -56,7 +55,7 @@ export function RuntimeAvailabilitySection({
 }: {
   credentials: readonly VendorCredential[];
 }): ReactElement {
-  const configuredVendorIds = new Set(credentials.map((credential) => credential.vendorId));
+  const rows = listRuntimeAvailabilityRows(credentials);
 
   return (
     <section className="border-border bg-card rounded-lg border p-4">
@@ -68,33 +67,14 @@ export function RuntimeAvailabilitySection({
         </p>
       </div>
       <div className="space-y-2">
-        {PUBLIC_RUNTIME_CATALOG.map((runtime) => {
-          const [vendor] = runtime.vendors;
-          const ready = vendor !== undefined && configuredVendorIds.has(vendor.vendorId);
-          const provider = vendor?.label ?? runtime.defaultProvider;
-          const status =
-            runtime.disabledReason ??
-            (ready ? "Ready" : `Add a ${vendor?.label ?? "provider"} key`);
-
-          return (
-            <RuntimeRow
-              key={runtime.runtimeId}
-              label={runtime.label}
-              provider={provider}
-              runtimeId={runtime.runtimeId}
-              status={status}
-              tone={ready && runtime.disabledReason === undefined ? "ready" : "muted"}
-            />
-          );
-        })}
-        {COMING_SOON_RUNTIMES.map((runtime) => (
+        {rows.map((runtime) => (
           <RuntimeRow
             key={runtime.runtimeId}
             label={runtime.label}
-            provider={runtime.providerLabel}
+            provider={runtime.provider}
             runtimeId={runtime.runtimeId}
-            status="Coming soon"
-            tone="muted"
+            status={runtime.status}
+            tone={runtime.tone}
           />
         ))}
       </div>

--- a/apps/web/src/shared/ui/brand-icons/runtime-icon-data.ts
+++ b/apps/web/src/shared/ui/brand-icons/runtime-icon-data.ts
@@ -1,22 +1,12 @@
 import claudeCodeSvgUrl from "@lobehub/icons-static-svg/icons/claudecode-color.svg";
-import cursorAgentSvgUrl from "@lobehub/icons-static-svg/icons/cursor.svg";
-import geminiSvgUrl from "@lobehub/icons-static-svg/icons/gemini-color.svg";
-import hermesSvgUrl from "@lobehub/icons-static-svg/icons/hermesagent.svg";
-import piSvgUrl from "@lobehub/icons-static-svg/icons/inflection.svg";
 import openaiSvgUrl from "@lobehub/icons-static-svg/icons/openai.svg";
-import openclawSvgUrl from "@lobehub/icons-static-svg/icons/openclaw-color.svg";
 import opencodeSvgUrl from "@lobehub/icons-static-svg/icons/opencode.svg";
 import { getRuntimeIconKey } from "@mosoo/runtime-catalog";
 
 const RUNTIME_ICON_URL_BY_KEY: Record<string, string> = {
   "claude-code": claudeCodeSvgUrl,
-  cursor: cursorAgentSvgUrl,
-  gemini: geminiSvgUrl,
-  hermes: hermesSvgUrl,
   openai: openaiSvgUrl,
   opencode: opencodeSvgUrl,
-  openclaw: openclawSvgUrl,
-  pi: piSvgUrl,
 };
 
 export function getRuntimeIconUrl(runtimeId: string): string | null {

--- a/apps/web/tests/provider-runtime-availability.test.ts
+++ b/apps/web/tests/provider-runtime-availability.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+import { PUBLIC_RUNTIME_CATALOG, listPlannedRuntimeDisplayEntries } from "@mosoo/runtime-catalog";
+
+import type { VendorCredential } from "../src/domains/vendor-credential/api/vendor-credential-client";
+import { listRuntimeAvailabilityRows } from "../src/routes/providers/runtime-availability-model";
+
+function credential(vendorId: string): VendorCredential {
+  return {
+    apiBase: null,
+    id: "01J000000000000000000000AA",
+    isDefault: true,
+    maskedApiKey: "sk-***",
+    models: null,
+    name: "Default",
+    appId: "01J00000000000000000000009",
+    vendorId,
+  };
+}
+
+describe("provider runtime availability", () => {
+  test("does not render planned runtime display entries", () => {
+    const availabilityRows = listRuntimeAvailabilityRows([
+      credential("anthropic"),
+      credential("openai"),
+    ]);
+    const availabilityRuntimeIds = availabilityRows.map((runtime) => runtime.runtimeId);
+    const publicRuntimeIds = PUBLIC_RUNTIME_CATALOG.map((runtime) => runtime.runtimeId);
+
+    expect(listPlannedRuntimeDisplayEntries("provider-settings")).toEqual([]);
+    expect(availabilityRuntimeIds).toEqual(publicRuntimeIds);
+  });
+});

--- a/pkgs/runtime-catalog/catalog/runtime-catalog.jsonc
+++ b/pkgs/runtime-catalog/catalog/runtime-catalog.jsonc
@@ -253,41 +253,5 @@
       },
     },
   ],
-  "plannedRuntimes": [
-    {
-      "runtimeId": "openclaw",
-      "label": "OpenClaw",
-      "providerLabel": "OpenClaw",
-      "iconKey": "openclaw",
-      "surfaces": ["landing", "provider-settings"],
-    },
-    {
-      "runtimeId": "hermes",
-      "label": "Hermes",
-      "providerLabel": "Hermes",
-      "iconKey": "hermes",
-      "surfaces": ["landing", "provider-settings"],
-    },
-    {
-      "runtimeId": "gemini",
-      "label": "Gemini",
-      "providerLabel": "Google",
-      "iconKey": "gemini",
-      "surfaces": ["landing"],
-    },
-    {
-      "runtimeId": "pi",
-      "label": "Pi",
-      "providerLabel": "Inflection AI",
-      "iconKey": "pi",
-      "surfaces": ["landing", "provider-settings"],
-    },
-    {
-      "runtimeId": "cursor-agent",
-      "label": "Cursor Agent",
-      "providerLabel": "Cursor",
-      "iconKey": "cursor",
-      "surfaces": ["landing"],
-    },
-  ],
+  "plannedRuntimes": [],
 }

--- a/pkgs/runtime-catalog/src/catalog.generated.ts
+++ b/pkgs/runtime-catalog/src/catalog.generated.ts
@@ -456,40 +456,4 @@ export const GENERATED_RUNTIME_CATALOG = [
   },
 ] as const;
 
-export const GENERATED_PLANNED_RUNTIME_DISPLAY_CATALOG = [
-  {
-    iconKey: "openclaw",
-    label: "OpenClaw",
-    providerLabel: "OpenClaw",
-    runtimeId: "openclaw",
-    surfaces: ["landing", "provider-settings"],
-  },
-  {
-    iconKey: "hermes",
-    label: "Hermes",
-    providerLabel: "Hermes",
-    runtimeId: "hermes",
-    surfaces: ["landing", "provider-settings"],
-  },
-  {
-    iconKey: "gemini",
-    label: "Gemini",
-    providerLabel: "Google",
-    runtimeId: "gemini",
-    surfaces: ["landing"],
-  },
-  {
-    iconKey: "pi",
-    label: "Pi",
-    providerLabel: "Inflection AI",
-    runtimeId: "pi",
-    surfaces: ["landing", "provider-settings"],
-  },
-  {
-    iconKey: "cursor",
-    label: "Cursor Agent",
-    providerLabel: "Cursor",
-    runtimeId: "cursor-agent",
-    surfaces: ["landing"],
-  },
-] as const;
+export const GENERATED_PLANNED_RUNTIME_DISPLAY_CATALOG = [] as const;

--- a/pkgs/runtime-catalog/src/runtime-catalog.ts
+++ b/pkgs/runtime-catalog/src/runtime-catalog.ts
@@ -124,6 +124,14 @@ export interface PlannedRuntimeDisplayEntry {
   readonly surfaces: readonly RuntimeDisplaySurface[];
 }
 
+interface GeneratedPlannedRuntimeDisplayEntry {
+  readonly iconKey: string;
+  readonly label: string;
+  readonly providerLabel: string;
+  readonly runtimeId: string;
+  readonly surfaces: readonly string[];
+}
+
 type RuntimeCatalogEntryInput = Omit<
   RuntimeCatalogEntry,
   "defaultModel" | "defaultProvider" | "runtimeId"
@@ -244,7 +252,7 @@ function createGeneratedRuntimeCatalogEntry(
 }
 
 function plannedRuntimeDisplayEntry(
-  input: (typeof GENERATED_PLANNED_RUNTIME_DISPLAY_CATALOG)[number],
+  input: GeneratedPlannedRuntimeDisplayEntry,
 ): PlannedRuntimeDisplayEntry {
   return {
     iconKey: input.iconKey,
@@ -373,8 +381,9 @@ export const PUBLIC_VENDORS: readonly RuntimeCatalogVendor[] = ALL_VENDORS.filte
     ),
 );
 
-export const PLANNED_RUNTIME_DISPLAY_CATALOG: readonly PlannedRuntimeDisplayEntry[] =
-  GENERATED_PLANNED_RUNTIME_DISPLAY_CATALOG.map(plannedRuntimeDisplayEntry);
+export const PLANNED_RUNTIME_DISPLAY_CATALOG: readonly PlannedRuntimeDisplayEntry[] = (
+  GENERATED_PLANNED_RUNTIME_DISPLAY_CATALOG as readonly GeneratedPlannedRuntimeDisplayEntry[]
+).map(plannedRuntimeDisplayEntry);
 
 export const PUBLIC_RUNTIME_DISPLAY_CATALOG: readonly RuntimeDisplayCatalogEntry[] =
   PUBLIC_RUNTIME_CATALOG.map(toPublicRuntimeDisplayEntry);

--- a/pkgs/runtime-catalog/tests/runtime-model-identity-admission.test.ts
+++ b/pkgs/runtime-catalog/tests/runtime-model-identity-admission.test.ts
@@ -226,9 +226,9 @@ describe("runtime catalog identity admission", () => {
         runtimeId: "opencode",
       }),
     );
-    expect(
-      listPlannedRuntimeDisplayEntries("provider-settings").map((entry) => entry.runtimeId),
-    ).toEqual(["openclaw", "hermes", "pi"]);
+    expect(listPlannedRuntimeDisplayEntries("provider-settings")).toEqual([]);
+    expect(listPlannedRuntimeDisplayEntries("landing")).toEqual([]);
+    expect(listRuntimeShowcaseDisplayEntries()).toEqual(PUBLIC_RUNTIME_DISPLAY_CATALOG);
     expect(getRuntimeIconKey("acp-fallback")).toBe("opencode");
     expect(getRuntimeDisplayColor("openai-runtime")).toBe("#7A9DFF");
   });


### PR DESCRIPTION
## Summary
- remove planned runtime promise entries from the runtime catalog and regenerated artifact
- remove landing runtime showcase Coming soon UI and planned-only runtime icon mappings
- keep Providers Runtime availability limited to public launchable runtimes

## Verification
- bash ./init.sh development
- vp run --filter @mosoo/runtime-catalog catalog:generate
- vp run --filter @mosoo/runtime-catalog test
- vp run --filter @mosoo/runtime-catalog tc
- vp exec bun test apps/web/tests/provider-runtime-availability.test.ts
- vp run --filter @mosoo/web tc
- vp fmt --check --ignore-path .gitignore apps/web/src/routes/providers/runtime-availability-section.tsx apps/web/src/routes/providers/runtime-availability-model.ts apps/web/tests/provider-runtime-availability.test.ts apps/web/src/routes/login/landing/runtime-showcase.tsx apps/web/src/shared/ui/brand-icons/runtime-icon-data.ts pkgs/runtime-catalog/catalog/runtime-catalog.jsonc pkgs/runtime-catalog/src/catalog.generated.ts pkgs/runtime-catalog/src/runtime-catalog.ts pkgs/runtime-catalog/tests/runtime-model-identity-admission.test.ts
- git diff --check
- rg -n "openclaw|hermes|runtimeId\": \"pi\"|iconKey\": \"pi\"|Coming soon" pkgs/runtime-catalog apps/web/src/routes/login/landing apps/web/src/routes/providers apps/web/src/shared/ui/brand-icons apps/web/tests -S returned no matches
- pre-push hooks via PATH="$PWD/node_modules/.bin:$PATH" git push --force-with-lease origin fix/providers-hide-planned-runtimes