### PR TITLE
fix(session-chat): drop copy action bar on tool-only assistant turns

### DIFF
--- a/apps/web/src/features/session-chat/assistant-ui/session-message-parts.tsx
+++ b/apps/web/src/features/session-chat/assistant-ui/session-message-parts.tsx
@@ -1,4 +1,4 @@
-import { ActionBarPrimitive, MessagePrimitive } from "@assistant-ui/react";
+import { ActionBarPrimitive, MessagePrimitive, useMessage } from "@assistant-ui/react";
 import type { TextMessagePartComponent } from "@assistant-ui/react";
 import { Copy } from "lucide-react";
 import type { ReactElement } from "react";
@@ -54,6 +54,16 @@ export function UserMessage(): ReactElement {
 }
 
 export function AssistantMessage(): ReactElement {
+  // Copy only makes sense when the turn actually produced prose. Tool-only turns
+  // (e.g. a file write that emits just tool cards) have nothing to copy, so we
+  // drop the action bar entirely rather than render an empty copy button under
+  // the card. This also reclaims the h-6 slot the bar used to reserve even while
+  // hidden — that reserved space was what inflated the gap between consecutive
+  // tool cards.
+  const hasCopyableText = useMessage((message) =>
+    message.content.some((part) => part.type === "text" && part.text.trim().length > 0),
+  );
+
   return (
     <MessagePrimitive.Root className="group/aui-msg flex min-w-0 justify-start">
       <div className="text-fg-1 w-full min-w-0 text-[14.5px] leading-[1.55]">
@@ -69,17 +79,19 @@ export function AssistantMessage(): ReactElement {
         </div>
         {/* In-flow, compact, hover-revealed — kept off the next message so it
             neither overlaps it nor inflates the gap the way the old layout did. */}
-        <ActionBarPrimitive.Root
-          hideWhenRunning
-          className="text-fg-3 mt-1 flex h-6 gap-1 opacity-0 transition-opacity group-hover/aui-msg:opacity-100"
-        >
-          <ActionBarPrimitive.Copy
-            aria-label="Copy message"
-            className="hover:bg-ink-900/[0.05] hover:text-fg-1 inline-flex size-6 items-center justify-center rounded-md transition-colors"
+        {hasCopyableText ? (
+          <ActionBarPrimitive.Root
+            hideWhenRunning
+            className="text-fg-3 mt-1 flex h-6 gap-1 opacity-0 transition-opacity group-hover/aui-msg:opacity-100"
           >
-            <Copy className="size-3.5" />
-          </ActionBarPrimitive.Copy>
-        </ActionBarPrimitive.Root>
+            <ActionBarPrimitive.Copy
+              aria-label="Copy message"
+              className="hover:bg-ink-900/[0.05] hover:text-fg-1 inline-flex size-6 items-center justify-center rounded-md transition-colors"
+            >
+              <Copy className="size-3.5" />
+            </ActionBarPrimitive.Copy>
+          </ActionBarPrimitive.Root>
+        ) : null}
       </div>
     </MessagePrimitive.Root>
   );


### PR DESCRIPTION
## Summary

- Fix the oversized vertical gap between consecutive `tool` cards in the agent preview chat, and remove the stray copy button that appeared under tool-only assistant turns.

## Why

- Each tool call arrives as its own assistant message, and every assistant message reserved an `h-6` copy action-bar slot at the bottom — kept in the layout (via `opacity-0`) even while hidden. For tool-only turns this reserved slot both inflated the gap between consecutive tool cards and revealed a stray copy button under the card on hover. A tool-only turn has no prose to copy, so the action bar should not be there at all.
- Fix: only render the copy action bar when the turn actually produced copyable text. This removes the reserved slot (tightening the gap between tool cards) and the meaningless copy button in one change.

## Verification

- Commands: `vp exec tsc --noEmit` (pass), `vp lint .` (pass), `bun test tests/session-message-convert.test.ts tests/agent-session-panel-boundary.test.ts` (12 pass / 0 fail).
- Manual: rendered the exact reported state (two tool-only assistant turns followed by a prose turn) in a local harness against the real `SessionThread` — see before/after screenshots.

## Risk And Blast Radius

- Affected packages: `apps/web` (`features/session-chat/assistant-ui/session-message-parts.tsx`).
- Affected user flows: agent preview / session chat rendering only. Copy button still shows on assistant turns that contain prose.
- Rollback: revert the single commit.

## Evidence

- UI/UX: before/after screenshots attached to the tracking issue YEF-772.
  - Before: large empty gap between the two `tool` cards and a stray copy button under the second card.
  - After: tool cards sit on the normal 8px message gap; no copy button on tool-only turns; copy still available on the prose turn.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- `hasCopyableText` gate in `AssistantMessage` — it inspects `useMessage` content parts for any non-empty text part.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Subject starts lowercase
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence (attached to issue YEF-772)

## Generated Files, Schema, And Lockfile

- N/A — no generated files, schema, or lockfile touched.
