### PR TITLE
fix(runtime): map Zhipu provider for OpenCode

### DIFF
--- a/apps/api/src/modules/runtime/application/session-definition/hydrate-run-context.service.ts
+++ b/apps/api/src/modules/runtime/application/session-definition/hydrate-run-context.service.ts
@@ -176,18 +176,39 @@ export function buildRuntimeVendorEnvVars(
 }
 
 function buildOpenCodeConfig(input: RuntimeVendorEnvironmentInput): string {
-  const model = input.model.includes("/") ? input.model : `${input.vendor.vendorId}/${input.model}`;
+  const openCodeProviderId = resolveOpenCodeProviderId(input.vendor);
+  const model = resolveOpenCodeModelId(input.vendor, input.model);
   const providerConfig = buildOpenCodeProviderConfig(input);
 
   return JSON.stringify({
     $schema: "https://opencode.ai/config.json",
-    enabled_providers: [input.vendor.vendorId],
+    enabled_providers: [openCodeProviderId],
     model,
     provider: {
-      [input.vendor.vendorId]: providerConfig,
+      [openCodeProviderId]: providerConfig,
     },
     small_model: model,
   });
+}
+
+function resolveOpenCodeProviderId(vendor: RuntimeCatalogVendor): string {
+  return vendor.openCodeProvider?.providerId ?? vendor.vendorId;
+}
+
+function resolveOpenCodeModelId(vendor: RuntimeCatalogVendor, model: string): string {
+  const openCodeProviderId = resolveOpenCodeProviderId(vendor);
+
+  if (!model.includes("/")) {
+    return `${openCodeProviderId}/${model}`;
+  }
+
+  const vendorPrefix = `${vendor.vendorId}/`;
+
+  if (openCodeProviderId !== vendor.vendorId && model.startsWith(vendorPrefix)) {
+    return `${openCodeProviderId}/${model.slice(vendorPrefix.length)}`;
+  }
+
+  return model;
 }
 
 function buildOpenCodeProviderConfig(input: RuntimeVendorEnvironmentInput): OpenCodeProviderConfig {

--- a/apps/api/tests/available-models.test.ts
+++ b/apps/api/tests/available-models.test.ts
@@ -104,6 +104,15 @@ function createAvailableModelsDatabase(): SqliteD1Database {
       NULL
     ),
     (
+      'credential-zhipu',
+      '${APP_ID}',
+      'zhipu',
+      'Zhipu default',
+      'secret-zhipu',
+      NULL,
+      NULL
+    ),
+    (
       'credential-custom',
       '${APP_ID}',
       'openai-compatible',
@@ -182,6 +191,13 @@ describe("available models", () => {
     });
     expect(
       entries.find((entry) => entry.vendorId === "gemini" && entry.modelId === "gemini-3.5-flash"),
+    ).toMatchObject({
+      available: true,
+      statusDetail: null,
+      statusLabel: "Available",
+    });
+    expect(
+      entries.find((entry) => entry.vendorId === "zhipu" && entry.modelId === "glm-4.7"),
     ).toMatchObject({
       available: true,
       statusDetail: null,

--- a/apps/api/tests/runtime-vendor-env-vars.test.ts
+++ b/apps/api/tests/runtime-vendor-env-vars.test.ts
@@ -138,6 +138,7 @@ describe("runtime vendor env vars", () => {
     },
     {
       baseURL: "https://api.z.ai/api/paas/v4",
+      openCodeProviderId: "zai",
       model: "glm-4.7",
       name: "Zhipu",
       npm: "@ai-sdk/openai-compatible",
@@ -152,8 +153,9 @@ describe("runtime vendor env vars", () => {
     },
   ])(
     "generates OpenCode adapter provider config for $name official API keys",
-    ({ baseURL, model, name, npm, vendor }) => {
+    ({ baseURL, model, name, npm, openCodeProviderId, vendor }) => {
       const typedVendor: RuntimeCatalogVendor = vendor;
+      const providerId = openCodeProviderId ?? typedVendor.vendorId;
       const envVars = buildRuntimeVendorEnvVars({
         credential: {
           apiBase: null,
@@ -172,11 +174,11 @@ describe("runtime vendor env vars", () => {
 
       expect(envVars[typedVendor.apiKeyEnvVar]).toBe("sk-provider");
       expect(config).toMatchObject({
-        enabled_providers: [typedVendor.vendorId],
-        model: `${typedVendor.vendorId}/${model}`,
-        small_model: `${typedVendor.vendorId}/${model}`,
+        enabled_providers: [providerId],
+        model: `${providerId}/${model}`,
+        small_model: `${providerId}/${model}`,
         provider: {
-          [typedVendor.vendorId]: {
+          [providerId]: {
             name,
             npm,
             options: {
@@ -188,6 +190,38 @@ describe("runtime vendor env vars", () => {
       });
     },
   );
+
+  test("rewrites Mosoo Zhipu model prefix to OpenCode's Z.ai provider id", () => {
+    const envVars = buildRuntimeVendorEnvVars({
+      credential: {
+        apiBase: null,
+        apiKey: "sk-zhipu",
+        credentialId: "01J000000000000000000000C9",
+        models: null,
+      },
+      model: "zhipu/glm-4.6",
+      runtimeId: "acp-fallback",
+      vendor: VENDOR_ZHIPU,
+    });
+    const config = JSON.parse(envVars["OPENCODE_CONFIG_CONTENT"] ?? "{}") as Record<
+      string,
+      unknown
+    >;
+
+    expect(config).toMatchObject({
+      enabled_providers: ["zai"],
+      model: "zai/glm-4.6",
+      provider: {
+        zai: {
+          options: {
+            apiKey: "{env:ZHIPU_API_KEY}",
+            baseURL: "https://api.z.ai/api/paas/v4",
+          },
+        },
+      },
+      small_model: "zai/glm-4.6",
+    });
+  });
 
   test("generates OpenCode custom provider config for a DeepSeek-backed OpenAI-compatible model", () => {
     const envVars = buildRuntimeVendorEnvVars({

--- a/apps/web/tests/provider-runtime-availability.test.ts
+++ b/apps/web/tests/provider-runtime-availability.test.ts
@@ -41,6 +41,16 @@ describe("provider runtime availability", () => {
     });
   });
 
+  test("marks Zhipu credentials as OpenCode-ready through the catalog adapter mapping", () => {
+    const availabilityRows = listRuntimeAvailabilityRows([credential("zhipu")]);
+    const openCodeRow = availabilityRows.find((runtime) => runtime.runtimeId === "acp-fallback");
+
+    expect(openCodeRow).toMatchObject({
+      status: "Ready · Zhipu configured",
+      tone: "ready",
+    });
+  });
+
   test("marks custom OpenAI-compatible credentials as runtime readiness for custom-capable runtimes", () => {
     const availabilityRows = listRuntimeAvailabilityRows([credential("openai-compatible")]);
     const openCodeRow = availabilityRows.find((runtime) => runtime.runtimeId === "acp-fallback");

--- a/apps/web/tests/runtime-default.test.ts
+++ b/apps/web/tests/runtime-default.test.ts
@@ -40,4 +40,12 @@ describe("default agent runtime", () => {
       runtimeId: "acp-fallback",
     });
   });
+
+  test("uses the Mosoo Zhipu provider identity when only Zhipu is configured", () => {
+    expect(resolveDefaultAgentRuntime([credential("zhipu")])).toEqual({
+      model: "glm-4.7",
+      provider: "zhipu",
+      runtimeId: "acp-fallback",
+    });
+  });
 });

--- a/docs/prd/runtime-catalog.md
+++ b/docs/prd/runtime-catalog.md
@@ -46,19 +46,19 @@ When a maintainer adds a runtime, they should be able to:
 
 ## 5. Concept Definitions
 
-| Concept                    | Product definition                                                                                                               |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| Runtime                    | A launchable Agent driver choice shown to users, such as Claude Agent SDK, OpenAI Runtime, or OpenCode.                          |
-| Transport                  | The control path Runtime uses to talk to the Driver backend, such as `claude-agent-sdk`, `openai-app-server`, or `acp-fallback`. |
-| Provider                   | A Mosoo product-facing credential provider that can back one or more runtimes. Its id is chosen by Mosoo, not by an upstream registry. |
-| Adapter profile            | The provider-specific protocol shape a runtime backend must render, such as OpenAI Responses API, Anthropic Messages, or OpenAI-compatible base URL. |
-| Provider model source      | Metadata describing where Mosoo can import or refresh a Provider's model list, such as a `models.dev` provider id or a Provider `/models` endpoint. |
-| Provider model             | A known model option shipped by Mosoo for a first-class Provider.                                                                |
-| Custom OpenAI-compatible   | App-defined credentials with user-provided Base URL and Model IDs. It is an action entry point, not a fixed Provider card.       |
-| Public runtime             | A runtime visible and selectable in Agent creation.                                                                              |
-| Internal runtime           | A cataloged runtime that is not user-selectable.                                                                                 |
-| Planned runtime            | Display-only roadmap metadata. It must not affect runtime admission or launchability.                                            |
-| Icon key                   | A catalog-owned symbolic key that Web maps to an imported brand asset.                                                           |
+| Concept                  | Product definition                                                                                                                                   |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime                  | A launchable Agent driver choice shown to users, such as Claude Agent SDK, OpenAI Runtime, or OpenCode.                                              |
+| Transport                | The control path Runtime uses to talk to the Driver backend, such as `claude-agent-sdk`, `openai-app-server`, or `acp-fallback`.                     |
+| Provider                 | A Mosoo product-facing credential provider that can back one or more runtimes. Its id is chosen by Mosoo, not by an upstream registry.               |
+| Adapter profile          | The provider-specific protocol shape a runtime backend must render, such as OpenAI Responses API, Anthropic Messages, or OpenAI-compatible base URL. |
+| Provider model source    | Metadata describing where Mosoo can import or refresh a Provider's model list, such as a `models.dev` provider id or a Provider `/models` endpoint.  |
+| Provider model           | A known model option shipped by Mosoo for a first-class Provider.                                                                                    |
+| Custom OpenAI-compatible | App-defined credentials with user-provided Base URL and Model IDs. It is an action entry point, not a fixed Provider card.                           |
+| Public runtime           | A runtime visible and selectable in Agent creation.                                                                                                  |
+| Internal runtime         | A cataloged runtime that is not user-selectable.                                                                                                     |
+| Planned runtime          | Display-only roadmap metadata. It must not affect runtime admission or launchability.                                                                |
+| Icon key                 | A catalog-owned symbolic key that Web maps to an imported brand asset.                                                                               |
 
 ## 6. Relationship Lock
 
@@ -95,12 +95,12 @@ Provider ids are Mosoo product ids. They should be stable, readable, and aligned
 
 Examples:
 
-| Mosoo Provider id | User-facing label | Possible upstream model source |
-| ----------------- | ----------------- | ------------------------------ |
-| `gemini`          | Gemini            | `models.dev` provider `google` |
+| Mosoo Provider id | User-facing label | Possible upstream model source                               |
+| ----------------- | ----------------- | ------------------------------------------------------------ |
+| `gemini`          | Gemini            | `models.dev` provider `google`                               |
 | `qwen`            | Qwen              | `models.dev` provider `alibaba` or regional Alibaba variants |
-| `kimi`            | Kimi              | `models.dev` provider `moonshotai` |
-| `zhipu`           | Zhipu             | `models.dev` provider `zai` or `zhipuai` |
+| `kimi`            | Kimi              | `models.dev` provider `moonshotai`                           |
+| `zhipu`           | Zhipu             | `models.dev` provider `zai` or `zhipuai`                     |
 | `minimax`         | MiniMax           | `models.dev` provider `minimax` or regional MiniMax variants |
 
 This is not a runtime mapping layer. The catalog generator may use `modelSource` to import or refresh Provider model metadata, but generated Mosoo artifacts should expose Mosoo Provider ids to API, Web, and Driver code.
@@ -141,6 +141,7 @@ When adding a model source, first decide the identity boundary:
 
 - Add a new **Vendor** when credentials, billing, model ownership, or user-facing provider identity differ. DeepSeek is a vendor because it uses `DEEPSEEK_API_KEY`, DeepSeek-owned models, and a DeepSeek API base.
 - Add or reuse an **Adapter profile** when the same runtime transport must render a different protocol config for that vendor. If OpenCode already ships a native provider such as DeepSeek, Mosoo should use the native provider shape and avoid an adapter shim.
+- When an OpenCode upstream provider id differs from the Mosoo Provider id, keep the Mosoo `vendorId` as the product identity and set the adapter's OpenCode provider id in the catalog. For example, Mosoo `zhipu` renders as OpenCode `zai/...` while credentials and UI remain `zhipu`.
 - Do not encode a vendor as another vendor's model prefix. `opencode/deepseek-v4-pro` means OpenCode Zen owns the credential and endpoint; `deepseek/deepseek-v4-pro` means DeepSeek owns them, even if OpenCode launches the ACP process.
 - OpenAI can have multiple adapter profiles across runtimes: the OpenAI Runtime path uses the OpenAI runtime / Responses-style backend contract, while ACP fallback may use OpenCode-native or OpenAI-compatible config. The provider id remains `openai`; the adapter profile changes by runtime path.
 

--- a/pkgs/runtime-catalog/catalog/runtime-catalog.jsonc
+++ b/pkgs/runtime-catalog/catalog/runtime-catalog.jsonc
@@ -157,6 +157,7 @@
       },
       "openCodeProvider": {
         "name": "Zhipu",
+        "providerId": "zai",
         "npmPackage": "@ai-sdk/openai-compatible",
         "apiBaseOption": "baseURL",
       },

--- a/pkgs/runtime-catalog/scripts/generate-runtime-catalog.ts
+++ b/pkgs/runtime-catalog/scripts/generate-runtime-catalog.ts
@@ -76,6 +76,7 @@ interface RawOpenCodeProvider {
   apiBaseOption?: "baseURL";
   name: string;
   npmPackage: string;
+  providerId?: string;
 }
 
 interface RawModel {
@@ -282,11 +283,13 @@ function readOpenCodeProvider(value: unknown, label: string): RawOpenCodeProvide
   if (apiBaseOption !== undefined && apiBaseOption !== "baseURL") {
     fail(`${label}.apiBaseOption must be baseURL.`);
   }
+  const providerId = readOptionalString(provider["providerId"], `${label}.providerId`);
 
   return {
     ...(apiBaseOption === undefined ? {} : { apiBaseOption }),
     name: readString(provider["name"], `${label}.name`),
     npmPackage: readString(provider["npmPackage"], `${label}.npmPackage`),
+    ...(providerId === undefined ? {} : { providerId }),
   };
 }
 

--- a/pkgs/runtime-catalog/src/catalog.generated.ts
+++ b/pkgs/runtime-catalog/src/catalog.generated.ts
@@ -164,6 +164,7 @@ export const GENERATED_VENDOR_CATALOG = [
       apiBaseOption: "baseURL",
       name: "Zhipu",
       npmPackage: "@ai-sdk/openai-compatible",
+      providerId: "zai",
     },
     vendorId: "zhipu",
   },

--- a/pkgs/runtime-catalog/src/runtime-catalog.ts
+++ b/pkgs/runtime-catalog/src/runtime-catalog.ts
@@ -68,6 +68,12 @@ export interface RuntimeCatalogOpenCodeProvider {
   readonly apiBaseOption?: "baseURL";
   readonly name: string;
   readonly npmPackage: string;
+  /**
+   * Provider id expected by OpenCode for this adapter. Mosoo keeps its own
+   * product-facing provider id in `vendorId`; this field is only for rendered
+   * OpenCode config/model ids when upstream uses a different provider key.
+   */
+  readonly providerId?: string;
 }
 
 /**
@@ -208,6 +214,9 @@ function runtimeCatalogVendor(
               : {}),
             name: openCodeProvider.name,
             npmPackage: openCodeProvider.npmPackage,
+            ...("providerId" in openCodeProvider
+              ? { providerId: openCodeProvider.providerId }
+              : {}),
           },
         }
       : {}),

--- a/pkgs/runtime-catalog/tests/runtime-model-identity-admission.test.ts
+++ b/pkgs/runtime-catalog/tests/runtime-model-identity-admission.test.ts
@@ -11,6 +11,7 @@ import {
   VENDOR_DEEPSEEK,
   VENDOR_OPENAI,
   VENDOR_OPENAI_COMPATIBLE,
+  VENDOR_ZHIPU,
   admitRuntimeModelIdentity,
   admitRuntimeModelIdentityForCatalog,
   getRuntimeDisplayColor,
@@ -269,6 +270,17 @@ describe("runtime catalog identity admission", () => {
     expect(listRuntimeShowcaseDisplayEntries()).toEqual(PUBLIC_RUNTIME_DISPLAY_CATALOG);
     expect(getRuntimeIconKey("acp-fallback")).toBe("opencode");
     expect(getRuntimeDisplayColor("openai-runtime")).toBe("#7A9DFF");
+  });
+
+  test("keeps Mosoo Zhipu identity while rendering OpenCode with the Z.ai provider id", () => {
+    expect(VENDOR_ZHIPU.vendorId).toBe("zhipu");
+    expect(VENDOR_ZHIPU.modelSource).toMatchObject({
+      kind: "models.dev",
+      providerId: "zai",
+    });
+    expect(VENDOR_ZHIPU.openCodeProvider).toMatchObject({
+      providerId: "zai",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- map Mosoo Zhipu vendor to OpenCode provider id `zai` while preserving product-facing vendor id `zhipu`
- render OpenCode config/model ids with the upstream provider id and rewrite old `zhipu/...` model ids
- update runtime catalog generation, admission/readiness tests, and the driver submodule pointer

## Driver dependency
- langgenius/mosoo-agent-driver#25

## Verification
- vp run --filter @mosoo/runtime-catalog catalog:generate
- vp run --filter @mosoo/runtime-catalog test
- vp run --filter @mosoo/runtime-catalog tc
- just test-file apps/api/tests/runtime-vendor-env-vars.test.ts
- just test-file apps/api/tests/available-models.test.ts
- just test-file apps/web/tests/provider-runtime-availability.test.ts
- just test-file apps/web/tests/runtime-default.test.ts
- just tc-package @mosoo/api
- just tc-package @mosoo/web
- apps/driver: vp fmt --check --ignore-path .gitignore src/runtimes/acp/acp-event-translator.ts tests/acp-event-translator.test.ts
- apps/driver: vp exec bun test tests/acp-event-translator.test.ts
- apps/driver: vp exec bun test tests/acp-provider-fixtures.test.ts
- apps/driver: bun run tc
- apps/driver: vp exec bun test tests/opencode-acp-live.test.ts with live Zhipu key
- git diff --check
- git -C apps/driver diff --check
- bash ./init.sh development