### PR TITLE
perf(web): split stable framework into a long-cached vendor chunk

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -33,6 +33,28 @@ const toolConfig = {
 
 const webConfig = {
   ...toolConfig,
+  build: {
+    rollupOptions: {
+      output: {
+        // Pull the stable framework runtime (React, React DOM, the router, and
+        // TanStack Query) out of the app entry chunk into its own long-lived
+        // vendor chunk. These packages change only on dependency bumps, so a
+        // returning visitor keeps them in cache across every app deploy instead
+        // of re-downloading ~150 KB of unchanged framework code baked into the
+        // entry. The framework and its peers share one chunk so React stays a
+        // single instance and there is no cross-chunk import waterfall.
+        advancedChunks: {
+          groups: [
+            {
+              name: "framework",
+              priority: 10,
+              test: /[\\/]node_modules[\\/](\.bun[\\/])?(react|react-dom|scheduler|react-router|react-router-dom|@tanstack[\\/]react-query|@tanstack[\\/]query-core)[@\\/]/,
+            },
+          ],
+        },
+      },
+    },
+  },
   plugins: [...react(), tailwindcss()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- Split the stable framework runtime (React, React DOM, React Router, TanStack Query) out of the `@mosoo/web` app entry chunk into a dedicated, long-cached `framework` chunk via Rolldown `advancedChunks`.

## Why

- The framework was bundled into the app entry chunk (371 KB raw / ~130 KB gz). Because app code churns on every deploy, the entry hash changed every release and forced returning visitors to re-download the entire entry — including ~150 KB of framework code that never changed.
- After the split, the entry chunk holds app code only (148 KB raw / 48 KB gz) and the framework lands in its own chunk (260 KB raw / 81 KB gz) whose hash is stable across app deploys. Repeat visits now serve ~81 KB gz of framework straight from cache.
- First-visit byte total is unchanged; several tiny eager chunks (jsx-runtime, react-dom shim, QueryClientProvider, useQuery) also fold into the framework chunk, trimming the initial request count from 16 to 13.

## Verification

- Commands: `vp run --filter @mosoo/web tc` (pass), `vp lint apps/web/vite.config.ts` (pass), `vp run --filter @mosoo/web test` (112 pass / 0 fail), `vp build` (production build succeeds).
- Manual steps: inspected `dist/` chunk manifest before/after to confirm the entry shrank and a stable `framework-*.js` chunk was emitted; confirmed the framework and its peers share one chunk so React remains a single instance with no cross-chunk import waterfall.

## Risk And Blast Radius

- Affected packages: `@mosoo/web` (build config only — no runtime source changes).
- Affected user flows or APIs: none; only the static chunk layout of the production build changes.
- Rollback: revert this commit; the build returns to a single entry chunk.

## Evidence

- Bundle manifest (raw KB): entry `index` 371.4 → 147.6; new `framework` chunk 260.5; initial critical-path request count 16 → 13; initial critical-path byte total unchanged (~675 KB raw).
- Gzipped: `framework` 81 KB gz (cached across deploys), `index` 48 KB gz (app code, re-fetched per deploy).
- Test output: `112 pass, 0 fail, 438 expect() calls`.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none — first byte-for-byte identical payload on cold cache; benefit is warm-cache repeat loads.

## Reviewer Focus

- Closest review area: the `advancedChunks` `test` regex in `apps/web/vite.config.ts` — it matches both the Bun `.bun/<pkg>@` layout and the nested `node_modules/<pkg>/` layout.
- Known trade-offs: first-visit splits one entry request into two (entry + framework); both are `modulepreload`-hinted so they load in parallel over HTTP/2 with no added waterfall. Net win is on repeat visits.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `perf`
- [x] Subject starts lowercase
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A (no visible UI change)
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A — single build-config file changed; lockfile untouched.
