### PR TITLE
docs(readme): clarify clean clone onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,38 @@ Mosoo is still in alpha exploration. Product boundaries, data models, deployment
 
 ## Local Development
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full development flow. Install `bun >= 1.4.0-canary.1`, `just >= 1.51`, and a running Docker-compatible CLI / daemon first. The shortest local path is:
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full development flow.
+
+Prerequisites:
+
+- `bun >= 1.4.0-canary.1`
+- `just >= 1.51`
+- Agent runtime / sandbox flows also need Docker Desktop; see the contribution guide before validating those paths.
+
+From a clean clone:
 
 ```bash
+git clone --recurse-submodules https://github.com/langgenius/mosoo.git
+cd mosoo
 just setup
 just dev
 ```
 
+`just setup` installs dependencies, initializes submodules, creates or completes `apps/api/.dev.vars`, installs Git hooks, and applies the local D1 baseline. `just dev` reapplies the local D1 migration before starting the web, API, and blog dev servers.
+
+Local URLs:
+
 - Web: `http://localhost:5173`
 - API: `http://localhost:8787`
 - Blog: `http://localhost:4321/blog`
-- Regular email login uses OTP.
-- In local development, email addresses ending with `@mosoo.ai` skip OTP and log in directly.
+
+Minimum smoke:
+
+```bash
+curl http://localhost:5173/api/health
+curl http://localhost:8787/api/health
+```
+
+API health is `/api/health`, not `/health`. Regular email login uses OTP; under local loopback origins, addresses ending with `@mosoo.ai` skip OTP and log in directly.
+
+If setup fails, start with the focused recipe: submodule issues use `git submodule update --init`, missing local secrets use `just env-init`, and D1 schema errors use `just db-migrate`. For details and verification expectations, read [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
- Clarify clean-clone local development prerequisites and shortest setup path.
- Document local URLs, `@mosoo.ai` local login, and `/api/health` smoke checks.
- Keep README scoped to shortest path, common failure entry points, and doc links.

## Verification
- `bash ./init.sh development`
- `just setup`
- `just fmt-check-path README.md`
- `git diff --check`
- `just commit-check`

`just check` was not run because this is a README-only docs change and the targeted README/setup/commit checks cover the changed surface.

Note: commit creation initially hit the known Codex worktree false positive where `check-illegal-windows-names` scanned `.git/.../COMMIT_EDITMSG`. No hook or repo config was changed; commit metadata was verified with `just commit-check`.