### PR TITLE
fix(agent): route publish token CTA to settings

### DIFF
--- a/apps/web/src/routes/agent/lifecycle/api-access-panel.tsx
+++ b/apps/web/src/routes/agent/lifecycle/api-access-panel.tsx
@@ -1,6 +1,7 @@
 import { BookOpen, Check, Code, Copy, KeyRound } from "lucide-react";
 import { useMemo, useState } from "react";
 import type { ReactElement, ReactNode } from "react";
+import { Link } from "react-router-dom";
 
 import { Button } from "@/shared/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shared/ui/dialog";
@@ -108,10 +109,10 @@ export function AgentApiAccessPanel({
         <ApiAccessDetailRow
           action={
             <Button asChild className="gap-1 text-[11.5px]" size="xs" variant="outline">
-              <a href={distribution.tokenSettingsPath}>
+              <Link to={distribution.tokenSettingsPath}>
                 <KeyRound className="size-3" />
                 Create token
-              </a>
+              </Link>
             </Button>
           }
           label="API token"

--- a/apps/web/tests/app-settings-boundary.test.ts
+++ b/apps/web/tests/app-settings-boundary.test.ts
@@ -65,6 +65,18 @@ describe("App settings boundary", () => {
     expect(combinedSource.toLowerCase()).not.toContain("published agent");
   });
 
+  test("routes publish API token guidance to Access Tokens settings", () => {
+    const apiAccessPanel = readSource("../src/routes/agent/lifecycle/api-access-panel.tsx");
+    const distributionInfo = readSource("../src/routes/agent/lifecycle/distribution-info.ts");
+
+    expect(distributionInfo).toContain(
+      'const ACCESS_TOKEN_SETTINGS_PATH = "/settings/access-tokens";',
+    );
+    expect(apiAccessPanel).toContain('import { Link } from "react-router-dom";');
+    expect(apiAccessPanel).toContain("<Link to={distribution.tokenSettingsPath}>");
+    expect(apiAccessPanel).not.toContain("<a href={distribution.tokenSettingsPath}>");
+  });
+
   test("does not expose Web organization mutation clients", () => {
     const organizationApiIndex = readSource("../src/domains/organization/api/index.ts");
 


### PR DESCRIPTION
## Summary

- Route the agent publish API token CTA through React Router to `/settings/access-tokens`.
- Add a boundary test to keep publish API token guidance pointed at Access Tokens settings.

## Root Cause

The publish API access panel rendered the Access Tokens CTA as a raw anchor. Keeping the CTA on the app router makes the guidance resolve to the intended settings route consistently.

## Verification

- `bun test apps/web/tests/app-settings-boundary.test.ts`
- `bun run --filter @mosoo/web tc`
- `bun run --filter @mosoo/web lint`
- `bun run commit:check`

Closes YEF-768
