### PR TITLE
fix(skills): persist large skill snapshot entries

### DIFF
--- a/apps/api/src/modules/skills/application/skill-package-snapshot.service.ts
+++ b/apps/api/src/modules/skills/application/skill-package-snapshot.service.ts
@@ -7,12 +7,14 @@ import type { NormalizedSkillPackage, SkillPackageEntry } from "@mosoo/skill-pac
 import { and, asc, eq, inArray } from "drizzle-orm";
 
 import type { ApiBindings } from "../../../platform/cloudflare/worker-types";
-import { getAppDatabase } from "../../../platform/db/drizzle";
+import { getAppDatabase, runAppDatabaseBatch } from "../../../platform/db/drizzle";
 import { currentTimestampMs, toIsoString } from "../../../time";
 import { buildSkillBlobKey, readSkillBlobBytes, writeSkillBlob } from "./skill-blob-store";
 import { loadNormalizedSkillPackage } from "./skill-package-source.service";
 import { inferMimeType, SKILL_ARCHIVE_EXTRACT_OPTIONS, sha256Hex } from "./skill-package.shared";
 import type { InspectSkillInput } from "./skill-package.shared";
+
+const SKILL_SNAPSHOT_ENTRY_INSERT_BATCH_SIZE = 10;
 
 export interface PublishedSkillSnapshot {
   entries: SkillSnapshotEntry[];
@@ -44,6 +46,7 @@ export async function publishSkillSnapshot(
   const normalized = await loadNormalizedSkillPackage(input);
   const archiveBytes = createZipArchive(normalized.entries);
   const blobSha256 = await sha256Hex(archiveBytes);
+  const entries = await Promise.all(normalized.entries.map(toSkillSnapshotEntry));
   const existingSnapshot =
     (await getAppDatabase(bindings.DB)
       .select(skillSnapshotColumns())
@@ -58,6 +61,8 @@ export async function publishSkillSnapshot(
       .get()) ?? null;
 
   if (existingSnapshot) {
+    await ensureSkillSnapshotEntries(bindings.DB, existingSnapshot.id, entries);
+
     return {
       entries: await listSkillSnapshotEntries(bindings.DB, existingSnapshot.id),
       snapshot: toSkillSnapshotRecord(existingSnapshot),
@@ -67,7 +72,6 @@ export async function publishSkillSnapshot(
   const timestampMs = currentTimestampMs();
   const snapshotId = createPlatformId<SkillSnapshotId>();
   const blobKey = buildSkillBlobKey(owner.appId, blobSha256);
-  const entries = await Promise.all(normalized.entries.map(toSkillSnapshotEntry));
   const snapshotAuthor = normalized.frontmatter.author ?? normalized.frontmatter.name;
   const uncompressedSize = calculateUncompressedSize(normalized);
 
@@ -76,9 +80,8 @@ export async function publishSkillSnapshot(
     bytes: archiveBytes,
   });
 
-  await getAppDatabase(bindings.DB)
-    .insert(skillSnapshotsTable)
-    .values({
+  await runAppDatabaseBatch(bindings.DB, (database) => [
+    database.insert(skillSnapshotsTable).values({
       author: snapshotAuthor,
       blobKey,
       blobSha256,
@@ -91,25 +94,9 @@ export async function publishSkillSnapshot(
       skillMarkdownPath: normalized.skillMarkdownPath,
       uncompressedSize,
       version: normalized.frontmatter.version ?? null,
-    })
-    .run();
-
-  if (entries.length > 0) {
-    await getAppDatabase(bindings.DB)
-      .insert(skillSnapshotEntriesTable)
-      .values(
-        entries.map((entry) => ({
-          entryKind: entry.entryKind,
-          isExecutable: entry.isExecutable,
-          mimeType: entry.mimeType,
-          path: entry.path,
-          sha256: entry.sha256,
-          size: entry.size,
-          snapshotId,
-        })),
-      )
-      .run();
-  }
+    }),
+    ...createSkillSnapshotEntryInsertQueries(database, snapshotId, entries),
+  ]);
 
   return {
     entries,
@@ -129,6 +116,57 @@ export async function publishSkillSnapshot(
       version: normalized.frontmatter.version ?? null,
     },
   };
+}
+
+async function ensureSkillSnapshotEntries(
+  database: D1Database,
+  snapshotId: SkillSnapshotId,
+  entries: SkillSnapshotEntry[],
+): Promise<void> {
+  const existingEntries = await listSkillSnapshotEntries(database, snapshotId);
+
+  if (existingEntries.length === entries.length) {
+    return;
+  }
+
+  await runAppDatabaseBatch(database, (db) => [
+    db
+      .delete(skillSnapshotEntriesTable)
+      .where(eq(skillSnapshotEntriesTable.snapshotId, snapshotId)),
+    ...createSkillSnapshotEntryInsertQueries(db, snapshotId, entries),
+  ]);
+}
+
+function createSkillSnapshotEntryInsertQueries(
+  database: ReturnType<typeof getAppDatabase>,
+  snapshotId: SkillSnapshotId,
+  entries: SkillSnapshotEntry[],
+) {
+  const queries = [];
+
+  for (let index = 0; index < entries.length; index += SKILL_SNAPSHOT_ENTRY_INSERT_BATCH_SIZE) {
+    const batch = entries.slice(index, index + SKILL_SNAPSHOT_ENTRY_INSERT_BATCH_SIZE);
+
+    if (batch.length === 0) {
+      continue;
+    }
+
+    queries.push(
+      database.insert(skillSnapshotEntriesTable).values(
+        batch.map((entry) => ({
+          entryKind: entry.entryKind,
+          isExecutable: entry.isExecutable,
+          mimeType: entry.mimeType,
+          path: entry.path,
+          sha256: entry.sha256,
+          size: entry.size,
+          snapshotId,
+        })),
+      ),
+    );
+  }
+
+  return queries;
 }
 
 export async function listSkillSnapshotEntries(

--- a/apps/api/tests/skill-package-snapshot.test.ts
+++ b/apps/api/tests/skill-package-snapshot.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+
+import { skillSnapshotEntriesTable } from "@mosoo/db";
+import type { AppId } from "@mosoo/id";
+import { createZipArchive } from "@mosoo/skill-package";
+
+import { publishSkillSnapshot } from "../src/modules/skills/application/skill-package-snapshot.service";
+import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
+import {
+  createPublicHttpTestBindings,
+  PublicApiMemoryFileBucket,
+} from "./helpers/public-api-http-test-fixture";
+import { SqliteD1Database } from "./helpers/sqlite-d1";
+
+const APP_ID = "01J00000000000000000000002" as AppId;
+const textEncoder = new TextEncoder();
+
+class BindLimitedD1Database implements D1Database {
+  constructor(
+    private readonly inner: D1Database,
+    private readonly maxBindings: number,
+  ) {}
+
+  prepare(query: string): D1PreparedStatement {
+    const statement = this.inner.prepare(query);
+
+    return {
+      ...statement,
+      bind: (...values: unknown[]) => {
+        if (values.length > this.maxBindings) {
+          throw new Error(`Test D1 bind limit exceeded: ${values.length} > ${this.maxBindings}`);
+        }
+
+        return statement.bind(...values);
+      },
+    };
+  }
+
+  batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+    return this.inner.batch<T>(statements);
+  }
+
+  dump(): Promise<ArrayBuffer> {
+    return this.inner.dump();
+  }
+
+  exec(query: string): Promise<D1ExecResult> {
+    return this.inner.exec(query);
+  }
+
+  withSession(): D1DatabaseSession {
+    return this.inner.withSession();
+  }
+}
+
+function encode(value: string): Uint8Array {
+  return textEncoder.encode(value);
+}
+
+function createSkillSnapshotDatabase(): SqliteD1Database {
+  const database = new SqliteD1Database({ foreignKeys: false });
+
+  database.execute(`
+    CREATE TABLE skill_snapshot (
+      id text PRIMARY KEY NOT NULL,
+      author text NOT NULL,
+      blob_key text NOT NULL,
+      blob_sha256 text NOT NULL,
+      blob_size integer NOT NULL,
+      created_at integer NOT NULL,
+      description text NOT NULL,
+      name text NOT NULL,
+      app_id text NOT NULL,
+      skill_markdown_path text NOT NULL,
+      uncompressed_size integer NOT NULL,
+      version text
+    );
+
+    CREATE UNIQUE INDEX skill_snapshot_blob_sha256_idx
+      ON skill_snapshot (app_id, blob_sha256);
+
+    CREATE TABLE skill_snapshot_entry (
+      entry_kind text NOT NULL,
+      is_executable integer NOT NULL,
+      mime_type text,
+      path text NOT NULL,
+      sha256 text,
+      size integer NOT NULL,
+      snapshot_id text NOT NULL,
+      PRIMARY KEY (snapshot_id, path)
+    );
+  `);
+
+  return database;
+}
+
+function createLargeWrappedSkillArchive(): Uint8Array {
+  return createZipArchive([
+    {
+      body: encode("---\nname: xlsx\ndescription: spreadsheet skill\n---\n# XLSX\n"),
+      entryKind: "file",
+      isExecutable: false,
+      path: "xlsx/SKILL.md",
+    },
+    ...Array.from({ length: 20 }, (_, index) => ({
+      body: encode(`support file ${index}`),
+      entryKind: "file" as const,
+      isExecutable: false,
+      path: `xlsx/references/file-${index}.txt`,
+    })),
+  ]);
+}
+
+describe("publishSkillSnapshot", () => {
+  test("stores large skill snapshot entries without exceeding a single D1 bind limit", async () => {
+    const sqlite = createSkillSnapshotDatabase();
+    const limitedDatabase = new BindLimitedD1Database(sqlite, 100);
+    const bucket = new PublicApiMemoryFileBucket();
+    const bindings = createPublicHttpTestBindings(limitedDatabase, {
+      fileBucket: bucket as unknown as R2Bucket,
+    }) as ApiBindings;
+
+    const published = await publishSkillSnapshot(
+      bindings,
+      { appId: APP_ID },
+      {
+        file: {
+          bytes: createLargeWrappedSkillArchive(),
+          name: "xlsx.zip",
+        },
+      },
+    );
+
+    const rows = await sqlite
+      .app()
+      .select({ path: skillSnapshotEntriesTable.path })
+      .from(skillSnapshotEntriesTable)
+      .all();
+
+    expect(published.snapshot.name).toBe("xlsx");
+    expect(published.entries).toHaveLength(22);
+    expect(rows).toHaveLength(22);
+    expect(rows.map((row) => row.path)).toContain("SKILL.md");
+    expect(rows.map((row) => row.path)).toContain("references/file-19.txt");
+  });
+});


### PR DESCRIPTION
## Summary

- Chunk skill snapshot entry inserts so larger skill archives stay under D1's per-statement bind limit.
- Repair existing content-addressed snapshots whose metadata row exists but entry rows were never fully persisted.
- Add regression coverage for large wrapped skill archives.

## Root Cause

`publishSkillSnapshot` inserted every `skill_snapshot_entry` row for a normalized skill package in one statement. Larger packages, such as the xlsx skill zip, exceeded the D1 bind limit during `/api/skill/package`, while `/api/skill/inspect` still worked because inspection does not persist entries.

## Validation

- `just test-file apps/api/tests/skill-package-snapshot.test.ts`
- `just test-file apps/api/tests/skill-package-source.test.ts`
- `just fmt-check-path apps/api/src/modules/skills/application/skill-package-snapshot.service.ts`
- `just fmt-check-path apps/api/tests/skill-package-snapshot.test.ts`
- `just tc-package @mosoo/api`
- Local HTTP upload to `/api/skill/package` returned 200 for `xlsx.zip`.
- Browser upload through `/integrations/skills` succeeded locally.

## Screenshot

Before:

<img width="510" height="588" alt="image" src="https://github.com/user-attachments/assets/9463f2fe-e1ec-4bec-9672-5fb26eb76309" />

After:

<img width="565" height="627" alt="image" src="https://github.com/user-attachments/assets/9e5bf834-fb05-448e-8fd3-6fbb30e49f17" />
