### PR TITLE
fix(agent): route publish success to threads

### DIFF
--- a/apps/web/src/routes/agent/agent-detail.route.tsx
+++ b/apps/web/src/routes/agent/agent-detail.route.tsx
@@ -330,11 +330,7 @@ export function AgentDetailPage() {
       {/* Content */}
       <div className="min-h-0 flex-1 overflow-hidden">
         {mode === "preview" && (
-          <PreviewMode
-            agent={agent}
-            onSwitchMode={handleSelectMode}
-            headerActionTarget={headerActionTarget}
-          />
+          <PreviewMode agent={agent} headerActionTarget={headerActionTarget} />
         )}
         {mode === "logs" && <LogsTab agentId={agent.id} appId={agent.appId} />}
         {mode === "cost" && <AgentCostTab agentId={agent.id} appId={agent.appId} />}

--- a/apps/web/src/routes/agent/components/preview-mode.tsx
+++ b/apps/web/src/routes/agent/components/preview-mode.tsx
@@ -8,7 +8,7 @@ import { publishAgent } from "@/domains/agent/api/agent-client";
 import { agentKeys } from "@/domains/agent/query/agent-queries";
 import { toAgentId, toAppId } from "@/routes/typed-id";
 
-import type { Agent, AgentMode } from "../agent.types";
+import type { Agent } from "../agent.types";
 import { AgentApiAccessDialog } from "../lifecycle/api-access-panel";
 import type { LifecycleActionKind } from "../lifecycle/live-config-action-dialog";
 import { PendingChangesBanner } from "../lifecycle/pending-changes-banner";
@@ -59,7 +59,6 @@ const PREVIEW_MODE_INITIAL_STATE: PreviewModeState = {
 export interface PreviewModeProps {
   agent: Agent;
   headerActionTarget: HTMLDivElement | null;
-  onSwitchMode: (mode: AgentMode | "logs") => void;
 }
 
 function publishStatusMessage({
@@ -107,11 +106,7 @@ function previewModeReducer(state: PreviewModeState, action: PreviewModeAction):
 
 // Preview surface for Draft stage 2 and Live debug-and-iterate flows.
 // The writable form classifies dirty fields and routes them to the right apply action.
-export function PreviewMode({
-  agent,
-  headerActionTarget,
-  onSwitchMode,
-}: PreviewModeProps): ReactElement {
+export function PreviewMode({ agent, headerActionTarget }: PreviewModeProps): ReactElement {
   const queryClient = useQueryClient();
   const model = useAgentEditorModel({ agent });
   useAgentEditorAutoSave(model);
@@ -286,12 +281,6 @@ export function PreviewMode({
         agent={agent}
         onOpenChange={(next) => {
           dispatch({ open: next, type: "setSuccessModalOpen" });
-          if (!next) {
-            onSwitchMode("consume");
-          }
-        }}
-        onOpenChat={() => {
-          onSwitchMode("consume");
         }}
         open={showSuccessModal}
       />

--- a/apps/web/src/routes/agent/lifecycle/publish-success-modal.tsx
+++ b/apps/web/src/routes/agent/lifecycle/publish-success-modal.tsx
@@ -1,5 +1,5 @@
-import { ArrowRight, Check, Copy, ExternalLink, Globe } from "lucide-react";
-import { useMemo, useState } from "react";
+import { ArrowRight, Check, Globe } from "lucide-react";
+import { useMemo } from "react";
 
 import { Button } from "@/shared/ui/button";
 import {
@@ -15,45 +15,21 @@ import type { Agent } from "../agent.types";
 import { AgentApiAccessPanel } from "./api-access-panel";
 import { buildAgentDistribution } from "./distribution-info";
 
-async function writeClipboardText(text: string): Promise<boolean> {
-  if (!navigator.clipboard) {
-    return false;
-  }
-
-  try {
-    await navigator.clipboard.writeText(text);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 export function PublishSuccessModal({
   agent,
-  onOpenChat,
   onOpenChange,
   onViewDistribution,
   open,
 }: {
   agent: Agent;
   onOpenChange: (open: boolean) => void;
-  onOpenChat?: () => void;
   onViewDistribution?: () => void;
   open: boolean;
 }) {
   const distribution = useMemo(() => buildAgentDistribution(agent), [agent]);
-  const [copiedKey, setCopiedKey] = useState<"web" | null>(null);
 
-  async function copy(text: string, key: "web") {
-    const didCopy = await writeClipboardText(text);
-    if (!didCopy) {
-      return;
-    }
-
-    setCopiedKey(key);
-    globalThis.setTimeout(() => {
-      setCopiedKey(null);
-    }, 1500);
+  function openThreadDialog(): void {
+    globalThis.location.assign(distribution.threadsPath);
   }
 
   return (
@@ -79,30 +55,18 @@ export function PublishSuccessModal({
             <div className="flex items-start gap-3">
               <Globe className="text-fg-3 mt-0.5 size-4 shrink-0" />
               <div className="min-w-0 flex-1">
-                <div className="text-foreground text-[13px] font-medium">Web UI</div>
-                <div className="text-fg-2 mt-0.5 truncate font-mono text-[12px]">
-                  {distribution.webUrl}
-                </div>
+                <div className="text-foreground text-[13px] font-medium">Try in Mosoo</div>
+                <div className="text-fg-2 mt-0.5 text-[12px]">Start a Thread with this agent.</div>
               </div>
-              <div className="flex shrink-0 gap-1">
-                <Button
-                  className="gap-1 text-[11.5px]"
-                  onClick={() => {
-                    void copy(distribution.webUrl, "web");
-                  }}
-                  size="xs"
-                  variant="outline"
-                >
-                  {copiedKey === "web" ? <Check className="size-3" /> : <Copy className="size-3" />}
-                  {copiedKey === "web" ? "Copied" : "Copy"}
-                </Button>
-                <Button asChild className="gap-1 text-[11.5px]" size="xs" variant="outline">
-                  <a href={distribution.webUrl} rel="noreferrer" target="_blank">
-                    <ExternalLink className="size-3" />
-                    Open
-                  </a>
-                </Button>
-              </div>
+              <Button
+                className="gap-1 text-[11.5px]"
+                onClick={openThreadDialog}
+                size="xs"
+                variant="outline"
+              >
+                Open
+                <ArrowRight className="size-3" />
+              </Button>
             </div>
           </div>
 
@@ -117,15 +81,8 @@ export function PublishSuccessModal({
               View distribution
             </Button>
           ) : null}
-          <Button
-            className="gap-1.5"
-            onClick={() => {
-              onOpenChange(false);
-              onOpenChat?.();
-            }}
-            size="sm"
-          >
-            Open in Chat
+          <Button className="gap-1.5" onClick={openThreadDialog} size="sm">
+            Try in Mosoo
             <ArrowRight className="size-3.5" />
           </Button>
         </div>

--- a/apps/web/tests/agent-publish-success-boundary.test.ts
+++ b/apps/web/tests/agent-publish-success-boundary.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+function readSource(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+describe("agent publish success boundary", () => {
+  test("routes Try in Mosoo through locked Threads instead of exposing a web URL", () => {
+    const source = readSource("../src/routes/agent/lifecycle/publish-success-modal.tsx");
+
+    expect(source).toContain("Try in Mosoo");
+    expect(source).toContain("Start a Thread with this agent.");
+    expect(source).toContain("globalThis.location.assign(distribution.threadsPath)");
+
+    expect(source).not.toContain("Web UI");
+    expect(source).not.toContain("distribution.webUrl");
+    expect(source).not.toContain("Open in Chat");
+    expect(source).not.toContain("onOpenChat");
+  });
+});


### PR DESCRIPTION
## Summary

- Remove the post-publish Web UI raw URL and copy action.
- Rename the success-card destination to Try in Mosoo.
- Route Open / Try in Mosoo to the locked Threads composer for the same agent.
- Add a boundary test covering the expected publish-success source behavior.

## Verification

- `bun run fmt:check:path apps/web/src/routes/agent/lifecycle/publish-success-modal.tsx apps/web/src/routes/agent/components/preview-mode.tsx apps/web/src/routes/agent/agent-detail.route.tsx apps/web/tests/agent-publish-success-boundary.test.ts`
- `bun run --filter @mosoo/web lint`
- `bun run --filter @mosoo/web tc`
- `bun test apps/web/tests/agent-publish-success-boundary.test.ts`
- Playwright visual QA on `http://localhost:5174`; screenshot attached to YEF-767 in Multica.

## Notes

- Generated files: no
- GraphQL codegen: no
- DB baseline: no

Closes YEF-767
Fixes #175
