### PR TITLE
fix(runtime): reject custom providers for openai app-server

### DIFF
--- a/apps/api/src/modules/vendor-credentials/application/available-models.ts
+++ b/apps/api/src/modules/vendor-credentials/application/available-models.ts
@@ -145,7 +145,6 @@ function resolvePresetEntry(
 }
 
 function resolveCustomEntries(
-  input: AvailableModelsInput,
   acceptsCustomProvider: boolean,
   runtimeLabel: string | null,
   credentialRows: readonly VendorCredentialRow[],
@@ -154,10 +153,6 @@ function resolveCustomEntries(
   const entries: ResolvedModelEntry[] = [];
 
   for (const { modelId, row } of listEffectiveCustomCredentialModelRows(rows)) {
-    if (!acceptsCustomProvider && modelId !== input.currentModelId) {
-      continue;
-    }
-
     entries.push({
       available: acceptsCustomProvider,
       displayName: `${modelId} (custom)`,
@@ -265,7 +260,6 @@ export async function resolveAvailableModels(
   const credentialRows = await listAppVendorCredentialRows(database, input.appId);
   const availableVendorIds = collectAvailableVendorIds(credentialRows);
   const customEntries = resolveCustomEntries(
-    input,
     scope.acceptsCustomProvider,
     scope.label,
     credentialRows,

--- a/apps/api/tests/available-models.test.ts
+++ b/apps/api/tests/available-models.test.ts
@@ -118,7 +118,7 @@ function createAvailableModelsDatabase(): SqliteD1Database {
 }
 
 describe("available models", () => {
-  test("resolves preset and custom availability", async () => {
+  test("keeps custom models visible but unavailable for OpenAI runtime", async () => {
     const entries = await resolveAvailableModels(createAvailableModelsDatabase(), {
       appId: APP_ID,
       runtimeId: "openai-runtime",
@@ -132,10 +132,11 @@ describe("available models", () => {
         (entry) => entry.vendorId === "openai-compatible" && entry.modelId === "qwen-coder",
       ),
     ).toMatchObject({
-      available: true,
+      available: false,
+      reason: "wrong-runtime",
       source: "custom",
-      statusDetail: null,
-      statusLabel: "Available",
+      statusDetail: "Custom · Custom default is not available for OpenAI Runtime.",
+      statusLabel: "Not available",
     });
     expect(entries.find((entry) => entry.vendorId === "anthropic")).toMatchObject({
       available: false,
@@ -286,10 +287,10 @@ describe("available models", () => {
       ),
     ).toMatchObject({
       available: false,
-      reason: "needs-key",
+      reason: "wrong-runtime",
       source: "custom",
-      statusDetail: "Configure a Provider key for Custom Provider.",
-      statusLabel: "Provider key required",
+      statusDetail: "Custom Provider is not available for OpenAI Runtime.",
+      statusLabel: "Not available",
     });
   });
 });

--- a/apps/api/tests/runtime-openai-compatible-models.test.ts
+++ b/apps/api/tests/runtime-openai-compatible-models.test.ts
@@ -66,6 +66,24 @@ function createAvailableModelsDatabase(): D1Database {
 }
 
 describe("OpenAI-compatible runtime model support", () => {
+  test("marks current custom models as wrong-runtime for OpenAI app-server runtime", async () => {
+    const entries = await resolveAvailableModels(createAvailableModelsDatabase(), {
+      currentModelId: "qwen-coder",
+      currentVendorId: VENDOR_OPENAI_COMPATIBLE.vendorId,
+      appId: APP_ID,
+      runtimeId: "openai-runtime",
+    });
+    const currentCustomEntry = entries.find(
+      (entry) =>
+        entry.vendorId === VENDOR_OPENAI_COMPATIBLE.vendorId && entry.modelId === "qwen-coder",
+    );
+
+    expect(currentCustomEntry).toMatchObject({
+      available: false,
+      reason: "wrong-runtime",
+    });
+  });
+
   test("marks current custom models as wrong-runtime when the selected runtime rejects custom providers", async () => {
     const entries = await resolveAvailableModels(createAvailableModelsDatabase(), {
       currentModelId: "qwen-coder",

--- a/apps/web/tests/provider-runtime-availability.test.ts
+++ b/apps/web/tests/provider-runtime-availability.test.ts
@@ -44,11 +44,16 @@ describe("provider runtime availability", () => {
   test("marks custom OpenAI-compatible credentials as runtime readiness for custom-capable runtimes", () => {
     const availabilityRows = listRuntimeAvailabilityRows([credential("openai-compatible")]);
     const openCodeRow = availabilityRows.find((runtime) => runtime.runtimeId === "acp-fallback");
+    const openAiRow = availabilityRows.find((runtime) => runtime.runtimeId === "openai-runtime");
     const claudeRow = availabilityRows.find((runtime) => runtime.runtimeId === "claude-agent-sdk");
 
     expect(openCodeRow).toMatchObject({
       status: "Ready · Custom model configured",
       tone: "ready",
+    });
+    expect(openAiRow).toMatchObject({
+      status: "Needs key · Add OpenAI",
+      tone: "muted",
     });
     expect(claudeRow).toMatchObject({
       status: "Needs key · Add Anthropic",

--- a/apps/web/tests/runtime-default.test.ts
+++ b/apps/web/tests/runtime-default.test.ts
@@ -3,13 +3,13 @@ import { describe, expect, test } from "bun:test";
 import type { VendorCredential } from "../src/domains/vendor-credential/api/vendor-credential-client";
 import { resolveDefaultAgentRuntime } from "../src/routes/agent/runtime-default";
 
-function credential(vendorId: string): VendorCredential {
+function credential(vendorId: string, models: readonly string[] | null = null): VendorCredential {
   return {
     apiBase: null,
     id: "01J000000000000000000000AA",
     isDefault: true,
     maskedApiKey: "sk-***",
-    models: null,
+    models,
     name: "Default",
     appId: "01J00000000000000000000009",
     vendorId,
@@ -29,6 +29,14 @@ describe("default agent runtime", () => {
     expect(resolveDefaultAgentRuntime([credential("opencode")])).toEqual({
       model: "deepseek-v4-pro",
       provider: "opencode",
+      runtimeId: "acp-fallback",
+    });
+  });
+
+  test("uses OpenCode for custom OpenAI-compatible credentials", () => {
+    expect(resolveDefaultAgentRuntime([credential("openai-compatible", ["qwen-coder"])])).toEqual({
+      model: "qwen-coder",
+      provider: "openai-compatible",
       runtimeId: "acp-fallback",
     });
   });

--- a/pkgs/runtime-catalog/catalog/runtime-catalog.jsonc
+++ b/pkgs/runtime-catalog/catalog/runtime-catalog.jsonc
@@ -412,7 +412,7 @@
       "label": "System Agent",
       "visibility": "internal",
       "transport": "openai-app-server",
-      "acceptsCustomProvider": true,
+      "acceptsCustomProvider": false,
       "capabilityProfile": "none",
       "disabledReason": "System Agent is an internal configuration helper.",
       "defaultIdentity": {
@@ -433,7 +433,7 @@
       "label": "OpenAI Runtime",
       "visibility": "public",
       "transport": "openai-app-server",
-      "acceptsCustomProvider": true,
+      "acceptsCustomProvider": false,
       "capabilityProfile": "standard",
       "defaultIdentity": {
         "providerId": "openai",

--- a/pkgs/runtime-catalog/src/catalog.generated.ts
+++ b/pkgs/runtime-catalog/src/catalog.generated.ts
@@ -488,7 +488,7 @@ export const GENERATED_RUNTIME_CATALOG = [
     ],
   },
   {
-    acceptsCustomProvider: true,
+    acceptsCustomProvider: false,
     defaultIdentity: {
       modelId: "gpt-5.4",
       providerId: "openai",
@@ -507,7 +507,7 @@ export const GENERATED_RUNTIME_CATALOG = [
     supportedModelIds: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3", "gpt-5.2"],
   },
   {
-    acceptsCustomProvider: true,
+    acceptsCustomProvider: false,
     defaultIdentity: {
       modelId: "gpt-5.4",
       providerId: "openai",

--- a/pkgs/runtime-catalog/tests/runtime-model-identity-admission.test.ts
+++ b/pkgs/runtime-catalog/tests/runtime-model-identity-admission.test.ts
@@ -122,7 +122,7 @@ describe("runtime catalog identity admission", () => {
     });
   });
 
-  test("admits supported preset and custom runtime model identities", () => {
+  test("admits supported preset and ACP custom runtime model identities", () => {
     const preset = admitRuntimeModelIdentity(
       createRuntimeModelIdentity({
         modelId: ANTHROPIC_DEFAULT_MODEL_ID,
@@ -140,7 +140,7 @@ describe("runtime catalog identity admission", () => {
           kind: "custom",
           providerId: VENDOR_OPENAI_COMPATIBLE.vendorId,
         },
-        runtimeId: "openai-runtime",
+        runtimeId: "acp-fallback",
       }),
     );
     const deepseekPreset = admitRuntimeModelIdentity(
@@ -180,6 +180,44 @@ describe("runtime catalog identity admission", () => {
       vendor: {
         vendorId: VENDOR_DEEPSEEK.vendorId,
       },
+    });
+  });
+
+  test("rejects custom providers for OpenAI app-server runtime", () => {
+    const systemAgentRuntime = RUNTIME_CATALOG.find(
+      (runtime) => runtime.runtimeId === SYSTEM_AGENT_RUNTIME_ID,
+    );
+    const openAiRuntime = RUNTIME_CATALOG.find((runtime) => runtime.runtimeId === "openai-runtime");
+    const custom = admitRuntimeModelIdentity(
+      createRuntimeModelIdentity({
+        modelId: "qwen-coder",
+        provider: {
+          kind: "custom",
+          providerId: VENDOR_OPENAI_COMPATIBLE.vendorId,
+        },
+        runtimeId: "openai-runtime",
+      }),
+    );
+    const systemAgentCustom = admitRuntimeModelIdentity(
+      createRuntimeModelIdentity({
+        modelId: "qwen-coder",
+        provider: {
+          kind: "custom",
+          providerId: VENDOR_OPENAI_COMPATIBLE.vendorId,
+        },
+        runtimeId: SYSTEM_AGENT_RUNTIME_ID,
+      }),
+    );
+
+    expect(systemAgentRuntime?.acceptsCustomProvider).toBe(false);
+    expect(openAiRuntime?.acceptsCustomProvider).toBe(false);
+    expect(custom).toMatchObject({
+      code: "provider-unsupported",
+      ok: false,
+    });
+    expect(systemAgentCustom).toMatchObject({
+      code: "runtime-disabled",
+      ok: false,
     });
   });
 


### PR DESCRIPTION
## Summary
- mark OpenAI app-server runtimes as not accepting custom OpenAI-compatible providers
- keep configured custom models visible as wrong-runtime for OpenAI Runtime
- keep custom OpenAI-compatible defaults and readiness on OpenCode/acp-fallback

## Verification
- vp run --filter @mosoo/runtime-catalog catalog:generate
- vp run --filter @mosoo/runtime-catalog test
- vp exec bun test apps/api/tests/available-models.test.ts apps/api/tests/runtime-openai-compatible-models.test.ts apps/api/tests/vendor-credential-runtime-selection.test.ts apps/api/tests/runtime-vendor-env-vars.test.ts
- vp exec bun test apps/web/tests/runtime-default.test.ts apps/web/tests/provider-runtime-availability.test.ts
- vp run --filter @mosoo/runtime-catalog tc
- vp run --filter @mosoo/api tc
- vp run --filter @mosoo/web tc
- vp fmt --check --ignore-path .gitignore apps/api/src/modules/vendor-credentials/application/available-models.ts apps/api/tests/available-models.test.ts apps/api/tests/runtime-openai-compatible-models.test.ts apps/web/tests/provider-runtime-availability.test.ts apps/web/tests/runtime-default.test.ts pkgs/runtime-catalog/catalog/runtime-catalog.jsonc pkgs/runtime-catalog/src/catalog.generated.ts pkgs/runtime-catalog/tests/runtime-model-identity-admission.test.ts
- git diff --check

## Notes
- No GraphQL schema or DB schema changes.
- Live provider/Docker smoke was not run; this change is catalog admission and model availability behavior.