### PR TITLE
fix(agent-detail): restore terminal tab entry

### DIFF
--- a/apps/web/src/routes/agent/agent-detail.route.tsx
+++ b/apps/web/src/routes/agent/agent-detail.route.tsx
@@ -55,6 +55,7 @@ function toDetailMode(value: string | null): DetailMode | null {
 
 function AgentDetailHeader({
   agent,
+  canUseTerminal,
   headerActionTargetRef,
   mode,
   onBack,
@@ -64,6 +65,7 @@ function AgentDetailHeader({
   runtime,
 }: {
   agent: Agent;
+  canUseTerminal: boolean;
   headerActionTargetRef: (node: HTMLDivElement | null) => void;
   mode: DetailMode;
   onBack: () => void;
@@ -118,6 +120,23 @@ function AgentDetailHeader({
             {tab.label}
           </button>
         ))}
+        {canUseTerminal && (
+          <button
+            type="button"
+            onClick={() => {
+              onSelectMode("terminal");
+            }}
+            className={cn(
+              "rounded-lg px-3.5 py-1.5 text-[13px] font-medium transition-all",
+              mode === "terminal"
+                ? "bg-ink-100 text-fg-1"
+                : "text-muted-foreground hover:bg-accent",
+            )}
+            aria-label="Open Terminal"
+          >
+            Terminal
+          </button>
+        )}
       </div>
 
       <div className="flex items-center gap-2">
@@ -279,6 +298,7 @@ export function AgentDetailPage() {
     <div className="flex h-full flex-col">
       <AgentDetailHeader
         agent={agent}
+        canUseTerminal={canUseTerminal}
         headerActionTargetRef={setHeaderActionTarget}
         mode={mode}
         onBack={() => {

--- a/apps/web/tests/agent-terminal-entry-boundary.test.ts
+++ b/apps/web/tests/agent-terminal-entry-boundary.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+function readSource(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+describe("Agent terminal entry boundary", () => {
+  test("keeps Pet owner Terminal as a gated header tab", () => {
+    const source = readSource("../src/routes/agent/agent-detail.route.tsx");
+    const terminalButtonIndex = source.indexOf('aria-label="Open Terminal"');
+    const gatedEntryIndex = source.lastIndexOf("canUseTerminal &&", terminalButtonIndex);
+
+    expect(source).toContain('import { ArrowLeft, Settings } from "lucide-react";');
+    expect(source).not.toContain("TerminalSquare");
+    expect(terminalButtonIndex).toBeGreaterThan(-1);
+    expect(gatedEntryIndex).toBeGreaterThan(-1);
+    expect(source).toContain('onSelectMode("terminal")');
+    expect(source).toContain(
+      'requestedMode === "terminal" && !canUseTerminal ? defaultMode : requestedMode',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- restore the gated Terminal tab in the Agent detail header for Pet owners
- keep the tab text-only by omitting the terminal icon
- add a boundary test so the visible entry stays coupled to canUseTerminal

## Verification
- bash ./init.sh development
- PATH="/Users/chenxiefan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" just fmt-check-path apps/web/src/routes/agent/agent-detail.route.tsx
- PATH="/Users/chenxiefan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" just fmt-check-path apps/web/tests/agent-terminal-entry-boundary.test.ts
- just test-file apps/web/tests/agent-terminal-entry-boundary.test.ts
- just test-file apps/web/tests/agent-debug-menu-policy.test.ts
- PATH="/Users/chenxiefan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" just tc-package @mosoo/web
- git diff --check