### PR TITLE
fix(account-menu): remove apps shortcut

### DIFF
--- a/apps/web/src/app/account-menu.tsx
+++ b/apps/web/src/app/account-menu.tsx
@@ -1,5 +1,4 @@
 import ChevronsDownUpIcon from "@hugeicons/core-free-icons/ChevronsDownUpIcon";
-import GridViewIcon from "@hugeicons/core-free-icons/GridViewIcon";
 import Logout01Icon from "@hugeicons/core-free-icons/Logout01Icon";
 import Settings02Icon from "@hugeicons/core-free-icons/Settings02Icon";
 import { Link } from "react-router-dom";
@@ -24,7 +23,6 @@ import { createHugeicon } from "./hugeicon";
 const AccountMenuChevronIcon = createHugeicon(ChevronsDownUpIcon, "AccountMenuChevronIcon");
 const AccountMenuSettingsIcon = createHugeicon(Settings02Icon, "AccountMenuSettingsIcon");
 const AccountMenuSignOutIcon = createHugeicon(Logout01Icon, "AccountMenuSignOutIcon");
-const AccountMenuAppsIcon = createHugeicon(GridViewIcon, "AccountMenuAppsIcon");
 
 interface AccountMenuUser {
   email: string;
@@ -113,12 +111,6 @@ export function AccountMenu({
             <div className="text-fg-3 mt-0.5 text-[11.5px] font-normal">{user?.email}</div>
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
-          <DropdownMenuItem asChild className="cursor-pointer rounded-md">
-            <Link to="/apps">
-              <AccountMenuAppsIcon className="size-4" />
-              Apps
-            </Link>
-          </DropdownMenuItem>
           <DropdownMenuItem asChild className="cursor-pointer rounded-md">
             <Link to="/settings">
               <AccountMenuSettingsIcon className="size-4" />

--- a/apps/web/tests/app-settings-boundary.test.ts
+++ b/apps/web/tests/app-settings-boundary.test.ts
@@ -81,6 +81,7 @@ describe("App settings boundary", () => {
     const primaryNav = readSource("../src/app/navigation.tsx");
 
     expect(accountMenu).toContain('to="/settings"');
+    expect(accountMenu).not.toContain('to="/apps"');
     expect(primaryNav).not.toContain('label: "Settings"');
   });
 });


### PR DESCRIPTION
## Summary

- Remove the `Apps` shortcut from the account dropdown menu.
- Keep the existing `Settings` and `Sign out` account actions.
- Add a boundary test so the account menu does not regain a direct `/apps` link.

## Validation

- `bun test apps/web/tests/app-settings-boundary.test.ts`
- `bun run --filter @mosoo/web lint`
- `bun run --filter @mosoo/web tc`
- `bun run --filter @mosoo/web test`
- `bun run commit:check`
- Playwright visual check: account dropdown shows Settings and Sign out, with no Apps item.

## Generated Files / Codegen / DB

None.

Closes #177
