### PR TITLE
fix(cost): price first-class runtime models

### DIFF
--- a/apps/api/src/modules/cost/domain/cost-pricing.ts
+++ b/apps/api/src/modules/cost/domain/cost-pricing.ts
@@ -79,12 +79,92 @@ const MODEL_PRICING: readonly ModelPricing[] = [
     outputUsdPerMillion: 14,
   }),
   deepseekPricing({
-    cacheReadUsdPerMillion: 0.145,
-    inputUsdPerMillion: 1.74,
+    cacheReadUsdPerMillion: 0.003625,
+    inputUsdPerMillion: 0.435,
     model: "deepseek-v4-pro",
-    outputUsdPerMillion: 3.48,
+    outputUsdPerMillion: 0.87,
   }),
-  {
+  deepseekPricing({
+    cacheReadUsdPerMillion: 0.0028,
+    inputUsdPerMillion: 0.14,
+    model: "deepseek-v4-flash",
+    outputUsdPerMillion: 0.28,
+  }),
+  providerPricing({
+    cacheReadUsdPerMillion: 0.15,
+    inputUsdPerMillion: 1.5,
+    model: "gemini-3.5-flash",
+    outputUsdPerMillion: 9,
+    provider: "gemini",
+    vendor: "Google",
+  }),
+  providerPricing({
+    cacheReadUsdPerMillion: 0.0552,
+    inputUsdPerMillion: 0.276,
+    model: "qwen3.7-plus",
+    outputUsdPerMillion: 1.101,
+    provider: "qwen",
+    vendor: "Alibaba",
+  }),
+  providerPricing({
+    cacheReadUsdPerMillion: 0.0552,
+    inputUsdPerMillion: 0.276,
+    model: "qwen3.6-plus",
+    outputUsdPerMillion: 1.651,
+    provider: "qwen",
+    vendor: "Alibaba",
+  }),
+  providerPricing({
+    cacheReadUsdPerMillion: 0.16,
+    inputUsdPerMillion: 0.95,
+    model: "kimi-k2.6",
+    outputUsdPerMillion: 4,
+    provider: "kimi",
+    vendor: "Moonshot AI",
+  }),
+  providerPricing({
+    cacheReadUsdPerMillion: 0.19,
+    inputUsdPerMillion: 0.95,
+    model: "kimi-k2.7-code",
+    outputUsdPerMillion: 4,
+    provider: "kimi",
+    vendor: "Moonshot AI",
+  }),
+  providerPricing({
+    cacheReadUsdPerMillion: 0.11,
+    inputUsdPerMillion: 0.6,
+    model: "glm-4.7",
+    outputUsdPerMillion: 2.2,
+    provider: "zhipu",
+    vendor: "Z.ai",
+  }),
+  providerPricing({
+    cacheReadUsdPerMillion: 0.11,
+    inputUsdPerMillion: 0.6,
+    model: "glm-4.6",
+    outputUsdPerMillion: 2.2,
+    provider: "zhipu",
+    vendor: "Z.ai",
+  }),
+  providerPricing({
+    cacheReadUsdPerMillion: 0.09,
+    inputUsdPerMillion: 0.45,
+    model: "MiniMax-M3",
+    outputUsdPerMillion: 1.8,
+    provider: "minimax",
+    vendor: "MiniMax",
+  }),
+  providerPricing({
+    cacheReadUsdPerMillion: 0.06,
+    cacheWriteUsdPerMillion: 0.375,
+    inputUsdPerMillion: 0.3,
+    model: "MiniMax-M2.7",
+    outputUsdPerMillion: 1.2,
+    provider: "minimax",
+    vendor: "MiniMax",
+  }),
+  // Keep legacy upstream provider IDs for usage rows written before Mosoo provider IDs were canonical.
+  providerPricing({
     cacheReadUsdPerMillion: 0.125,
     cacheWriteUsdPerMillion: 1.875,
     inputUsdPerMillion: 1.25,
@@ -92,8 +172,8 @@ const MODEL_PRICING: readonly ModelPricing[] = [
     outputUsdPerMillion: 10,
     provider: "google",
     vendor: "Google",
-  },
-  {
+  }),
+  providerPricing({
     cacheReadUsdPerMillion: 0.12,
     cacheWriteUsdPerMillion: 1.5,
     inputUsdPerMillion: 1.2,
@@ -101,7 +181,7 @@ const MODEL_PRICING: readonly ModelPricing[] = [
     outputUsdPerMillion: 6,
     provider: "alibaba",
     vendor: "Alibaba",
-  },
+  }),
   opencodePricing({
     cacheReadUsdPerMillion: 0.145,
     inputUsdPerMillion: 1.74,
@@ -186,6 +266,26 @@ function deepseekPricing(input: {
   };
 }
 
+function providerPricing(input: {
+  cacheReadUsdPerMillion: number;
+  cacheWriteUsdPerMillion?: number;
+  inputUsdPerMillion: number;
+  model: string;
+  outputUsdPerMillion: number;
+  provider: string;
+  vendor: string;
+}): ModelPricing {
+  return {
+    cacheReadUsdPerMillion: input.cacheReadUsdPerMillion,
+    cacheWriteUsdPerMillion: input.cacheWriteUsdPerMillion ?? 0,
+    inputUsdPerMillion: input.inputUsdPerMillion,
+    model: input.model,
+    outputUsdPerMillion: input.outputUsdPerMillion,
+    provider: input.provider,
+    vendor: input.vendor,
+  };
+}
+
 function opencodePricing(input: {
   cacheReadUsdPerMillion: number;
   cacheWriteUsdPerMillion?: number;
@@ -208,22 +308,83 @@ function scalePrice(value: number, factor: number): number {
   return Number((value * factor).toFixed(6));
 }
 
-function pricingKey(input: ModelPricingLookup): string {
-  return `${input.providerId}:${input.modelId}`;
+function normalizeProviderId(providerId: string): string {
+  return providerId.trim().toLowerCase();
+}
+
+function normalizeModelId(modelId: string): string {
+  return modelId.trim().toLowerCase();
+}
+
+function stripProviderPrefix(modelId: string): string {
+  const separatorIndex = modelId.lastIndexOf("/");
+
+  return separatorIndex === -1 ? modelId : modelId.slice(separatorIndex + 1);
+}
+
+function stripContextWindowSuffix(modelId: string): string {
+  return modelId.replace(/\[[^\]]+\]$/u, "");
+}
+
+function stripVersionSuffix(modelId: string): string {
+  return modelId.replace(/-(?:latest|\d{8}|\d{4}-\d{2}-\d{2})$/u, "");
+}
+
+function normalizeAnthropicSeparator(modelId: string): string {
+  return modelId.startsWith("claude-") ? modelId.replace(/\./gu, "-") : modelId;
+}
+
+function appendModelKey(keys: string[], modelId: string): void {
+  const normalizedModelId = normalizeModelId(modelId);
+
+  if (normalizedModelId.length === 0) {
+    return;
+  }
+
+  const candidates = [
+    normalizedModelId,
+    stripProviderPrefix(normalizedModelId),
+    stripContextWindowSuffix(normalizedModelId),
+    stripVersionSuffix(normalizedModelId),
+    stripVersionSuffix(stripContextWindowSuffix(stripProviderPrefix(normalizedModelId))),
+    normalizeAnthropicSeparator(normalizedModelId),
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate.length > 0 && !keys.includes(candidate)) {
+      keys.push(candidate);
+    }
+  }
+}
+
+function modelLookupKeys(modelId: string): readonly string[] {
+  const keys: string[] = [];
+
+  appendModelKey(keys, modelId);
+
+  return keys;
+}
+
+function pricingMapKey(providerId: string, modelId: string): string {
+  return `${normalizeProviderId(providerId)}:${normalizeModelId(modelId)}`;
 }
 
 const PRICING_BY_PROVIDER_MODEL = new Map(
-  MODEL_PRICING.map((pricing) => [
-    pricingKey({
-      modelId: pricing.model,
-      providerId: pricing.provider,
-    }),
-    pricing,
-  ]),
+  MODEL_PRICING.map((pricing) => [pricingMapKey(pricing.provider, pricing.model), pricing]),
 );
 
 export function findModelPricing(input: ModelPricingLookup): ModelPricing | null {
-  return PRICING_BY_PROVIDER_MODEL.get(pricingKey(input)) ?? null;
+  const providerId = normalizeProviderId(input.providerId);
+
+  for (const modelId of modelLookupKeys(input.modelId)) {
+    const pricing = PRICING_BY_PROVIDER_MODEL.get(`${providerId}:${modelId}`);
+
+    if (pricing) {
+      return pricing;
+    }
+  }
+
+  return null;
 }
 
 export function calculateUsageCost(input: {
@@ -265,7 +426,7 @@ export function calculateUsageCost(input: {
       model: pricing.model,
       outputUsdPerMillion: pricing.outputUsdPerMillion,
       provider: pricing.provider,
-      source: "mosoo_seed_2026_05_05",
+      source: "mosoo_seed_2026_07_01",
     }),
     pricing,
     pricingStatus: "priced",

--- a/apps/api/tests/cost-pricing.test.ts
+++ b/apps/api/tests/cost-pricing.test.ts
@@ -2,15 +2,22 @@ import { describe, expect, test } from "bun:test";
 
 import { PRESET_MODEL_CATALOG } from "@mosoo/runtime-catalog";
 
-import { findModelPricing } from "../src/modules/cost/domain/cost-pricing";
+import { calculateUsageCost, findModelPricing } from "../src/modules/cost/domain/cost-pricing";
 
-const COST_PRICED_PROVIDER_IDS = new Set(["anthropic", "openai", "opencode"]);
+const COST_PRICED_PROVIDER_IDS = new Set([
+  "anthropic",
+  "deepseek",
+  "gemini",
+  "kimi",
+  "minimax",
+  "opencode",
+  "openai",
+  "qwen",
+  "zhipu",
+]);
 
 function requiresCostPricing(model: (typeof PRESET_MODEL_CATALOG)[number]): boolean {
-  return (
-    COST_PRICED_PROVIDER_IDS.has(model.vendorId) ||
-    (model.vendorId === "deepseek" && model.modelId === "deepseek-v4-pro")
-  );
+  return COST_PRICED_PROVIDER_IDS.has(model.vendorId);
 }
 
 describe("cost pricing", () => {
@@ -33,5 +40,68 @@ describe("cost pricing", () => {
         providerId: "openai",
       }),
     ).toBeNull();
+  });
+
+  test("normalizes model IDs emitted by OpenCode-compatible providers", () => {
+    const cases = [
+      {
+        expectedModel: "kimi-k2.6",
+        modelId: "kimi/kimi-k2.6",
+        providerId: "kimi",
+      },
+      {
+        expectedModel: "kimi-k2.7-code",
+        modelId: "kimi-k2.7-code-2026-06-25",
+        providerId: "kimi",
+      },
+      {
+        expectedModel: "glm-4.6",
+        modelId: "zai/glm-4.6",
+        providerId: "zhipu",
+      },
+      {
+        expectedModel: "MiniMax-M3",
+        modelId: "minimax/minimax-m3",
+        providerId: "minimax",
+      },
+      {
+        expectedModel: "qwen3.6-plus",
+        modelId: "opencode/qwen3.6-plus",
+        providerId: "opencode",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const pricing = findModelPricing({
+        modelId: testCase.modelId,
+        providerId: testCase.providerId,
+      });
+
+      expect(pricing?.model, `${testCase.providerId}:${testCase.modelId}`).toBe(
+        testCase.expectedModel,
+      );
+    }
+  });
+
+  test("prices Kimi usage without driver-provided cost", () => {
+    const result = calculateUsageCost({
+      cacheCreationTokens: 40,
+      cacheReadTokens: 100,
+      inputTokens: 1_000,
+      model: "kimi-k2.6",
+      outputTokens: 200,
+      provider: "kimi",
+    });
+
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.totalCostUsd).toBeCloseTo(0.001671, 8);
+    expect(JSON.parse(result.priceSnapshotJson ?? "{}")).toMatchObject({
+      billableInputTokens: 900,
+      cacheReadUsdPerMillion: 0.16,
+      inputUsdPerMillion: 0.95,
+      model: "kimi-k2.6",
+      outputUsdPerMillion: 4,
+      provider: "kimi",
+    });
   });
 });

--- a/apps/api/tests/cost-usage-event.test.ts
+++ b/apps/api/tests/cost-usage-event.test.ts
@@ -254,6 +254,76 @@ describe("cost usage event", () => {
     });
   });
 
+  test("prices OpenCode-run Kimi usage from the persisted provider identity", async () => {
+    const database = createUsageEventDatabase();
+    const runContext = {
+      ...RUN_CONTEXT,
+      model: "kimi-k2.6",
+      provider: "kimi",
+      runtimeId: "opencode",
+    };
+    const usage = {
+      cachedReadTokens: 100,
+      cachedWriteTokens: 40,
+      inputTokens: 1_000,
+      model: "opencode/kimi-k2.6",
+      outputTokens: 200,
+      provider: "opencode",
+      source: "prompt_response",
+      usageContract: "openai_total_with_cached_breakdown",
+    } satisfies SessionUsageSummary;
+
+    await recordRuntimeUsageEvent(database, {
+      callKey: "opencode-kimi-call",
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      nativeCallId: null,
+      run: runContext,
+      usage,
+    });
+
+    const row = await database
+      .prepare(
+        `
+          SELECT
+            model,
+            price_snapshot_json,
+            pricing_status,
+            provider,
+            runtime_id,
+            total_cost_usd_micros
+          FROM usage_event
+        `,
+      )
+      .first<
+        Pick<
+          UsageEventProjection,
+          | "model"
+          | "price_snapshot_json"
+          | "pricing_status"
+          | "provider"
+          | "runtime_id"
+          | "total_cost_usd_micros"
+        >
+      >();
+
+    expect(row).toMatchObject({
+      model: "kimi-k2.6",
+      pricing_status: "priced",
+      provider: "kimi",
+      runtime_id: "opencode",
+      total_cost_usd_micros: 1_671,
+    });
+    const priceSnapshot = JSON.parse(row?.price_snapshot_json ?? "{}") as Record<string, unknown>;
+    expect(priceSnapshot).toMatchObject({
+      billableInputTokens: 900,
+      cacheReadUsdPerMillion: 0.16,
+      inputUsdPerMillion: 0.95,
+      model: "kimi-k2.6",
+      outputUsdPerMillion: 4,
+      provider: "kimi",
+    });
+  });
+
   test("apps channel session usage into channel run purpose", async () => {
     const database = createUsageEventDatabase();
     const usage = {


### PR DESCRIPTION
## Summary

- Add first-class cost pricing coverage for DeepSeek, Gemini, Qwen, Kimi, Zhipu, and MiniMax runtime providers.
- Normalize runtime-emitted model IDs before price lookup, including provider prefixes, date suffixes, context suffixes, case differences, and Anthropic dot/dash variants.
- Add regression coverage for OpenCode-run Kimi usage so persisted `kimi:kimi-k2.6` events are priced instead of falling through to `$0.00`.

## Verification

- `bash ./init.sh development`
- `PATH="/Users/chenxiefan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" just fmt-check-path apps/api/src/modules/cost/domain/cost-pricing.ts`
- `PATH="/Users/chenxiefan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" just fmt-check-path apps/api/tests/cost-pricing.test.ts`
- `PATH="/Users/chenxiefan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" just fmt-check-path apps/api/tests/cost-usage-event.test.ts`
- `bun test apps/api/tests/cost-pricing.test.ts apps/api/tests/cost-usage-event.test.ts`
- `just tc-package @mosoo/api`
- `git diff --check`

## Not Run

- `bun run graphql:codegen`: no GraphQL schema, document, or scalar mapping changes.
- DB migrate / `db:regen`: no DB schema, migration, or baseline changes.
