### PR TITLE
fix(providers): move custom model form into dialog

### DIFF
--- a/apps/api/src/modules/vendor-credentials/application/vendor-credential-validation.ts
+++ b/apps/api/src/modules/vendor-credentials/application/vendor-credential-validation.ts
@@ -47,6 +47,10 @@ function readUrlOrigin(value: string): string | null {
 }
 
 function enforcePresetProviderApiBase(vendorId: string, apiBase: string): void {
+  if (vendorId === VENDOR_OPENAI_COMPATIBLE.vendorId) {
+    return;
+  }
+
   const apiBaseOrigin = readUrlOrigin(apiBase);
 
   if (apiBaseOrigin === null) {

--- a/apps/api/tests/vendor-credential-commands.test.ts
+++ b/apps/api/tests/vendor-credential-commands.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test";
 
 import { parsePlatformId } from "@mosoo/id";
 import type { AppId } from "@mosoo/id";
-import { VENDOR_ANTHROPIC, VENDOR_OPENAI, VENDOR_OPENAI_COMPATIBLE } from "@mosoo/runtime-catalog";
+import {
+  VENDOR_ANTHROPIC,
+  VENDOR_DEEPSEEK,
+  VENDOR_OPENAI,
+  VENDOR_OPENAI_COMPATIBLE,
+} from "@mosoo/runtime-catalog";
 
 import {
   createVendorCredential,
@@ -87,6 +92,65 @@ describe("vendor credential commands", () => {
       .first<{ count: number }>();
     expect(credentialCount?.count).toBe(0);
     expect(secretCount?.count).toBe(0);
+
+    await expect(
+      createVendorCredential(fixture.bindings, fixture.viewer, {
+        apiBase: VENDOR_DEEPSEEK.defaultApiBase,
+        apiKey: "sk-create",
+        name: "OpenAI pointed at DeepSeek",
+        appId: fixture.ids.appId,
+        vendorId: VENDOR_OPENAI.vendorId,
+      }),
+    ).rejects.toThrow("Custom endpoint for openai cannot target DeepSeek.");
+
+    const finalCredentialCount = await fixture.database
+      .prepare("SELECT COUNT(*) AS count FROM vendor_credential")
+      .first<{ count: number }>();
+    const finalSecretCount = await fixture.database
+      .prepare("SELECT COUNT(*) AS count FROM vault_secret")
+      .first<{ count: number }>();
+    expect(finalCredentialCount?.count).toBe(0);
+    expect(finalSecretCount?.count).toBe(0);
+  });
+
+  test("allows OpenAI-compatible credentials to target DeepSeek-compatible endpoints", async () => {
+    const fixture = await createApiTestFixture();
+
+    const credential = await createVendorCredential(fixture.bindings, fixture.viewer, {
+      apiBase: VENDOR_DEEPSEEK.defaultApiBase,
+      apiKey: "sk-create",
+      models: ["deepseek-chat"],
+      name: "DeepSeek custom gateway",
+      appId: fixture.ids.appId,
+      vendorId: VENDOR_OPENAI_COMPATIBLE.vendorId,
+    });
+
+    expect(credential).toMatchObject({
+      apiBase: VENDOR_DEEPSEEK.defaultApiBase,
+      isDefault: true,
+      maskedApiKey: expect.any(String),
+      models: ["deepseek-chat"],
+      name: "DeepSeek custom gateway",
+      appId: fixture.ids.appId,
+      vendorId: VENDOR_OPENAI_COMPATIBLE.vendorId,
+    });
+
+    const row = await fixture.database
+      .prepare(
+        "SELECT api_base AS apiBase, models AS modelsJson, vendor_id AS vendorId FROM vendor_credential WHERE id = ?",
+      )
+      .bind(credential.id)
+      .first<{ apiBase: string; modelsJson: string; vendorId: string }>();
+    const secretCount = await fixture.database
+      .prepare("SELECT COUNT(*) AS count FROM vault_secret")
+      .first<{ count: number }>();
+
+    expect(row).toEqual({
+      apiBase: VENDOR_DEEPSEEK.defaultApiBase,
+      modelsJson: JSON.stringify(["deepseek-chat"]),
+      vendorId: VENDOR_OPENAI_COMPATIBLE.vendorId,
+    });
+    expect(secretCount?.count).toBe(1);
   });
 
   test("rejects trailing-dot localhost API bases before storing a credential", async () => {

--- a/apps/web/src/routes/providers/providers-tab.tsx
+++ b/apps/web/src/routes/providers/providers-tab.tsx
@@ -20,6 +20,14 @@ import { formatProviderErrorMessage } from "@/domains/vendor-credential/model/pr
 import { toAppId, toVendorCredentialId } from "@/routes/typed-id";
 import { VendorIcon, hasVendorIcon } from "@/shared/ui/brand-icons";
 import { Button } from "@/shared/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
 import { Input } from "@/shared/ui/input";
 import { PageHeader } from "@/shared/ui/page-header";
 
@@ -54,6 +62,7 @@ const EMPTY_FORM: CredentialForm = {
 };
 
 interface ProviderFormControls {
+  error: string | null;
   form: CredentialForm;
   onCancel: () => void;
   onChange: (form: CredentialForm) => void;
@@ -91,6 +100,10 @@ function formModels(form: CredentialForm): string[] | undefined {
 }
 
 function vendorLabel(vendorId: string): string {
+  if (vendorId === CUSTOM_PROVIDER_VENDOR_ID) {
+    return CUSTOM_PROVIDER_DISPLAY.label;
+  }
+
   return PUBLIC_VENDORS.find((vendor) => vendor.vendorId === vendorId)?.label ?? vendorId;
 }
 
@@ -110,7 +123,8 @@ export function ProvidersTab({ appId }: { appId: string }): ReactElement {
   const typedAppId = toAppId(appId);
   const queryClient = useQueryClient();
   const [form, setForm] = useState<CredentialForm>(EMPTY_FORM);
-  const [error, setError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [pageError, setPageError] = useState<string | null>(null);
   const [testState, setTestState] = useState<TestState>("idle");
   const credentialsQuery = useQuery({
     queryFn: async () => listVendorCredentials(typedAppId),
@@ -165,6 +179,7 @@ export function ProvidersTab({ appId }: { appId: string }): ReactElement {
     },
     onSuccess: async () => {
       setForm(EMPTY_FORM);
+      setFormError(null);
       setTestState("idle");
       await invalidateCredentials();
     },
@@ -187,11 +202,11 @@ export function ProvidersTab({ appId }: { appId: string }): ReactElement {
   });
 
   async function handleSave(): Promise<void> {
-    setError(null);
+    setFormError(null);
     try {
       await saveMutation.mutateAsync(form);
     } catch (caughtError) {
-      setError(getErrorMessage(caughtError, "Failed to save provider key."));
+      setFormError(getErrorMessage(caughtError, "Failed to save provider key."));
     }
   }
 
@@ -200,12 +215,12 @@ export function ProvidersTab({ appId }: { appId: string }): ReactElement {
     const firstModel = formModels(form)?.[0] ?? null;
 
     if (form.vendorId.length === 0 || apiKey.length === 0) {
-      setError("Provider and API key are required before testing.");
+      setFormError("Provider and API key are required before testing.");
       return;
     }
 
     setTestState("running");
-    setError(null);
+    setFormError(null);
 
     try {
       const result = await testVendorCredential({
@@ -217,17 +232,19 @@ export function ProvidersTab({ appId }: { appId: string }): ReactElement {
       });
       setTestState(result.ok ? "success" : "failure");
       if (!result.ok && result.errorCode !== null) {
-        setError(formatProviderErrorMessage(result.errorCode));
+        setFormError(formatProviderErrorMessage(result.errorCode));
       }
     } catch (caughtError) {
       setTestState("failure");
-      setError(formatProviderErrorMessage(getErrorMessage(caughtError, "Connection test failed.")));
+      setFormError(
+        formatProviderErrorMessage(getErrorMessage(caughtError, "Connection test failed.")),
+      );
     }
   }
 
   function startCreate(vendorId: string): void {
     setForm({ ...EMPTY_FORM, apiBase: defaultApiBaseForVendor(vendorId), vendorId });
-    setError(null);
+    setFormError(null);
     setTestState("idle");
   }
 
@@ -240,23 +257,23 @@ export function ProvidersTab({ appId }: { appId: string }): ReactElement {
       name: credential.name,
       vendorId: credential.vendorId,
     });
-    setError(null);
+    setFormError(null);
     setTestState("idle");
   }
 
-  // Shared add/edit form controls, rendered inline inside whichever vendor card
-  // is being edited (form.vendorId), so the form expands in place rather than as
-  // a separate card at the top of the list.
+  function closeFormDialog(): void {
+    setForm(EMPTY_FORM);
+    setFormError(null);
+    setTestState("idle");
+  }
+
   const formControls: ProviderFormControls = {
+    error: formError,
     form,
-    onCancel: () => {
-      setForm(EMPTY_FORM);
-      setError(null);
-      setTestState("idle");
-    },
+    onCancel: closeFormDialog,
     onChange: (nextForm) => {
       setForm(nextForm);
-      setError(null);
+      setFormError(null);
       setTestState("idle");
     },
     onSave: () => {
@@ -268,6 +285,7 @@ export function ProvidersTab({ appId }: { appId: string }): ReactElement {
     saving: saveMutation.isPending,
     testState,
   };
+  const formDialogOpen = form.vendorId.length > 0;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -290,9 +308,9 @@ export function ProvidersTab({ appId }: { appId: string }): ReactElement {
             </div>
           ) : null}
 
-          {error === null ? null : (
+          {pageError === null ? null : (
             <div className="border-destructive/30 bg-destructive/5 text-destructive rounded-md border px-3 py-2 text-sm">
-              {error}
+              {pageError}
             </div>
           )}
 
@@ -303,39 +321,36 @@ export function ProvidersTab({ appId }: { appId: string }): ReactElement {
           {PUBLIC_VENDORS.map((vendor) => (
             <ProviderCredentialSection
               credentials={groupedCredentials.get(vendor.vendorId) ?? []}
-              formControls={formControls}
               key={vendor.vendorId}
               onCreate={() => startCreate(vendor.vendorId)}
               onDelete={(credential) => {
                 void deleteMutation.mutateAsync(credential).catch((caughtError) => {
-                  setError(getErrorMessage(caughtError, "Failed to delete provider key."));
+                  setPageError(getErrorMessage(caughtError, "Failed to delete provider key."));
                 });
               }}
               onEdit={startEdit}
               onSetDefault={(credential) => {
                 void setDefaultMutation.mutateAsync(credential).catch((caughtError) => {
-                  setError(getErrorMessage(caughtError, "Failed to set default provider key."));
+                  setPageError(getErrorMessage(caughtError, "Failed to set default provider key."));
                 });
               }}
               vendor={vendor}
             />
           ))}
 
-          {(groupedCredentials.get(CUSTOM_PROVIDER_VENDOR_ID)?.length ?? 0) > 0 ||
-          form.vendorId === CUSTOM_PROVIDER_VENDOR_ID ? (
+          {(groupedCredentials.get(CUSTOM_PROVIDER_VENDOR_ID)?.length ?? 0) > 0 ? (
             <ProviderCredentialSection
               credentials={groupedCredentials.get(CUSTOM_PROVIDER_VENDOR_ID) ?? []}
-              formControls={formControls}
               onCreate={() => startCreate(CUSTOM_PROVIDER_VENDOR_ID)}
               onDelete={(credential) => {
                 void deleteMutation.mutateAsync(credential).catch((caughtError) => {
-                  setError(getErrorMessage(caughtError, "Failed to delete provider key."));
+                  setPageError(getErrorMessage(caughtError, "Failed to delete provider key."));
                 });
               }}
               onEdit={startEdit}
               onSetDefault={(credential) => {
                 void setDefaultMutation.mutateAsync(credential).catch((caughtError) => {
-                  setError(getErrorMessage(caughtError, "Failed to set default provider key."));
+                  setPageError(getErrorMessage(caughtError, "Failed to set default provider key."));
                 });
               }}
               vendor={CUSTOM_PROVIDER_DISPLAY}
@@ -343,11 +358,25 @@ export function ProvidersTab({ appId }: { appId: string }): ReactElement {
           ) : null}
         </div>
       </main>
+
+      <Dialog
+        open={formDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeFormDialog();
+          }
+        }}
+      >
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[560px]">
+          {formDialogOpen ? <ProviderCredentialDialogForm {...formControls} /> : null}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }
 
-function ProviderCredentialForm({
+function ProviderCredentialDialogForm({
+  error,
   form,
   onCancel,
   onChange,
@@ -356,6 +385,7 @@ function ProviderCredentialForm({
   saving,
   testState,
 }: {
+  error: string | null;
   form: CredentialForm;
   onCancel: () => void;
   onChange: (form: CredentialForm) => void;
@@ -372,76 +402,85 @@ function ProviderCredentialForm({
   const modelsInputId = `${formId}-models`;
 
   return (
-    <div className="border-border-soft mt-1 space-y-3 border-t pt-3">
-      <div className="flex items-center justify-between gap-3">
-        <div className="text-fg-1 text-[13px] font-semibold">
+    <>
+      <DialogHeader>
+        <DialogTitle>
           {form.id === null ? "Add" : "Edit"} {vendorLabel(form.vendorId)} key
+        </DialogTitle>
+        <DialogDescription>Store this Provider credential inside the active App.</DialogDescription>
+      </DialogHeader>
+      <div className="space-y-3">
+        <div className={endpointEnabled ? "grid gap-3 sm:grid-cols-2" : "grid gap-3"}>
+          <label className="space-y-1" htmlFor={nameInputId}>
+            <div className="text-muted-foreground text-xs font-medium">Name</div>
+            <Input
+              id={nameInputId}
+              placeholder="Production"
+              value={form.name}
+              onChange={(event) => onChange({ ...form, name: event.target.value })}
+            />
+          </label>
+          {endpointEnabled ? (
+            <label className="space-y-1" htmlFor={apiBaseInputId}>
+              <div className="text-muted-foreground text-xs font-medium">Base URL</div>
+              <Input
+                id={apiBaseInputId}
+                placeholder={defaultApiBaseForVendor(form.vendorId) || "https://api.example.com/v1"}
+                value={form.apiBase}
+                onChange={(event) => onChange({ ...form, apiBase: event.target.value })}
+              />
+            </label>
+          ) : null}
         </div>
-        <Button onClick={onCancel} size="sm" variant="ghost">
-          Cancel
-        </Button>
-      </div>
-      <div className={endpointEnabled ? "grid gap-3 sm:grid-cols-2" : "grid gap-3"}>
-        <label className="space-y-1" htmlFor={nameInputId}>
-          <div className="text-muted-foreground text-xs font-medium">Name</div>
+        <label className="block space-y-1" htmlFor={apiKeyInputId}>
+          <div className="text-muted-foreground text-xs font-medium">API key</div>
           <Input
-            id={nameInputId}
-            placeholder="Production"
-            value={form.name}
-            onChange={(event) => onChange({ ...form, name: event.target.value })}
+            id={apiKeyInputId}
+            placeholder={form.id === null ? "sk-..." : "Leave blank to keep current key"}
+            type="password"
+            value={form.apiKey}
+            onChange={(event) => onChange({ ...form, apiKey: event.target.value })}
           />
         </label>
-        {endpointEnabled ? (
-          <label className="space-y-1" htmlFor={apiBaseInputId}>
-            <div className="text-muted-foreground text-xs font-medium">Base URL</div>
+        {form.vendorId === CUSTOM_PROVIDER_VENDOR_ID ? (
+          <label className="block space-y-1" htmlFor={modelsInputId}>
+            <div className="text-muted-foreground text-xs font-medium">Models</div>
             <Input
-              id={apiBaseInputId}
-              placeholder={defaultApiBaseForVendor(form.vendorId) || "https://api.example.com/v1"}
-              value={form.apiBase}
-              onChange={(event) => onChange({ ...form, apiBase: event.target.value })}
+              id={modelsInputId}
+              placeholder="gpt-4.1, claude-sonnet-4"
+              value={form.modelsText}
+              onChange={(event) => onChange({ ...form, modelsText: event.target.value })}
             />
           </label>
         ) : null}
+        {error === null ? null : (
+          <div className="border-destructive/30 bg-destructive/5 text-destructive rounded-md border px-3 py-2 text-sm">
+            {error}
+          </div>
+        )}
       </div>
-      <label className="block space-y-1" htmlFor={apiKeyInputId}>
-        <div className="text-muted-foreground text-xs font-medium">API key</div>
-        <Input
-          id={apiKeyInputId}
-          placeholder={form.id === null ? "sk-..." : "Leave blank to keep current key"}
-          type="password"
-          value={form.apiKey}
-          onChange={(event) => onChange({ ...form, apiKey: event.target.value })}
-        />
-      </label>
-      {form.vendorId === CUSTOM_PROVIDER_VENDOR_ID ? (
-        <label className="block space-y-1" htmlFor={modelsInputId}>
-          <div className="text-muted-foreground text-xs font-medium">Models</div>
-          <Input
-            id={modelsInputId}
-            placeholder="gpt-4.1, claude-sonnet-4"
-            value={form.modelsText}
-            onChange={(event) => onChange({ ...form, modelsText: event.target.value })}
-          />
-        </label>
-      ) : null}
-      <div className="flex items-center justify-between gap-3">
+      <DialogFooter>
+        <div className="flex flex-1 items-center gap-2">
+          <Button onClick={onCancel} size="sm" variant="ghost">
+            Cancel
+          </Button>
+        </div>
         <div className="flex items-center gap-2">
           <Button disabled={testState === "running"} onClick={onTest} size="sm" variant="outline">
             {testState === "running" ? "Testing..." : "Test"}
           </Button>
-          <ProviderTestStatus error={null} state={testState} />
+          <ProviderTestStatus error={error} state={testState} />
         </div>
         <Button disabled={saving} onClick={onSave} size="sm">
           {saving ? "Saving..." : "Save"}
         </Button>
-      </div>
-    </div>
+      </DialogFooter>
+    </>
   );
 }
 
 function ProviderCredentialSection({
   credentials,
-  formControls,
   onCreate,
   onDelete,
   onEdit,
@@ -449,16 +488,12 @@ function ProviderCredentialSection({
   vendor,
 }: {
   credentials: readonly VendorCredential[];
-  formControls: ProviderFormControls;
   onCreate: () => void;
   onDelete: (credential: VendorCredential) => void;
   onEdit: (credential: VendorCredential) => void;
   onSetDefault: (credential: VendorCredential) => void;
   vendor: Pick<RuntimeCatalogVendor, "iconKey" | "label" | "vendorId">;
 }): ReactElement {
-  const { vendorId } = vendor;
-  const isFormOpen = formControls.form.vendorId === vendorId;
-
   return (
     <section className="border-border bg-card space-y-3 rounded-lg border p-4">
       <div className="flex items-center justify-between gap-3">
@@ -474,12 +509,10 @@ function ProviderCredentialSection({
             <p className="text-muted-foreground text-[12px]">App-level provider keys</p>
           </div>
         </div>
-        {isFormOpen ? null : (
-          <Button onClick={onCreate} size="sm" variant="outline">
-            <Plus className="size-3.5" />
-            Add key
-          </Button>
-        )}
+        <Button onClick={onCreate} size="sm" variant="outline">
+          <Plus className="size-3.5" />
+          Add key
+        </Button>
       </div>
       {credentials.length > 0 ? (
         <div className="space-y-2">
@@ -532,12 +565,11 @@ function ProviderCredentialSection({
             </div>
           ))}
         </div>
-      ) : isFormOpen ? null : (
+      ) : (
         <div className="text-muted-foreground/70 rounded-md border border-dashed px-3 py-3 text-[13px]">
           No key configured in this App.
         </div>
       )}
-      {isFormOpen ? <ProviderCredentialForm {...formControls} /> : null}
     </section>
   );
 }

--- a/apps/web/tests/providers-tab-dialog.test.tsx
+++ b/apps/web/tests/providers-tab-dialog.test.tsx
@@ -1,0 +1,344 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { JSDOM } from "jsdom";
+import { act } from "react";
+import type { Root } from "react-dom/client";
+
+const APP_ID = "01J00000000000000000000009";
+const CUSTOM_CREDENTIAL_ID = "01J000000000000000000000AA";
+const originalFetch = globalThis.fetch;
+let dom: JSDOM | null = null;
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+mock.module("@/shared/ui/brand-icons", () => ({
+  RuntimeIcon: () => null,
+  VendorIcon: () => null,
+  hasRuntimeIcon: () => false,
+  hasVendorIcon: () => false,
+}));
+
+interface CapturedGraphQLBody {
+  query: string;
+  variables?: unknown;
+}
+
+function installDom(): void {
+  dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/providers",
+  });
+  const { window } = dom;
+
+  globalThis.window = window as unknown as Window & typeof globalThis;
+  globalThis.document = window.document;
+  globalThis.HTMLElement = window.HTMLElement;
+  globalThis.HTMLButtonElement = window.HTMLButtonElement;
+  globalThis.HTMLInputElement = window.HTMLInputElement;
+  globalThis.Node = window.Node;
+  globalThis.NodeFilter = window.NodeFilter;
+  globalThis.Event = window.Event;
+  globalThis.MouseEvent = window.MouseEvent;
+  globalThis.CustomEvent = window.CustomEvent;
+  globalThis.KeyboardEvent = window.KeyboardEvent;
+  globalThis.MutationObserver = window.MutationObserver;
+  globalThis.getComputedStyle = window.getComputedStyle.bind(window);
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: window.navigator,
+  });
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+    configurable: true,
+    value: true,
+  });
+  Object.defineProperty(window.HTMLElement.prototype, "hasPointerCapture", {
+    configurable: true,
+    value: () => false,
+  });
+  Object.defineProperty(window.HTMLElement.prototype, "setPointerCapture", {
+    configurable: true,
+    value: () => undefined,
+  });
+  Object.defineProperty(window.HTMLElement.prototype, "releasePointerCapture", {
+    configurable: true,
+    value: () => undefined,
+  });
+}
+
+function uninstallDom(): void {
+  root = null;
+  container = null;
+  dom?.window.close();
+  dom = null;
+  delete globalThis.window;
+  delete globalThis.document;
+  delete globalThis.HTMLElement;
+  delete globalThis.HTMLButtonElement;
+  delete globalThis.HTMLInputElement;
+  delete globalThis.Node;
+  delete globalThis.NodeFilter;
+  delete globalThis.Event;
+  delete globalThis.MouseEvent;
+  delete globalThis.CustomEvent;
+  delete globalThis.KeyboardEvent;
+  delete globalThis.MutationObserver;
+  delete globalThis.getComputedStyle;
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: undefined,
+  });
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+    configurable: true,
+    value: undefined,
+  });
+}
+
+function parseGraphQLBody(init: RequestInit | undefined): CapturedGraphQLBody {
+  if (typeof init?.body !== "string") {
+    throw new Error("Expected GraphQL request body to be serialized JSON.");
+  }
+
+  const body = JSON.parse(init.body);
+
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    Array.isArray(body) ||
+    typeof body.query !== "string"
+  ) {
+    throw new Error("Expected GraphQL request body to include a query string.");
+  }
+
+  return body as CapturedGraphQLBody;
+}
+
+function listResponse(credentials: unknown[] = []): Response {
+  return Response.json({
+    data: {
+      vendorCredentialList: credentials,
+    },
+  });
+}
+
+function createdCustomCredentialResponse(): Response {
+  return Response.json({
+    data: {
+      createVendorCredential: {
+        apiBase: "https://custom.example.com/v1",
+        id: CUSTOM_CREDENTIAL_ID,
+        isDefault: true,
+        maskedApiKey: "sk-***",
+        models: ["custom-large", "custom-small"],
+        name: "Custom gateway",
+        appId: APP_ID,
+        vendorId: "openai-compatible",
+      },
+    },
+  });
+}
+
+function setupFetch(credentials: unknown[] = []): CapturedGraphQLBody[] {
+  const capturedBodies: CapturedGraphQLBody[] = [];
+
+  globalThis.fetch = async (_input, init) => {
+    const body = parseGraphQLBody(init);
+    capturedBodies.push(body);
+
+    if (body.query.includes("createVendorCredential")) {
+      return createdCustomCredentialResponse();
+    }
+
+    return listResponse(credentials);
+  };
+
+  return capturedBodies;
+}
+
+async function renderProviders(): Promise<void> {
+  const [{ createRoot }, { ProvidersTab }] = await Promise.all([
+    import("react-dom/client"),
+    import("../src/routes/providers/providers-tab"),
+  ]);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+
+  await act(async () => {
+    root?.render(
+      <QueryClientProvider client={queryClient}>
+        <ProvidersTab appId={APP_ID} />
+      </QueryClientProvider>,
+    );
+  });
+
+  await waitFor(() => {
+    expect(document.body.textContent).not.toContain("Loading providers");
+  });
+}
+
+async function click(element: Element): Promise<void> {
+  await act(async () => {
+    if (!(element instanceof HTMLElement)) {
+      throw new Error("Expected a clickable HTMLElement.");
+    }
+
+    element.click();
+  });
+}
+
+async function fillLabeledInput(labelText: string, value: string): Promise<void> {
+  const input = getInputByLabel(labelText);
+  const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+
+  if (valueSetter === undefined) {
+    throw new Error("Expected HTMLInputElement value setter.");
+  }
+
+  await act(async () => {
+    valueSetter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true, cancelable: true }));
+  });
+}
+
+async function openCustomModelDialog(): Promise<void> {
+  await click(getButton("Add custom model"));
+  await waitFor(() => {
+    expect(queryDialog()).not.toBeNull();
+  });
+}
+
+function getButton(name: string): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll("button")).find(
+    (element) => element.textContent?.trim() === name,
+  );
+
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Unable to find button: ${name}`);
+  }
+
+  return button;
+}
+
+function getInputByLabel(labelText: string): HTMLInputElement {
+  const label = Array.from(document.querySelectorAll("label")).find((element) =>
+    element.textContent?.includes(labelText),
+  );
+  const input = label?.htmlFor ? document.getElementById(label.htmlFor) : null;
+
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error(`Unable to find input for label: ${labelText}`);
+  }
+
+  return input;
+}
+
+function queryDialog(): Element | null {
+  return document.querySelector('[role="dialog"], [data-slot="dialog-content"]');
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    try {
+      assertion();
+      return;
+    } catch (caughtError) {
+      lastError = caughtError;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+
+  throw lastError;
+}
+
+beforeEach(() => {
+  installDom();
+});
+
+afterEach(async () => {
+  if (root !== null) {
+    await act(async () => {
+      root?.unmount();
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  globalThis.fetch = originalFetch;
+  uninstallDom();
+});
+
+describe("ProvidersTab custom model dialog", () => {
+  test("opens custom model form in a dialog instead of an inline custom card", async () => {
+    setupFetch();
+    await renderProviders();
+
+    expect(document.querySelector("main")?.textContent).not.toContain("Custom models");
+
+    await openCustomModelDialog();
+
+    const dialog = queryDialog();
+    expect(dialog?.textContent).toContain("Add Custom models key");
+    expect(dialog?.textContent).toContain("Base URL");
+    expect(dialog?.textContent).toContain("Models");
+    expect(document.querySelector("main")?.textContent).not.toContain("Add Custom models key");
+  });
+
+  test("cancel closes the custom model dialog and clears draft state", async () => {
+    setupFetch();
+    await renderProviders();
+
+    await openCustomModelDialog();
+    await fillLabeledInput("Name", "Draft gateway");
+    await click(getButton("Cancel"));
+
+    await waitFor(() => {
+      expect(queryDialog()).toBeNull();
+    });
+
+    await openCustomModelDialog();
+
+    expect(getInputByLabel("Name").value).toBe("");
+  });
+
+  test("save creates a custom credential and closes the dialog", async () => {
+    const capturedBodies = setupFetch();
+    await renderProviders();
+
+    await openCustomModelDialog();
+    await fillLabeledInput("Name", "Custom gateway");
+    await fillLabeledInput("Base URL", "https://custom.example.com/v1");
+    await fillLabeledInput("API key", "sk-test");
+    await fillLabeledInput("Models", "custom-large, custom-small");
+    await click(getButton("Save"));
+
+    await waitFor(() => {
+      expect(queryDialog()).toBeNull();
+    });
+
+    const createBody = capturedBodies.find((body) => body.query.includes("createVendorCredential"));
+
+    expect(createBody?.variables).toEqual({
+      input: {
+        apiBase: "https://custom.example.com/v1",
+        apiKey: "sk-test",
+        models: ["custom-large", "custom-small"],
+        name: "Custom gateway",
+        appId: APP_ID,
+        vendorId: "openai-compatible",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #160 (`fix/deepseek-runtime-catalog`). #160 has merged; this PR is now rebased on the post-#160 `main` and should merge as the UI/API follow-up.

- Move the Providers page custom OpenAI-compatible add/edit form into a dialog.
- Keep first-class Provider cards rendered from the catalog and avoid adding a fixed `openai-compatible` provider card.
- Keep saved custom credentials as an optional list section; add/edit flows now use the dialog and clear state on cancel/save.
- Add Web coverage for opening the custom model dialog, avoiding an inline fixed custom form, cancel clearing draft state, and save/create closing the dialog.
- Fix API validation so `openai-compatible` custom credentials can use DeepSeek-compatible or proxy endpoints while preset provider cards still reject cross-provider endpoints.

## Verification

- `bash ./init.sh development`
- `just test-file apps/api/tests/vendor-credential-commands.test.ts`
- `just test-file apps/web/tests/providers-tab-dialog.test.tsx`
- `just test-file apps/web/tests/provider-runtime-availability.test.ts`
- `just test-file apps/web/tests/model-picker-availability.test.ts`
- `just tc-package @mosoo/web`
- `just tc`

## Codegen

- GraphQL codegen not run: this PR does not change GraphQL schema, documents, mutations, queries, or scalar mappings.
- DB regeneration not run: this PR does not change DB schema, migrations, or baseline files.
