### PR TITLE
perf(web): lazy-load app shell to shrink entry chunk

### DIFF
--- a/apps/web/src/app/route-guards.tsx
+++ b/apps/web/src/app/route-guards.tsx
@@ -1,9 +1,26 @@
+import { lazy } from "react";
 import type { ReactElement, ReactNode } from "react";
 import { Navigate, useLocation } from "react-router-dom";
 
 import { UploadRecoveryDialog } from "../features/files/upload-recovery/upload-recovery-dialog";
-import { Layout, OrgLayout } from "./app-shell";
 import { useAppSession } from "./session-provider";
+
+// The authenticated app shell (sidebar navigation, account/help menus, org
+// chrome) only renders once a signed-in user clears the guards below. Loading
+// it lazily keeps the whole shell subtree out of the entry chunk, so the
+// public /login + landing route — the cold-start page for first-time and
+// logged-out visitors, where the shell never mounts — no longer pays to
+// download it. Both wrappers pull the same "./app-shell" module, so they share
+// one chunk and a signed-in visitor fetches it in parallel with the first route
+// chunk (both are dynamic imports resolved after the same auth check).
+const Layout = lazy(async () => {
+  const appShell = await import("./app-shell");
+  return { default: appShell.Layout };
+});
+const OrgLayout = lazy(async () => {
+  const appShell = await import("./app-shell");
+  return { default: appShell.OrgLayout };
+});
 
 interface RouteChildrenProps {
   children: ReactNode;


### PR DESCRIPTION
## Summary

Lazy-load the authenticated app shell (`Layout` / `OrgLayout`) in `route-guards.tsx` so its subtree splits out of the entry chunk instead of being downloaded on every first page load.

## Why

The shell (sidebar navigation, account/help menus, org chrome) was eagerly imported by `route-guards`, so its whole subtree was baked into the entry chunk and downloaded by every visitor — including the public `/login` + landing route, where the shell never mounts. The shell only renders after the auth guards pass, so it does not belong on the pre-auth critical path.

Both wrappers import the same `./app-shell` module and therefore share one chunk. A signed-in visitor fetches it in parallel with the first route chunk (both are dynamic imports resolved after the same auth check) and it is cached for subsequent navigations.

## Verification

- Commands: `vp exec tsc --noEmit` (tc) ✅, `vp lint src/app/route-guards.tsx` ✅, `vp build` ✅
- Production-build measurement, gzipped, identical methodology on both builds:

  | Metric | Before | After | Δ |
  | --- | --- | --- | --- |
  | Entry static import closure (downloaded before the SPA boots) | 165,699 B / 12 chunks | 129,632 B / 7 chunks | **−36,067 B (−21.8%)** |
  | Total emitted JS | 797,907 B / 98 files | 800,189 B / 101 files | +2,282 B (+0.29%) |

  The critical path shrinks ~36 KB gzipped with total JS essentially flat, confirming genuine deferral rather than duplication.
- Manual: served the production `dist/`; `index.html`, the entry chunk, and every remaining modulepreload chunk return 200; the shell is emitted as a standalone `app-shell-*.js` chunk.

## Risk And Blast Radius

- Affected packages: `@mosoo/web`
- Affected user flows: initial page load. First authenticated navigation now resolves the shell chunk under the existing top-level `Suspense` fallback in `router.tsx` (then cached); redirects and the pre-shell auth/loading states are unchanged.
- Rollback: revert this commit.

## Evidence

- No visual/UI changes — the same shell renders; only its load timing/packaging changes. UI/UX: N/A.
- Behavior: covered by the build measurement and served-dist smoke check above.

## Compatibility

- Public contract changes: none
- Env or config changes: none
- Deployment or migration: none

## Reviewer Focus

- Closest review area: `apps/web/src/app/route-guards.tsx` — the `lazy()` conversion of `Layout` / `OrgLayout` and that they resolve under the existing `Suspense` boundary.
- Known trade-off: the first authenticated page load fetches the shell chunk on demand (in parallel with the first route chunk) instead of having it inlined in the entry; it is cached thereafter. Net win for the public landing/login cold start.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Subject starts lowercase
- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A (no visible change)
- [x] Generated files: none

## Generated Files, Schema, And Lockfile

- N/A
