### PR TITLE
chore(deploy): route console through try.mosoo.ai

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -342,6 +342,6 @@ just deploy-web
 just deploy
 ```
 
-API production config lives in `apps/api/wrangler.toml`; web production config lives in `apps/web/wrangler.toml`. Cloudflare routes send `mosoo.ai/api/*` to the API Worker and `mosoo.ai/*` to the web Worker.
+API production config lives in `apps/api/wrangler.toml`; web production config lives in `apps/web/wrangler.toml`. Cloudflare routes send `try.mosoo.ai/api/*` to the API Worker, `try.mosoo.ai/*` to the console Web Worker, and `mosoo.ai/*` to the marketing / landing surface.
 
 Do not deploy production directly from an unreviewed local branch.

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -115,7 +115,7 @@ head_sampling_rate = 0.1
 
 [env.prod.vars]
 APP_NAME = "mosoo"
-WEB_ORIGIN = "https://mosoo.ai"
+WEB_ORIGIN = "https://try.mosoo.ai"
 AUTH_EMAIL_FROM = "Mosoo AUTH <auth@mosoo.ai>"
 FILE_BUCKET_NAME = "mosoo-file"
 SANDBOX_STATE_BUCKET_NAME = "mosoo-sandbox-state"
@@ -135,11 +135,13 @@ required = [
   "CLOUDFLARE_ACCOUNT_ID",
   "CLOUDFLARE_API_TOKEN",
   "CLOUDFLARE_ZONE_ID",
+  "GOOGLE_OAUTH_CLIENT_ID",
+  "GOOGLE_OAUTH_CLIENT_SECRET",
 ]
 
 [[env.prod.routes]]
 zone_name = "mosoo.ai"
-pattern = "mosoo.ai/api/*"
+pattern = "try.mosoo.ai/api/*"
 
 [[env.prod.durable_objects.bindings]]
 name = "DriverConnection"

--- a/apps/web/src/routes/agent/components/channel-webhook-origin.ts
+++ b/apps/web/src/routes/agent/components/channel-webhook-origin.ts
@@ -1,4 +1,4 @@
-const MOSOO_DEFAULT_WEB_ORIGIN = "https://mosoo.ai";
+import { MOSOO_CONSOLE_ORIGIN } from "@mosoo/contracts/origin";
 
 function readViteOriginOverride(): string | null {
   const value = import.meta.env.VITE_CHANNEL_WEBHOOK_ORIGIN;
@@ -28,7 +28,7 @@ export function resolveChannelWebhookOrigin(): string {
   }
 
   if (typeof globalThis.location === "undefined") {
-    return MOSOO_DEFAULT_WEB_ORIGIN;
+    return MOSOO_CONSOLE_ORIGIN;
   }
 
   return globalThis.location.origin;

--- a/apps/web/src/routes/agent/lifecycle/distribution-info.ts
+++ b/apps/web/src/routes/agent/lifecycle/distribution-info.ts
@@ -1,3 +1,4 @@
+import { MOSOO_CONSOLE_ORIGIN } from "@mosoo/contracts/origin";
 import { PUBLIC_API_PREFIX, PUBLIC_API_VERSION_PREFIX } from "@mosoo/contracts/public-api-core";
 
 import { MOSOO_API_REFERENCE_URL } from "@/shared/config/external-links";
@@ -19,7 +20,6 @@ export interface AgentDistribution {
 }
 
 const ACCESS_TOKEN_SETTINGS_PATH = "/settings/access-tokens";
-const MOSOO_PUBLIC_WEB_ORIGIN = "https://mosoo.ai";
 const AGENT_API_ENDPOINT_BASE_PATH = `${PUBLIC_API_PREFIX}${PUBLIC_API_VERSION_PREFIX}`;
 const AGENT_API_ENDPOINT_OPENAPI_PATH = `${AGENT_API_ENDPOINT_BASE_PATH}/openapi.json`;
 
@@ -42,7 +42,7 @@ function nameSlug(name: string): string {
 }
 
 function currentOrigin(): string {
-  return globalThis.window !== undefined ? globalThis.location.origin : MOSOO_PUBLIC_WEB_ORIGIN;
+  return globalThis.window !== undefined ? globalThis.location.origin : MOSOO_CONSOLE_ORIGIN;
 }
 
 /**

--- a/apps/web/src/routes/login/use-login.ts
+++ b/apps/web/src/routes/login/use-login.ts
@@ -1,3 +1,4 @@
+import { MOSOO_CONSOLE_ORIGIN, MOSOO_MARKETING_ORIGIN } from "@mosoo/contracts/origin";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -80,6 +81,20 @@ function clearPersistedLoginState(): void {
   } catch {
     // Session storage can be unavailable in restricted browser contexts.
   }
+}
+
+function isMarketingOrigin(): boolean {
+  return globalThis.location.origin === MOSOO_MARKETING_ORIGIN;
+}
+
+function toConsoleLoginUrl(redirectPath: string): string {
+  const url = new URL("/login", MOSOO_CONSOLE_ORIGIN);
+
+  if (redirectPath !== "/") {
+    url.searchParams.set("redirect", redirectPath);
+  }
+
+  return url.toString();
 }
 
 export function useLoginFlow(): LoginFlow {
@@ -197,6 +212,11 @@ export function useLoginFlow(): LoginFlow {
   }
 
   function openAuth(): void {
+    if (isMarketingOrigin()) {
+      globalThis.location.assign(toConsoleLoginUrl(redirectPath));
+      return;
+    }
+
     setStep("auth");
     setError(null);
     setEmail("");

--- a/apps/web/src/shared/config/external-links.ts
+++ b/apps/web/src/shared/config/external-links.ts
@@ -1,3 +1,5 @@
+import { MOSOO_MARKETING_ORIGIN } from "@mosoo/contracts/origin";
+
 export const MOSOO_GITHUB_URL = "https://github.com/langgenius/mosoo/";
 
 // TODO: replace with the verified product X (Twitter) handle once confirmed.
@@ -12,7 +14,4 @@ export const MOSOO_RELEASES_URL = `${MOSOO_GITHUB_URL}releases`;
 export const MOSOO_LICENSE_URL = `${MOSOO_GITHUB_URL}blob/main/LICENSE`;
 export const MOSOO_SECURITY_URL = `${MOSOO_GITHUB_URL}security`;
 
-// Blog lives at /blog on the same custom domain but is served by a separate
-// Cloudflare Worker (apps/blog). Use a plain <a href> so the browser leaves
-// the SPA and lets the blog worker take over.
-export const MOSOO_BLOG_URL = "/blog";
+export const MOSOO_BLOG_URL = `${MOSOO_MARKETING_ORIGIN}/blog`;

--- a/apps/web/tests/slack-channel-setup.test.ts
+++ b/apps/web/tests/slack-channel-setup.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { buildAgentChannelWebhookUrl } from "@mosoo/contracts/channel";
+import { MOSOO_CONSOLE_ORIGIN } from "@mosoo/contracts/origin";
 import { parse } from "yaml";
 
 import { buildSlackManifest } from "../src/routes/agent/components/settings-dialog-slack-manifest";
@@ -13,7 +14,7 @@ describe("Slack channel setup", () => {
     expect(parsed.display_information.name).toBe("Launch Agent");
     expect(parsed.settings.event_subscriptions.request_url).toBe(
       buildAgentChannelWebhookUrl({
-        origin: "https://mosoo.ai",
+        origin: MOSOO_CONSOLE_ORIGIN,
         provider: "slack",
       }),
     );

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -17,6 +17,12 @@ not_found_handling = "none"
 name = "mosoo-web-prod"
 workers_dev = false
 
+# Marketing landing and blog stay on the apex domain. Authenticated console
+# traffic uses try.mosoo.ai so OAuth, cookies, and API calls stay same-origin.
 [[env.prod.routes]]
 pattern = "mosoo.ai"
+custom_domain = true
+
+[[env.prod.routes]]
+pattern = "try.mosoo.ai"
 custom_domain = true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ To support lightweight deployment, fast iteration, and future governance expansi
 
 The architecture is built on the Cloudflare platform and uses a Serverless shape for elastic scaling:
 
-- **Frontend and ingress: Cloudflare Workers**. The Web Worker serves Vite-built static assets. The API Worker handles stateless GraphQL / Web API requests and WebSocket handshakes, then hands upgraded session connections to the corresponding Session Durable Object. Cloudflare routing sends `mosoo.ai/api/*` to the API Worker and all other paths to the Web Worker.
+- **Frontend and ingress: Cloudflare Workers**. The Web Worker serves Vite-built static assets. The API Worker handles stateless GraphQL / Web API requests and WebSocket handshakes, then hands upgraded session connections to the corresponding Session Durable Object. `mosoo.ai` is the marketing / landing origin. Authenticated console traffic uses `try.mosoo.ai`, with Cloudflare routing `try.mosoo.ai/api/*` to the API Worker and console paths to the Web Worker.
 - **State and connection management: Cloudflare Durable Objects**. Durable Objects hold upgraded WebSocket connections, high-frequency Session state, and distributed coordination points that need single-instance concurrency.
 - **Primary database: Cloudflare D1**. D1 stores Account records, Organization shell records, App records, core entity configuration, and metadata.
 - **Message queues: Cloudflare Queues**. Queues decouple the control plane from offline tasks. They provide consumer groups, ACK semantics, dead-letter queues, and at-least-once delivery for asynchronous work and cost log ingestion.
@@ -110,7 +110,7 @@ graph TD
 The Web layer provides the interactive client experience.
 
 - It is built with **React / React Router / Vite** and served through Cloudflare Workers Static Assets.
-- Browsers access a same-origin `/api/*` entry point. Cloudflare routes `mosoo.ai/api/*` to the API Worker and other paths to the Web Worker, preserving independent Web/API deployments while keeping a same-origin product experience.
+- Browsers access a same-origin `/api/*` entry point from the console origin. Cloudflare routes `try.mosoo.ai/api/*` to the API Worker and console paths on `try.mosoo.ai` to the Web Worker, preserving independent Web/API deployments while keeping a same-origin product experience. `mosoo.ai` remains the marketing / landing origin and sends login intent to the console origin.
 - WebSocket, using the `AG-UI WebSocket` protocol, carries bidirectional high-frequency streaming events such as text streaming and state synchronization.
 
 ### 4.2 API Layer

--- a/pkgs/contracts/package.json
+++ b/pkgs/contracts/package.json
@@ -19,6 +19,7 @@
     "./mcp": "./src/mcp/mcp.contract.ts",
     "./models": "./models/index.ts",
     "./operation-result": "./src/transport/operation-result.contract.ts",
+    "./origin": "./src/metadata/origin.contract.ts",
     "./app": "./src/app/app.contract.ts",
     "./public-api": "./src/http/public-api.contract.ts",
     "./public-api-core": "./src/http/public-api-core.contract.ts",

--- a/pkgs/contracts/src/index.ts
+++ b/pkgs/contracts/src/index.ts
@@ -10,6 +10,7 @@ export type * from "./environment/environment.contract";
 export * from "./file/file.contract";
 export type * from "./mcp/mcp.contract";
 export type * from "./metadata/app-info.contract";
+export * from "./metadata/origin.contract";
 export type * from "./transport/operation-result.contract";
 export * from "./http/public-api.contract";
 export type * from "./id/id.contract";

--- a/pkgs/contracts/src/metadata/origin.contract.ts
+++ b/pkgs/contracts/src/metadata/origin.contract.ts
@@ -1,0 +1,8 @@
+export const MOSOO_MARKETING_HOST = "mosoo.ai";
+export const MOSOO_MARKETING_ORIGIN = `https://${MOSOO_MARKETING_HOST}`;
+
+export const MOSOO_CONSOLE_HOST = "try.mosoo.ai";
+export const MOSOO_CONSOLE_ORIGIN = `https://${MOSOO_CONSOLE_HOST}`;
+
+export const MOSOO_PRODUCTION_API_ROUTE_PATTERN = `${MOSOO_CONSOLE_HOST}/api/*`;
+export const MOSOO_GOOGLE_OAUTH_CALLBACK_URL = `${MOSOO_CONSOLE_ORIGIN}/api/auth/callback/google`;

--- a/pkgs/contracts/tests/production-origin.test.ts
+++ b/pkgs/contracts/tests/production-origin.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+import {
+  MOSOO_CONSOLE_HOST,
+  MOSOO_CONSOLE_ORIGIN,
+  MOSOO_GOOGLE_OAUTH_CALLBACK_URL,
+  MOSOO_MARKETING_HOST,
+  MOSOO_PRODUCTION_API_ROUTE_PATTERN,
+} from "@mosoo/contracts/origin";
+
+function readRepoFile(path: string): string {
+  return readFileSync(new URL(`../../../${path}`, import.meta.url), "utf8");
+}
+
+describe("production origins", () => {
+  test("keeps Cloudflare routes and OAuth origin aligned", () => {
+    const apiWrangler = readRepoFile("apps/api/wrangler.toml");
+    const webWrangler = readRepoFile("apps/web/wrangler.toml");
+
+    expect(apiWrangler).toContain(`WEB_ORIGIN = "${MOSOO_CONSOLE_ORIGIN}"`);
+    expect(apiWrangler).toContain(`pattern = "${MOSOO_PRODUCTION_API_ROUTE_PATTERN}"`);
+    expect(apiWrangler).toContain('"GOOGLE_OAUTH_CLIENT_ID"');
+    expect(apiWrangler).toContain('"GOOGLE_OAUTH_CLIENT_SECRET"');
+    expect(webWrangler).toContain(`pattern = "${MOSOO_MARKETING_HOST}"`);
+    expect(webWrangler).toContain(`pattern = "${MOSOO_CONSOLE_HOST}"`);
+  });
+
+  test("documents the marketing and console split", () => {
+    const architecture = readRepoFile("docs/architecture.md");
+    const contributing = readRepoFile("CONTRIBUTING.md");
+
+    expect(architecture).toContain(`\`${MOSOO_MARKETING_HOST}\` is the marketing / landing origin`);
+    expect(architecture).toContain(`${MOSOO_PRODUCTION_API_ROUTE_PATTERN}`);
+    expect(contributing).toContain(`${MOSOO_PRODUCTION_API_ROUTE_PATTERN}`);
+  });
+
+  test("defines the production Google OAuth callback", () => {
+    expect(MOSOO_GOOGLE_OAUTH_CALLBACK_URL).toBe(
+      `${MOSOO_CONSOLE_ORIGIN}/api/auth/callback/google`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add shared production origin constants for `mosoo.ai` marketing and `try.mosoo.ai` console/API origins.
- Move prod API `WEB_ORIGIN` and API Worker route to `https://try.mosoo.ai` / `try.mosoo.ai/api/*`.
- Keep the Web Worker on `mosoo.ai` for landing/blog and add `try.mosoo.ai` for the authenticated console.
- Redirect landing Log in clicks from `mosoo.ai` to `https://try.mosoo.ai/login`, and update channel/API URL fallbacks to the console origin.
- Require Google OAuth prod secrets and add a contracts test that locks Cloudflare routes/docs to the shared origin contract.

## Google OAuth production settings

- Authorized JavaScript origin: `https://try.mosoo.ai`
- Authorized redirect URI: `https://try.mosoo.ai/api/auth/callback/google`

## Verification

Passed:

- `bash ./init.sh development`
- `bun run fmt:check:path -- CONTRIBUTING.md docs/architecture.md apps/api/wrangler.toml apps/web/wrangler.toml apps/web/src/routes/login/use-login.ts apps/web/src/shared/config/external-links.ts apps/web/src/routes/agent/components/channel-webhook-origin.ts apps/web/src/routes/agent/lifecycle/distribution-info.ts pkgs/contracts/package.json pkgs/contracts/src/index.ts pkgs/contracts/src/metadata/origin.contract.ts pkgs/contracts/tests/production-origin.test.ts`
- `bun test pkgs/contracts/tests/production-origin.test.ts`
- `bun run --filter @mosoo/contracts tc`
- `bun run --filter @mosoo/web tc`
- `bun run --filter @mosoo/api cf:types`
- `git diff --check`
- `bun run --filter @mosoo/api tc`
- `bun run --filter @mosoo/contracts test`
- `bun run --filter @mosoo/web test`

Known unrelated build blocker:

- `bun run --filter @mosoo/web build` fails in `apps/blog` before the web build starts because `@astrojs/mdx@7.0.0` imports `chunkToString` from `astro@6.4.8`, but the lockfile records `@astrojs/mdx@7.0.0` with peer `astro: ^7.0.0-alpha.0`. This PR does not change `apps/blog/package.json` or `bun.lock`.

## Notes

- Existing dirty submodule state in `apps/driver` was not staged or committed.
