### PR TITLE
refactor(app-settings): add secondary settings nav

### DIFF
--- a/apps/web/src/app/navigation.tsx
+++ b/apps/web/src/app/navigation.tsx
@@ -61,7 +61,6 @@ const NAV_SECTIONS: AppNavSection[] = [
       },
       { icon: createHugeicon(Key01Icon, "ProvidersIcon"), label: "Providers", path: "/providers" },
       {
-        children: [{ label: "App usage", path: "/app-settings/usage" }],
         icon: createHugeicon(Settings02Icon, "AppSettingsIcon"),
         label: "Settings",
         path: "/app-settings",

--- a/apps/web/src/app/route-registry.tsx
+++ b/apps/web/src/app/route-registry.tsx
@@ -72,9 +72,13 @@ const SettingsAccessTokens = lazyNamed(
   async () => import("../routes/settings/access-tokens-tab"),
   "AccessTokensTab",
 );
-const AppSettings = lazyNamed(
-  async () => import("../routes/app-settings/settings-tab"),
-  "AppSettingsTab",
+const AppSettingsLayout = lazyNamed(
+  async () => import("../routes/app-settings/app-settings.route"),
+  "AppSettingsLayout",
+);
+const AppSettingsGeneral = lazyNamed(
+  async () => import("../routes/app-settings/general-tab"),
+  "GeneralTab",
 );
 const AppUsage = lazyNamed(async () => import("../routes/app-settings/usage-tab"), "AppUsageTab");
 const AgentList = lazyNamed(
@@ -139,14 +143,22 @@ const appRoutes = [
   { element: protectedRoute(<AgentDetail />), path: "/agent/:agentId" },
   { element: protectedRoute(<Threads />), path: "/threads" },
   { element: protectedRoute(<Threads />), path: "/threads/:threadId" },
-  { element: protectedRoute(<AppSettings />), path: "/app-settings" },
-  { element: protectedRoute(<AppUsage />), path: "/app-settings/usage" },
+  {
+    children: [
+      { element: <Navigate to="/app-settings/general" replace />, index: true },
+      { element: <AppSettingsGeneral />, path: "general" },
+      { element: <AppUsage />, path: "usage" },
+      { element: <Navigate to="/app-settings/usage" replace />, path: "cost" },
+    ],
+    element: protectedRoute(<AppSettingsLayout />),
+    path: "/app-settings",
+  },
   {
     children: [
       { element: <Navigate to="/settings/profile" replace />, index: true },
       { element: <SettingsProfile />, path: "profile" },
       { element: <SettingsAccessTokens />, path: "access-tokens" },
-      { element: <Navigate to="/app-settings" replace />, path: "app" },
+      { element: <Navigate to="/app-settings/general" replace />, path: "app" },
       { element: <Navigate to="/app-settings/usage" replace />, path: "usage" },
       { element: <Navigate to="/environment" replace />, path: "environments" },
       { element: <Navigate to="/app-settings/usage" replace />, path: "cost" },

--- a/apps/web/src/routes/app-settings/app-settings-nav.tsx
+++ b/apps/web/src/routes/app-settings/app-settings-nav.tsx
@@ -1,0 +1,45 @@
+import { BarChart3, Box } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { NavLink } from "react-router-dom";
+
+import { cn } from "@/shared/lib/class-names";
+
+interface AppSettingsNavItem {
+  icon: LucideIcon;
+  label: string;
+  path: string;
+}
+
+const APP_SETTINGS_NAV_ITEMS: AppSettingsNavItem[] = [
+  { icon: Box, label: "General", path: "/app-settings/general" },
+  { icon: BarChart3, label: "App usage", path: "/app-settings/usage" },
+];
+
+export function AppSettingsNav() {
+  return (
+    <aside className="border-border-soft flex w-[220px] shrink-0 flex-col gap-3 border-r px-3 py-5">
+      <div className="text-fg-3 px-2.5 pb-1 text-[10px] font-semibold tracking-[0.14em] uppercase">
+        App
+      </div>
+      <div className="flex flex-col gap-0.5">
+        {APP_SETTINGS_NAV_ITEMS.map((item) => (
+          <NavLink
+            key={item.path}
+            to={item.path}
+            className={({ isActive }) =>
+              cn(
+                "flex items-center gap-2.5 rounded-md px-2.5 py-2 text-[13px] font-medium transition-colors",
+                isActive
+                  ? "bg-ink-100 text-fg-1"
+                  : "text-fg-2 hover:bg-ink-900/[0.04] hover:text-fg-1",
+              )
+            }
+          >
+            <item.icon className="size-4" />
+            <span>{item.label}</span>
+          </NavLink>
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/routes/app-settings/app-settings.route.tsx
+++ b/apps/web/src/routes/app-settings/app-settings.route.tsx
@@ -1,0 +1,14 @@
+import { Outlet } from "react-router-dom";
+
+import { AppSettingsNav } from "./app-settings-nav";
+
+export function AppSettingsLayout() {
+  return (
+    <div className="flex h-full overflow-hidden">
+      <AppSettingsNav />
+      <div className="flex h-full min-w-0 flex-1 flex-col overflow-hidden">
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/app-settings/general-tab.tsx
+++ b/apps/web/src/routes/app-settings/general-tab.tsx
@@ -13,14 +13,14 @@ import { CommandBlock } from "@/shared/ui/command-block";
 
 import { SettingsTabBody, SettingsTabHeader } from "../settings/settings-tab-layout";
 
-export function AppSettingsTab() {
+export function GeneralTab() {
   const { activeApp } = useAppSession();
   const formKey = activeApp === null ? "no-app" : `${activeApp.id}:${activeApp.name}`;
 
-  return <AppSettingsForm key={formKey} activeApp={activeApp} />;
+  return <GeneralForm key={formKey} activeApp={activeApp} />;
 }
 
-function AppSettingsForm({ activeApp }: { activeApp: AppSummary | null }) {
+function GeneralForm({ activeApp }: { activeApp: AppSummary | null }) {
   const queryClient = useQueryClient();
 
   const [name, setName] = useState(activeApp?.name ?? "");
@@ -56,7 +56,7 @@ function AppSettingsForm({ activeApp }: { activeApp: AppSummary | null }) {
 
   return (
     <>
-      <SettingsTabHeader title="Settings" />
+      <SettingsTabHeader title="General" />
       <SettingsTabBody>
         <div className="space-y-2">
           <label className="text-foreground text-sm font-medium" htmlFor="app-name">

--- a/apps/web/tests/app-navigation-boundary.test.ts
+++ b/apps/web/tests/app-navigation-boundary.test.ts
@@ -34,8 +34,7 @@ describe("App navigation boundary", () => {
     expect(providersIndex).toBeGreaterThan(-1);
     expect(settingsIndex).toBeGreaterThan(providersIndex);
     expect(source).toContain('path: "/app-settings"');
-    expect(source).toContain('label: "App usage"');
-    expect(source).toContain('path: "/app-settings/usage"');
+    expect(source).not.toContain('label: "App usage"');
   });
 
   test("App shell offers back-to-org, an app switcher, and a New agent action", () => {

--- a/apps/web/tests/app-settings-boundary.test.ts
+++ b/apps/web/tests/app-settings-boundary.test.ts
@@ -12,7 +12,6 @@ describe("App settings boundary", () => {
 
     expect(routeRegistry).not.toContain("organization-general-tab");
     expect(routeRegistry).not.toContain("OrganizationGeneralTab");
-    expect(routeRegistry).not.toContain('path: "general"');
     expect(settingsNav).not.toContain('label: "Organization"');
     expect(settingsNav).not.toContain('path: "/settings/general"');
     expect(settingsNav).not.toContain("ownerOnly");
@@ -39,6 +38,7 @@ describe("App settings boundary", () => {
 
   test("keeps App settings in the App sidebar as Settings", () => {
     const settingsNav = readSource("../src/routes/settings/settings-nav.tsx");
+    const appSettingsNav = readSource("../src/routes/app-settings/app-settings-nav.tsx");
     const routeRegistry = readSource("../src/app/route-registry.tsx");
     const primaryNav = readSource("../src/app/navigation.tsx");
 
@@ -46,17 +46,22 @@ describe("App settings boundary", () => {
     expect(settingsNav).not.toContain('label: "General"');
     expect(settingsNav).not.toContain('path: "/settings/app"');
     expect(primaryNav).toContain('label: "Settings"');
-    expect(primaryNav).toContain('label: "App usage"');
+    expect(primaryNav).not.toContain('label: "App usage"');
     expect(primaryNav).toContain('path: "/app-settings"');
-    expect(primaryNav).toContain('path: "/app-settings/usage"');
+    expect(appSettingsNav).toContain('label: "General"');
+    expect(appSettingsNav).toContain('label: "App usage"');
+    expect(appSettingsNav).toContain('path: "/app-settings/general"');
+    expect(appSettingsNav).toContain('path: "/app-settings/usage"');
     expect(routeRegistry).toContain(
-      '{ element: protectedRoute(<AppSettings />), path: "/app-settings" }',
+      'async () => import("../routes/app-settings/app-settings.route")',
     );
     expect(routeRegistry).toContain(
-      '{ element: protectedRoute(<AppUsage />), path: "/app-settings/usage" }',
+      '{ element: <Navigate to="/app-settings/general" replace />, index: true }',
     );
+    expect(routeRegistry).toContain('{ element: <AppSettingsGeneral />, path: "general" }');
+    expect(routeRegistry).toContain('{ element: <AppUsage />, path: "usage" }');
     expect(routeRegistry).toContain(
-      '{ element: <Navigate to="/app-settings" replace />, path: "app" }',
+      '{ element: <Navigate to="/app-settings/general" replace />, path: "app" }',
     );
     expect(routeRegistry).not.toContain("OrganizationGeneralTab");
   });


### PR DESCRIPTION
## Summary

- Make `/app-settings` a settings shell with a second-level App settings sidebar.
- Add `General` and `App usage` as App-scoped secondary nav items.
- Keep the primary App sidebar item as a single `Settings` entry instead of expanding App usage there.
- Route `/app-settings` to `/app-settings/general`, and preserve legacy usage/cost redirects to `/app-settings/usage`.
- Update navigation and settings boundary tests for the new IA.

## Validation

- `bun run fmt:check:path apps/web/src/app/navigation.tsx apps/web/src/app/route-registry.tsx apps/web/src/routes/app-settings/app-settings-nav.tsx apps/web/src/routes/app-settings/app-settings.route.tsx apps/web/src/routes/app-settings/general-tab.tsx apps/web/src/routes/app-settings/usage-tab.tsx apps/web/tests/app-settings-boundary.test.ts apps/web/tests/app-navigation-boundary.test.ts`
- `bun test apps/web/tests/app-settings-boundary.test.ts apps/web/tests/app-navigation-boundary.test.ts`
- `bun --filter @mosoo/web tc`
- `bun --filter @mosoo/web lint`
- `bun --filter @mosoo/web test`

## Generated files

- Generated files: no
- GraphQL codegen: no
- DB baseline updates: no