### PR TITLE
fix(deploy): stabilize production release

### DIFF
--- a/apps/api/bin/deploy-prod.ts
+++ b/apps/api/bin/deploy-prod.ts
@@ -249,6 +249,6 @@ writeStdout("▶ Building driver");
 runVp(["run", "--filter", "agent-driver", "build"]);
 
 writeStdout("▶ Deploying worker");
-run(["deploy", "--env", ENV]);
+run(["deploy", "--env", ENV, "--minify"]);
 
 writeStdout("✓ deploy complete");

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -176,7 +176,7 @@ bucket_name = "mosoo-sandbox-state"
 [[env.prod.d1_databases]]
 binding = "DB"
 database_name = "mosoo-prod"
-database_id = "36b60a1f-b724-42e1-adb7-1d759ed16d2d"
+database_id = "c851724c-2aa2-4c10-ac92-df74ae6e5dd0"
 migrations_dir = "../../pkgs/db/drizzle"
 
 [[env.prod.queues.producers]]

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -10,7 +10,7 @@
     "lint": "vp lint ."
   },
   "dependencies": {
-    "@astrojs/mdx": "^7.0.0",
+    "@astrojs/mdx": "^6.0.3",
     "@astrojs/sitemap": "^3.7.3",
     "@mosoo/design-tokens": "workspace:*",
     "@tailwindcss/vite": "^4.3.1",

--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,7 @@
     "apps/blog": {
       "name": "@mosoo/blog",
       "dependencies": {
-        "@astrojs/mdx": "^7.0.0",
+        "@astrojs/mdx": "^6.0.3",
         "@astrojs/sitemap": "^3.7.3",
         "@mosoo/design-tokens": "workspace:*",
         "@tailwindcss/vite": "^4.3.1",
@@ -361,7 +361,7 @@
 
     "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.2.0", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.0", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw=="],
 
-    "@astrojs/mdx": ["@astrojs/mdx@7.0.0", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.0", "@astrojs/markdown-remark": "7.2.0", "@mdx-js/mdx": "^3.1.1", "acorn": "^8.16.0", "es-module-lexer": "^2.0.0", "estree-util-visit": "^2.0.0", "hast-util-to-html": "^9.0.5", "piccolore": "^0.1.3", "rehype-raw": "^7.0.0", "remark-gfm": "^4.0.1", "remark-smartypants": "^3.0.2", "source-map": "^0.7.6", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "@astrojs/markdown-satteri": "^0.3.1-alpha.0", "astro": "^7.0.0-alpha.0" }, "optionalPeers": ["@astrojs/markdown-satteri"] }, "sha512-LKwNA8nnLtEM0auoP6OfH/UnlKe1Ub59qZjbcYkZjPBGw6PkJewWkA/1qwLpECvV6gMDd6TR6eqV9p/VYZrcrQ=="],
+    "@astrojs/mdx": ["@astrojs/mdx@6.0.3", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.0", "@astrojs/markdown-remark": "7.2.0", "@mdx-js/mdx": "^3.1.1", "acorn": "^8.16.0", "es-module-lexer": "^2.0.0", "estree-util-visit": "^2.0.0", "hast-util-to-html": "^9.0.5", "piccolore": "^0.1.3", "rehype-raw": "^7.0.0", "remark-gfm": "^4.0.1", "remark-smartypants": "^3.0.2", "source-map": "^0.7.6", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "@astrojs/markdown-satteri": "0.3.0", "astro": "^6.4.0" }, "optionalPeers": ["@astrojs/markdown-satteri"] }, "sha512-+4P3ZvwsRAqAbBgY+uZMewFo3ficlIBPZfu/Luk+v4ia/ZOuFhpsw7r+7672uT2Fc1UPdp7yW0eU5egvSq0wbw=="],
 
     "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
 


### PR DESCRIPTION
## Summary

- Point production API D1 binding at the WH-2099 `mosoo-prod` database.
- Minify API Worker uploads during production deploys to keep the script bundle below the observed upload failure threshold.
- Pin the blog MDX integration to the Astro 6-compatible major and refresh `bun.lock`.

## Why

- The production deployment needed to run under the WH-2099 Cloudflare account and use the newly provisioned D1 database.
- The non-minified API Worker upload was `10278.78 KiB` and repeatedly failed during the Workers script PUT; `--minify` reduced the upload to `4149.73 KiB` and deployed successfully.
- `@astrojs/mdx@7.0.0` expects Astro 7, but the repo currently uses Astro 6.4.x, which broke the web/blog build.

## Verification

- Commands (`just check`, `just test-file <path>`, `just graphql-codegen`, etc.):
  - `bun install --frozen-lockfile`
  - `rtk vp exec bun pkgs/runtime-catalog/scripts/generate-runtime-catalog.ts --check`
  - `rtk vp run --filter @mosoo/runtime-catalog test`
  - `rtk just check`
  - `CLOUDFLARE_ACCOUNT_ID=2a66b3c81860bc4990156be493151f93 rtk just deploy-api`
  - `PATH=/opt/homebrew/bin:$PATH CLOUDFLARE_ACCOUNT_ID=2a66b3c81860bc4990156be493151f93 rtk just deploy-web`
  - `PATH=/opt/homebrew/bin:$PATH rtk just check`
- Manual steps:
  - Verified `mosoo-api-prod` deployment version `f737af5e-861d-423a-a3ad-f3cf51126f4d`.
  - Verified `mosoo-web-prod` deployment version `1f912cab-2b99-443f-ae63-3e498b54c57b`.
  - Verified `https://try.mosoo.ai/` returns `HTTP/2 200` using `curl --interface en0 --resolve try.mosoo.ai:443:104.18.0.1`.
  - Verified `https://try.mosoo.ai/api/health` returns `{"name":"mosoo","ok":true}`.
  - Verified `https://try.mosoo.ai/api/graphql` returns `{"data":{"__typename":"Query"}}`.
  - Verified a missing blog URL returns `HTTP/2 404`.

## Risk And Blast Radius

- Affected packages:
  - `@mosoo/api`
  - `@mosoo/blog`
- Affected user flows or APIs:
  - Production deploy flow.
  - Production API D1 binding.
  - Blog build during web deploy.
- Rollback:
  - Revert this PR to restore the previous D1 binding, API deploy command, and MDX dependency.
  - Cloudflare Workers can also be rolled back to the previous API/Web deployment versions if needed.

## Evidence

- UI/UX: N/A, no visible UI behavior change.
- API or behavior:
  - API health and GraphQL probes passed against `try.mosoo.ai` after deployment.
- Logs, recordings, or test output:
  - `just check` passed after the changes.
  - Cloudflare deployments list shows the API and Web versions above.

## Compatibility

- Public contract changes:
  - None.
- Env or config changes:
  - Production D1 database id now points at the WH-2099 `mosoo-prod` database.
- Deployment or migration:
  - Production D1 baseline migration was applied to the new WH-2099 database.
  - Production API and Web Workers were deployed successfully.

## Reviewer Focus

- Closest review areas:
  - `apps/api/bin/deploy-prod.ts`
  - `apps/api/wrangler.toml`
  - `apps/blog/package.json`
  - `bun.lock`
- Known trade-offs:
  - `--minify` is now part of the production API deploy path to avoid oversized Worker uploads.

## Required Checks

- [x] PR title: `type(scope): subject` (e.g. `fix(fmt): restore pre-commit checks`)
- [x] Type: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`, `build`, `ci`, `style`, or `revert`
- [x] Subject starts lowercase; `!` only for intentional breaking changes (e.g. `feat(api)!: remove legacy session field`)
- [x] Branch follows `type/scope-subject` when maintained in this repository; fork branch names may vary
- [x] Commits: `type(scope): subject`, English only
- [x] CLA: if prompted by CLA Assistant, every human contributor has signed by posting the exact required PR comment
- [x] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence, or N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- Touched artifacts:
  - `bun.lock`
- GraphQL codegen (`just graphql-codegen`): N/A
- DB baseline (`just db-regen`): N/A
- Lockfile (`bun.lock`): updated by `bun install` after pinning `@astrojs/mdx` to `^6.0.3`
- Confirm no hand-edits to generated paths (`schema.generated.graphql`, `apps/web/src/gql/**`, `pkgs/db/drizzle/**`): confirmed
