### PR TITLE
fix(publish): remove footer try mosoo CTA

### DIFF
--- a/apps/web/src/routes/agent/lifecycle/publish-success-modal.tsx
+++ b/apps/web/src/routes/agent/lifecycle/publish-success-modal.tsx
@@ -73,19 +73,16 @@ export function PublishSuccessModal({
           <AgentApiAccessPanel agent={agent} />
         </div>
 
-        <Separator />
-
-        <div className="flex justify-end gap-2 px-6 py-3">
-          {onViewDistribution ? (
-            <Button onClick={onViewDistribution} size="sm" variant="outline">
-              View distribution
-            </Button>
-          ) : null}
-          <Button className="gap-1.5" onClick={openThreadDialog} size="sm">
-            Try in Mosoo
-            <ArrowRight className="size-3.5" />
-          </Button>
-        </div>
+        {onViewDistribution ? (
+          <>
+            <Separator />
+            <div className="flex justify-end gap-2 px-6 py-3">
+              <Button onClick={onViewDistribution} size="sm" variant="outline">
+                View distribution
+              </Button>
+            </div>
+          </>
+        ) : null}
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/tests/agent-publish-success-boundary.test.ts
+++ b/apps/web/tests/agent-publish-success-boundary.test.ts
@@ -6,9 +6,10 @@ function readSource(path: string): string {
 }
 
 describe("agent publish success boundary", () => {
-  test("routes Try in Mosoo through locked Threads instead of exposing a web URL", () => {
+  test("keeps the Thread entry in the modal body without the footer Try CTA", () => {
     const source = readSource("../src/routes/agent/lifecycle/publish-success-modal.tsx");
 
+    expect(source.match(/Try in Mosoo/g)?.length ?? 0).toBe(1);
     expect(source).toContain("Try in Mosoo");
     expect(source).toContain("Start a Thread with this agent.");
     expect(source).toContain("globalThis.location.assign(distribution.threadsPath)");


### PR DESCRIPTION
## Summary

- Remove the footer `Try in Mosoo` primary CTA from the publish success modal.
- Keep the body Thread entry and API access panel intact.
- Update the publish success boundary test so the modal keeps only one `Try in Mosoo` entry.

## Validation

- `just test-file apps/web/tests/agent-publish-success-boundary.test.ts`
- `just fmt-check-path apps/web/src/routes/agent/lifecycle/publish-success-modal.tsx`
- `just fmt-check-path apps/web/tests/agent-publish-success-boundary.test.ts`
- `just tc-package @mosoo/web`
- `git diff --check`

## Generated Files / Codegen / DB

- Generated files: none
- GraphQL codegen: not changed
- DB baseline: not changed