### PR TITLE
fix(agent-detail): remove Terminal tab from agent header

### DIFF
--- a/apps/web/src/routes/agent/agent-detail.route.tsx
+++ b/apps/web/src/routes/agent/agent-detail.route.tsx
@@ -1,5 +1,4 @@
-import { ArrowLeft, Settings, TerminalSquare } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
+import { ArrowLeft, Settings } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
@@ -40,12 +39,6 @@ const MODE_TABS: { id: DetailMode; label: string }[] = [
   { id: "cost", label: "Cost" },
 ];
 
-interface DebugModeItem {
-  icon: LucideIcon;
-  id: Extract<DetailMode, "terminal">;
-  label: string;
-}
-
 function toDetailMode(value: string | null): DetailMode | null {
   switch (value) {
     case "consume":
@@ -62,7 +55,6 @@ function toDetailMode(value: string | null): DetailMode | null {
 
 function AgentDetailHeader({
   agent,
-  debugItems,
   headerActionTargetRef,
   mode,
   onBack,
@@ -72,7 +64,6 @@ function AgentDetailHeader({
   runtime,
 }: {
   agent: Agent;
-  debugItems: DebugModeItem[];
   headerActionTargetRef: (node: HTMLDivElement | null) => void;
   mode: DetailMode;
   onBack: () => void;
@@ -127,25 +118,6 @@ function AgentDetailHeader({
             {tab.label}
           </button>
         ))}
-        {debugItems.map((item) => {
-          const Icon = item.icon;
-          return (
-            <button
-              key={item.id}
-              type="button"
-              onClick={() => {
-                onSelectMode(item.id);
-              }}
-              className={cn(
-                "flex items-center gap-1.5 rounded-lg px-3.5 py-1.5 text-[13px] font-medium transition-all",
-                mode === item.id ? "bg-ink-100 text-fg-1" : "text-muted-foreground hover:bg-accent",
-              )}
-            >
-              <Icon aria-hidden="true" size={14} />
-              {item.label}
-            </button>
-          );
-        })}
       </div>
 
       <div className="flex items-center gap-2">
@@ -194,10 +166,6 @@ export function AgentDetailPage() {
     itemId: "terminal",
     viewerRole: detailQuery.data?.viewerRole ?? null,
   });
-  const debugItems: DebugModeItem[] = [];
-  if (canUseTerminal) {
-    debugItems.push({ icon: TerminalSquare, id: "terminal", label: "Terminal" });
-  }
   const urlMode = toDetailMode(searchParams.get("tab") ?? searchParams.get("mode"));
 
   const handleSelectMode = useCallback(
@@ -311,7 +279,6 @@ export function AgentDetailPage() {
     <div className="flex h-full flex-col">
       <AgentDetailHeader
         agent={agent}
-        debugItems={debugItems}
         headerActionTargetRef={setHeaderActionTarget}
         mode={mode}
         onBack={() => {


### PR DESCRIPTION
## Summary

- Remove the **Terminal** tab/icon from the agent-detail header (`AgentDetailPage`). The header center group now shows only Preview / Logs / Cost.

## Why

- Requested in [YEF-766](https://multica.ai): the Terminal entry is a debug-only surface that should not be exposed in the header UI.

## Verification

- Commands: `vp exec tsc --noEmit` (clean), `vp lint .` (clean) in `apps/web`.
- Manual steps: rendered the header in an isolated preview against the app theme tokens to confirm the Terminal tab is gone while Preview/Logs/Cost are unchanged. Before/after screenshots are attached to the YEF-766 issue comment.

## Risk And Blast Radius

- Affected packages: `@mosoo/web` (`apps/web/src/routes/agent/agent-detail.route.tsx`) only.
- Affected user flows: agent-detail header. The terminal *mode* itself is untouched and still resolves; only its header entry point is removed (the `?tab=terminal` deep link remains gated by `canUseTerminal`).
- Rollback: revert this commit.

## Evidence

- UI/UX: before/after screenshots posted on the YEF-766 issue (Terminal tab present → removed).

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: header tab rendering in `AgentDetailHeader`; removed the now-unused `DebugModeItem` type, `debugItems` prop/array, and `TerminalSquare`/`LucideIcon` imports.
- Known trade-offs: none.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `fix`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: sign if prompted
- [x] Self-assigned
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence
- [x] Generated files: none touched

## Generated Files, Schema, And Lockfile

- N/A
