### PR TITLE
fix(providers): remove duplicate provider error between test and save

### DIFF
--- a/apps/web/src/routes/providers/provider-test-status.tsx
+++ b/apps/web/src/routes/providers/provider-test-status.tsx
@@ -1,35 +1,20 @@
-import { Check, X } from "lucide-react";
+import { Check } from "lucide-react";
 import type { ReactElement } from "react";
 
 type TestConnectionState = "failure" | "idle" | "running" | "success";
 
-export function ProviderTestStatus({
-  error,
-  state,
-}: {
-  error: string | null;
-  state: TestConnectionState;
-}): ReactElement | null {
-  if (state === "success") {
-    return (
-      <span className="inline-flex items-center gap-1 text-[12px] text-green-700">
-        <Check className="size-3.5 shrink-0" />
-        Connection ok
-      </span>
-    );
-  }
-
-  if (state !== "failure") {
+// Only the success state renders inline next to the Test button. Failures are
+// surfaced by the form-level alert above the footer, so showing them here too
+// would duplicate the same message between the Test and Save buttons.
+export function ProviderTestStatus({ state }: { state: TestConnectionState }): ReactElement | null {
+  if (state !== "success") {
     return null;
   }
 
   return (
-    <output
-      aria-live="polite"
-      className="text-destructive inline-flex max-w-[32rem] items-start gap-1 text-[12px] leading-snug break-words whitespace-normal"
-    >
-      <X className="mt-0.5 size-3.5 shrink-0" />
-      {error ?? "Provider error"}
-    </output>
+    <span className="inline-flex items-center gap-1 text-[12px] text-green-700">
+      <Check className="size-3.5 shrink-0" />
+      Connection ok
+    </span>
   );
 }

--- a/apps/web/src/routes/providers/providers-tab.tsx
+++ b/apps/web/src/routes/providers/providers-tab.tsx
@@ -483,7 +483,7 @@ function ProviderCredentialDialogForm({
           <Button disabled={testState === "running"} onClick={onTest} size="sm" variant="outline">
             {testState === "running" ? "Testing..." : "Test"}
           </Button>
-          <ProviderTestStatus error={error} state={testState} />
+          <ProviderTestStatus state={testState} />
         </div>
         <Button disabled={saving} onClick={onSave} size="sm">
           {saving ? "Saving..." : "Save"}


### PR DESCRIPTION
## Summary

- Removes the duplicate provider-error message that appeared between the **Test** and **Save** buttons in the provider-key dialog (e.g. "Add MiniMax key").
- The connection-failure error is now shown only once, in the form-level alert above the footer. `ProviderTestStatus` keeps rendering the "Connection ok" success indicator inline next to **Test**.

## Why

- On a failed connection test, the same `Provider error: ...` string was rendered twice: in the alert box above the footer **and** inline between Test and Save. The inline copy was visually redundant and crowded the footer.

## Verification

- Commands: `bun run tc` (web), `bun run lint` (web), `bun run fmt:check:path` on both changed files — all pass.
- Manual: rendered the dialog footer in the failure state; only the form-level alert remains, the inline error is gone, Cancel/Test/Save layout is clean.

## Risk And Blast Radius

- Affected packages: `@mosoo/web`
- Affected user flows: Providers tab → add/edit provider key dialog (Test button feedback).
- Rollback: revert this commit; no data or API impact.

## Evidence

- UI/UX, provider-key dialog in the connection-failure state:
  - **Before:** error shown twice — once in the alert box above the footer, and again inline as `✕ Provider error: Failed to fetch` wedged between the Test and Save buttons.
  - **After:** error shown once in the alert box; footer is just `Cancel … Test  Save`. The inline slot still shows "Connection ok" on a successful test.
- Before/after screenshot attached to the tracking issue YEF-765.

## Compatibility

- Public contract changes: none
- Env or config changes: none
- Deployment or migration: none

## Reviewer Focus

- `apps/web/src/routes/providers/provider-test-status.tsx`: now renders only the success state; failure handled by the form-level alert.
- `apps/web/src/routes/providers/providers-tab.tsx`: drops the now-unused `error` prop from `<ProviderTestStatus>`.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `fix`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A — no generated files, schema, or lockfile changes.
- Confirm no hand-edits to generated paths: confirmed.
