### PR TITLE
fix(api): harden keyless bound endpoint and guard prod D1 deploys

### DIFF
--- a/apps/api/bin/deploy-prod.ts
+++ b/apps/api/bin/deploy-prod.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 import type { BunRuntime } from "../../../config/bun-script-types";
+import {
+  extractTableNames,
+  findMissingProdTables,
+  parseExpectedTableNames,
+} from "./prod-schema-guard";
 
 declare const Bun: BunRuntime;
 
@@ -42,6 +47,60 @@ function runVp(args: string[], cwd = repoRoot): void {
 
 function applyD1Migrations(): void {
   run(["d1", "migrations", "apply", D1_BINDING, "--remote", "--env", ENV]);
+}
+
+const BASELINE_SQL_PATH = `${repoRoot}/pkgs/db/drizzle/0000_baseline.sql`;
+
+/**
+ * Refuse to deploy a Worker whose schema references tables missing from prod.
+ * Runs AFTER `applyD1Migrations`, so on the correct incremental path every
+ * table is already present; it only fires when a rewritten baseline was skipped
+ * because wrangler matched its filename as already-applied (DEPLOY-D1-001).
+ */
+async function assertProdSchemaMatchesBaseline(): Promise<void> {
+  const baselineSql = await Bun.file(BASELINE_SQL_PATH).text();
+  const expectedTables = parseExpectedTableNames(baselineSql);
+
+  const result = Bun.spawnSync(
+    [
+      wranglerBin,
+      "d1",
+      "execute",
+      D1_BINDING,
+      "--remote",
+      "--env",
+      ENV,
+      "--json",
+      "--command",
+      "SELECT name FROM sqlite_master WHERE type='table'",
+    ],
+    { cwd: apiDir },
+  );
+  const stdout = result.stdout.toString("utf8");
+  const stderr = result.stderr.toString("utf8");
+
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `wrangler d1 execute (schema check) exited with ${result.exitCode}\nstderr: ${stderr}\nstdout: ${stdout}`,
+    );
+  }
+
+  const missingTables = findMissingProdTables(expectedTables, extractTableNames(stdout));
+
+  if (missingTables.length > 0) {
+    throw new Error(
+      [
+        "✗ Prod D1 schema drift: the migration baseline defines tables absent from prod.",
+        `  Missing: ${missingTables.join(", ")}`,
+        "  Cause: wrangler records applied migrations by FILENAME, so a rewritten",
+        "  0000_baseline.sql is skipped on a database that already recorded it (DEPLOY-D1-001).",
+        "  Fix: add the change as a NEW migration file instead of rewriting the applied",
+        "  baseline (or apply it manually), then re-run the deploy.",
+      ].join("\n"),
+    );
+  }
+
+  writeStdout(`  prod schema OK (${expectedTables.length} baseline tables present)`);
 }
 
 const CHANNEL_FINAL_DELIVERY_QUEUES: readonly string[] = [
@@ -111,6 +170,12 @@ function ensureChannelFinalDeliveryQueues(): void {
 
 writeStdout("▶ Applying pending D1 migrations");
 applyD1Migrations();
+
+writeStdout("▶ Verifying prod D1 schema matches the migration baseline");
+await assertProdSchemaMatchesBaseline().catch((error: unknown) => {
+  writeStdout(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});
 
 writeStdout("▶ Ensuring channel-final-delivery queues exist");
 ensureChannelFinalDeliveryQueues();

--- a/apps/api/bin/prod-schema-guard.ts
+++ b/apps/api/bin/prod-schema-guard.ts
@@ -1,0 +1,65 @@
+/**
+ * Fail-fast guard against the DEPLOY-D1-001 hazard.
+ *
+ * `wrangler d1 migrations apply` records applied migrations by FILENAME, so a
+ * rewritten `0000_baseline.sql` (this repo's alpha workflow) is treated as
+ * already-applied on a database that recorded the previous baseline. A new
+ * `CREATE TABLE` in the rewritten baseline then never reaches prod, yet the
+ * Worker deploys referencing it. We keep the fast rewrite-the-baseline flow but
+ * refuse to ship a Worker whose expected tables are missing from live prod.
+ *
+ * These functions are pure (no I/O) so the deploy script can stay thin and the
+ * detection logic stays unit-testable. Table-level only: this catches a missing
+ * table — the catastrophic case where every query against it fails — not an
+ * added column on an existing table.
+ */
+
+const CREATE_TABLE_PATTERN = /CREATE TABLE(?:\s+IF NOT EXISTS)?\s+`([^`]+)`/gi;
+
+/** Table names declared by the migration baseline wrangler treats as applied. */
+export function parseExpectedTableNames(migrationSql: string): string[] {
+  const names = new Set<string>();
+
+  for (const match of migrationSql.matchAll(CREATE_TABLE_PATTERN)) {
+    const name = match[1];
+
+    if (name !== undefined) {
+      names.add(name);
+    }
+  }
+
+  return [...names];
+}
+
+/** Expected tables that are not present in the live database. */
+export function findMissingProdTables(
+  expectedTableNames: readonly string[],
+  liveTableNames: readonly string[],
+): string[] {
+  const live = new Set(liveTableNames);
+  return expectedTableNames.filter((name) => !live.has(name));
+}
+
+interface D1ExecuteResult {
+  results?: ReadonlyArray<{ name?: unknown }>;
+}
+
+/**
+ * Extract `name` rows from `wrangler d1 execute --json` output. The `--json`
+ * flag prints the result array on stdout; we slice from the first `[` to the
+ * last `]` to tolerate any leading log lines, then fail loudly on an
+ * unrecognized shape rather than silently reporting zero tables.
+ */
+export function extractTableNames(rawStdout: string): string[] {
+  const start = rawStdout.indexOf("[");
+  const end = rawStdout.lastIndexOf("]");
+
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(`Could not locate JSON array in \`d1 execute\` output:\n${rawStdout}`);
+  }
+
+  const parsed = JSON.parse(rawStdout.slice(start, end + 1)) as D1ExecuteResult[];
+  const rows = parsed[0]?.results ?? [];
+
+  return rows.map((row) => row.name).filter((name): name is string => typeof name === "string");
+}

--- a/apps/api/src/adapters/http/routes/public-api-route.ts
+++ b/apps/api/src/adapters/http/routes/public-api-route.ts
@@ -26,6 +26,7 @@ import {
   parseFileIdParam,
   parseThreadIdParam,
   parseThreadEventsLimit,
+  readBoundAgentCallRequestBody,
   readCreateThreadRequest,
   readCreateThreadFileRequest,
   readCreateThreadFileUploadRequest,
@@ -90,7 +91,7 @@ export function registerPublicApiRoute(app: Hono<ApiGatewayEnvironment>) {
 
   v1.post("/bound/:token", async (c) => {
     try {
-      const body = (await c.req.json()) as unknown;
+      const body = await readBoundAgentCallRequestBody(c);
       const { createBoundAgentThreadAndWait } = await loadBoundAgentAskService();
       const result = await createBoundAgentThreadAndWait({
         bindings: c.env,

--- a/apps/api/src/adapters/http/routes/public-thread-api-request.ts
+++ b/apps/api/src/adapters/http/routes/public-thread-api-request.ts
@@ -557,6 +557,16 @@ export async function readCreateThreadFileUploadRequest(
   };
 }
 
+/**
+ * Read and JSON-parse the bound-agent call body under the shared public-API
+ * body-size cap. The bound endpoint is keyless and internet-facing, so it must
+ * refuse oversized bodies the same way every PAT thread route does instead of
+ * buffering an unbounded request into the isolate.
+ */
+export async function readBoundAgentCallRequestBody(c: RawJsonRequestContext): Promise<unknown> {
+  return readJsonBodyWithLimit(c, PUBLIC_THREAD_JSON_BODY_MAX_BYTES);
+}
+
 export async function readCreateThreadRequest(
   c: RawJsonRequestContext,
 ): Promise<ParsedCreateThreadRequest> {

--- a/apps/api/src/modules/public-api/app-agent-bound-ask.service.ts
+++ b/apps/api/src/modules/public-api/app-agent-bound-ask.service.ts
@@ -28,6 +28,7 @@ import {
 } from "./app-agent-bound-call";
 import type { BoundAgentCallInput } from "./app-agent-bound-call";
 import { publicNotFound } from "./public-api-errors";
+import { enforcePublicApiRateLimit } from "./public-api-rate-limit.service";
 import { readPublicThreadRunFinalOutput } from "./public-thread-events";
 import { cleanupFailedThreadCreation } from "./public-thread-store";
 
@@ -154,6 +155,12 @@ export async function createBoundAgentThreadAndWait(
 
   const agent = await getAgentRow(request.bindings.DB, claims.agentId);
   ensureBoundAgentServable(agent, claims);
+
+  // The capability URL is keyless, long-lived, and internet-facing: without a
+  // limit a single leaked URL could launch unbounded owner-billed runs. Reuse
+  // the shared public-API limiter keyed on the capability identity, in a
+  // dedicated `bound:` bucket namespace so it never collides with PAT tokenIds.
+  await enforcePublicApiRateLimit(request.bindings.DB, `bound:${agent.appId}:${agent.id}`);
 
   const ownerViewer = await resolveBoundAgentOwnerViewer(request.bindings, agent.appId);
 

--- a/apps/api/tests/bound-agent-body-limit.test.ts
+++ b/apps/api/tests/bound-agent-body-limit.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { PUBLIC_THREAD_JSON_BODY_MAX_BYTES } from "@mosoo/contracts/public-api";
+
+import { readBoundAgentCallRequestBody } from "../src/adapters/http/routes/public-thread-api-request";
+import { PublicApiError } from "../src/modules/public-api/public-api-errors";
+
+function contextFor(request: Request): { req: { raw: Request } } {
+  return { req: { raw: request } };
+}
+
+describe("readBoundAgentCallRequestBody", () => {
+  test("rejects a body whose Content-Length exceeds the public-API cap", async () => {
+    const request = new Request("https://api.test/api/v1/bound/token", {
+      body: '{"message":"hi"}',
+      headers: { "content-length": String(PUBLIC_THREAD_JSON_BODY_MAX_BYTES + 1) },
+      method: "POST",
+    });
+
+    await expect(readBoundAgentCallRequestBody(contextFor(request))).rejects.toBeInstanceOf(
+      PublicApiError,
+    );
+  });
+
+  test("parses a well-formed body within the cap", async () => {
+    const request = new Request("https://api.test/api/v1/bound/token", {
+      body: JSON.stringify({ message: "hello" }),
+      method: "POST",
+    });
+
+    await expect(readBoundAgentCallRequestBody(contextFor(request))).resolves.toEqual({
+      message: "hello",
+    });
+  });
+});

--- a/apps/api/tests/prod-schema-guard.test.ts
+++ b/apps/api/tests/prod-schema-guard.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  extractTableNames,
+  findMissingProdTables,
+  parseExpectedTableNames,
+} from "../bin/prod-schema-guard";
+
+describe("parseExpectedTableNames", () => {
+  test("extracts backtick-quoted table names, dedups, and handles IF NOT EXISTS", () => {
+    const sql = [
+      "CREATE TABLE `agent` (",
+      "  `id` text PRIMARY KEY NOT NULL",
+      ");",
+      "CREATE TABLE IF NOT EXISTS `session_run` (",
+      "  `id` text PRIMARY KEY NOT NULL",
+      ");",
+      "CREATE INDEX `agent_app_idx` ON `agent` (`app_id`);",
+    ].join("\n");
+
+    expect(parseExpectedTableNames(sql).toSorted()).toEqual(["agent", "session_run"]);
+  });
+
+  test("returns an empty list when there are no CREATE TABLE statements", () => {
+    expect(parseExpectedTableNames("CREATE INDEX `x` ON `y` (`z`);")).toEqual([]);
+  });
+});
+
+describe("findMissingProdTables", () => {
+  test("returns expected tables absent from the live database", () => {
+    expect(findMissingProdTables(["agent", "session_run", "app"], ["agent", "app"])).toEqual([
+      "session_run",
+    ]);
+  });
+
+  test("returns empty when every expected table is present (extra live tables are ignored)", () => {
+    expect(findMissingProdTables(["agent"], ["agent", "d1_migrations", "_cf_KV"])).toEqual([]);
+  });
+});
+
+describe("extractTableNames", () => {
+  test("parses the wrangler d1 execute --json result shape", () => {
+    const stdout = JSON.stringify([
+      { results: [{ name: "agent" }, { name: "session_run" }], success: true, meta: {} },
+    ]);
+
+    expect(extractTableNames(stdout)).toEqual(["agent", "session_run"]);
+  });
+
+  test("tolerates leading log lines before the JSON array", () => {
+    const stdout = `🌀 Executing on remote database DB\n${JSON.stringify([
+      { results: [{ name: "agent" }] },
+    ])}`;
+
+    expect(extractTableNames(stdout)).toEqual(["agent"]);
+  });
+
+  test("throws (fails closed) when no JSON array is present", () => {
+    expect(() => extractTableNames("error: could not connect")).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Two evidence-backed, root-cause fixes surfaced by a full code audit. Both are the "truly severe → fix at root + prevent recurrence" class (leaked-URL billing/DoS, and silent prod schema divergence); the rest of the audit findings are scale-time optimizations we're deliberately deferring.

- **`fix(public-api)`** — the keyless, internet-facing `POST /api/v1/bound/:token` endpoint bypassed the rate limit and body-size cap every PAT-authenticated public route enforces. A single leaked capability URL (it lives in the URL path, is unrevocable, 10-year TTL) could be replayed to launch unbounded agent runs billed to the app owner and hold ~25s Worker slots each — a single-tenant cost-exhaustion / DoS. Fix reuses the existing limiter keyed on the capability identity (`bound:appId:agentId` bucket) and the shared streaming body-size cap. No new system added; the special-case bypass is removed so the route matches its siblings.
- **`fix(deploy)`** — `wrangler` records applied D1 migrations by **filename**, so the repo's rewrite-the-baseline workflow makes a new `CREATE TABLE` in `0000_baseline.sql` a silent no-op on a DB that already recorded the baseline; the Worker then deploys referencing tables that don't exist in prod. Adds a fail-fast guard between migration-apply and Worker-deploy that diffs the baseline's declared tables against the live prod schema and aborts on drift.

## Why

- Bound endpoint: leaked/replayed capability URL → unbounded owner-billed runs + Worker DoS. Directly threatens billing and availability for a single tenant.
- Deploy guard: the next schema-bearing change is near-certain to hit the silent-drop path (baseline has been rewritten 14× historically), producing a prod Worker whose queries reference missing tables — an invisible-until-runtime outage. Preserves move-fast baseline-rewrite while making that outcome impossible to ship unnoticed.

## Verification

- Commands: `bun test tests` in `apps/api` → **771 pass / 0 fail** (incl. 2 new test files, 10 new cases); `@mosoo/api tc` (typecheck) → exit 0; `vp lint` on touched files → clean; `vp fmt --check` → clean.
- New tests: `tests/prod-schema-guard.test.ts` (parse/diff/extract, incl. fail-closed on garbage output), `tests/bound-agent-body-limit.test.ts` (oversized body → `PublicApiError`, in-cap body parses).

## Risk And Blast Radius

- Affected packages: `@mosoo/api` only.
- Affected flows: bound-agent single-call API (now rate-limited at 120/min per capability + body cap), and the prod deploy script (adds a read-only `d1 execute` schema check before deploy).
- Rollback: revert; no data or schema migration involved.

## Reviewer Focus

- Rate-limit bucket key namespace (`bound:` prefix) not colliding with PAT tokenIds.
- The guard is **table-level** only (catches a missing table, the catastrophic case — not an added column on an existing table); noted in code comment. Runs after `applyD1Migrations`, so the correct incremental path always passes.
- Known deferrals (audit findings intentionally NOT in this PR): full per-account spend budget, IP-based limiting on the bound path, `channel-final-delivery-dlq` consumer, DB scale indexes, web bundle trims. These are scale-time optimizations, not launch blockers.

## Compatibility

- Public contract changes: none (adds 429/400 responses to a path that had no limits).
- Env or config changes: none.
- Deployment: the deploy script now performs a read-only prod schema check; requires the same wrangler auth it already uses.

## Required Checks

- [x] PR title `type(scope): subject`
- [x] Commits `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
- [x] UI/UX: N/A (backend only)
- [x] Generated files / DB baseline: none hand-edited
