### PR TITLE
fix(app-overview): update install guide command

### DIFF
--- a/apps/web/src/routes/app-overview/app-overview-install.tsx
+++ b/apps/web/src/routes/app-overview/app-overview-install.tsx
@@ -1,51 +1,15 @@
-import { useMutation } from "@tanstack/react-query";
-import { Check, ChevronDown, Copy, Download } from "lucide-react";
+import { Check, Copy } from "lucide-react";
 import type { ReactElement } from "react";
 import { useState } from "react";
 
-import { createPersonalAccessToken } from "@/domains/auth/api/personal-access-token-client";
-import { cn } from "@/shared/lib/class-names";
 import { Button } from "@/shared/ui/button";
 
-// The on-screen token stays masked; the real value only ever lands on the
-// clipboard so it is not rendered into the DOM.
-const MASKED_TOKEN = "mst_••••••••••••";
-const OTHER_AGENTS = ["Codex", "Cursor", "Cline"] as const;
-const READY_STEPS = ["Installs the @mosoo skill", "Signs the CLI in", "Ready to deploy"] as const;
-
-// A copyable, downloadable skill so any coding agent (Codex / Cursor / Cline …)
-// can drive Mosoo without the bundled `npx mosoo` wrapper.
-const MOSOO_SKILL_MARKDOWN = `---
-name: mosoo
-description: Deploy and run agents on your Mosoo App from any coding agent.
----
-
-# mosoo
-
-Hand work to your Mosoo App from any coding agent.
-
-## Log in
-
-\`\`\`bash
-npx mosoo login --token <your mst_ token>
-\`\`\`
-
-## Deploy
-
-\`\`\`bash
-npx mosoo deploy
-\`\`\`
-
-## Run an agent
-
-\`\`\`bash
-npx mosoo run <agent> --prompt "ship the release notes"
-\`\`\`
-`;
-
-function buildLoginCommand(token: string): string {
-  return `npx mosoo login --token ${token}`;
-}
+const INSTALL_COMMAND = "curl -fsSL https://install.mosoo.ai/install.sh | bash";
+const READY_STEPS = [
+  "Installs or updates Mosoo CLI",
+  "Updates the Codex @mosoo skill",
+  "Signs in to cloud and runs doctor",
+] as const;
 
 async function writeClipboardText(value: string): Promise<boolean> {
   if (typeof navigator === "undefined" || !navigator.clipboard) {
@@ -60,173 +24,80 @@ async function writeClipboardText(value: string): Promise<boolean> {
   }
 }
 
-function downloadTextFile(filename: string, contents: string): void {
-  if (typeof document === "undefined") {
-    return;
-  }
-
-  const blob = new Blob([contents], { type: "text/markdown" });
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.download = filename;
-  anchor.href = url;
-  anchor.click();
-  URL.revokeObjectURL(url);
-}
-
 export function AppOverviewInstallGuide(): ReactElement {
-  const [token, setToken] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [copyFailed, setCopyFailed] = useState(false);
-  const [skillCopied, setSkillCopied] = useState(false);
-  // Default to expanded so the @mosoo skill + Copy/Download actions are visible
-  // without an extra click for users on Codex / Cursor / Cline.
-  const [showOtherAgents, setShowOtherAgents] = useState(true);
 
-  const createTokenMutation = useMutation({
-    mutationFn: async () => createPersonalAccessToken("mosoo CLI"),
-    onSuccess: (response) => {
-      setToken(response.value);
-    },
-  });
-
-  async function copyLoginCommand(): Promise<void> {
+  async function copyInstallCommand(): Promise<void> {
     setCopyFailed(false);
 
-    try {
-      // Mint one real CLI token on first copy, then reuse it for the session.
-      const value = token ?? (await createTokenMutation.mutateAsync()).value;
-      const didCopy = await writeClipboardText(buildLoginCommand(value));
-
-      if (!didCopy) {
-        setCopyFailed(true);
-        return;
-      }
-
-      setCopied(true);
-      globalThis.setTimeout(() => {
-        setCopied(false);
-      }, 1500);
-    } catch {
-      setCopyFailed(true);
-    }
-  }
-
-  async function copySkill(): Promise<void> {
-    const didCopy = await writeClipboardText(MOSOO_SKILL_MARKDOWN);
+    const didCopy = await writeClipboardText(INSTALL_COMMAND);
 
     if (!didCopy) {
+      setCopyFailed(true);
       return;
     }
 
-    setSkillCopied(true);
+    setCopied(true);
     globalThis.setTimeout(() => {
-      setSkillCopied(false);
+      setCopied(false);
     }, 1500);
   }
 
-  const minting = createTokenMutation.isPending;
-
   return (
-    <section className="py-6">
-      <div className="mx-auto flex max-w-xl flex-col items-center text-center">
-        <h2 className="text-foreground text-2xl font-semibold tracking-tight">
+    <section className="py-8 sm:py-10">
+      <div className="mx-auto flex max-w-3xl flex-col items-center text-center">
+        <h2 className="text-foreground text-3xl font-semibold tracking-tight sm:text-4xl">
           Hand Mosoo to your agent
         </h2>
-        <p className="text-muted-foreground mt-2 text-sm">
-          One command installs the @mosoo skill, signs the CLI in, and your coding agent is ready to
-          deploy.
+        <p className="text-muted-foreground mt-3 max-w-2xl text-base leading-7">
+          One command installs Mosoo CLI, refreshes the Codex skill, signs in to try.mosoo.ai, and
+          checks cloud readiness.
         </p>
 
-        <div className="border-border bg-bg-sunken mt-6 flex w-full items-center gap-3 rounded-lg border px-4 py-2.5">
-          <code className="text-fg-1 min-w-0 flex-1 truncate text-left font-mono text-sm">
+        <div className="border-border bg-bg-sunken mt-8 flex w-full flex-col items-stretch gap-3 rounded-lg border px-4 py-3 sm:flex-row sm:items-center">
+          <code className="text-fg-1 min-w-0 flex-1 truncate text-left font-mono text-[13px] sm:text-base">
             <span className="text-fg-3 select-none">$ </span>
-            npx mosoo login --token {MASKED_TOKEN}
+            {INSTALL_COMMAND}
           </code>
           <Button
-            disabled={minting}
             onClick={() => {
-              void copyLoginCommand();
+              void copyInstallCommand();
             }}
-            size="sm"
+            className="w-full sm:w-auto"
+            size="default"
             variant="accent"
           >
             {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
-            {copied ? "Copied" : minting ? "Generating…" : "Copy command"}
+            {copied ? "Copied" : "Copy command"}
           </Button>
         </div>
 
-        {copyFailed && token !== null ? (
+        {copyFailed ? (
           <div className="mt-2 w-full text-left">
             <input
-              aria-label="mosoo login command"
+              aria-label="mosoo install command"
               readOnly
-              value={buildLoginCommand(token)}
+              value={INSTALL_COMMAND}
               onFocus={(event) => {
                 event.currentTarget.select();
               }}
               className="border-border bg-bg-sunken text-fg-1 w-full rounded-md border px-3 py-2 font-mono text-xs"
             />
             <p className="text-fg-3 mt-1 text-xs">
-              Copy failed — select and copy the command above.
+              Copy failed. Select and copy the command above.
             </p>
           </div>
         ) : null}
 
-        <div className="text-fg-2 mt-6 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-xs font-medium">
+        <div className="text-fg-2 mt-7 grid w-full max-w-2xl grid-cols-1 gap-2 text-xs font-medium sm:grid-cols-3">
           {READY_STEPS.map((label) => (
-            <span className="inline-flex items-center gap-1.5" key={label}>
+            <span className="inline-flex items-center justify-center gap-1.5" key={label}>
               <Check className="size-3.5 text-green-600" />
               {label}
             </span>
           ))}
         </div>
-
-        <button
-          type="button"
-          onClick={() => {
-            setShowOtherAgents((open) => !open);
-          }}
-          className="text-fg-3 hover:text-fg-1 mt-6 inline-flex items-center gap-1 text-xs transition-colors"
-        >
-          Using another agent? {OTHER_AGENTS.join(" · ")}
-          <ChevronDown
-            className={cn("size-3.5 transition-transform", showOtherAgents && "rotate-180")}
-          />
-        </button>
-
-        {showOtherAgents ? (
-          <div className="border-border bg-bg-sunken mt-3 w-full rounded-lg border p-4 text-left">
-            <p className="text-muted-foreground text-xs">
-              Copy or download the @mosoo skill for Codex, Cursor, Cline, or any coding agent.
-            </p>
-            <pre className="text-fg-2 bg-card/60 mt-3 max-h-48 overflow-auto rounded-md p-3 font-mono text-[11px] leading-relaxed">
-              {MOSOO_SKILL_MARKDOWN}
-            </pre>
-            <div className="mt-3 flex items-center gap-2">
-              <Button
-                onClick={() => {
-                  void copySkill();
-                }}
-                size="sm"
-                variant="outline"
-              >
-                {skillCopied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
-                {skillCopied ? "Copied" : "Copy skill"}
-              </Button>
-              <Button
-                onClick={() => {
-                  downloadTextFile("SKILL.md", MOSOO_SKILL_MARKDOWN);
-                }}
-                size="sm"
-                variant="ghost"
-              >
-                <Download className="size-3.5" />
-                Download SKILL.md
-              </Button>
-            </div>
-          </div>
-        ) : null}
       </div>
     </section>
   );

--- a/apps/web/src/routes/app-overview/app-overview.route.tsx
+++ b/apps/web/src/routes/app-overview/app-overview.route.tsx
@@ -19,7 +19,7 @@ export function AppOverviewPage() {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <header className="border-border bg-background flex shrink-0 items-center justify-between gap-4 border-b px-8 py-5">
+      <header className="border-border bg-background flex shrink-0 flex-col items-start justify-between gap-4 border-b px-4 py-5 sm:px-6 lg:flex-row lg:items-center lg:px-8">
         <div className="min-w-0">
           <div className="text-muted-foreground flex items-center gap-2 text-xs font-semibold uppercase">
             <Box className="size-3.5" />
@@ -32,17 +32,17 @@ export function AppOverviewPage() {
             <AppIdBadge appId={activeApp.id} />
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex w-full flex-wrap items-center gap-2 lg:w-auto">
           <Link
             to="/providers"
-            className="border-border hover:bg-muted inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-semibold transition-colors"
+            className="border-border hover:bg-muted inline-flex h-9 flex-1 items-center justify-center gap-2 rounded-md border px-3 text-sm font-semibold transition-colors sm:flex-none"
           >
             <KeyRound className="size-4" />
             Provider keys
           </Link>
           <Link
             to="/agent?create=1"
-            className="bg-primary text-primary-foreground hover:bg-primary-hover inline-flex h-9 items-center gap-2 rounded-md px-3 text-sm font-semibold shadow-xs transition-colors"
+            className="bg-primary text-primary-foreground hover:bg-primary-hover inline-flex h-9 flex-1 items-center justify-center gap-2 rounded-md px-3 text-sm font-semibold shadow-xs transition-colors sm:flex-none"
           >
             <Bot className="size-4" />
             New agent
@@ -50,8 +50,8 @@ export function AppOverviewPage() {
         </div>
       </header>
 
-      <main className="min-h-0 flex-1 overflow-y-auto px-8 py-10">
-        <div className="mx-auto max-w-2xl">
+      <main className="min-h-0 flex-1 overflow-y-auto px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
+        <div className="mx-auto max-w-4xl">
           <AppOverviewInstallGuide />
         </div>
       </main>

--- a/apps/web/tests/app-overview-boundary.test.ts
+++ b/apps/web/tests/app-overview-boundary.test.ts
@@ -29,7 +29,7 @@ describe("App overview boundary", () => {
     expect(routeSource).not.toContain('to="/join');
   });
 
-  test("hands the App to a coding agent with one CLI command on the console root", () => {
+  test("hands the App to a coding agent with the installer command on the console root", () => {
     const routeSource = readSource("../src/routes/app-overview/app-overview.route.tsx");
     const installSource = readSource("../src/routes/app-overview/app-overview-install.tsx");
     const appIdBadgeSource = readSource("../src/shared/ui/app-id-badge.tsx");
@@ -37,17 +37,43 @@ describe("App overview boundary", () => {
     expect(routeSource).toContain("AppOverviewInstallGuide");
     expect(routeSource).toContain("AppIdBadge");
     expect(installSource).toContain("Hand Mosoo to your agent");
-    expect(installSource).toContain("npx mosoo login");
+    expect(installSource).toContain("curl -fsSL https://install.mosoo.ai/install.sh | bash");
+    expect(installSource).toContain("Installs or updates Mosoo CLI");
+    expect(installSource).toContain("Updates the Codex @mosoo skill");
+    expect(installSource).toContain("Signs in to cloud and runs doctor");
+    expect(installSource).toContain("try.mosoo.ai");
     expect(installSource).toContain("@mosoo skill");
     expect(installSource).toContain("Codex");
     expect(appIdBadgeSource).toContain("Copy app ID");
-    // The CLI token is minted on demand and only copied — never rendered.
-    expect(installSource).toContain("createPersonalAccessToken");
-    expect(installSource).toContain("MASKED_TOKEN");
+    expect(installSource).not.toContain("createPersonalAccessToken");
+    expect(installSource).not.toContain("MASKED_TOKEN");
+    expect(installSource).not.toContain("Signs the CLI in");
+    expect(installSource).not.toContain("Ready to deploy");
+    expect(installSource).not.toContain("No global config");
+    expect(installSource).not.toContain("Using another agent");
+    expect(installSource).not.toContain("Copy or download");
+    expect(installSource).not.toContain("Copy skill");
+    expect(installSource).not.toContain("Download SKILL.md");
 
     expect(installSource).not.toContain("Organization");
     expect(installSource).not.toContain("Members");
     expect(installSource).not.toContain("Invite");
+  });
+
+  test("keeps the install guide responsive and accessible", () => {
+    const routeSource = readSource("../src/routes/app-overview/app-overview.route.tsx");
+    const installSource = readSource("../src/routes/app-overview/app-overview-install.tsx");
+
+    expect(routeSource).toContain("max-w-4xl");
+    expect(routeSource).toContain("lg:flex-row");
+    expect(installSource).toContain("max-w-3xl");
+    expect(installSource).toContain("sm:flex-row");
+    expect(installSource).not.toContain("aria-expanded");
+    expect(installSource).not.toContain("aria-controls");
+    expect(installSource).not.toContain("Codex, Cursor, Cline");
+    expect(installSource).not.toContain("whitespace-pre-wrap");
+    expect(installSource).not.toContain("—");
+    expect(installSource).not.toContain(" · ");
   });
 
   test("keeps the App console root free of Chinese copy", () => {


### PR DESCRIPTION
## Summary

- Replace the App overview install command with the public `install.mosoo.ai` installer command.
- Update the setup outcome copy to match the installer defaults: CLI update, Codex skill update, cloud sign-in, and doctor check.
- Remove the manual skill preview/copy/download panel from the install guide.

## Validation

- `vp fmt --check --ignore-path .gitignore apps/web/src/routes/app-overview/app-overview-install.tsx apps/web/src/routes/app-overview/app-overview.route.tsx apps/web/tests/app-overview-boundary.test.ts`
- `just test-file apps/web/tests/app-overview-boundary.test.ts`
- `just tc-package @mosoo/web`
- `git diff --check origin/main...HEAD`
- `just commit-check`

## Generated files

None.

## GraphQL codegen

Not run. This PR does not change GraphQL schema or documents.

## DB baseline

Not updated. This PR does not change database schema or migrations.
