### PR TITLE
docs(readme): document local dev prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Mosoo is still in alpha exploration. Product boundaries, data models, deployment
 
 ## Local Development
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full development flow. The shortest local path is:
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full development flow. Install `bun >= 1.4.0-canary.1`, `just >= 1.51`, and a running Docker-compatible CLI / daemon first. The shortest local path is:
 
 ```bash
 just setup


### PR DESCRIPTION
Closes YEF-780

## Summary

- Document the local development prerequisites directly in the README before the `just setup` / `just dev` path.

## Why

- A fresh README-only setup reached `just dev`, then Wrangler failed because no Docker-compatible CLI / daemon was available to build the configured local container image.
- The README now names that prerequisite up front, alongside the existing `bun` and `just` toolchain requirements.

## Verification

- Commands (`just check`, `just test-file <path>`, `just graphql-codegen`, etc.):
  - `just fmt-check-path README.md`
  - `just commit-check`
  - `just setup`
  - `just check`
- Manual steps:
  - Attempt 1 from current `main`:
    - `git clone https://github.com/langgenius/mosoo /tmp/mosoo-readme-attempt1.CbNhCE/mosoo`
    - `just setup`
    - `just dev`
    - Result: `just setup` passed; `just dev` failed when Wrangler reported the Docker CLI was required but unavailable.
  - Attempt 2 from the local repaired branch:
    - `git clone --no-local /Users/evanmore/multica_workspaces_desktop-api.multica.ai/baf2a510-889b-4b05-b7c8-c079f5c28938/41a3fd9d/workdir/mosoo /tmp/mosoo-readme-attempt2.C1i6Ll/mosoo`
    - `bun --version`
    - `just --version`
    - `docker version`
    - Result: README showed the new prerequisite line; `bun` was `1.4.0`, `just` was `1.51.0`, and `docker version` failed with `command not found`.
  - Attempt 3 from the pushed GitHub branch:
    - `git clone --branch docs/readme-dev-prerequisites https://github.com/langgenius/mosoo /tmp/mosoo-readme-attempt3.APsift/mosoo`
    - `bun --version`
    - `just --version`
    - `docker version`
    - Result: README showed the new prerequisite line; `bun` was `1.4.0`, `just` was `1.51.0`, and `docker version` failed with `command not found`, so the rehearsal stopped at the documented host prerequisite gate.

## Risk And Blast Radius

- Affected packages: docs only (`README.md`).
- Affected user flows or APIs: local development onboarding documentation only.
- Rollback: revert this README sentence.

## Evidence

- UI/UX: N/A.
- API or behavior: N/A.
- Logs, recordings, or test output:
  - `just check` passed after bootstrapping the checkout.

## Compatibility

- Public contract changes: none.
- Env or config changes: none.
- Deployment or migration: none.

## Reviewer Focus

- Closest review areas: whether the README should mention Docker directly or defer all prerequisites to `CONTRIBUTING.md`.
- Known trade-offs: this documents the current `just dev` requirement instead of changing the dev command to run without containers.

## Required Checks

- [x] PR title: `type(scope): subject` (e.g. `fix(fmt): restore pre-commit checks`)
- [x] Type: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`, `build`, `ci`, `style`, or `revert`
- [x] Subject starts lowercase; `!` only for intentional breaking changes (e.g. `feat(api)!: remove legacy session field`)
- [x] Branch follows `type/scope-subject` when maintained in this repository; fork branch names may vary
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: if prompted by CLA Assistant, every human contributor has signed by posting the exact required PR comment
- [x] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence, or N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A.
- GraphQL codegen (`just graphql-codegen`): N/A.
- DB baseline (`just db-regen`): N/A.
- Lockfile (`bun.lock`): N/A.
- Confirm no hand-edits to generated paths (`schema.generated.graphql`, `apps/web/src/gql/**`, `pkgs/db/drizzle/**`): confirmed.
