### PR TITLE
refactor(app-settings): move app usage into settings

### DIFF
--- a/apps/web/src/app/navigation.tsx
+++ b/apps/web/src/app/navigation.tsx
@@ -61,8 +61,9 @@ const NAV_SECTIONS: AppNavSection[] = [
       },
       { icon: createHugeicon(Key01Icon, "ProvidersIcon"), label: "Providers", path: "/providers" },
       {
+        children: [{ label: "App usage", path: "/app-settings/usage" }],
         icon: createHugeicon(Settings02Icon, "AppSettingsIcon"),
-        label: "App settings",
+        label: "Settings",
         path: "/app-settings",
       },
     ],

--- a/apps/web/src/app/route-registry.tsx
+++ b/apps/web/src/app/route-registry.tsx
@@ -72,8 +72,11 @@ const SettingsAccessTokens = lazyNamed(
   async () => import("../routes/settings/access-tokens-tab"),
   "AccessTokensTab",
 );
-const SettingsUsage = lazyNamed(async () => import("../routes/settings/usage-tab"), "UsageTab");
-const SettingsApp = lazyNamed(async () => import("../routes/settings/app-tab"), "AppTab");
+const AppSettings = lazyNamed(
+  async () => import("../routes/app-settings/settings-tab"),
+  "AppSettingsTab",
+);
+const AppUsage = lazyNamed(async () => import("../routes/app-settings/usage-tab"), "AppUsageTab");
 const AgentList = lazyNamed(
   async () => import("../routes/agent/agent-list.route"),
   "AgentListPage",
@@ -136,24 +139,25 @@ const appRoutes = [
   { element: protectedRoute(<AgentDetail />), path: "/agent/:agentId" },
   { element: protectedRoute(<Threads />), path: "/threads" },
   { element: protectedRoute(<Threads />), path: "/threads/:threadId" },
-  { element: protectedRoute(<SettingsApp />), path: "/app-settings" },
+  { element: protectedRoute(<AppSettings />), path: "/app-settings" },
+  { element: protectedRoute(<AppUsage />), path: "/app-settings/usage" },
   {
     children: [
       { element: <Navigate to="/settings/profile" replace />, index: true },
       { element: <SettingsProfile />, path: "profile" },
       { element: <SettingsAccessTokens />, path: "access-tokens" },
       { element: <Navigate to="/app-settings" replace />, path: "app" },
-      { element: <SettingsUsage />, path: "usage" },
+      { element: <Navigate to="/app-settings/usage" replace />, path: "usage" },
       { element: <Navigate to="/environment" replace />, path: "environments" },
-      { element: <Navigate to="/settings/usage" replace />, path: "cost" },
+      { element: <Navigate to="/app-settings/usage" replace />, path: "cost" },
     ],
     element: protectedRoute(<SettingsLayout />),
     path: "/settings",
   },
   { element: protectedRoute(<Navigate to="/settings/profile" replace />), path: "/profile" },
-  { element: protectedRoute(<Navigate to="/settings/usage" replace />), path: "/usage" },
+  { element: protectedRoute(<Navigate to="/app-settings/usage" replace />), path: "/usage" },
   { element: protectedRoute(<Providers />), path: "/providers" },
-  { element: protectedRoute(<Navigate to="/settings/usage" replace />), path: "/cost" },
+  { element: protectedRoute(<Navigate to="/app-settings/usage" replace />), path: "/cost" },
 ] satisfies RouteObject[];
 
 export function AppRoutes(): ReactNode {

--- a/apps/web/src/routes/app-settings/settings-tab.tsx
+++ b/apps/web/src/routes/app-settings/settings-tab.tsx
@@ -1,6 +1,7 @@
+import type { AppSummary } from "@mosoo/contracts/app";
 import { useQueryClient } from "@tanstack/react-query";
 import { Check, Loader2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { useAppSession } from "@/app/session-provider";
 import { renameApp } from "@/domains/app/api/app-client";
@@ -10,20 +11,22 @@ import { isTruthy } from "@/shared/lib/truthiness";
 import { Button } from "@/shared/ui/button";
 import { CommandBlock } from "@/shared/ui/command-block";
 
-import { SettingsTabBody, SettingsTabHeader } from "./settings-tab-layout";
+import { SettingsTabBody, SettingsTabHeader } from "../settings/settings-tab-layout";
 
-export function AppTab() {
+export function AppSettingsTab() {
   const { activeApp } = useAppSession();
+  const formKey = activeApp === null ? "no-app" : `${activeApp.id}:${activeApp.name}`;
+
+  return <AppSettingsForm key={formKey} activeApp={activeApp} />;
+}
+
+function AppSettingsForm({ activeApp }: { activeApp: AppSummary | null }) {
   const queryClient = useQueryClient();
 
   const [name, setName] = useState(activeApp?.name ?? "");
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    setName(activeApp?.name ?? "");
-  }, [activeApp?.name]);
 
   const trimmedName = name.trim();
   const dirty = activeApp !== null && trimmedName !== activeApp.name;
@@ -53,7 +56,7 @@ export function AppTab() {
 
   return (
     <>
-      <SettingsTabHeader title="App settings" />
+      <SettingsTabHeader title="Settings" />
       <SettingsTabBody>
         <div className="space-y-2">
           <label className="text-foreground text-sm font-medium" htmlFor="app-name">
@@ -80,7 +83,7 @@ export function AppTab() {
           <Button onClick={() => void handleSave()} disabled={!canSave} size="sm">
             {saving ? (
               <>
-                <Loader2 className="mr-1 size-4 animate-spin" /> Saving…
+                <Loader2 className="mr-1 size-4 animate-spin" /> Saving...
               </>
             ) : saved ? (
               <>

--- a/apps/web/src/routes/app-settings/usage-tab.tsx
+++ b/apps/web/src/routes/app-settings/usage-tab.tsx
@@ -1,0 +1,5 @@
+import { CostPage } from "../cost/cost.route";
+
+export function AppUsageTab() {
+  return <CostPage />;
+}

--- a/apps/web/src/routes/settings/settings-nav.tsx
+++ b/apps/web/src/routes/settings/settings-nav.tsx
@@ -1,5 +1,5 @@
 import type { LucideIcon } from "lucide-react";
-import { BarChart3, KeyRound, User } from "lucide-react";
+import { KeyRound, User } from "lucide-react";
 import { NavLink } from "react-router-dom";
 
 import { cn } from "@/shared/lib/class-names";
@@ -15,8 +15,8 @@ interface SettingsNavSection {
   label: string;
 }
 
-// Settings keeps account-global controls and account-adjacent reporting. App
-// settings live in the primary App sidebar as a standalone page.
+// Settings keeps account-global controls. App-scoped settings live in the
+// primary App sidebar.
 const SETTINGS_NAV_SECTIONS: SettingsNavSection[] = [
   {
     items: [
@@ -24,10 +24,6 @@ const SETTINGS_NAV_SECTIONS: SettingsNavSection[] = [
       { icon: KeyRound, label: "API tokens", path: "/settings/access-tokens" },
     ],
     label: "Account",
-  },
-  {
-    items: [{ icon: BarChart3, label: "App usage", path: "/settings/usage" }],
-    label: "App",
   },
 ];
 

--- a/apps/web/src/routes/settings/usage-tab.tsx
+++ b/apps/web/src/routes/settings/usage-tab.tsx
@@ -1,7 +1,0 @@
-import { CostPage } from "../cost/cost.route";
-
-// App usage renders the cost report inside the Settings shell, so it behaves
-// like the Profile and API tokens tabs instead of jumping to a standalone page.
-export function UsageTab() {
-  return <CostPage />;
-}

--- a/apps/web/tests/app-navigation-boundary.test.ts
+++ b/apps/web/tests/app-navigation-boundary.test.ts
@@ -26,14 +26,16 @@ describe("App navigation boundary", () => {
     expect(source).not.toContain('path: "/channels"');
   });
 
-  test("places App settings directly below Providers in primary App nav", () => {
+  test("places App Settings directly below Providers in primary App nav", () => {
     const source = readSource("../src/app/navigation.tsx");
     const providersIndex = source.indexOf('label: "Providers"');
-    const appSettingsIndex = source.indexOf('label: "App settings"');
+    const settingsIndex = source.indexOf('label: "Settings"');
 
     expect(providersIndex).toBeGreaterThan(-1);
-    expect(appSettingsIndex).toBeGreaterThan(providersIndex);
+    expect(settingsIndex).toBeGreaterThan(providersIndex);
     expect(source).toContain('path: "/app-settings"');
+    expect(source).toContain('label: "App usage"');
+    expect(source).toContain('path: "/app-settings/usage"');
   });
 
   test("App shell offers back-to-org, an app switcher, and a New agent action", () => {

--- a/apps/web/tests/app-settings-boundary.test.ts
+++ b/apps/web/tests/app-settings-boundary.test.ts
@@ -19,39 +19,41 @@ describe("App settings boundary", () => {
     expect(settingsNav).not.toContain("viewerRole");
   });
 
-  test("keeps Settings to account controls and App usage rendered in-shell", () => {
+  test("keeps account Settings to account controls", () => {
     const routeRegistry = readSource("../src/app/route-registry.tsx");
     const settingsNav = readSource("../src/routes/settings/settings-nav.tsx");
 
     expect(settingsNav).toContain('label: "Profile"');
     expect(settingsNav).toContain('label: "API tokens"');
-    expect(settingsNav).toContain('label: "App usage"');
-    // App usage is a nested Settings tab (like Profile / API tokens), not a jump
-    // to a standalone /cost page.
-    expect(settingsNav).toContain('path: "/settings/usage"');
-    expect(settingsNav).not.toContain('path: "/cost"');
-    expect(routeRegistry).toContain('{ element: <SettingsUsage />, path: "usage" }');
+    expect(settingsNav).not.toContain('label: "App usage"');
+    expect(settingsNav).not.toContain('label: "App"');
+    expect(settingsNav).not.toContain('path: "/settings/usage"');
     expect(routeRegistry).toContain(
-      '{ element: <Navigate to="/settings/usage" replace />, path: "cost" }',
+      '{ element: <Navigate to="/app-settings/usage" replace />, path: "usage" }',
     );
     expect(routeRegistry).toContain(
-      '{ element: protectedRoute(<Navigate to="/settings/usage" replace />), path: "/usage" }',
+      '{ element: <Navigate to="/app-settings/usage" replace />, path: "cost" }',
     );
+    expect(routeRegistry).not.toContain("<SettingsUsage />");
   });
 
-  test("keeps App settings standalone from account Settings", () => {
+  test("keeps App settings in the App sidebar as Settings", () => {
     const settingsNav = readSource("../src/routes/settings/settings-nav.tsx");
     const routeRegistry = readSource("../src/app/route-registry.tsx");
     const primaryNav = readSource("../src/app/navigation.tsx");
 
     expect(settingsNav).toContain('label: "Account"');
-    expect(settingsNav).toContain('label: "App"');
     expect(settingsNav).not.toContain('label: "General"');
     expect(settingsNav).not.toContain('path: "/settings/app"');
-    expect(primaryNav).toContain('label: "App settings"');
+    expect(primaryNav).toContain('label: "Settings"');
+    expect(primaryNav).toContain('label: "App usage"');
     expect(primaryNav).toContain('path: "/app-settings"');
+    expect(primaryNav).toContain('path: "/app-settings/usage"');
     expect(routeRegistry).toContain(
-      '{ element: protectedRoute(<SettingsApp />), path: "/app-settings" }',
+      '{ element: protectedRoute(<AppSettings />), path: "/app-settings" }',
+    );
+    expect(routeRegistry).toContain(
+      '{ element: protectedRoute(<AppUsage />), path: "/app-settings/usage" }',
     );
     expect(routeRegistry).toContain(
       '{ element: <Navigate to="/app-settings" replace />, path: "app" }',
@@ -101,6 +103,7 @@ describe("App settings boundary", () => {
 
     expect(accountMenu).toContain('to="/settings"');
     expect(accountMenu).not.toContain('to="/apps"');
-    expect(primaryNav).not.toContain('label: "Settings"');
+    expect(primaryNav).toContain('label: "Settings"');
+    expect(primaryNav).toContain('path: "/app-settings"');
   });
 });


### PR DESCRIPTION
## Summary

- Make `/app-settings` a settings shell with a second-level App settings sidebar.
- Add `General` and `App usage` as App-scoped secondary nav items.
- Keep the primary App sidebar item as a single `Settings` entry instead of expanding App usage there.
- Preserve legacy usage/cost routes by redirecting them to `/app-settings/usage`, and route legacy `/settings/app` to `/app-settings/general`.
- Update navigation and settings boundary tests for the new IA.

## Validation

- `bun run fmt:check:path apps/web/src/app/navigation.tsx apps/web/src/app/route-registry.tsx apps/web/src/routes/app-settings/app-settings-nav.tsx apps/web/src/routes/app-settings/app-settings.route.tsx apps/web/src/routes/app-settings/general-tab.tsx apps/web/src/routes/app-settings/usage-tab.tsx apps/web/tests/app-settings-boundary.test.ts apps/web/tests/app-navigation-boundary.test.ts`
- `bun test apps/web/tests/app-settings-boundary.test.ts apps/web/tests/app-navigation-boundary.test.ts`
- `bun --filter @mosoo/web tc`
- `bun --filter @mosoo/web lint`
- `bun --filter @mosoo/web test`

## Generated files

- Generated files: no
- GraphQL codegen: no
- DB baseline updates: no