### PR TITLE
fix(deploy): protect production d1 migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,14 @@
 - Commit messages must at least satisfy `type(scope): subject`. Use `!` only for intentional breaking changes, and keep `type`, `scope`, and `subject` semantically accurate.
 - Commit policy is enforced locally by `prek` (`commit-msg`, `pre-push`) and in CI (`pr-title-lint`, `pr-commits-lint`). `commit-msg` validates subject format plus author, committer, and `Co-authored-by` / `Signed-off-by` identity. Use a real human contributor identity; never commit as `claude-code`, `[codex]`, a bot, or a ticket-prefixed subject.
 
+## Production Deployment And D1 Safety
+
+- Production D1 deploys must never reset, wipe, drop, recreate, or replace the production database as part of a normal release.
+- `just deploy-api` and any production API deploy script may only apply pending remote D1 migrations before deploying the Worker.
+- Once production has data, schema changes must be represented as new migration files under `pkgs/db/drizzle`; do not rewrite an already-applied baseline and expect production to update.
+- Any destructive production D1 SQL, including `DROP TABLE`, table recreation, truncation, or lossy data transformation, requires explicit user approval plus a backup and rollback plan before execution.
+- Before changing deployment scripts or D1 migrations, verify the diff contains no production reset path and no destructive SQL unless the user explicitly requested it.
+
 ## Monorepo Scaling And Performance Constraints
 
 - Design database queries explicitly around access paths. Prefer `ORDER BY id` for list sorting, and do not default to `ORDER BY created_at`. ORM layers must not hide default filters or sorting; query conditions must be declared at the call site.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,10 +133,10 @@ just test-file apps/api/tests/session-run-cancel.test.ts
 
 ## Database And Migrations
 
-During alpha, historical migrations are not maintained. The database policy stays simple:
+During alpha, local historical migrations are not maintained. The local database policy stays simple:
 
 - The schema source of truth is `pkgs/db/src/schema/**`.
-- The current baseline is `pkgs/db/drizzle/**`.
+- The current local bootstrap baseline is `pkgs/db/drizzle/**`.
 - When schema and database state diverge, do not add compatibility patches for old local data.
 - Rebuild the local database state directly.
 
@@ -147,7 +147,9 @@ just db-regen
 just db-migrate
 ```
 
-If local database state is dirty, delete the corresponding local database and `.wrangler` state directories, then rebuild. Production release follows the same no-history posture: unless the current schema explicitly supports old data, old data is not considered compatible.
+If local database state is dirty, delete the corresponding local database and `.wrangler` state directories, then rebuild.
+
+Production D1 is not reset during deploy. `just deploy-api` applies only pending remote D1 migrations before deploying the API Worker. Once production has data, schema changes must add a new migration under `pkgs/db/drizzle` instead of rewriting an already-applied baseline.
 
 ## GraphQL Codegen
 

--- a/apps/api/bin/deploy-prod.ts
+++ b/apps/api/bin/deploy-prod.ts
@@ -9,54 +9,8 @@ const repoRoot = `${apiDir}/../..`;
 const D1_BINDING = "DB";
 const ENV = "prod";
 
-type JsonRecord = Record<string, unknown>;
-
-function isJsonRecord(value: unknown): value is JsonRecord {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function readD1Results(value: unknown): JsonRecord[] {
-  if (!Array.isArray(value)) {
-    throw new TypeError("Wrangler D1 JSON output must be an array.");
-  }
-
-  const [firstResultSet] = value;
-
-  if (!isJsonRecord(firstResultSet)) {
-    return [];
-  }
-
-  const rows = firstResultSet.results;
-
-  if (!Array.isArray(rows)) {
-    return [];
-  }
-
-  return rows.map((row, index) => {
-    if (!isJsonRecord(row)) {
-      throw new Error(`Wrangler D1 row at index ${index} is not an object.`);
-    }
-
-    return row;
-  });
-}
-
-function readRequiredStringColumn(row: JsonRecord, column: string): string {
-  const value = row[column];
-
-  if (typeof value !== "string" || value.length === 0) {
-    throw new Error(`Expected D1 column "${column}" to be a non-empty string.`);
-  }
-
-  return value;
-}
-
 function writeStdout(message: string): void {
   process.stdout.write(`${message}\n`);
-}
-
-function writeStderr(message: string): void {
-  process.stderr.write(`${message}\n`);
 }
 
 const wranglerBin = `${apiDir}/node_modules/.bin/wrangler`;
@@ -74,26 +28,6 @@ function run(args: string[], cwd = apiDir): void {
   }
 }
 
-function runJson(args: string[], cwd = apiDir): unknown {
-  const result = Bun.spawnSync([wranglerBin, ...args], { cwd });
-  const stdout = result.stdout.toString("utf8");
-  const stderr = result.stderr.toString("utf8");
-
-  if (result.exitCode !== 0) {
-    throw new Error(
-      `wrangler ${args.join(" ")} exited with ${result.exitCode}\nstderr: ${stderr}\nstdout: ${stdout}`,
-    );
-  }
-
-  const match = /\[[\s\S]*\][\s]*$/.exec(stdout);
-  if (!match) {
-    throw new Error(`No JSON in wrangler output:\n${stdout}`);
-  }
-
-  const parsed: unknown = JSON.parse(match[0]);
-  return parsed;
-}
-
 function runVp(args: string[], cwd = repoRoot): void {
   const result = Bun.spawnSync([vpBin, ...args], {
     cwd,
@@ -104,67 +38,6 @@ function runVp(args: string[], cwd = repoRoot): void {
   if (result.exitCode !== 0) {
     process.exit(result.exitCode);
   }
-}
-
-async function withSqlFile<T>(sql: string, fn: (path: string) => T | Promise<T>): Promise<T> {
-  const tmpFile = `/tmp/d1-${Date.now()}-${crypto.randomUUID()}.sql`;
-  await Bun.write(tmpFile, sql);
-  try {
-    return await fn(tmpFile);
-  } finally {
-    try {
-      await Bun.file(tmpFile).delete();
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      writeStderr(`warning: unable to delete temp SQL file ${tmpFile}: ${message}`);
-    }
-  }
-}
-
-function d1Query(sql: string): JsonRecord[] {
-  const response = runJson([
-    "d1",
-    "execute",
-    D1_BINDING,
-    "--env",
-    ENV,
-    "--remote",
-    "--command",
-    sql,
-    "--json",
-  ]);
-  return readD1Results(response);
-}
-
-function listProdTables(): string[] {
-  const rows = d1Query(
-    "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_cf_%' AND name NOT LIKE 'cf_%' ORDER BY name",
-  );
-  return rows.map((row) => readRequiredStringColumn(row, "name"));
-}
-
-function quoteSqlIdentifier(identifier: string): string {
-  return `"${identifier.replaceAll('"', '""')}"`;
-}
-
-async function wipeProdD1(): Promise<void> {
-  const tables = listProdTables();
-
-  if (tables.length === 0) {
-    writeStdout("  D1 already empty");
-    return;
-  }
-
-  const sql = [
-    "PRAGMA foreign_keys=OFF;",
-    ...tables.map((table) => `DROP TABLE IF EXISTS ${quoteSqlIdentifier(table)};`),
-    "PRAGMA foreign_keys=ON;",
-  ].join("\n");
-
-  await withSqlFile(sql, (file) => {
-    run(["d1", "execute", D1_BINDING, "--env", ENV, "--remote", "--file", file]);
-  });
-  writeStdout(`  dropped ${tables.length} table(s)`);
 }
 
 function applyD1Migrations(): void {
@@ -236,10 +109,7 @@ function ensureChannelFinalDeliveryQueues(): void {
   }
 }
 
-writeStdout("▶ Wiping prod D1 tables");
-await wipeProdD1();
-
-writeStdout("▶ Applying current D1 migrations");
+writeStdout("▶ Applying pending D1 migrations");
 applyD1Migrations();
 
 writeStdout("▶ Ensuring channel-final-delivery queues exist");


### PR DESCRIPTION
## Summary

- Remove the production D1 wipe step from the API deploy script.
- Document that production API deploys may only apply pending D1 migrations.
- Add an agent guardrail that blocks production D1 reset paths and destructive SQL without explicit approval, backup, and rollback planning.

## Why

- Production D1 must never be reset during a normal release.
- Future schema changes need to land as new migrations instead of rewriting an already-applied baseline.

## Verification

- Commands:
  - `just db-migrate`
  - `CLOUDFLARE_ACCOUNT_ID=2a66b3c81860bc4990156be493151f93 vp exec wrangler d1 migrations list DB --remote --env prod`
  - `git diff --check`
  - `just check`
  - `vp fmt --check AGENTS.md CONTRIBUTING.md apps/api/bin/deploy-prod.ts --ignore-path .gitignore`
  - `vp lint apps/api/bin/deploy-prod.ts`
- Manual steps:
  - Started local `@mosoo/api` and `@mosoo/web` dev servers.
  - Verified `GET http://127.0.0.1:8787/api/health` returned 200.
  - Verified `POST http://127.0.0.1:8787/api/graphql` returned 200 for `query { __typename }`.
  - Verified `HEAD http://127.0.0.1:5173/` returned 200.

## Risk And Blast Radius

- Affected packages: `apps/api` deployment script, repository contribution docs, agent instructions.
- Affected user flows or APIs: production API deployment only; runtime API behavior is unchanged.
- Rollback: revert this PR to restore the previous deploy script behavior. Do not do that after production data exists.

## Evidence

- UI/UX: N/A, no visible UI changes.
- API or behavior: local API health and GraphQL smoke checks passed.
- Logs, recordings, or test output: `just check` passed locally; remote D1 migration list reported no pending migrations.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: `just deploy-api` no longer drops production D1 tables before applying migrations. It applies pending remote D1 migrations before deploying the Worker.

## Reviewer Focus

- Closest review areas: `apps/api/bin/deploy-prod.ts` deploy flow and the production D1 guardrails in docs.
- Known trade-offs: this does not introduce a full historical migration workflow generator; it only prevents production reset during deploy and documents the new migration constraint.

## Required Checks

- [x] PR title: `type(scope): subject` (e.g. `fix(fmt): restore pre-commit checks`)
- [x] Type: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`, `build`, `ci`, `style`, or `revert`
- [x] Subject starts lowercase; `!` only for intentional breaking changes (e.g. `feat(api)!: remove legacy session field`)
- [x] Branch follows `type/scope-subject` when maintained in this repository; fork branch names may vary
- [x] Commits: `type(scope): subject`, English only
- [x] CLA: if prompted by CLA Assistant, every human contributor has signed by posting the exact required PR comment
- [x] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence, or N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A, or list touched artifacts: N/A
- GraphQL codegen (`just graphql-codegen`): N/A
- DB baseline (`just db-regen`): N/A
- Lockfile (`bun.lock`): N/A
- Confirm no hand-edits to generated paths (`schema.generated.graphql`, `apps/web/src/gql/**`, `pkgs/db/drizzle/**`): confirmed
