### PR TITLE
fix(sidebar): make app settings standalone

### DIFF
--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -2,11 +2,9 @@ import AppWindowIcon from "@hugeicons/core-free-icons/AppWindowIcon";
 import CheckIcon from "@hugeicons/core-free-icons/CheckIcon";
 import ChevronLeftIcon from "@hugeicons/core-free-icons/ChevronLeftIcon";
 import ChevronsDownUpIcon from "@hugeicons/core-free-icons/ChevronsDownUpIcon";
-import GridViewIcon from "@hugeicons/core-free-icons/GridViewIcon";
 import PanelLeftCloseIcon from "@hugeicons/core-free-icons/PanelLeftCloseIcon";
 import PanelLeftOpenIcon from "@hugeicons/core-free-icons/PanelLeftOpenIcon";
 import PlusSignIcon from "@hugeicons/core-free-icons/PlusSignIcon";
-import Settings02Icon from "@hugeicons/core-free-icons/Settings02Icon";
 import type { AppSummary } from "@mosoo/contracts/app";
 import type { ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
@@ -19,7 +17,6 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/shared/ui/dropdown-menu";
 import { Separator } from "@/shared/ui/separator";
@@ -37,9 +34,7 @@ const BackIcon = createHugeicon(ChevronLeftIcon, "BackIcon");
 const CheckmarkIcon = createHugeicon(CheckIcon, "CheckmarkIcon");
 const CollapseSidebarIcon = createHugeicon(PanelLeftCloseIcon, "CollapseSidebarIcon");
 const ExpandSidebarIcon = createHugeicon(PanelLeftOpenIcon, "ExpandSidebarIcon");
-const ManageAppsIcon = createHugeicon(GridViewIcon, "ManageAppsIcon");
 const NewAgentIcon = createHugeicon(PlusSignIcon, "NewAgentIcon");
-const SettingsIcon = createHugeicon(Settings02Icon, "SettingsIcon");
 const SwitcherChevronIcon = createHugeicon(ChevronsDownUpIcon, "SwitcherChevronIcon");
 
 // One-click return to the parent Org layer (the Apps list).
@@ -73,8 +68,7 @@ function BackToOrgLink({ collapsed, orgName }: { collapsed: boolean; orgName: st
   );
 }
 
-// App switcher: shows the active App and switches Apps inline via a dropdown,
-// plus shortcuts to manage Apps and open App settings.
+// App switcher: shows the active App and switches Apps inline via a dropdown.
 function AppSwitcher({
   activeApp,
   apps,
@@ -138,19 +132,6 @@ function AppSwitcher({
             ) : null}
           </DropdownMenuItem>
         ))}
-        <DropdownMenuSeparator />
-        <DropdownMenuItem asChild className="cursor-pointer rounded-md">
-          <Link to="/apps">
-            <ManageAppsIcon className="size-4" />
-            Manage apps
-          </Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem asChild className="cursor-pointer rounded-md">
-          <Link to="/settings/app">
-            <SettingsIcon className="size-4" />
-            App settings
-          </Link>
-        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/web/src/app/navigation.tsx
+++ b/apps/web/src/app/navigation.tsx
@@ -63,7 +63,7 @@ const NAV_SECTIONS: AppNavSection[] = [
       {
         icon: createHugeicon(Settings02Icon, "AppSettingsIcon"),
         label: "App settings",
-        path: "/settings/app",
+        path: "/app-settings",
       },
     ],
   },

--- a/apps/web/src/app/navigation.tsx
+++ b/apps/web/src/app/navigation.tsx
@@ -6,6 +6,7 @@ import InboxIcon from "@hugeicons/core-free-icons/InboxIcon";
 import Key01Icon from "@hugeicons/core-free-icons/Key01Icon";
 import PackageIcon from "@hugeicons/core-free-icons/PackageIcon";
 import PuzzleIcon from "@hugeicons/core-free-icons/PuzzleIcon";
+import Settings02Icon from "@hugeicons/core-free-icons/Settings02Icon";
 import type { MouseEvent } from "react";
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
@@ -59,6 +60,11 @@ const NAV_SECTIONS: AppNavSection[] = [
         path: "/integrations",
       },
       { icon: createHugeicon(Key01Icon, "ProvidersIcon"), label: "Providers", path: "/providers" },
+      {
+        icon: createHugeicon(Settings02Icon, "AppSettingsIcon"),
+        label: "App settings",
+        path: "/settings/app",
+      },
     ],
   },
 ];

--- a/apps/web/src/app/route-registry.tsx
+++ b/apps/web/src/app/route-registry.tsx
@@ -136,12 +136,13 @@ const appRoutes = [
   { element: protectedRoute(<AgentDetail />), path: "/agent/:agentId" },
   { element: protectedRoute(<Threads />), path: "/threads" },
   { element: protectedRoute(<Threads />), path: "/threads/:threadId" },
+  { element: protectedRoute(<SettingsApp />), path: "/app-settings" },
   {
     children: [
       { element: <Navigate to="/settings/profile" replace />, index: true },
       { element: <SettingsProfile />, path: "profile" },
       { element: <SettingsAccessTokens />, path: "access-tokens" },
-      { element: <SettingsApp />, path: "app" },
+      { element: <Navigate to="/app-settings" replace />, path: "app" },
       { element: <SettingsUsage />, path: "usage" },
       { element: <Navigate to="/environment" replace />, path: "environments" },
       { element: <Navigate to="/settings/usage" replace />, path: "cost" },

--- a/apps/web/src/routes/settings/app-tab.tsx
+++ b/apps/web/src/routes/settings/app-tab.tsx
@@ -53,7 +53,7 @@ export function AppTab() {
 
   return (
     <>
-      <SettingsTabHeader title="App" />
+      <SettingsTabHeader title="App settings" />
       <SettingsTabBody>
         <div className="space-y-2">
           <label className="text-foreground text-sm font-medium" htmlFor="app-name">

--- a/apps/web/src/routes/settings/settings-nav.tsx
+++ b/apps/web/src/routes/settings/settings-nav.tsx
@@ -1,5 +1,5 @@
 import type { LucideIcon } from "lucide-react";
-import { BarChart3, Box, KeyRound, User } from "lucide-react";
+import { BarChart3, KeyRound, User } from "lucide-react";
 import { NavLink } from "react-router-dom";
 
 import { cn } from "@/shared/lib/class-names";
@@ -15,8 +15,8 @@ interface SettingsNavSection {
   label: string;
 }
 
-// Settings split by ownership: account-global controls vs the active App's own
-// controls. Org-level settings live in the account/billing shell, not here.
+// Settings keeps account-global controls and account-adjacent reporting. App
+// settings live in the primary App sidebar as a standalone page.
 const SETTINGS_NAV_SECTIONS: SettingsNavSection[] = [
   {
     items: [
@@ -26,10 +26,7 @@ const SETTINGS_NAV_SECTIONS: SettingsNavSection[] = [
     label: "Account",
   },
   {
-    items: [
-      { icon: Box, label: "General", path: "/settings/app" },
-      { icon: BarChart3, label: "App usage", path: "/settings/usage" },
-    ],
+    items: [{ icon: BarChart3, label: "App usage", path: "/settings/usage" }],
     label: "App",
   },
 ];

--- a/apps/web/tests/app-navigation-boundary.test.ts
+++ b/apps/web/tests/app-navigation-boundary.test.ts
@@ -26,12 +26,24 @@ describe("App navigation boundary", () => {
     expect(source).not.toContain('path: "/channels"');
   });
 
+  test("places App settings directly below Providers in primary App nav", () => {
+    const source = readSource("../src/app/navigation.tsx");
+    const providersIndex = source.indexOf('label: "Providers"');
+    const appSettingsIndex = source.indexOf('label: "App settings"');
+
+    expect(providersIndex).toBeGreaterThan(-1);
+    expect(appSettingsIndex).toBeGreaterThan(providersIndex);
+    expect(source).toContain('path: "/settings/app"');
+  });
+
   test("App shell offers back-to-org, an app switcher, and a New agent action", () => {
     const source = readSource("../src/app/app-shell.tsx");
 
     expect(source).toContain("BackToOrgLink");
     expect(source).toContain("AppSwitcher");
     expect(source).toContain("New agent");
+    expect(source).not.toContain("Manage apps");
+    expect(source).not.toContain("App settings");
     expect(source).not.toContain("OrganizationSwitcher");
   });
 });

--- a/apps/web/tests/app-navigation-boundary.test.ts
+++ b/apps/web/tests/app-navigation-boundary.test.ts
@@ -33,7 +33,7 @@ describe("App navigation boundary", () => {
 
     expect(providersIndex).toBeGreaterThan(-1);
     expect(appSettingsIndex).toBeGreaterThan(providersIndex);
-    expect(source).toContain('path: "/settings/app"');
+    expect(source).toContain('path: "/app-settings"');
   });
 
   test("App shell offers back-to-org, an app switcher, and a New agent action", () => {

--- a/apps/web/tests/app-settings-boundary.test.ts
+++ b/apps/web/tests/app-settings-boundary.test.ts
@@ -39,16 +39,23 @@ describe("App settings boundary", () => {
     );
   });
 
-  test("splits Settings into Account and App sections", () => {
+  test("keeps App settings standalone from account Settings", () => {
     const settingsNav = readSource("../src/routes/settings/settings-nav.tsx");
     const routeRegistry = readSource("../src/app/route-registry.tsx");
+    const primaryNav = readSource("../src/app/navigation.tsx");
 
     expect(settingsNav).toContain('label: "Account"');
     expect(settingsNav).toContain('label: "App"');
-    expect(settingsNav).toContain('label: "General"');
-    expect(settingsNav).toContain('path: "/settings/app"');
-    // App General is App-owned identity, not Organization-owned settings.
-    expect(routeRegistry).toContain('{ element: <SettingsApp />, path: "app" }');
+    expect(settingsNav).not.toContain('label: "General"');
+    expect(settingsNav).not.toContain('path: "/settings/app"');
+    expect(primaryNav).toContain('label: "App settings"');
+    expect(primaryNav).toContain('path: "/app-settings"');
+    expect(routeRegistry).toContain(
+      '{ element: protectedRoute(<SettingsApp />), path: "/app-settings" }',
+    );
+    expect(routeRegistry).toContain(
+      '{ element: <Navigate to="/app-settings" replace />, path: "app" }',
+    );
     expect(routeRegistry).not.toContain("OrganizationGeneralTab");
   });
 

--- a/apps/web/tests/app-settings-boundary.test.ts
+++ b/apps/web/tests/app-settings-boundary.test.ts
@@ -76,7 +76,7 @@ describe("App settings boundary", () => {
     expect(organizationApiIndex.trim()).toBe('export type * from "./organization-types";');
   });
 
-  test("keeps Settings entry in the account menu without adding it to primary App nav", () => {
+  test("keeps account Settings in the account menu without adding a generic primary nav item", () => {
     const accountMenu = readSource("../src/app/account-menu.tsx");
     const primaryNav = readSource("../src/app/navigation.tsx");
 


### PR DESCRIPTION
Closes #176

## Summary

- Remove the `Manage apps` and `App settings` shortcuts from the app switcher dropdown.
- Add `App settings` directly below `Providers` in the primary App sidebar.
- Mount App settings as a standalone `/app-settings` page and redirect the legacy `/settings/app` path there.
- Remove the App settings `General` entry from the account Settings subnav.

## Verification

- `bun run fmt:check:path apps/web/src/app/navigation.tsx apps/web/src/app/route-registry.tsx apps/web/src/routes/settings/settings-nav.tsx apps/web/src/routes/settings/app-tab.tsx apps/web/tests/app-navigation-boundary.test.ts apps/web/tests/app-settings-boundary.test.ts`
- `bun test apps/web/tests/app-navigation-boundary.test.ts apps/web/tests/app-settings-boundary.test.ts`
- `bun run --filter @mosoo/web lint`
- `bun run --filter @mosoo/web tc`
- Local Playwright UI QA for the sidebar route and `/settings/app` redirect.

## Release Notes

- Generated files: none.
- GraphQL codegen: not needed.
- DB baseline updates: none.
