### PR TITLE
fix(runtime): include custom models in opencode config

### DIFF
--- a/apps/api/src/modules/runtime/application/session-definition/hydrate-run-context.service.ts
+++ b/apps/api/src/modules/runtime/application/session-definition/hydrate-run-context.service.ts
@@ -69,6 +69,7 @@ const HYDRATED_RUN_CONTEXT_CACHE_TTL_MS = 20_000;
 const hydratedRunContextCache = new Map<string, HydratedRunContextCacheEntry>();
 
 interface OpenCodeProviderConfig {
+  readonly models?: Record<string, { name: string }>;
   readonly name?: string;
   readonly npm?: string;
   readonly options: Record<string, string>;
@@ -193,10 +194,17 @@ function buildOpenCodeProviderConfig(input: RuntimeVendorEnvironmentInput): Open
   const options: Record<string, string> = {
     apiKey: `{env:${input.vendor.apiKeyEnvVar}}`,
   };
+  const models =
+    input.credential.models === null
+      ? undefined
+      : Object.fromEntries(input.credential.models.map((modelId) => [modelId, { name: modelId }]));
   const provider = input.vendor.openCodeProvider;
 
   if (provider === undefined) {
-    return { options };
+    return {
+      ...(models === undefined ? {} : { models }),
+      options,
+    };
   }
 
   if (provider.apiBaseOption !== undefined) {
@@ -204,6 +212,7 @@ function buildOpenCodeProviderConfig(input: RuntimeVendorEnvironmentInput): Open
   }
 
   return {
+    ...(models === undefined ? {} : { models }),
     name: provider.name,
     npm: provider.npmPackage,
     options,

--- a/apps/api/src/modules/vendor-credentials/application/vendor-credential.secret-resolution.ts
+++ b/apps/api/src/modules/vendor-credentials/application/vendor-credential.secret-resolution.ts
@@ -13,6 +13,7 @@ import {
   storeSecret,
 } from "../../mcp/application/mcp-secret-store";
 import { findCustomCredentialRowForModel } from "./vendor-credential-custom-models";
+import { parseCredentialModels } from "./vendor-credential.mapper";
 import {
   getAppVendorCredentialRow,
   listAppCustomCredentialRows,
@@ -241,6 +242,7 @@ async function resolveCredentialFromRow(
     apiBase: command.credential.apiBase,
     apiKey: secret.apiKey,
     credentialId: command.credential.id,
+    models: parseCredentialModels(command.credential.modelsJson),
   };
 }
 

--- a/apps/api/src/modules/vendor-credentials/application/vendor-credential.types.ts
+++ b/apps/api/src/modules/vendor-credentials/application/vendor-credential.types.ts
@@ -15,4 +15,5 @@ export interface ResolvedVendorCredential {
   apiBase: string | null;
   apiKey: string;
   credentialId: VendorCredentialId;
+  models: string[] | null;
 }

--- a/apps/api/tests/runtime-vendor-env-vars.test.ts
+++ b/apps/api/tests/runtime-vendor-env-vars.test.ts
@@ -23,6 +23,7 @@ describe("runtime vendor env vars", () => {
           apiBase: "http://api.example.com/v1",
           apiKey: "sk-runtime",
           credentialId: "01J000000000000000000000C3",
+          models: null,
         },
         model: "gpt-5.4",
         runtimeId: "openai-runtime",
@@ -38,6 +39,7 @@ describe("runtime vendor env vars", () => {
           apiBase: "https://localhost./v1",
           apiKey: "sk-runtime",
           credentialId: "01J000000000000000000000C4",
+          models: null,
         },
         model: "gpt-5.4",
         runtimeId: "openai-runtime",
@@ -54,6 +56,7 @@ describe("runtime vendor env vars", () => {
         apiBase: null,
         apiKey: "sk-opencode",
         credentialId: "01J000000000000000000000C5",
+        models: null,
       },
       model: "qwen3.6-plus",
       runtimeId: "acp-fallback",
@@ -85,6 +88,7 @@ describe("runtime vendor env vars", () => {
         apiBase: null,
         apiKey: "sk-deepseek",
         credentialId: "01J000000000000000000000C6",
+        models: null,
       },
       model: "deepseek-v4-pro",
       runtimeId: "acp-fallback",
@@ -155,6 +159,7 @@ describe("runtime vendor env vars", () => {
           apiBase: null,
           apiKey: "sk-provider",
           credentialId: "01J000000000000000000000C7",
+          models: null,
         },
         model,
         runtimeId: "acp-fallback",
@@ -184,14 +189,15 @@ describe("runtime vendor env vars", () => {
     },
   );
 
-  test("generates OpenCode custom provider config from stored OpenAI-compatible Base URL", () => {
+  test("generates OpenCode custom provider config for a DeepSeek-backed OpenAI-compatible model", () => {
     const envVars = buildRuntimeVendorEnvVars({
       credential: {
-        apiBase: "https://models.example.com/v1",
+        apiBase: "https://api.deepseek.com",
         apiKey: "sk-custom",
         credentialId: "01J000000000000000000000C8",
+        models: ["deepseek-v4-flash"],
       },
-      model: "qwen-coder",
+      model: "deepseek-v4-flash",
       runtimeId: "acp-fallback",
       vendor: VENDOR_OPENAI_COMPATIBLE,
     });
@@ -201,18 +207,23 @@ describe("runtime vendor env vars", () => {
     >;
 
     expect(envVars["OPENAI_COMPATIBLE_API_KEY"]).toBe("sk-custom");
-    expect(envVars["OPENAI_COMPATIBLE_BASE_URL"]).toBe("https://models.example.com/v1");
+    expect(envVars["OPENAI_COMPATIBLE_BASE_URL"]).toBe("https://api.deepseek.com");
     expect(config).toMatchObject({
       enabled_providers: ["openai-compatible"],
-      model: "openai-compatible/qwen-coder",
-      small_model: "openai-compatible/qwen-coder",
+      model: "openai-compatible/deepseek-v4-flash",
+      small_model: "openai-compatible/deepseek-v4-flash",
       provider: {
         "openai-compatible": {
+          models: {
+            "deepseek-v4-flash": {
+              name: "deepseek-v4-flash",
+            },
+          },
           name: "OpenAI Compatible",
           npm: "@ai-sdk/openai-compatible",
           options: {
             apiKey: "{env:OPENAI_COMPATIBLE_API_KEY}",
-            baseURL: "https://models.example.com/v1",
+            baseURL: "https://api.deepseek.com",
           },
         },
       },

--- a/apps/api/tests/vendor-credential-runtime-selection.test.ts
+++ b/apps/api/tests/vendor-credential-runtime-selection.test.ts
@@ -199,17 +199,17 @@ describe("vendor credential runtime selection", () => {
       vendorId: "openai",
     });
     await insertVendorCredential(database, {
-      apiBase: "https://secondary.example.com/v1",
+      apiBase: "https://secondary.deepseek.example/v1",
       credentialId: CUSTOM_SECONDARY_CREDENTIAL_ID,
-      models: ["qwen-coder"],
+      models: ["deepseek-v4-flash"],
       name: "B Custom",
       secretId: secondaryCustomSecretId,
       vendorId: VENDOR_OPENAI_COMPATIBLE.vendorId,
     });
     await insertVendorCredential(database, {
-      apiBase: "https://primary.example.com/v1",
+      apiBase: "https://api.deepseek.com",
       credentialId: CUSTOM_PRIMARY_CREDENTIAL_ID,
-      models: ["qwen-coder"],
+      models: ["deepseek-v4-flash"],
       name: "A Custom",
       secretId: primaryCustomSecretId,
       vendorId: VENDOR_OPENAI_COMPATIBLE.vendorId,
@@ -218,22 +218,23 @@ describe("vendor credential runtime selection", () => {
     const credential = await resolveVendorApiKey({
       bindings,
       executionOwnerUserId: APP_OWNER_ID,
-      options: { modelId: "qwen-coder" },
+      options: { modelId: "deepseek-v4-flash" },
       appId: APP_ID,
       vendorId: VENDOR_OPENAI_COMPATIBLE.vendorId,
     });
 
     expect(credential).toEqual({
-      apiBase: "https://primary.example.com/v1",
+      apiBase: "https://api.deepseek.com",
       apiKey: "custom-primary-key",
       credentialId: CUSTOM_PRIMARY_CREDENTIAL_ID,
+      models: ["deepseek-v4-flash"],
     });
 
     await expect(
       resolveVendorApiKey({
         bindings,
         executionOwnerUserId: OTHER_ACCOUNT_ID,
-        options: { modelId: "qwen-coder" },
+        options: { modelId: "deepseek-v4-flash" },
         appId: APP_ID,
         vendorId: VENDOR_OPENAI_COMPATIBLE.vendorId,
       }),
@@ -285,6 +286,7 @@ describe("vendor credential runtime selection", () => {
       apiBase: null,
       apiKey: "openai-key",
       credentialId: OPENAI_CREDENTIAL_ID,
+      models: null,
     });
   });
 


### PR DESCRIPTION
## Summary
- Follow-up after #163 was merged.
- Carries stored OpenAI-compatible custom model IDs through credential resolution into runtime hydration.
- Emits `provider.<id>.models` in `OPENCODE_CONFIG_CONTENT` so OpenCode can resolve DeepSeek-backed custom OpenAI-compatible models such as `deepseek-v4-flash` instead of failing with a generic OpenCode service error.

## Evidence
- `gh pr view 163` reported `state=MERGED` and `mergedAt=2026-06-29T11:51:29Z`, so this is a new PR instead of updating #163.
- Screenshot/user repro shows runtime `acp-fallback`, provider `openai-compatible`, model `deepseek-v4-flash`, then `Internal error: OpenCode service failure`.
- Local OpenCode 1.17.7 black-box check with `https://api.deepseek.com` and `deepseek-v4-flash`: when `provider.openai-compatible.models.deepseek-v4-flash` is present, `opencode models openai-compatible` lists `openai-compatible/deepseek-v4-flash`.
- Cloudflare production tail could not be fetched from this machine because Wrangler resolved to account `e919...` and Cloudflare returned `Worker does not exist` for `mosoo-api-prod`; no production secrets or API keys were printed.

## Validation
- `bash ./init.sh development`
- `just test-file apps/api/tests/runtime-vendor-env-vars.test.ts`
- `just test-file apps/api/tests/vendor-credential-runtime-selection.test.ts`
- `just test-file apps/api/tests/vendor-credential-commands.test.ts`
- `just test-file apps/web/tests/providers-tab-dialog.test.tsx`
- `just tc`

GraphQL codegen: not run, no GraphQL schema/query/mutation/scalar changes.
DB regen/migrate: not run, no DB schema or migration changes.