### PR TITLE
docs(contributing): simplify public contribution path

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,4 @@
-Skip inapplicable sections. Fill Summary, Why, Verification, and Required Checks. External contributors may mark repository-maintainer-only items as N/A.
-
-**Ship PR only:** base `main` (or `release/*`); branch `type/scope-subject` (no tool/agent prefixes). See `CONTRIBUTING.md` → _Pull Requests_.
-
-First-time human contributors may be asked by CLA Assistant to sign `CLA.md`. If prompted, reply in the PR conversation with exactly: `I have read the CLA Document and I hereby sign the CLA`. Do not paste the signature into this PR description.
+Fill what changed. Use N/A for irrelevant or maintainer-only items. See `CONTRIBUTING.md` for branch, CLA, generated file, and CI rules.
 
 ## Summary
 
@@ -14,49 +10,18 @@ First-time human contributors may be asked by CLA Assistant to sign `CLA.md`. If
 
 ## Verification
 
-- Commands (`just check`, `just test-file <path>`, `just graphql-codegen`, etc.):
+- Commands:
 - Manual steps:
+- Not run:
 
-## Risk And Blast Radius
+## Impact
 
-- Affected packages:
-- Affected user flows or APIs:
-- Rollback:
-
-## Evidence
-
-- UI/UX: before/after screenshots for visible changes. Local login via the `@mosoo.ai` development login channel at `http://localhost:5173`.
-- API or behavior:
-- Logs, recordings, or test output:
-
-## Compatibility
-
-- Public contract changes:
+- User/API/contract changes:
+- Generated files / GraphQL / DB / lockfile:
 - Env or config changes:
-- Deployment or migration:
+- Risk and rollback:
 
-## Reviewer Focus
+## Review
 
 - Closest review areas:
 - Known trade-offs:
-
-## Required Checks
-
-- [ ] PR title: `type(scope): subject` (e.g. `fix(fmt): restore pre-commit checks`)
-- [ ] Type: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`, `build`, `ci`, `style`, or `revert`
-- [ ] Subject starts lowercase; `!` only for intentional breaking changes (e.g. `feat(api)!: remove legacy session field`)
-- [ ] Branch follows `type/scope-subject` when maintained in this repository; fork branch names may vary
-- [ ] Commits: `type(scope): subject`, English only
-- [ ] CLA: if prompted by CLA Assistant, every human contributor has signed by posting the exact required PR comment
-- [ ] Self-assigned, or maintainer assigned for external contributors
-- [ ] Diff scoped; no unrelated cleanup
-- [ ] UI/UX: screenshots in Evidence, or N/A
-- [ ] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited
-
-## Generated Files, Schema, And Lockfile
-
-- N/A, or list touched artifacts:
-- GraphQL codegen (`just graphql-codegen`):
-- DB baseline (`just db-regen`):
-- Lockfile (`bun.lock`):
-- Confirm no hand-edits to generated paths (`schema.generated.graphql`, `apps/web/src/gql/**`, `pkgs/db/drizzle/**`):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,12 @@ The following generated files must not be edited by hand:
 
 If generated output is wrong, fix the schema, contract, resolver, or PRD source that produced it.
 
+Minimum generated-file rules:
+
+- GraphQL schema, scalar mapping, query, mutation, or fragment changes require `just graphql-codegen`.
+- DB schema changes require `just db-regen`; production migrations are covered in [Database And Migrations](#database-and-migrations).
+- Dependency changes require committing the resulting `bun.lock`; install-only lockfile churn should stay out of the PR.
+
 ## Toolchain
 
 Required tools:
@@ -79,6 +85,7 @@ Reusable coding-agent skills live in the [`langgenius/mosoo-skills`](https://git
 - The skills become available after `git submodule update --init` (or cloning with `--recurse-submodules`). Without it, `.claude/skills` points at an empty submodule directory.
 - To bump to the latest skills: `git submodule update --remote .skills/mosoo-skills`, then commit the updated submodule pointer.
 - Do not edit skills under `.skills/mosoo-skills` here — they are owned upstream in `mosoo-skills`.
+- Fork contributors should initialize submodules before validating a PR; maintainers update submodule pointers only when the PR intentionally changes the vendored revision.
 
 ## Local Development
 
@@ -265,17 +272,17 @@ fix/auth-local-backdoor
 chore/dev-docs-layout
 ```
 
-Use `!` only for intentional breaking changes. Every Issue and PR must be self-assigned. PRs should keep a clear scope, describe verification results, and explicitly state whether they include generated files, GraphQL codegen, or DB baseline updates.
+Use `!` only for intentional breaking changes. PRs should keep a clear scope, describe verification results, and explicitly state whether they include generated files, GraphQL codegen, DB baseline updates, or lockfile changes.
 
 ### Pull Requests
 
 - Open PRs **only to `main`** (or `release/*`). No PR chains between feature branches.
-- Private-stage PRs should use branches in the upstream repository so required `pull_request` checks can run.
-- Fork PRs are usable only when private fork workflows are enabled, or when a maintainer handles verification and bypass explicitly.
-- Metadata gates support fork PRs through `pull_request_target`; upstream branch PRs still use `pull_request`.
-- Repository code checks stay on `pull_request`.
-- Branch names use `type/scope-subject` above.
-- Run `just check` before marking ready for review. CI runs the same gate for non-draft `pull_request` PRs.
+- Public contributors use a fork PR. Fork branch names may vary, but `type/scope-subject` is preferred when practical.
+- Maintainers with repository write access use upstream branches named `type/scope-subject`.
+- External contributors may mark maintainer-only items as N/A: assignee, internal verification, release or deployment checks, and any upstream-branch-only workflow notes.
+- CLA Assistant runs on PR metadata. If it asks you to sign, read `CLA.md` and post the exact requested PR comment once; do not paste the signature into the PR description.
+- CI metadata gates validate PR title, commit messages, CLA status, and ship policy. Non-draft PRs also run the repository check from `.github/workflows/pr-check.yml`.
+- Run `just check` before marking ready for review when practical. If you cannot run it, list the smaller commands you did run and why the full gate was skipped.
 - Big pivots: update the boundary docs first, then prefer **one umbrella PR** with `just check` and boundary tests as the review contract.
 
 ### Enforced Commit Policy


### PR DESCRIPTION
## Summary

- Simplify the PR template to the minimum fields maintainers need.
- Consolidate public contribution rules in CONTRIBUTING.md for fork PRs, maintainer branches, CLA, CI, submodules, generated files, DB baseline, GraphQL codegen, and lockfile changes.

## Verification

- `bash ./init.sh development`
- `just fmt-check-path CONTRIBUTING.md`
- `just fmt-check-path .github/PULL_REQUEST_TEMPLATE.md`
- `just check`
- `just commit-check`

## Impact

- User/API/contract changes: N/A
- Generated files / GraphQL / DB / lockfile: N/A
- Env or config changes: N/A
- Risk and rollback: docs-only; revert the commit if needed

## Review

- Closest review areas: PR template brevity and external contributor wording
- Known trade-offs: keeps detailed rules in CONTRIBUTING.md instead of the PR template