### PR TITLE
docs(prd): correct misstated Musk deletion test in agent-versions deferral note

### DIFF
--- a/docs/prd/agent-versions.md
+++ b/docs/prd/agent-versions.md
@@ -26,7 +26,7 @@ On top of that:
 
 - With a 4-week launch window and 3 engineers, **Terminal / Logs / Files are the capabilities the ops surface actually lacks**.
 - The "what if we publish the wrong version and need to roll back" case has no real evidence of frequency pre-launch (and if it does happen, a quick shout in Slack and we roll it back by hand).
-- Applying Musk's "delete 10% then add it back" test to the 10 scope items in v1.1: 9 of them would not be added back after deletion — a sign of over-engineering.
+- Applying Musk's deletion test (delete aggressively; if you don't end up adding back at least 10% of what you deleted, you didn't delete enough) to the 10 scope items in v1.1: 9 of them would not be added back after deletion — a sign of over-engineering.
 
 So: **the v1.1 design is frozen and kept on the shelf, to be picked back up when a real signal appears.** The Versions tab UI does not change by a single character.
 


### PR DESCRIPTION
Skip inapplicable sections. Fill Summary, Why, Verification, and Required Checks.

## Summary

- Correct the paraphrase of Musk's deletion test in `docs/prd/agent-versions.md`. The old wording — Musk's "delete 10% then add it back" test — inverted the rule; the documented rule (Isaacson, *Elon Musk*, 2023) is: delete aggressively, and if you don't end up adding back at least 10% of what you deleted, you didn't delete enough.

## Why

- Fact-check pass over reader-verifiable claims in repo docs (issue YEF-779). The garbled phrase misattributes a nonexistent formulation to a named person and contradicts `docs/prd/good-prd.md` §2.4, which states the same rule correctly. The deferral argument's logic (9 of 10 items would not be added back → over-engineering) is unchanged.

## Verification

- Commands (`just check`, `just test-file <path>`, `just graphql-codegen`, etc.): `just fmt-check-path docs/prd/agent-versions.md` — passes.
- Manual steps: confirmed `good-prd.md` §2.4 and the corrected sentence now state the same rule; no other occurrence of the garbled phrase in the repo.

## Risk And Blast Radius

- Affected packages: none (docs only).
- Affected user flows or APIs: none.
- Rollback: revert the single commit.

## Evidence

- UI/UX: N/A (docs-only).
- API or behavior: N/A.
- Logs, recordings, or test output: fmt check passes on the touched file.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: whether the corrected phrasing matches the team's intended reading of the deletion test.
- Known trade-offs: none.

## Required Checks

- [x] PR title: `type(scope): subject`
- [x] Type: `docs`
- [x] Subject starts lowercase; no breaking change
- [x] Branch follows `type/scope-subject`
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: N/A (agent-authored)
- [x] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A
