### PR TITLE
fix(skill): allow arbitrary support files in skill packages

### DIFF
--- a/pkgs/agent-package/src/archive-path-policy.ts
+++ b/pkgs/agent-package/src/archive-path-policy.ts
@@ -19,7 +19,6 @@ interface ArchivePathDeclaration {
   targetType: AgentResolutionIssue["targetType"];
 }
 
-const SKILL_ALLOWED_ROOTS = ["assets/", "references/", "scripts/"] as const;
 const ARCHIVE_PATH_FORBIDDEN_SEGMENTS = new Set([
   ".env",
   ".state",
@@ -321,10 +320,7 @@ function isAllowedArchivePath(
 
     const relativePath = path.slice(skillPath.length);
 
-    if (
-      relativePath === "SKILL.md" ||
-      SKILL_ALLOWED_ROOTS.some((allowedRoot) => relativePath.startsWith(allowedRoot))
-    ) {
+    if (relativePath.length > 0) {
       return true;
     }
   }

--- a/pkgs/skill-package/src/bundle.ts
+++ b/pkgs/skill-package/src/bundle.ts
@@ -250,4 +250,4 @@ export function admitSkillPackageArchivePath(path: string): string {
   return admitSkillPackageArchivePathValue(path).path;
 }
 
-export { SKILL_PACKAGE_ALLOWED_ROOTS, SKILL_PACKAGE_MANIFEST_PATH } from "./path-admission";
+export { SKILL_PACKAGE_MANIFEST_PATH } from "./path-admission";

--- a/pkgs/skill-package/src/path-admission.ts
+++ b/pkgs/skill-package/src/path-admission.ts
@@ -12,7 +12,6 @@ export interface SkillPackagePathAdmission {
 }
 
 export const SKILL_PACKAGE_MANIFEST_PATH = "SKILL.md";
-export const SKILL_PACKAGE_ALLOWED_ROOTS = ["assets", "references", "scripts"] as const;
 
 const RESERVED_PATH_KEYS = new Set([
   "__proto__",
@@ -31,7 +30,6 @@ const RESERVED_PATH_KEYS = new Set([
   "tokens",
   "vault",
 ]);
-const ALLOWED_ROOTS = new Set<string>(SKILL_PACKAGE_ALLOWED_ROOTS);
 
 export function createSkillPackagePathAdmission(): SkillPackagePathAdmission {
   const entries = new Map<string, SkillPackagePathKind>();
@@ -186,18 +184,6 @@ function rejectUnsupportedArchivePath(admitted: AdmittedSkillPackagePath): void 
     throw new SkillPackageError(
       `The skill package manifest path cannot contain child entries: ${admitted.path}`,
     );
-  }
-
-  const [root] = admitted.path.split("/");
-
-  if (root === undefined || !ALLOWED_ROOTS.has(root)) {
-    throw new SkillPackageError(
-      `The skill package path is outside allowed roots: ${admitted.path}`,
-    );
-  }
-
-  if (admitted.path === root && admitted.entryKind !== "directory") {
-    throw new SkillPackageError(`The skill package root must be a directory: ${root}`);
   }
 }
 

--- a/pkgs/skill-package/tests/path-admission.test.ts
+++ b/pkgs/skill-package/tests/path-admission.test.ts
@@ -85,7 +85,7 @@ describe("skill package path admission", () => {
     ).toThrow(SkillPackageError);
   });
 
-  test("admits only the manifest file and declared skill roots", () => {
+  test("admits the manifest file and arbitrary supporting roots", () => {
     const normalized = normalizeSkillEntries({
       "SKILL.md": { body: markdown },
       "assets/logo.png": { body: data },
@@ -106,26 +106,32 @@ describe("skill package path admission", () => {
       ].toSorted(),
     );
 
-    expect(() =>
+    expect(
       normalizeSkillEntries({
         "SKILL.md": { body: markdown },
         "README.md": { body: data },
-      }),
-    ).toThrow(SkillPackageError);
-
-    expect(() =>
-      normalizeSkillEntries({
-        "SKILL.md": { body: markdown },
         examples: { body: data, entryKind: "directory" },
-      }),
-    ).toThrow(SkillPackageError);
+      }).entries.map((entry) => entry.path),
+    ).toContain("README.md");
+  });
 
-    expect(() =>
-      normalizeSkillEntries({
-        "SKILL.md": { body: markdown },
-        scripts: { body: data },
-      }),
-    ).toThrow(SkillPackageError);
+  test("admits anthropics-style skills with custom support directories", () => {
+    const normalized = normalizeSkillEntries({
+      "SKILL.md": { body: markdown },
+      "LICENSE.txt": { body: data },
+      "canvas-fonts/WorkSans-Regular.ttf": { body: data },
+      "canvas-fonts/WorkSans-OFL.txt": { body: data },
+    });
+
+    expect(normalized.entries.map((entry) => entry.path).toSorted()).toEqual(
+      [
+        "canvas-fonts",
+        "canvas-fonts/WorkSans-OFL.txt",
+        "canvas-fonts/WorkSans-Regular.ttf",
+        "LICENSE.txt",
+        "SKILL.md",
+      ].toSorted(),
+    );
   });
 
   test("rejects invalid manifest entry shapes", () => {
@@ -142,18 +148,18 @@ describe("skill package path admission", () => {
     ).toThrow(SkillPackageError);
   });
 
-  test("rejects traversal and unsupported roots in frontmatter paths", () => {
+  test("rejects traversal in frontmatter paths but allows custom roots", () => {
     expect(() =>
       parseSkillMarkdown(
         "---\nname: Test\ndescription: Test skill.\ndependencies:\n  - ../shared\n---\n",
       ),
     ).toThrow(SkillPackageError);
 
-    expect(() =>
+    expect(
       parseSkillMarkdown(
         "---\nname: Test\ndescription: Test skill.\ndependencies:\n  - docs/guide.md\n---\n",
-      ),
-    ).toThrow(SkillPackageError);
+      ).frontmatter.dependencies,
+    ).toEqual(["docs/guide.md"]);
 
     expect(
       parseSkillMarkdown(
@@ -236,23 +242,25 @@ describe("skill package path admission", () => {
     );
   });
 
-  test("rejects unsupported roots after stripping single wrapper zip archives", () => {
-    expect(() =>
-      normalizeZipEntries([
-        {
-          body: markdown,
-          entryKind: "file",
-          isExecutable: false,
-          path: "mosoo/SKILL.md",
-        },
-        {
-          body: data,
-          entryKind: "file",
-          isExecutable: false,
-          path: "mosoo/examples/a.md",
-        },
-      ]),
-    ).toThrow(SkillPackageError);
+  test("admits custom roots after stripping single wrapper zip archives", () => {
+    const normalized = normalizeZipEntries([
+      {
+        body: markdown,
+        entryKind: "file",
+        isExecutable: false,
+        path: "mosoo/SKILL.md",
+      },
+      {
+        body: data,
+        entryKind: "file",
+        isExecutable: false,
+        path: "mosoo/examples/a.md",
+      },
+    ]);
+
+    expect(normalized.entries.map((entry) => entry.path).toSorted()).toEqual(
+      ["examples", "examples/a.md", "SKILL.md"].toSorted(),
+    );
   });
 
   test("rejects zip archives with multiple wrappers or wrapper-external files", () => {
@@ -291,7 +299,7 @@ describe("skill package path admission", () => {
     ).toThrow(SkillPackageError);
   });
 
-  test("rejects unsupported zip roots when normalizing entry records", () => {
+  test("admits root-level support files when normalizing entry records", () => {
     const archive = createZipArchive([
       {
         body: markdown,
@@ -309,7 +317,11 @@ describe("skill package path admission", () => {
     const record = toEntryRecord(extractZipArchive(archive));
 
     expect(record["notes.txt"]).toBeDefined();
-    expect(() => normalizeSkillEntries(record)).toThrow(SkillPackageError);
+    expect(
+      normalizeSkillEntries(record)
+        .entries.map((entry) => entry.path)
+        .toSorted(),
+    ).toEqual(["notes.txt", "SKILL.md"].toSorted());
   });
 });
 


### PR DESCRIPTION
## Summary

- Drop the skill-package root whitelist (`assets/`, `references/`, `scripts/`) so skill zips and GitHub imports may bundle arbitrary support files and directories next to `SKILL.md` (e.g. `LICENSE.txt`, `canvas-fonts/`).
- Keep every other admission rule intact: `SKILL.md` must be a root-level file with no child entries; reserved-key, dotfile, traversal, control-character, absolute-path, duplicate, and file/directory-collision checks are unchanged, as are the 256-entry / 2 MB-per-file / 25 MB-total / 10 MB-upload limits.
- Relax the agent-package export policy the same way so exported agents can carry skills that use custom support roots.
- Frontmatter `dependencies` entries may now reference any admitted path, not only whitelisted roots.

## Why

Real-world skills do not restrict themselves to `assets/`/`references/`/`scripts/`. The reference case from YEF-782 is [anthropics/skills canvas-design](https://github.com/anthropics/skills/tree/main/skills/canvas-design), which ships a root-level `LICENSE.txt` and a `canvas-fonts/` directory with 80 font files. Uploading a zip of that skill (or importing its GitHub URL) failed with `The skill package path is outside allowed roots: canvas-fonts/...`.

## Verification

- Commands: `bun test pkgs/skill-package pkgs/agent-package` (20 pass), `bun test apps/api/tests` (762 pass), `tc` + `lint` + `fmt --check` for both touched packages — all green.
- Manual steps: zipped the actual anthropics/skills `canvas-design` directory (2.6 MB, 85 entries) and ran it through the real pipeline (`looksLikeZipArchive` → `extractZipArchive` with production limits → `normalizeSkillEntries` → snapshot repack round-trip). Wrapper directory is stripped, frontmatter parses (`name: canvas-design`), and normalization now succeeds end to end.

## Risk And Blast Radius

- Affected packages: `@mosoo/skill-package`, `@mosoo/agent-package`, transitively the skill upload/import API and agent package export/import.
- Affected user flows or APIs: `POST /skill/inspect`, `POST /skill/package`, GitHub/skills.sh skill import, agent package export.
- Rollback: revert this commit; the whitelist is self-contained in `rejectUnsupportedArchivePath` and `isAllowedArchivePath`.

## Evidence

- API or behavior: before — canvas-design zip rejected with `The skill package path is outside allowed roots: canvas-fonts/...`; after — validation passes and the snapshot repack round-trip preserves all 84 normalized entries.
- Logs, recordings, or test output: see Verification.

## Compatibility

- Public contract changes: removed the `SKILL_PACKAGE_ALLOWED_ROOTS` export from `@mosoo/skill-package` (repo-internal; the only external copy lives in mosoo-agent-driver, updated in the companion PR). Previously rejected packages are now accepted; nothing previously accepted is rejected.
- Env or config changes: none.
- Deployment or migration: none. A companion mosoo-agent-driver PR relaxes the driver's vendored copy so materialization accepts the same packages; the `apps/driver` submodule pin can be bumped after it merges.

## Reviewer Focus

- Closest review areas: `pkgs/skill-package/src/path-admission.ts` (`rejectUnsupportedArchivePath`) and `pkgs/agent-package/src/archive-path-policy.ts` (`isAllowedArchivePath`) — confirm the remaining invariants are sufficient without the whitelist.
- Known trade-offs: skill packages may now contain arbitrary (non-reserved) file names; size/entry limits and reserved-segment rules remain the guardrails.

## Required Checks

- [x] PR title: `type(scope): subject` (e.g. `fix(fmt): restore pre-commit checks`)
- [x] Type: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`, `build`, `ci`, `style`, or `revert`
- [x] Subject starts lowercase; `!` only for intentional breaking changes
- [x] Branch follows `type/scope-subject` when maintained in this repository; fork branch names may vary
- [x] Commits: `type(scope): subject`, English only
- [ ] CLA: if prompted by CLA Assistant, every human contributor has signed by posting the exact required PR comment
- [x] Self-assigned, or maintainer assigned for external contributors
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: screenshots in Evidence, or N/A
- [x] Generated files, codegen, DB baseline, lockfile only when required; none hand-edited

## Generated Files, Schema, And Lockfile

- N/A
