### PR TITLE
fix(runtime): allow startup skill package downloads

### DIFF
--- a/apps/api/src/adapters/http/routes/driver-route.ts
+++ b/apps/api/src/adapters/http/routes/driver-route.ts
@@ -19,8 +19,8 @@ import {
   toRuntimeMcpProxyPublicErrorDetails,
 } from "../../../modules/runtime/application/runtime-mcp-proxy-errors";
 import { resolveRuntimeMcpProxyTarget } from "../../../modules/runtime/application/runtime-mcp-proxy.service";
-import { readSkillPackageBytesFromSnapshot } from "../../../modules/skills/application/skill-package-snapshot.service";
 import { getDriverInstanceRecord } from "../../../modules/runtime/infrastructure/driver-instance/driver-instance-record.repository";
+import { readSkillPackageBytesFromSnapshot } from "../../../modules/skills/application/skill-package-snapshot.service";
 import type { ApiGatewayEnvironment } from "../../../platform/cloudflare/worker-types";
 import { toPlatformId } from "../../../shared/platform-id";
 import { toArrayBufferResponseBody } from "../../../shared/response-body";

--- a/apps/api/src/adapters/http/routes/driver-route.ts
+++ b/apps/api/src/adapters/http/routes/driver-route.ts
@@ -2,6 +2,7 @@ import type { CredentialId, DriverInstanceId, McpServerId, SkillSnapshotId } fro
 import type { Context } from "hono";
 import { Hono } from "hono";
 
+import type { RuntimeActionTokenPayload } from "../../../modules/runtime/application/runtime-driver-access.service";
 import {
   cleanupDriverInstances,
   requireRuntimeDriverInstanceGrant,
@@ -19,6 +20,7 @@ import {
 } from "../../../modules/runtime/application/runtime-mcp-proxy-errors";
 import { resolveRuntimeMcpProxyTarget } from "../../../modules/runtime/application/runtime-mcp-proxy.service";
 import { readSkillPackageBytesFromSnapshot } from "../../../modules/skills/application/skill-package-snapshot.service";
+import { getDriverInstanceRecord } from "../../../modules/runtime/infrastructure/driver-instance/driver-instance-record.repository";
 import type { ApiGatewayEnvironment } from "../../../platform/cloudflare/worker-types";
 import { toPlatformId } from "../../../shared/platform-id";
 import { toArrayBufferResponseBody } from "../../../shared/response-body";
@@ -100,6 +102,47 @@ function driverPlatformIdErrorResponse(error: unknown): Response | null {
   return platformIdRouteErrorResponse(error, (message) => ({ error: message }));
 }
 
+async function isStartupSkillDownloadGrant(
+  c: Context<ApiGatewayEnvironment>,
+  grant: RuntimeActionTokenPayload & { action: "skill_snapshot" },
+): Promise<boolean> {
+  const driver = await getDriverInstanceRecord(c.env.DB, grant.driverInstanceId);
+  return driver?.status === "provisioning" || driver?.status === "connecting";
+}
+
+async function requireSkillSnapshotDownloadGrant(
+  c: Context<ApiGatewayEnvironment>,
+  input: {
+    grant: RuntimeActionTokenPayload & { action: "skill_snapshot" };
+    snapshotId: SkillSnapshotId;
+  },
+): Promise<void> {
+  try {
+    await requireRuntimeDriverInstanceGrant(c.env.DB, {
+      driverInstanceId: input.grant.driverInstanceId,
+      requireAction: "skill_snapshot",
+      snapshotId: input.snapshotId,
+    });
+    return;
+  } catch (error) {
+    if (
+      !(error instanceof Error) ||
+      error.message !== "Snapshot is not available for this driver instance."
+    ) {
+      throw error;
+    }
+
+    // Cold drivers materialize skills during boot, before the run lease is linked
+    // to session_run.driver_instance_id. The signed action token already binds
+    // this request to the driver instance and snapshot; this fallback only spans
+    // that provisioning window.
+    if (await isStartupSkillDownloadGrant(c, input.grant)) {
+      return;
+    }
+    throw error;
+  }
+}
+
 async function proxyRuntimeMcpRequest(
   request: Request,
   input: {
@@ -169,9 +212,8 @@ export function registerDriverRoute(app: Hono<ApiGatewayEnvironment>) {
     }
 
     try {
-      await requireRuntimeDriverInstanceGrant(c.env.DB, {
-        driverInstanceId: grant.driverInstanceId,
-        requireAction: "skill_snapshot",
+      await requireSkillSnapshotDownloadGrant(c, {
+        grant,
         snapshotId,
       });
     } catch (error) {

--- a/apps/api/tests/driver-skill-package-route.test.ts
+++ b/apps/api/tests/driver-skill-package-route.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from "bun:test";
+
+import { driverInstancesTable, skillSnapshotsTable } from "@mosoo/db";
+import { Hono } from "hono";
+
+import { registerDriverRoute } from "../src/adapters/http/routes/driver-route";
+import { getRuntimeDriverSkillPackagePath } from "../src/modules/runtime/domain/runtime-driver-routes";
+import { createRuntimeActionToken } from "../src/modules/runtime/infrastructure/runtime-boot-token";
+import type { ApiBindings, ApiGatewayEnvironment } from "../src/platform/cloudflare/worker-types";
+import {
+  PUBLIC_API_TEST_IDS,
+  PublicApiMemoryFileBucket,
+  createPublicHttpContractDatabase,
+  createPublicHttpTestBindings,
+  createTestExecutionContext,
+  nowMsForTest,
+} from "./helpers/public-api-http-test-fixture";
+
+const SKILL_SNAPSHOT_ID = "01J0000000000000000000000S";
+const OTHER_SKILL_SNAPSHOT_ID = "01J0000000000000000000000T";
+const SKILL_BLOB_KEY = "app/01J0000000000000000000000Q/skill-blob/test.skill";
+
+function ensureSkillRouteTables(
+  database: Awaited<ReturnType<typeof createPublicHttpContractDatabase>>,
+) {
+  database.execute(`
+    CREATE TABLE IF NOT EXISTS skill_snapshot (
+      author text NOT NULL,
+      blob_key text NOT NULL,
+      blob_sha256 text NOT NULL,
+      blob_size integer NOT NULL,
+      created_at integer NOT NULL,
+      description text NOT NULL,
+      id text PRIMARY KEY NOT NULL,
+      name text NOT NULL,
+      app_id text NOT NULL,
+      skill_markdown_path text NOT NULL,
+      uncompressed_size integer NOT NULL,
+      version text
+    );
+
+    CREATE TABLE IF NOT EXISTS session_run_skill (
+      blob_sha256 text,
+      created_at integer NOT NULL,
+      materialization_status text NOT NULL,
+      mount_path text NOT NULL,
+      resolution_mode text NOT NULL,
+      session_run_id text NOT NULL,
+      skill_id text NOT NULL,
+      skill_name text NOT NULL,
+      snapshot_id text,
+      updated_at integer NOT NULL,
+      warning_code text,
+      PRIMARY KEY (session_run_id, skill_id)
+    );
+  `);
+}
+
+function createDriverRouteTestApp(): Hono<ApiGatewayEnvironment> {
+  const app = new Hono<ApiGatewayEnvironment>();
+  registerDriverRoute(app);
+  return app;
+}
+
+async function insertSkillSnapshot(database: Awaited<ReturnType<typeof createPublicHttpContractDatabase>>) {
+  await database
+    .app()
+    .insert(skillSnapshotsTable)
+    .values({
+      appId: PUBLIC_API_TEST_IDS.app,
+      author: "Skill Author",
+      blobKey: SKILL_BLOB_KEY,
+      blobSha256: "sha-skill",
+      blobSize: "skill-zip".length,
+      createdAt: nowMsForTest(),
+      description: "Skill package route test.",
+      id: SKILL_SNAPSHOT_ID,
+      name: "route-skill",
+      skillMarkdownPath: "SKILL.md",
+      uncompressedSize: 10,
+      version: null,
+    })
+    .run();
+}
+
+async function insertDriverInstance(
+  database: Awaited<ReturnType<typeof createPublicHttpContractDatabase>>,
+  status: "provisioning" | "connecting" | "ready",
+) {
+  const nowMs = Date.now();
+  await database
+    .app()
+    .insert(driverInstancesTable)
+    .values({
+      bootTokenExpiresAt: nowMs + 60_000,
+      bootTokenHash: new Uint8Array([1, 2, 3]),
+      bootTokenUsedAt: null,
+      closeCode: null,
+      closeReason: null,
+      connectionId: null,
+      createdAt: nowMs,
+      driverPid: null,
+      driverStartedAt: null,
+      driverVersion: null,
+      errorMessage: null,
+      expiresAt: nowMs + 60_000,
+      heartbeatCount: 0,
+      id: PUBLIC_API_TEST_IDS.driverOwner,
+      lastHeartbeatAt: null,
+      processId: null,
+      protocol: "orpc-ws",
+      protocolVersion: 1,
+      runtime: "openai-runtime",
+      sandboxId: PUBLIC_API_TEST_IDS.sandbox,
+      sandboxSessionId: PUBLIC_API_TEST_IDS.ownerSession,
+      status,
+      statusChangedAt: nowMs,
+      statusSource: "api",
+      updatedAt: nowMs,
+    })
+    .run();
+}
+
+async function createSkillDownloadRequest(
+  bindings: ApiBindings,
+  snapshotId = SKILL_SNAPSHOT_ID,
+  resourceId = SKILL_SNAPSHOT_ID,
+): Promise<Request> {
+  const grant = await createRuntimeActionToken(bindings, {
+    action: "skill_snapshot",
+    driverInstanceId: PUBLIC_API_TEST_IDS.driverOwner,
+    expiresAt: Date.now() + 60_000,
+    resourceId,
+  });
+  return new Request(
+    `https://api.example.com${getRuntimeDriverSkillPackagePath(snapshotId)}?grant=${grant}`,
+  );
+}
+
+describe("driver skill package route", () => {
+  test("allows startup driver skill package downloads before the run lease is linked", async () => {
+    const database = await createPublicHttpContractDatabase();
+    const bucket = new PublicApiMemoryFileBucket();
+    const bindings = createPublicHttpTestBindings(database, {
+      fileBucket: bucket as unknown as R2Bucket,
+    }) as ApiBindings;
+
+    ensureSkillRouteTables(database);
+    await insertSkillSnapshot(database);
+    await insertDriverInstance(database, "provisioning");
+    await bucket.put(SKILL_BLOB_KEY, "skill-zip");
+
+    const response = await createDriverRouteTestApp().request(
+      await createSkillDownloadRequest(bindings),
+      undefined,
+      bindings,
+      createTestExecutionContext(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/zip");
+    expect(await response.text()).toBe("skill-zip");
+  });
+
+  test("does not allow ready drivers without a run lease to download skills", async () => {
+    const database = await createPublicHttpContractDatabase();
+    const bucket = new PublicApiMemoryFileBucket();
+    const bindings = createPublicHttpTestBindings(database, {
+      fileBucket: bucket as unknown as R2Bucket,
+    }) as ApiBindings;
+
+    ensureSkillRouteTables(database);
+    await insertSkillSnapshot(database);
+    await insertDriverInstance(database, "ready");
+    await bucket.put(SKILL_BLOB_KEY, "skill-zip");
+
+    const response = await createDriverRouteTestApp().request(
+      await createSkillDownloadRequest(bindings),
+      undefined,
+      bindings,
+      createTestExecutionContext(),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: "Snapshot is not available for this driver instance.",
+    });
+  });
+
+  test("still rejects grants for a different skill snapshot", async () => {
+    const database = await createPublicHttpContractDatabase();
+    const bindings = createPublicHttpTestBindings(database) as ApiBindings;
+
+    ensureSkillRouteTables(database);
+    await insertDriverInstance(database, "provisioning");
+
+    const response = await createDriverRouteTestApp().request(
+      await createSkillDownloadRequest(bindings, SKILL_SNAPSHOT_ID, OTHER_SKILL_SNAPSHOT_ID),
+      undefined,
+      bindings,
+      createTestExecutionContext(),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: "Runtime action grant does not match this skill snapshot.",
+    });
+  });
+});

--- a/apps/api/tests/driver-skill-package-route.test.ts
+++ b/apps/api/tests/driver-skill-package-route.test.ts
@@ -62,7 +62,9 @@ function createDriverRouteTestApp(): Hono<ApiGatewayEnvironment> {
   return app;
 }
 
-async function insertSkillSnapshot(database: Awaited<ReturnType<typeof createPublicHttpContractDatabase>>) {
+async function insertSkillSnapshot(
+  database: Awaited<ReturnType<typeof createPublicHttpContractDatabase>>,
+) {
   await database
     .app()
     .insert(skillSnapshotsTable)


### PR DESCRIPTION
## Summary
- Allow driver skill package downloads during the cold-start window before the run lease is linked to `session_run.driver_instance_id`.
- Keep the existing run-lease authorization for ready drivers, and only fall back for signed `skill_snapshot` grants while the driver is `provisioning` or `connecting`.
- Add driver route coverage for startup download success, ready-driver denial without a lease, and mismatched snapshot grant rejection.

## Root Cause
Runtime skill materialization happens during driver boot. At that point the signed runtime action token is valid, but the run lease has not been attached to the `session_run` row yet, so the driver-only package route denied the snapshot lookup with 403.

## Validation
- `bun test apps/api/tests/driver-skill-package-route.test.ts`
- `bun test apps/api/tests/http-route-platform-id-error.test.ts apps/api/tests/driver-skill-package-route.test.ts`
- `bun run --filter @mosoo/api lint`
- `bun run --filter @mosoo/api tc`
- `bun run --filter @mosoo/api test` (759 pass, 0 fail)
- CLI E2E via `mosoo`: created and published Agent `01KWF032MG531JN39G9WD19NWA`, then ran `mosoo public-thread-api threads create --agent-id 01KWF032MG531JN39G9WD19NWA --wait --final-output`; run `01KWF03E1F07EXZ44A27464BF1` completed. Events show `SKILL.md` materialized at `.mosoo/skill/01KWEZAKHAKG4V5TDSZ4X1HJ3P/SKILL.md`, the skill file was read, and the response included marker `MOSOO_SKILL_E2E_RETRY_20260701T135145Z`.

## Notes
- This PR validates the upload/download/materialization path and removes the 403 blocker. It does not require exact model output matching, since strict phrasing adherence is outside this authorization fix.
- Contains no generated files, GraphQL codegen, or DB baseline updates.
- Existing unrelated dirty worktree entries were not staged: `apps/driver`, `.agents/`, and `docs/prd/app-builder.zh-Hans.md`.
