### PR TITLE
chore(docs): update public docs links

### DIFF
--- a/.github/workflows/docs-openapi-dispatch.yml
+++ b/.github/workflows/docs-openapi-dispatch.yml
@@ -26,7 +26,7 @@ jobs:
           fi
 
           curl --fail --request POST \
-            --url "https://api.github.com/repos/KurosawaGeeker/mosoo-docs/dispatches" \
+            --url "https://api.github.com/repos/langgenius/mosoo-docs/dispatches" \
             --header "Accept: application/vnd.github+json" \
             --header "Authorization: Bearer ${GH_TOKEN}" \
             --header "X-GitHub-Api-Version: 2022-11-28" \

--- a/apps/web/src/features/help/help-docs-dialog.tsx
+++ b/apps/web/src/features/help/help-docs-dialog.tsx
@@ -82,7 +82,7 @@ export function HelpDocsDialog({
         <DialogHeader className="sr-only">
           <DialogTitle>Help &amp; docs</DialogTitle>
           <DialogDescription>
-            Search the Mosoo documentation hosted at docs.mosoo.ai.
+            Search the Mosoo documentation hosted at mosoo.ai/docs.
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/web/src/shared/config/external-links.ts
+++ b/apps/web/src/shared/config/external-links.ts
@@ -5,11 +5,11 @@ export const MOSOO_GITHUB_URL = "https://github.com/langgenius/mosoo/";
 // TODO: replace with the verified product X (Twitter) handle once confirmed.
 export const MOSOO_X_URL = "https://x.com/mosoo";
 
-export const MOSOO_API_REFERENCE_URL = "https://docs.mosoo.ai/zh-Hans/auth-and-access";
+export const MOSOO_DOCS_URL = "https://mosoo.ai/docs/";
+export const MOSOO_API_REFERENCE_URL = `${MOSOO_DOCS_URL}api-reference/`;
 
 export const MOSOO_DEPLOY_URL = `https://deploy.workers.cloudflare.com/?url=${MOSOO_GITHUB_URL}`;
 
-export const MOSOO_DOCS_URL = `${MOSOO_GITHUB_URL}blob/main/README.md`;
 export const MOSOO_RELEASES_URL = `${MOSOO_GITHUB_URL}releases`;
 export const MOSOO_LICENSE_URL = `${MOSOO_GITHUB_URL}blob/main/LICENSE`;
 export const MOSOO_SECURITY_URL = `${MOSOO_GITHUB_URL}security`;

--- a/apps/web/src/shared/config/help-docs.ts
+++ b/apps/web/src/shared/config/help-docs.ts
@@ -1,7 +1,7 @@
-// Index of the Mosoo help documentation hosted at https://docs.mosoo.ai.
+// Index of the Mosoo help documentation hosted at https://mosoo.ai/docs.
 //
 // The `HELP_DOCS` array below is generated from the site's public documentation
-// manifest (https://docs.mosoo.ai/llms.txt). To refresh it after the docs change,
+// manifest (https://mosoo.ai/docs/llms.txt). To refresh it after the docs change,
 // run:
 //
 //   just help-docs-index
@@ -9,7 +9,7 @@
 // The script rewrites the region between the GENERATED markers in place; keep the
 // markers intact and avoid hand-editing entries inside them.
 
-export const HELP_DOCS_BASE_URL = "https://docs.mosoo.ai";
+export const HELP_DOCS_BASE_URL = "https://mosoo.ai/docs";
 
 /** Public manifest listing every help page, consumed by the generator script. */
 export const HELP_DOCS_MANIFEST_URL = `${HELP_DOCS_BASE_URL}/llms.txt`;
@@ -28,73 +28,99 @@ export interface HelpDoc {
 
 export const HELP_DOCS: readonly HelpDoc[] = [
   // <generated:help-docs> -- do not edit by hand; see header comment.
-  { section: "Getting started", title: "Mosoo API", url: "https://docs.mosoo.ai/" },
-  { section: "Getting started", title: "Quickstart", url: "https://docs.mosoo.ai/quickstart" },
+  { section: "Getting started", title: "Mosoo API", url: "https://mosoo.ai/docs/" },
+  { section: "Getting started", title: "Quickstart", url: "https://mosoo.ai/docs/quickstart" },
   {
     section: "Getting started",
     title: "Authentication and access",
-    url: "https://docs.mosoo.ai/auth-and-access",
-  },
-  { section: "CLI", title: "CLI", url: "https://docs.mosoo.ai/cli/overview" },
-  {
-    section: "API reference",
-    title: "Add a Thread file",
-    url: "https://docs.mosoo.ai/api-reference/add-a-thread-file",
+    url: "https://mosoo.ai/docs/auth-and-access",
   },
   {
-    section: "API reference",
-    title: "Archive a Thread",
-    url: "https://docs.mosoo.ai/api-reference/archive-a-thread",
+    section: "Getting started",
+    title: "Mosoo API for coding agents",
+    url: "https://mosoo.ai/docs/coding-agents",
   },
+  { section: "CLI", title: "CLI", url: "https://mosoo.ai/docs/cli/overview" },
+  { section: "API reference", title: "API Reference", url: "https://mosoo.ai/docs/api-reference" },
   {
     section: "API reference",
-    title: "Create a Thread for an Agent API Endpoint",
-    url: "https://docs.mosoo.ai/api-reference/create-a-thread-for-a-published-agent",
+    title: "Complete Thread file upload",
+    url: "https://mosoo.ai/docs/api-reference/complete-thread-file-upload",
   },
   {
     section: "API reference",
-    title: "Delete a Thread",
-    url: "https://docs.mosoo.ai/api-reference/delete-a-thread",
+    title: "Download Thread file content",
+    url: "https://mosoo.ai/docs/api-reference/download-thread-file-content",
   },
   {
     section: "API reference",
-    title: "List Thread events",
-    url: "https://docs.mosoo.ai/api-reference/list-thread-events",
-  },
-  {
-    section: "API reference",
-    title: "List Thread files",
-    url: "https://docs.mosoo.ai/api-reference/list-thread-files",
+    title: "Upload Thread file content",
+    url: "https://mosoo.ai/docs/api-reference/upload-thread-file-content",
   },
   {
     section: "API reference",
     title: "List Threads for an Agent API Endpoint",
-    url: "https://docs.mosoo.ai/api-reference/list-threads-for-a-published-agent",
+    url: "https://mosoo.ai/docs/api-reference/list-threads-for-an-agent-api-endpoint",
   },
   {
     section: "API reference",
-    title: "Remove a Thread file",
-    url: "https://docs.mosoo.ai/api-reference/remove-a-thread-file",
+    title: "Create a Thread for an Agent API Endpoint",
+    url: "https://mosoo.ai/docs/api-reference/create-a-thread-for-an-agent-api-endpoint",
   },
   {
     section: "API reference",
     title: "Retrieve Thread summary",
-    url: "https://docs.mosoo.ai/api-reference/retrieve-thread-summary",
+    url: "https://mosoo.ai/docs/api-reference/retrieve-thread-summary",
+  },
+  {
+    section: "API reference",
+    title: "Delete a Thread",
+    url: "https://mosoo.ai/docs/api-reference/delete-a-thread",
+  },
+  {
+    section: "API reference",
+    title: "Archive a Thread",
+    url: "https://mosoo.ai/docs/api-reference/archive-a-thread",
+  },
+  {
+    section: "API reference",
+    title: "List Thread events",
+    url: "https://mosoo.ai/docs/api-reference/list-thread-events",
   },
   {
     section: "API reference",
     title: "Send user messages, permission decisions, or interrupts to a Thread",
-    url: "https://docs.mosoo.ai/api-reference/send-user-messages-permission-decisions-or-interrupts-to-a-thread",
+    url: "https://mosoo.ai/docs/api-reference/send-user-messages-permission-decisions-or-interrupts-to-a-thread",
   },
   {
     section: "API reference",
     title: "Stream Thread events",
-    url: "https://docs.mosoo.ai/api-reference/stream-thread-events",
+    url: "https://mosoo.ai/docs/api-reference/stream-thread-events",
+  },
+  {
+    section: "API reference",
+    title: "List Thread files",
+    url: "https://mosoo.ai/docs/api-reference/list-thread-files",
+  },
+  {
+    section: "API reference",
+    title: "Add a Thread file",
+    url: "https://mosoo.ai/docs/api-reference/add-a-thread-file",
+  },
+  {
+    section: "API reference",
+    title: "Create a Thread file upload",
+    url: "https://mosoo.ai/docs/api-reference/create-a-thread-file-upload",
+  },
+  {
+    section: "API reference",
+    title: "Remove a Thread file",
+    url: "https://mosoo.ai/docs/api-reference/remove-a-thread-file",
   },
   {
     section: "API reference",
     title: "Unarchive a Thread",
-    url: "https://docs.mosoo.ai/api-reference/unarchive-a-thread",
+    url: "https://mosoo.ai/docs/api-reference/unarchive-a-thread",
   },
   // </generated:help-docs>
 ];

--- a/apps/web/tests/help-docs.test.ts
+++ b/apps/web/tests/help-docs.test.ts
@@ -28,13 +28,13 @@ describe("help docs index", () => {
     expect(HELP_DOCS).toContainEqual(
       expect.objectContaining({
         title: "Create a Thread for an Agent API Endpoint",
-        url: "https://docs.mosoo.ai/api-reference/create-a-thread-for-a-published-agent",
+        url: "https://mosoo.ai/docs/api-reference/create-a-thread-for-an-agent-api-endpoint",
       }),
     );
     expect(HELP_DOCS).toContainEqual(
       expect.objectContaining({
         title: "List Threads for an Agent API Endpoint",
-        url: "https://docs.mosoo.ai/api-reference/list-threads-for-a-published-agent",
+        url: "https://mosoo.ai/docs/api-reference/list-threads-for-an-agent-api-endpoint",
       }),
     );
     expect(HELP_DOCS.map((doc) => doc.title.toLowerCase()).join("\n")).not.toContain(

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "graphql:codegen": "vp exec tsx node_modules/.bin/graphql-codegen --config config/graphql-codegen.ts",
     "commit:check": "vp exec bun scripts/validate-commit-range.ts origin/main HEAD",
     "graphql:codegen:check": "vp exec tsx scripts/check-graphql-codegen.ts",
+    "help-docs-index": "bun scripts/generate-help-docs-index.ts",
     "hooks:install": "vp exec prek -c config/prek.toml install",
     "knip": "vp exec knip --config config/knip.jsonc",
     "lint": "vp run -w cf:types && vp lint vite.config.ts config/bun-script-types.d.ts config/vite-plus.shared.ts scripts apps pkgs e2e",

--- a/scripts/generate-help-docs-index.ts
+++ b/scripts/generate-help-docs-index.ts
@@ -1,5 +1,5 @@
 // Regenerates the HELP_DOCS index in apps/web/src/shared/config/help-docs.ts from
-// the public documentation manifest at https://docs.mosoo.ai/llms.txt.
+// the public documentation manifest at https://mosoo.ai/docs/llms.txt.
 //
 // Usage:
 //   just help-docs-index
@@ -11,7 +11,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
-const MANIFEST_URL = "https://docs.mosoo.ai/llms.txt";
+const MANIFEST_URL = "https://mosoo.ai/docs/llms.txt";
 const TARGET_PATH = fileURLToPath(
   new URL("../apps/web/src/shared/config/help-docs.ts", import.meta.url),
 );
@@ -22,9 +22,9 @@ const SECTION_ORDER = ["Getting started", "CLI", "API reference"] as const;
 type Section = (typeof SECTION_ORDER)[number];
 
 const TITLE_OVERRIDES_BY_PATHNAME: Record<string, string> = {
-  "api-reference/create-a-thread-for-a-published-agent":
+  "api-reference/create-a-thread-for-an-agent-api-endpoint":
     "Create a Thread for an Agent API Endpoint",
-  "api-reference/list-threads-for-a-published-agent": "List Threads for an Agent API Endpoint",
+  "api-reference/list-threads-for-an-agent-api-endpoint": "List Threads for an Agent API Endpoint",
 };
 
 // Lower number sorts first within "Getting started"; everything else keeps
@@ -43,7 +43,7 @@ interface HelpDocEntry {
 }
 
 function classifySection(pathname: string): Section {
-  if (pathname.startsWith("api-reference/")) {
+  if (pathname === "api-reference" || pathname.startsWith("api-reference/")) {
     return "API reference";
   }
   if (pathname.startsWith("cli/")) {
@@ -53,19 +53,24 @@ function classifySection(pathname: string): Section {
 }
 
 function toPageUrl(rawUrl: string): { pathname: string; url: string } {
-  const parsed = new URL(rawUrl);
-  let pathname = parsed.pathname.replace(/^\/+/, "").replace(/\.md$/, "");
-  if (pathname === "index") {
-    pathname = "";
+  const parsed = new URL(rawUrl, "https://mosoo.ai");
+  const publicPathname = parsed.pathname.replace(/^\/+/, "").replace(/\.md$/, "");
+  let docsPathname = publicPathname;
+  if (docsPathname === "docs" || docsPathname === "docs/index" || docsPathname === "index") {
+    docsPathname = "";
+  } else if (docsPathname.startsWith("docs/")) {
+    docsPathname = docsPathname.slice("docs/".length);
   }
-  return { pathname, url: `${parsed.origin}/${pathname}` };
+  const pageUrl =
+    docsPathname === "" ? "https://mosoo.ai/docs/" : `${parsed.origin}/${publicPathname}`;
+  return { pathname: docsPathname, url: pageUrl };
 }
 
 function parseManifest(text: string): HelpDocEntry[] {
   // The manifest is a markdown link list: "- [Title](url): optional description".
   // We index the rendered help pages only, so non-".md" links (e.g. OpenAPI JSON
   // specs) are skipped.
-  const linePattern = /^\s*-\s+\[([^\]]+)\]\((https?:\/\/[^)]+)\)/;
+  const linePattern = /^\s*-\s+\[([^\]]+)\]\(([^)]+)\)/;
   const entries: HelpDocEntry[] = [];
 
   for (const line of text.split("\n")) {
@@ -75,11 +80,23 @@ function parseManifest(text: string): HelpDocEntry[] {
     }
 
     const rawUrl = match[2].trim();
-    if (!rawUrl.endsWith(".md")) {
+    if (
+      !rawUrl.startsWith("/") &&
+      !rawUrl.startsWith("http://") &&
+      !rawUrl.startsWith("https://")
+    ) {
+      continue;
+    }
+
+    if (rawUrl.endsWith(".json")) {
       continue;
     }
 
     const { pathname, url } = toPageUrl(rawUrl);
+    if (pathname === "zh-Hans" || pathname.startsWith("zh-Hans/")) {
+      continue;
+    }
+
     const title = TITLE_OVERRIDES_BY_PATHNAME[pathname] ?? match[1].trim();
     entries.push({ manifestIndex: entries.length, section: classifySection(pathname), title, url });
   }


### PR DESCRIPTION
## Summary
- replace main-repo public docs links with `https://mosoo.ai/docs/` and the new API reference path
- regenerate the app help docs index from the public docs `llms.txt`
- dispatch OpenAPI syncs to `langgenius/mosoo-docs`

## Verification
- `PATH=/Users/chenxiefan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH just help-docs-index`
- `PATH=/Users/chenxiefan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run fmt:check:path -- apps/web/src/shared/config/help-docs.ts scripts/generate-help-docs-index.ts apps/web/src/shared/config/external-links.ts apps/web/tests/help-docs.test.ts package.json .github/workflows/docs-openapi-dispatch.yml apps/web/src/features/help/help-docs-dialog.tsx`
- `PATH=/Users/chenxiefan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun test apps/web/tests/help-docs.test.ts apps/web/tests/app-settings-boundary.test.ts`
- `git diff --check -- .github/workflows/docs-openapi-dispatch.yml apps/web/src/features/help/help-docs-dialog.tsx apps/web/src/shared/config/external-links.ts apps/web/src/shared/config/help-docs.ts apps/web/tests/help-docs.test.ts package.json scripts/generate-help-docs-index.ts`
- `curl -L -o /dev/null -s -w "%{http_code}"` for `https://mosoo.ai/`, `https://mosoo.ai/blog/`, `https://mosoo.ai/docs/`, and API reference pages returned `200`
