### PR TITLE
feat(runtime): full-access permission default across driver runtimes

### DIFF
--- a/apps/api/src/modules/runtime/application/agent-runtime-profile.ts
+++ b/apps/api/src/modules/runtime/application/agent-runtime-profile.ts
@@ -3,7 +3,12 @@ import type { AgentKind, AgentReadiness } from "@mosoo/contracts/agent";
 import type { AccountId, AgentId, SandboxId, SandboxSessionId, SessionId } from "@mosoo/id";
 import { getSessionOrganizationPath, getSessionRuntimeStatePath } from "agent-driver/paths";
 
-import type { DriverConfigRevision, DriverProfileConfig } from "../domain/driver-snapshot";
+import type {
+  DriverConfigRevision,
+  DriverPermissionPolicy,
+  DriverProfileConfig,
+} from "../domain/driver-snapshot";
+import { DEFAULT_DRIVER_PERMISSION_POLICY } from "../domain/driver-snapshot";
 import { getSupportedRuntimeId } from "../domain/runtime-config";
 import { resolveAgentRuntimeSandboxSubject } from "../domain/runtime-sandbox-subject";
 
@@ -16,6 +21,7 @@ export function createAgentRuntimeProfile(input: {
   executionOwnerUserId: AccountId;
   kind: AgentKind;
   model: string;
+  permissionPolicy?: DriverPermissionPolicy;
   prompt: string;
   provider: string;
   providerOptions: JsonObject;
@@ -41,6 +47,7 @@ export function createAgentRuntimeProfile(input: {
     envVars: input.envVars,
     kind: input.kind,
     model: input.model,
+    permissionPolicy: input.permissionPolicy ?? DEFAULT_DRIVER_PERMISSION_POLICY,
     prompt: input.prompt,
     provider: input.provider,
     providerOptions: input.providerOptions,

--- a/apps/api/src/modules/runtime/application/session-runs/queue-run.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/queue-run.service.ts
@@ -9,10 +9,11 @@ import type {
   SessionId,
 } from "@mosoo/id";
 
-import { logInfo } from "../../../../platform/cloudflare/logger";
+import { logError, logInfo } from "../../../../platform/cloudflare/logger";
 import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
 import { toIsoString } from "../../../../time";
 import { enqueueSessionRunDispatchCommand } from "../../../api-command/application/api-command-enqueue";
+import { dispatchQueuedSessionRun } from "./dispatch-queued-run.service";
 import type { AuthenticatedViewer } from "../../../auth/application/viewer-auth.service";
 import { fileStore } from "../../../files/application/file-store";
 import { appendSessionRuntimeEvents } from "../../../sessions/application/session-event-write.service";
@@ -157,11 +158,42 @@ export async function queueSessionRun(request: QueueSessionRunRequest): Promise<
     ...(input.accessViewer ? { accessViewer: input.accessViewer } : {}),
   });
 
+  // O1: dispatch inline via waitUntil so an interactive run does not wait for
+  // the api-command queue's batch window (max_batch_timeout = 5s). The queue
+  // enqueue above stays as the durable fallback if the worker is evicted before
+  // waitUntil runs; the queued->booting CAS inside dispatch makes this
+  // exactly-once (whichever path wins, the other logs dispatch.skipped).
+  if (request.executionContext) {
+    const inlineDispatch = dispatchQueuedSessionRun({
+      bindings,
+      input: {
+        attachmentIds: input.attachmentIds,
+        prompt: input.prompt,
+        queuedAtMs,
+        session: { id: input.session.id, app_id: input.session.app_id },
+        sessionRunId: createdRun.id,
+        traceId: createdRun.traceId,
+        ...(input.accessViewer ? { accessViewer: input.accessViewer } : {}),
+      },
+      requestUrl,
+      viewer,
+    }).catch((error: unknown) => {
+      logError("session.run.inline_dispatch.failed", {
+        message: error instanceof Error ? error.message : String(error),
+        runId: createdRun.id,
+        sessionId: input.session.id,
+        traceId: createdRun.traceId,
+      });
+    });
+    request.executionContext.waitUntil(inlineDispatch);
+  }
+
   logInfo("session.run.accepted", {
     acceptedLatencyMs: Date.now() - queueStartedAtMs,
     agentId: input.session.agent_id,
     attachmentCount: input.attachmentIds.length,
     clientRequestId: input.clientRequestId,
+    inlineDispatch: Boolean(request.executionContext),
     runId: createdRun.id,
     runtimeId,
     sessionId: input.session.id,

--- a/apps/api/src/modules/runtime/application/session-runs/queue-run.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/queue-run.service.ts
@@ -13,13 +13,13 @@ import { logError, logInfo } from "../../../../platform/cloudflare/logger";
 import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
 import { toIsoString } from "../../../../time";
 import { enqueueSessionRunDispatchCommand } from "../../../api-command/application/api-command-enqueue";
-import { dispatchQueuedSessionRun } from "./dispatch-queued-run.service";
 import type { AuthenticatedViewer } from "../../../auth/application/viewer-auth.service";
 import { fileStore } from "../../../files/application/file-store";
 import { appendSessionRuntimeEvents } from "../../../sessions/application/session-event-write.service";
 import { insertSessionMessageRecord } from "../../../sessions/application/session-message-write.service";
 import { getSupportedRuntimeId } from "../../domain/runtime-config";
 import { createSessionRunRecordIfSessionIdle } from "../../infrastructure/session-runs/session-run-store.repository";
+import { dispatchQueuedSessionRun } from "./dispatch-queued-run.service";
 import { createQueuedSessionRunRuntimeEvents } from "./session-run-view-events.service";
 import { reconcileStaleActiveSessionRun } from "./stale-run-reconciliation.service";
 

--- a/apps/api/src/modules/runtime/domain/driver-snapshot.ts
+++ b/apps/api/src/modules/runtime/domain/driver-snapshot.ts
@@ -62,6 +62,17 @@ export interface DriverConfigRevision {
   readonly sessionId: SessionId;
 }
 
+/**
+ * How the driver mediates tool-permission requests. Mirrors the driver-side
+ * `DriverPermissionPolicy` (agent-driver). `full_access` (default) = the
+ * sandbox is the isolation boundary, tool calls auto-approved with no
+ * control-plane round-trip; `supervised` = route every tool call to the
+ * permission broker for an interactive decision.
+ */
+export type DriverPermissionPolicy = "full_access" | "supervised";
+
+export const DEFAULT_DRIVER_PERMISSION_POLICY = "full_access" satisfies DriverPermissionPolicy;
+
 export interface DriverProfileConfig {
   readonly agentId: AgentId;
   readonly configRevision: DriverConfigRevision;
@@ -69,6 +80,7 @@ export interface DriverProfileConfig {
   readonly envVars: Record<string, string>;
   readonly kind: AgentKind;
   readonly model: string;
+  readonly permissionPolicy: DriverPermissionPolicy;
   readonly prompt: string;
   readonly provider: string;
   readonly providerOptions: JsonObject;
@@ -172,6 +184,7 @@ export interface DriverExecutionSpec {
   readonly configRevision: DriverConfigRevision;
   readonly environment: DriverExecutionEnvironment;
   readonly model: string;
+  readonly permissionPolicy: DriverPermissionPolicy;
   readonly profilePrompt: string;
   readonly provider: string;
   readonly providerOptions: JsonObject;

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/session-viewer-event-delivery-buffer.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/session-viewer-event-delivery-buffer.ts
@@ -2,6 +2,7 @@ import {
   appendCompactedAgUiSessionEvents,
   compactAgUiSessionEvents,
   getAgUiSessionEventDeltaLength,
+  isAgUiSessionRunStartedEvent,
   isAgUiSessionRunTerminalEvent,
 } from "@mosoo/ag-ui-session";
 import { discardPromiseResult, ignorePromiseRejection } from "@mosoo/effects";
@@ -33,12 +34,21 @@ function hasTerminalEvent(events: SessionDeliveryEvent[]): boolean {
   return events.some(isAgUiSessionRunTerminalEvent);
 }
 
+function hasRunStartedEvent(events: SessionDeliveryEvent[]): boolean {
+  return events.some(isAgUiSessionRunStartedEvent);
+}
+
+function hasDeltaEvent(events: SessionDeliveryEvent[]): boolean {
+  return events.some((event) => getAgUiSessionEventDeltaLength(event) > 0);
+}
+
 function estimateDeltaBytes(events: SessionDeliveryEvent[]): number {
   return events.reduce((bytes, event) => bytes + getAgUiSessionEventDeltaLength(event), 0);
 }
 
 export class SessionViewerEventDeliveryBuffer {
   #buffer: BufferedSessionViewerEvents | null = null;
+  #pendingFirstDelta = false;
   readonly #ctx: DurableObjectState;
   readonly #env: ApiBindings;
   #gate: Promise<void> = Promise.resolve();
@@ -73,9 +83,22 @@ export class SessionViewerEventDeliveryBuffer {
       sessionId: buffered?.sessionId ?? sessionId,
     };
 
+    // O2: cut first-token latency. Arm on RUN_STARTED, then flush the first
+    // delta of the run immediately instead of waiting out the 150ms timer.
+    // This fires at most once per run, so per-delta batching for the rest of
+    // the stream is preserved.
+    if (hasRunStartedEvent(compactedEvents)) {
+      this.#pendingFirstDelta = true;
+    }
+    const isFirstDeltaOfRun = this.#pendingFirstDelta && hasDeltaEvent(compactedEvents);
+    if (isFirstDeltaOfRun) {
+      this.#pendingFirstDelta = false;
+    }
+
     if (
       nextEvents.length >= SESSION_VIEWER_EVENT_DELIVERY_MAX_EVENTS ||
       nextDeltaBytes >= SESSION_VIEWER_EVENT_DELIVERY_MAX_DELTA_BYTES ||
+      isFirstDeltaOfRun ||
       hasTerminalEvent(compactedEvents)
     ) {
       this.#startFlush();
@@ -153,6 +176,7 @@ export class SessionViewerEventDeliveryBuffer {
 
   resetAfterFlush(): void {
     this.#buffer = null;
+    this.#pendingFirstDelta = false;
     this.#gate = Promise.resolve();
 
     if (this.#timer !== null) {

--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-execution-spec.builder.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-execution-spec.builder.ts
@@ -185,6 +185,7 @@ export async function buildExecutionSpec(
       variables: { ...input.profile.envVars },
     },
     model: input.profile.model,
+    permissionPolicy: input.profile.permissionPolicy,
     profilePrompt: appendRuntimeArtifactContextToPrompt(input.profile.prompt),
     provider: input.profile.provider,
     providerOptions: input.profile.providerOptions,

--- a/apps/api/tests/session-viewer-event-delivery-buffer.test.ts
+++ b/apps/api/tests/session-viewer-event-delivery-buffer.test.ts
@@ -163,6 +163,43 @@ describe("SessionViewerEventDeliveryBuffer", () => {
     ]);
   });
 
+  test("flushes the first delta of a run immediately, then batches the rest", async () => {
+    const { buffer, published, waitForWaitUntil } = createBufferHarness();
+    const runStarted = {
+      input: null,
+      parentRunId: null,
+      runId: "run-1",
+      threadId: "thread-1",
+      type: "RUN_STARTED",
+    } satisfies AgUiSessionEvent;
+
+    // RUN_STARTED + first delta: must publish without an explicit flush() —
+    // i.e. it bypassed the 150ms timer.
+    buffer.enqueue("session-1", [
+      runStarted,
+      { delta: "hi", messageId: "assistant-1", type: "TEXT_MESSAGE_CONTENT" },
+    ]);
+    await waitForWaitUntil();
+
+    expect(published).toHaveLength(1);
+    expect(published[0]?.events).toContainEqual({
+      delta: "hi",
+      messageId: "assistant-1",
+      type: "TEXT_MESSAGE_CONTENT",
+    });
+
+    // A subsequent small delta must NOT flush immediately (batching preserved):
+    // nothing new is published until an explicit flush.
+    buffer.enqueue("session-1", [
+      { delta: "there", messageId: "assistant-1", type: "TEXT_MESSAGE_CONTENT" },
+    ]);
+    await waitForWaitUntil();
+    expect(published).toHaveLength(1);
+
+    await buffer.flush();
+    expect(published).toHaveLength(2);
+  });
+
   test("requeues failed deliveries before events enqueued during the failed publish", async () => {
     const { buffer, published, pushResponse, waitForPublish } = createBufferHarness();
     const failedResponse = createDeferred<Response>();

--- a/docs/perf-permission-work/00-findings.md
+++ b/docs/perf-permission-work/00-findings.md
@@ -1,0 +1,158 @@
+# mosoo driver: full-access permissions + TTFT/streaming measurement + lifecycle — consolidated findings
+
+Date: 2026-07-02. Evidence-first. Every claim carries a `file:line` or an external source read at source level.
+
+## Scope (from user)
+
+1. **Goal A — permissions**: make full-access / yolo the DEFAULT for all three runtimes (claude-agent-sdk, codex app-server, opencode ACP), like multica.
+2. **Goal B — measurement + optimization**: build a measurement system; quantitatively optimize (i) time-to-first-token (TTFT) and (ii) streaming-output UX along the journey *configure provider key → create agent → create run → response streams to console*. 没有测量就没有优化.
+3. **Goal C — lifecycle**: simplify/harden run lifecycle state management + state machine on that path.
+
+Deliverable: research the reference map (15 repos), rate P0/P1/P2, then optimize → PR.
+
+---
+
+## Part 1 — Reference-map verdict (15 repos, all cloned & read at source level; 15/15 real)
+
+7 P0, 5 P1, 3 P2. **Unanimous convergence on Goal A**: every P0 defaults to full-access with the same rationale — *the sandbox is the isolation boundary; do not gate per-tool-call*.
+
+### P0 (borrow before implementing)
+
+- **vercel-ai-harness** (`vercel/ai`: `@ai-sdk/harness` + `harness-claude-code`/`-codex`/`-opencode` + `sandbox-vercel`) — the exact architectural twin (same runtime trio). `DEFAULT_PERMISSION_MODE='allow-all'`; claude→`bypassPermissions`+`allowDangerouslySkipPermissions`; codex→`danger-full-access`+`approval never`; opencode→auto-`always`. Also: monotonic-seq bridge event log + disk mirror + resume cursor + graded recovery ladder (attach/replay → replay-from-disk → rerun); `HarnessV1StreamPart` chunk vocab with explicit text-start/delta/end ids (makes TTFT = time-to-first text-delta directly measurable); two-axis `sessionState × turnState` machine; snapshot-template prewarm; dual-signal bridge-ready race.
+- **multica** (`multica-ai/multica`) — THE goal-A reference. claude `--permission-mode bypassPermissions` (pinned in a blocked-args map so user args can't override); codex via CODEX_HOME config.toml managed block (`sandbox_mode workspace-write`+`network_access true` on Linux) + JSON-RPC handlers auto-accepting every `item/*/requestApproval`; opencode `--dangerously-skip-permissions` (deliberately NOT via `OPENCODE_PERMISSION` env — key-order merge footgun). Marker-delimited idempotent managed-config block. First-turn no-progress watchdog + phase-split latency histograms.
+- **openhands-sdk** (`OpenHands/agent-sdk`, arxiv 2511.03690) — `NeverConfirm()` default as a first-class discriminated-union policy object; centralized confirmation in the agent loop (not per-runtime); confirmation = durable `WAITING_FOR_CONFIRMATION` run-state pause + implicit resume via unmatched-action recovery; transient `StreamingDeltaEvent` channel (deltas to PubSub, NOT persisted; only final MessageEvent logged); ws reconnect `resend_mode all|since|null`; single execution-status enum with `is_terminal()`.
+- **opencomputer** (`diggerhq/opencomputer`) — `bypassPermissions` hardcoded; two-level session-status × turn-state joined by `yield_reason`; append-only seq log with SSE `id=seq` (native `Last-Event-ID` resume) + `after=<seq>`; credential lifecycle (validate runtime/model/credential at agent-create, write-only last4, resolve+pin at run-create → no wasted boot on bad key); runtime engine pre-baked in image + `bench-launch.sh` scripted timing.
+- **open-managed-agents** (`openma-ai/open-managed-agents`) — **on CF Workers+DO, same substrate**. `span.model_request_start / span.model_first_token / span.model_request_end` wire events (OMA extension) → per-call TTFT is a first-class queryable event; console `derive()` renders TTFT bars from the log; dual-port storage (canonical EventLogRepo + StreamRepo for in-flight chunks); platform-agnostic `SessionStateMachine` over one `RuntimeAdapter` port with DO-alarm orphan-turn detection; `recoverInterruptedState` pure fn (finalize orphan streams, inject placeholder tool_results so Anthropic doesn't 400); `permission_policy` default `always_allow`; one-shot POST→turn-scoped SSE that opens stream BEFORE appending user msg (kills subscribe race).
+- **agentos** (`rivet-dev/agentos`) — actor≈DO. allow-all ("VM is the boundary"), only network egress scoped (default-allowlist LLM hosts); server-side auto-approve hook resolving before any client round-trip; deterministic **mock-LLM latency benchmark with committed `baseline.json` regression gate** (`--gate`/`--update-baseline`, p50/p95/p99, tolerance+noiseFloor; prompt latency excluded as LLM-bound); **"never-hit-by-normal-use" defaults audit** (stock 5s/60s/30s/64KiB timeouts that silently broke streaming); broadcast-before-persist event pump with single-pump-per-session (abort-on-replace); durable-actor/disposable-VM lazy-resume lifecycle.
+- **vercel-eve** (`vercel/eve`, Apache-2.0, public June 2026) — omitted approval = `never()`; denial hygiene (unanswered → ignored/denied; splice `execution-denied` tool-result so replayed unmatched tool_use doesn't 400); durable replayable stream (`?startIndex=` cursor, auto-reconnect, bounded open-retry for the create→attach race); session/turn/step taxonomy with parked `session.waiting`; ack-then-stream API (return id instantly, stream separately); every event stamped `meta.at` → TTFT computed server-side from the log (zero console instrumentation); compensating controls (secrets at sandbox firewall, egress scoping).
+
+### P1 (strong secondary)
+
+- **sandboxed-issue-triage-agent** — clean TTFT instrumentation shape (in-band NDJSON `elapsedMs` stage events, run-id correlation header, client chunk timing, zero-output recovery, secret redaction). One instructive defect: no client-abort stream cancel.
+- **mastra** — `@mastra/acp` defaults to inline auto-approve (`options[0]`) = the exact opencode-ACP full-access pattern; `ModelSpanTracker.completionStartTime` on first delta = TTFT; canonical chunk envelope + per-provider delta extractors + degraded-stream fallback.
+- **litellm-agent-control-plane** — `bypassPermissions`+`allowDangerouslySkipPermissions` unconditional claude default; minimal starting/running/completed/failed/timed_out machine; status derived from idempotent seq+event_key log; reconciles stuck-`running` from replay; SSE tee + bounded snapshot+broadcast replay.
+- **runtm** — literal `--dangerously-skip-permissions`, safety in sandbox fs/net allowlists; declarative transitions-table state machine at one chokepoint with per-state timestamps; atomic slot-reservation ownership + TTL orphan recovery; traceparent/histogram scaffolding + SSE→NDJSON framing.
+- **flue** (`withastro/flue`) — real (agent-harness over pi-ai, Node + CF Workers/DO), NOT hydration. offset-resumable Durable Streams + 3s-batched delta persistence; derive-state-from-durable-history classifier; producer epoch fencing; DO stale-attempt sweep. Strong for goal C + streaming.
+
+### P2 (marginal — do not block on)
+
+- **codex-complexity-optimizer** — a Codex skill (regex/AST complexity scanner). NO measurement harness/timing (the hoped-for methodology doesn't exist). Borrow only: before/after report template + "heuristics are leads, measurement is proof" discipline.
+- **ponytail** — a YAGNI prompt ruleset for 16 agents, not a perf/refactor tool. Only its `benchmarks/agentic/run.py` (arms×n runs, medians, rescore-from-artifacts, harvests `permission_denials` from headless `--permission-mode bypassPermissions`) is a hygiene template.
+- **karpathy-skills** — one behavioral skill (Think/Simplicity/Surgical/Goal-Driven). Generic hygiene; "define numeric success criteria, loop until verified" framing only.
+
+---
+
+## Part 2 — mosoo current state (local, evidence)
+
+### Permissions (all three interactive-by-default; control plane blocks yolo)
+
+- Broker: `interactiveRequests=true` default, 5-min timeout → `reject_once`; decisions only `allow_once|reject_once`; `interactiveRequests=false` = **deny-all** (wrong for full-access). — `apps/driver/src/core/driver-permission-broker.ts:8,10,38,79-85,130-132`. Never constructed with options anywhere; no env controls it — `driver-process.ts:65`, `agent-driver-kernel.ts:152`, `bin/driver.ts:20`.
+- Claude: `permissionMode:'default'` + `canUseTool`→broker; `providerOptions` CAN override mode via deep-merge (test proves `acceptEdits`) but control plane blocks it. — `apps/driver/src/runtimes/claude/agent-sdk-query-options.ts:137,35-68,132,111-116,170`.
+- Codex: `approvalPolicy:'on-request'` on thread/start + thread/resume + **every** turn/start; sandbox ALREADY `danger-full-access`. Generated protocol supports `untrusted|on-failure|on-request|never` + sandbox `read-only|workspace-write|danger-full-access`. — `apps/driver/src/runtimes/openai/app-server-driver-backend.ts:35,71,178,182`, `app-server-env.ts:1`, `generated/app-server-protocol-types.ts:8-10`.
+- ACP (opencode): `session/request_permission`→broker; only `allow_once/reject_once` kinds considered (`allow_always/reject_always` ignored); `session/new` carries NO permission config; driver never writes opencode.json. Child env sets `HOME=homePath` (hook point). ACP command from `MOSOO_ACP_FALLBACK_COMMAND/_ARGS`. — `acp-client-request-handler.ts:81-84,172-212,251-278`, `acp-permission-events.ts:56-68`, `acp-session-setup.ts:35-42`, `acp-configuration.ts:21-42,58-76`.
+- Control plane **actively blocks** yolo: `SECURITY_BOUNDARY_SETTING_KEYS` includes `permissionMode, approval_policy, sandbox_mode, allowDangerouslySkipPermissions, default_permissions, canUseTool` → `runtime_settings_security_boundary` error. No per-agent permissionMode/approvalPolicy field in D1/GraphQL. — `pkgs/runtime-catalog/src/runtime-advanced-settings.ts:100-125,193-198`, `agent-stored-config.service.ts:28,355-358`.
+- Insertion points: boot payload has `builtInTools`+`providerOptions` but no permission field — `apps/driver/src/protocol/boot/index.ts:156,162,385-396`; spec builder passes providerOptions — `runtime-driver-execution-spec.builder.ts:179-190`.
+- Tests asserting current defaults: `claude-agent-sdk-query-options.test.ts:55,173`, `openai-app-server-turn-start.test.ts:15`, `driver-permission-broker.test.ts:66`, `runtime-advanced-settings.test.ts:88-96`. ACP/CMA permission fixtures also.
+
+### Lifecycle state machines (4 layers)
+
+1. **SessionRun** (XState + `decideSessionRunTransition`, D1 CHECK + unique active-driver lease): `queued/booting/running/waiting_input/completed/failed/cancelled/expired`. — `session-run.contract.ts:18-29`, `session-run-lifecycle.machine.ts:53-97`, `runs.schema.ts:60-70`.
+2. **Session** (projection of last run status, statusSeq CAS, `repair_needed` path): `IDLE/RUNNING/RESCHEDULING/TERMINATED`. — `session.contract.ts:22`, `session-lifecycle.ts:6-24`, `session-run-write.repository.ts:531-728`.
+3. **DriverInstance** (NO transition guard — ad-hoc WHERE-clause guards): `provisioning/connecting/ready/stopping/stopped/failed`. — `driver-instance-lifecycle.machine.ts:1-46`.
+4. **RuntimeSubject** (full XState guard): `cold/restoring/active/backing_up/destroying/error`. — `runtime-subject-lifecycle.machine.ts:43-170`.
+
+Known-rough:
+- **Involuntary reclaim**: driver socket close → fails active run with retryable `runtime.turn_interrupted — please resend` but **nothing retries**; RESCHEDULING/120s-window is only entered by runtime *state operations*, never reclaim. Backstop = stale-run-reconciliation (heartbeat 1s, cutoff 30s) fails runs **non-retryably** — contradicts terminal-run-release's retryable:true for the same physical event. — `driver-instance/do.ts:135-166`, `terminal-run-release.ts:30-54`, `stale-run-reconciliation.service.ts:36-59`, `runtime-config.ts:7-9`.
+- **Half-built ack**: driver keeps `lastAcceptedSeq` from receipts but **nothing consumes it** (grep: only debug logs); dedupe = in-memory receipts + per-batch D1 receipt read under serial gate. — `driver-event-publisher.ts:19-89`, `rpc-event-ingestion-controller.ts:65-157`.
+- `session.status` redundant projection with 2 repair paths + multiple write sites = main complexity hotspot.
+
+### Latency / measurement
+
+- Have: `runtime.timing.recorded` phase recorder (hydration→prepare_run→provisioning→dispatch on API; driver_backend/driver_turn on driver; Claude times provider first event) — `session-runtime-timing.ts:27-110`, `driver-runtime-timing.ts:48-74`. End-to-end bench `benchmarks/sandbox-agent` (createThreadMs/firstAssistantTextMs/tokenCompletedMs, p50/p95). **claude-agent-sdk emits its own `ttft_ms`/`ttft_stream_ms`/`warm_spare_claimed`.**
+- Missing/broken:
+  - **CF Queue hop `max_batch_timeout=5s`** on the TTFT-critical path, unmeasured; `executionContext` threaded but never used → no inline fast path. — `wrangler.toml:88-92`, `queue-run.service.ts:70-76`, `api-command-processor.ts:453-456`.
+  - First delta gated behind D1-persistence-commit + ≤150ms viewer buffer; no first-token fast flush. — `session-viewer-event-delivery-buffer.ts:15-17,56-86`.
+  - Each SDK delta = one ack-gated `pushEvents` RPC (throughput bound by driver→DO RTT). — `driver-event-publisher.ts:27-84`, `agent-sdk-event-writer.ts:205-218`.
+  - Skill packages downloaded serially at driver-backend start (CLIs pre-baked in Dockerfile; skills are not). — `skill-materialization.ts:131,181-185`, `Dockerfile:1-43`, commit 1a857ee7.
+  - Console renders 24 chars/frame (intentional smoothing latency). — `session-stream-render-scheduler.ts:20-27`.
+  - No T0 accept-stage timing; ACP has zero timing; OpenAI times turn/start ack not first token; timing events have **no apps/web consumer**; traceId null in provisioning/prewarm; no inter-chunk gap metric; `pkgs/observability` has no histogram/percentile facility.
+- Prewarm already exists (session-create + viewer-connect) — `create-agent-session.service.ts:338-352`, `session-viewer-socket.service.ts:57-58`, `prewarm-agent-session-runtime.service.ts`.
+- Provider keys: D1 `vendor_credential` (metadata) + `vault_secret` AES-GCM envelope; injected as env vars into boot-payload JSON in the sandbox (`OPENCODE_CONFIG_CONTENT` JSON for acp-fallback). — `vendor-credential.schema.ts:12-35`, `mcp-secret-store.ts:92-176`, `hydrate-run-context.service.ts:153-192,342-382`.
+
+---
+
+## Part 3 — latest SDK/protocol facts (external, read at source level 2026-07-02)
+
+### claude-agent-sdk (latest 0.3.198; `^0.3.158` resolves to it)
+- `PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'dontAsk' | 'auto'`.
+- yolo = `permissionMode:'bypassPermissions'` + **required** `allowDangerouslySkipPermissions:true`. **Cannot run as root on Unix** (check Dockerfile user!). Deny rules + hooks still apply even under bypass.
+- **0.3.198 warns** if `canUseTool` is set alongside `bypassPermissions`/`allowedTools` (shadowed) → must NOT pass canUseTool when bypassing.
+- `dontAsk` = never prompt, deny-if-not-pre-approved, `canUseTool` never called (good "non-interactive but not-yolo" tier).
+- TTFT: result carries `ttft_ms/ttft_stream_ms/time_to_request_ms/time_to_request_from_spawn_ms/warm_spare_claimed`; stream_event carries `ttft_ms`. `startup()`→`WarmQuery` prewarm (~20x faster first query). `includePartialMessages:true` for `stream_event` text deltas. MCP connects in background by default (0.3.142).
+- Behavior changes to verify vs current code: 0.3.162 Grep/Glob→embedded search; native-binary spawn since 0.2.113.
+
+### codex app-server (latest stable 0.142.5; main 0.143-alpha; **mosoo ships 0.135.0**)
+- `AskForApproval` wire values are **kebab-case**: `"untrusted" | "on-request" | "never"` (+ experimental `granular`). `"on-failure"` removed on main (PR #28418, 2026-06-23) but still present/aliased in 0.142.x and 0.135.
+- `thread/start.sandbox` = `SandboxMode` shorthand `"read-only"|"workspace-write"|"danger-full-access"`. `turn/start.sandboxPolicy` = full tagged union with **camelCase** `type` tags (`dangerFullAccess`, `workspaceWrite{...}`).
+- **yolo** = `thread/start {approvalPolicy:"never", sandbox:"danger-full-access"}` (== CLI `--dangerously-bypass-approvals-and-sandbox`). mosoo already has the sandbox; only needs `on-request`→`never` at the 4 sites.
+- Approval server→client requests (v2): `item/commandExecution/requestApproval`, `item/fileChange/requestApproval`, `item/permissions/requestApproval`, `mcpServer/elicitation/request`. Decisions camelCase `accept|acceptForSession|decline|cancel` (v2); v1 `applyPatchApproval`/`execCommandApproval` snake_case `approved|approved_for_session|denied|abort` (deprecated). With `approvalPolicy:"never"` these effectively never fire for exec/patch.
+- Streaming: `item/agentMessage/delta` (concatenate per itemId), 1:1 passthrough, **no batching**; `turn/started`→items→`turn/completed`. Built-in session-startup prewarm. `optOutNotificationMethods` capability to suppress.
+- **Doc footgun**: README/site examples show camelCase `unlessTrusted`/`workspaceWrite` — STALE; generated schema + serde tests are authoritative (kebab-case for `AskForApproval`/`SandboxMode`).
+
+### opencode over ACP (sst/opencode → now anomalyco/opencode; mosoo ships 1.17.7)
+- opencode.json `permission`: keys `read/edit/glob/grep/bash/task/skill/lsp/question/webfetch/websearch/external_directory/doom_loop` + `*`; values `allow|ask|deny`; per-command/path globs; agent-level overrides.
+- **yolo cleanest path**: inject config `permission:{"*":"allow"}` (or per-key) so `permission.asked` never fires → no ACP `session/request_permission` at all. `OPENCODE_CONFIG_CONTENT` env (mosoo already uses this for acp-fallback) is the injection channel. **Multica warning: do NOT use `OPENCODE_PERMISSION` env** (key-order deep-merge footgun) — use config content.
+- ACP: if client doesn't implement `requestPermission`, opencode auto-**rejects** — explains why non-interactive currently blocks. Option kinds `allow_once/allow_always/reject_once` (no reject_always). ACP `session/set_mode` maps to opencode agents (could define a `yolo` agent, but config injection is simpler).
+- TTFT footgun: **blocking models.dev fetch up to 10s** on cold start (`models-dev.ts:138-238`) → pre-seed `models.json` cache or `OPENCODE_DISABLE_MODELS_FETCH=1`. Built-in profiler `OPENCODE_ACP_PROFILE=1`.
+
+### Cloudflare Sandbox SDK (GA Apr 2026, 0.8.9)
+- `sleepAfter` (default 10m), `keepAlive` (heartbeat 30s, survives DO hibernation), `containerTimeouts` (instanceGet 30s, portReady 90s).
+- Instance types lite→standard-4; cold start "1–3s" (image-dependent); Cloudflare pre-schedules/pre-fetches images (no user pre-warm API); **active-CPU pricing** (idle-on-LLM is free → keepAlive pool is cheap).
+- **Backup/restore API** (Feb 2026 GA): `createBackup`/`restoreBackup`, restore ~2s vs ~30s fresh clone+install; COW FUSE overlay; lost on sleep (re-restore). Directory-level only (no memory snapshot yet).
+- `execStream`/`startProcess`+`waitForPort`/`streamProcessLogs` for streaming; stable preview URLs via `token`.
+
+---
+
+## Part 4 — P0/P1/P2 optimization backlog (mosoo changes)
+
+### Goal A — full-access defaults (P0, small, high-value)
+- **A1** Claude: default `permissionMode:'bypassPermissions'` + `allowDangerouslySkipPermissions:true`; drop `canUseTool` when bypassing (0.3.198 shadow warning). Keep broker path for opt-in stricter modes. — `agent-sdk-query-options.ts:137`. **Precondition: verify Dockerfile runs driver as non-root** (bypass forbidden as root).
+- **A2** Codex: `on-request`→`never` at all 4 sites (sandbox already danger-full-access). — `app-server-driver-backend.ts:35,71,178,182`.
+- **A3** ACP/opencode: inject `permission:{"*":"allow"}` via `OPENCODE_CONFIG_CONTENT` (NOT `OPENCODE_PERMISSION`) so requests never fire; belt-and-braces: broker policy auto-selects allow option under full-access. — `hydrate-run-context.service.ts` (buildOpenCodeConfig) + `acp-client-request-handler.ts`.
+- **A4** Broker policy layer: add a `full-access` policy evaluated BEFORE the socket round-trip → auto-allow synchronously (emit requested/resolved events for audit only). Default = full-access. — `driver-permission-broker.ts`. (openhands/agentos/OMA/eve pattern.)
+- **A5** Control plane: reconcile `SECURITY_BOUNDARY_SETTING_KEYS` with the new default (either add a first-class per-agent `permissionPolicy` field so supervised mode is opt-in-able, or document that yolo is fixed). — `runtime-advanced-settings.ts`, contracts, D1.
+- **A6** Update the 5 tests asserting old defaults; add tests asserting yolo defaults + opt-in supervised.
+- Compensating controls (eve/agentos): keep secrets in env/firewall, scope sandbox egress — "no prompts" ≠ "no boundary".
+
+### Goal B — measurement system (P0, required before optimizing)
+- **B1** T0 accept-stage timing + stamp `queuedAtMs` on run row. — `queue-run.service.ts`.
+- **B2** `queue_wait` timing event (`now - queuedAtMs`) in dispatch consumer → quantify the 5s exposure. — `api-command-processor.ts`.
+- **B3** Timing parity: ACP `driver_backend`+`driver_turn` provider.first_event; OpenAI provider.first_event (not just turn/start ack). Split skill.materialize as its own phase. — `acp-driver-backend.ts`, `app-server-event-bridge.ts`, `agent-sdk-driver-backend.ts`.
+- **B4** Driver publisher: per-push ack-RTT / batch size / pending-queue depth → per-run summary (chunk count, mean/p95/max inter-push gap) emitted once at run.completed (NOT per delta). — `driver-event-publisher.ts`.
+- **B5** Server-side TTFT from the event log (eve pattern): first `agent.message.delta` viewer-delivery `at` − run-accept `at`; emit as timing event + wide event. — `session-runtime-timing.ts`.
+- **B6** Thread real traceId (not null) in provisioning/prewarm recorders. — `runtime-driver-provisioning.service.ts`, `driver-session.service.ts`.
+- **B7** Bench upgrade: inter-chunk gap distribution per case; join runtime.timing events by runId into a per-stage waterfall in results.csv; use WS path (not 2s SSE poll) or document quantization. — `sandbox-agent-bench.ts`.
+- **B8** Deterministic mock-provider bench + committed `baseline.json` regression gate (agentos pattern), p50/p95 per phase, `--gate`/`--update-baseline`. — new under `benchmarks/`.
+- **B9** apps/web: consume `sessionRuntimeTiming` (already emitted, dropped) → per-run waterfall; `performance.mark` send→first-render. — `process-timeline.tsx`, `session-stream-socket.ts`.
+
+### Goal B — optimizations (apply by measured bottleneck, theory-of-constraints order)
+- **O1** (biggest measured): inline dispatch fast-path via `executionContext.waitUntil` for interactive runs, queue as dedupe-keyed fallback; OR a dedicated low-latency queue `max_batch_timeout=0/1`. Prove with B2. — `queue-run.service.ts`, `wrangler.toml`.
+- **O2** First-token fast flush: flush the first text delta of a run immediately (like terminal-event fast flush); decouple delta viewer-delivery from D1-persistence gating (broadcast-before-persist, agentos/openhands). — `session-viewer-event-delivery-buffer.ts`.
+- **O3** Claude prewarm via `startup()`/`WarmQuery` in driver boot; verify `includePartialMessages:true`. — `agent-sdk-driver-backend.ts`.
+- **O4** OpenCode cold-start: pre-seed `models.json` or `OPENCODE_DISABLE_MODELS_FETCH=1` (kill ≤10s fetch). — acp config/env.
+- **O5** Skill-download off the TTFT path (parallel/prewarm/cache); CF backup-restore for warm sandboxes (~2s). — driver boot + provisioning.
+- **O6** "Never-hit-by-normal-use" timeout audit (agentos) across DO ws/viewer/queue caps/RPC timeouts.
+
+### Goal C — lifecycle (P1, larger/riskier)
+- **C1** Involuntary reclaim → requeue/resume (or RESCHEDULING window) instead of dead-ending at "please resend"; reconcile retryable semantics. — `terminal-run-release.ts`, `stale-run-reconciliation.service.ts`.
+- **C2** Finish OR delete the ack cursor (persist `lastAcceptedSeq`, resume-from-cursor on reconnect, skip D1 receipt reads for seq≤cursor) — per prior audit, do NOT rebuild ingest. — `driver-event-publisher.ts`, ingestion controller.
+- **C3** `decideDriverInstanceTransition` guard (mirror run/subject machines) → one validated chokepoint. — `driver-instance-lifecycle.machine.ts`.
+- **C4** Consolidate `session.status` projection to a single write site (or derive it). — `session-run-write.repository.ts`.
+- **C5** `recoverInterruptedState`-style pure fn (OMA) with in-memory-adapter unit tests → fills the zero-reclaim-tests gap.
+
+---
+
+## Open decision (needs user): PR scope
+
+- **Full-access posture**: unconditional fixed default (multica) vs default-value-with-opt-in-supervised (OMA/eve/openhands). The latter needs A5 (new per-agent policy field + relax SECURITY_BOUNDARY). Recommended: default-with-opt-in.
+- **PR breadth**: (i) A+B only (yolo + measurement + proven top optimizations O1/O2), shippable & low-risk; vs (ii) A+B+C (also lifecycle/reclaim), larger & riskier. Recommended: (i) first, C as follow-up.

--- a/docs/perf-permission-work/01-performance-comparison.md
+++ b/docs/perf-permission-work/01-performance-comparison.md
@@ -1,0 +1,115 @@
+# Before/after performance comparison
+
+Scope: the "configure key → create agent → create run → first token streams to
+console" journey. Numbers are grouped by whether they are **measured** (driven
+against live provider APIs by `apps/driver/bench/ttft-bench.ts`, which exercises
+the real driver kernel + provider registry) or **projected** from a measured
+code constant (control-plane hops that can only be faithfully timed on a
+Cloudflare deploy — local wrangler Queues/DO ≠ CF).
+
+Model for all measured rows: `claude-sonnet-4-5`, live Anthropic API, same
+machine/session. Absolute numbers are environment-relative; the deltas are the
+point.
+
+## Executive summary
+
+| optimization | metric | before | after | delta | status |
+|---|---|---|---|---|---|
+| Full-access default (tool task) | success rate | 0% | **100%** | +100pp | **measured** |
+| Full-access default (tool task) | total time | ~16.5s | **~11.6s** | **−30%** | **measured** |
+| Claude CLI prewarm | first-token TTFT p50 | 6992 ms | **4870 ms** | **−30%** | **measured** |
+| Claude CLI prewarm | first-token TTFT p95 | 8366 ms | **4896 ms** | **−41%** | **measured** |
+| O1 inline queue dispatch | queue wait on TTFT path | ≤5000 ms | **~0 ms** | up to −5s | projected |
+| O2 first-token flush | first-delta broadcast | ≤150 ms + D1 write | **~0 ms** | up to −150ms+ | projected |
+| O4 opencode models.dev | cold-start fetch | ≤10 000 ms | **~0 ms** | up to −10s | projected |
+
+---
+
+## 1. Full-access default vs supervised-reject — MEASURED
+
+The old default (`permissionMode: default` + broker) routes every tool call to
+the control plane and, when non-interactive or on the 5-minute timeout, rejects.
+A tool-writing task under each posture (`marker.txt` must actually be written):
+
+| posture | ok% | file created | total p50 |
+|---|---|---|---|
+| supervised (reject) | **0%** (0/3) | **0%** | ~16.5 s |
+| full-access (allow) | **100%** (3/3) | **100%** | ~11.6 s |
+
+The reject posture is not just slower — it **fails the task** (the agent burns
+turns working around the denied Write, then gives up). Full-access is both
+correct and faster. Reproduce: `TTFT_SCENARIOS=tool_write_allow,tool_write_reject`.
+
+## 2. Claude CLI prewarm — MEASURED
+
+`@anthropic-ai/claude-agent-sdk` spawns its native CLI lazily on the first
+`query()` iteration, so the whole spawn + initialize handshake lands inside the
+first turn's time-to-first-token. `startup()` moves that into `backend.start()`,
+which the control plane already runs ahead of the first user message.
+
+`no_tool` scenario (pure TTFT), 5 trials each (+1 warmup discarded):
+
+| config | boot p50 | TTFT p50 | TTFT p95 | per-trial TTFT (ms) |
+|---|---|---|---|---|
+| prewarm off | ~0 ms | 6992 | 8366 | 8366, 7008, 6992, 6396, 6629 |
+| prewarm on | 2225 ms | **4870** | **4896** | 4870, 4882, 4896, 4634, 4411 |
+
+**−2122 ms (−30%) p50, −3470 ms (−41%) p95.** Two effects:
+1. The CLI-spawn cost (~2.2 s) leaves the turn's critical path and moves to
+   boot, which is hidden behind provisioning/prewarm — invisible to the user.
+2. Variance collapses (on 4411–4896 ms vs off 6396–8366 ms): the spawn was a
+   *variable* tax on every cold first turn; removing it makes TTFT predictable.
+
+Raw method + data: `apps/driver/bench/outputs/prewarm-ab.md`.
+
+## 3. Streaming cadence — MEASURED baseline
+
+`long_output` (~200-word reply), inter-delta gap distribution at the driver
+boundary: **p50 ≈ 466 ms, p95 ≈ 582 ms**, ~12 deltas. Claude delivers chunky
+deltas, not token-by-token; the console already smooths these (24 chars/frame
+rAF scheduler that escalates when the queue backs up). No driver-level streaming
+defect was found. The only first-token *latency* add on the streaming path is
+control-plane O2 (below).
+
+---
+
+## Projected control-plane optimizations (need a CF deploy to measure)
+
+Each cites the exact measured constant it removes. These live in the Workers/DO
+layer; local wrangler does not replicate CF Queue batching or DO scheduling, so
+faithful numbers require a staging deploy (`just bench-sandbox-agent
+--require-cloudflare`).
+
+### O1 — inline dispatch fast-path (up to −5 s)
+Every interactive run is dispatched through the `api-command` Cloudflare Queue
+with `max_batch_timeout = 5` (`apps/api/wrangler.toml:88`); the already-threaded
+`executionContext` is never used for an inline `waitUntil` dispatch. Worst case
+adds ~5 s of pure batching wait before context hydration even starts. Fix:
+dispatch inline for interactive runs, keep the queue as a dedupe-keyed fallback.
+Expected: removes up to ~5 s from cold-run TTFT.
+
+### O2 — first-token fast flush (up to −150 ms + one D1 write)
+The viewer delivery buffer flushes on a 150 ms timer / 4 KB / 64 events, and
+delta delivery is additionally gated behind the D1 persistence commit
+(`session-viewer-event-delivery-buffer.ts:15-17`). So the first visible token
+waits for a timer tick and a durable write. Fix: flush the first text delta of a
+run immediately and decouple delta broadcast from persistence
+(broadcast-before-persist). Expected: removes ~150 ms + one D1 round-trip from
+first-token latency.
+
+### O4 — opencode models.dev fetch (up to −10 s, opencode cold start)
+OpenCode blocks startup on a `models.dev/api.json` fetch (10 s timeout) when the
+cache/embedded snapshot is cold. Fix: pre-seed `models.json` in the image or set
+`OPENCODE_DISABLE_MODELS_FETCH=1`. Expected: removes up to ~10 s from opencode
+cold-start TTFT.
+
+---
+
+## Environment caveats
+
+- Measured numbers are laptop + shared key; occasional API throttling produced
+  outliers in noisier runs (a single 47 s and a single 19 s TTFT in a 3-trial
+  run) — excluded; the 5-trial p50/p95 above are stable.
+- OpenAI/Codex is not measurable in this environment (test key lacks the driver
+  default `gpt-5.4`; local codex app-server hangs on boot). The prewarm applies
+  to the Claude runtime; the full-access default applies to all three.

--- a/docs/perf-permission-work/01-performance-comparison.md
+++ b/docs/perf-permission-work/01-performance-comparison.md
@@ -19,8 +19,8 @@ point.
 | Full-access default (tool task) | total time | ~16.5s | **~11.6s** | **−30%** | **measured** |
 | Claude CLI prewarm | first-token TTFT p50 | 6992 ms | **4870 ms** | **−30%** | **measured** |
 | Claude CLI prewarm | first-token TTFT p95 | 8366 ms | **4896 ms** | **−41%** | **measured** |
-| O1 inline queue dispatch | queue wait on TTFT path | ≤5000 ms | **~0 ms** | up to −5s | projected |
-| O2 first-token flush | first-delta broadcast | ≤150 ms + D1 write | **~0 ms** | up to −150ms+ | projected |
+| O1 inline queue dispatch | queue wait on TTFT path | ≤5000 ms | **~0 ms** | up to −5s | **implemented**, measure on staging |
+| O2 first-token flush | first-delta broadcast | ≤150 ms timer | **~0 ms** | up to −150ms | **implemented**, measure on staging |
 | O4 opencode models.dev | cold-start fetch | ≤10 000 ms | **~0 ms** | up to −10s | projected |
 
 ---
@@ -73,31 +73,31 @@ control-plane O2 (below).
 
 ---
 
-## Projected control-plane optimizations (need a CF deploy to measure)
+## Control-plane optimizations — IMPLEMENTED + tested; measurement pending a staging deploy
 
-Each cites the exact measured constant it removes. These live in the Workers/DO
-layer; local wrangler does not replicate CF Queue batching or DO scheduling, so
-faithful numbers require a staging deploy (`just bench-sandbox-agent
---require-cloudflare`).
+O1 and O2 are implemented and unit/integration-tested (API suite 772 pass), but
+their *latency numbers* can only be measured faithfully on a Cloudflare deploy —
+local wrangler does not replicate CF Queue batching or DO scheduling. Each cites
+the exact constant it removes. To measure: deploy `main` and this branch as
+`wrangler versions upload --env prod` **preview** versions (no traffic shift) and
+run `just bench-sandbox-agent` against each preview URL.
 
-### O1 — inline dispatch fast-path (up to −5 s)
-Every interactive run is dispatched through the `api-command` Cloudflare Queue
-with `max_batch_timeout = 5` (`apps/api/wrangler.toml:88`); the already-threaded
-`executionContext` is never used for an inline `waitUntil` dispatch. Worst case
-adds ~5 s of pure batching wait before context hydration even starts. Fix:
-dispatch inline for interactive runs, keep the queue as a dedupe-keyed fallback.
-Expected: removes up to ~5 s from cold-run TTFT.
+### O1 — inline dispatch fast-path (up to −5 s) — IMPLEMENTED
+`queueSessionRun` now dispatches interactive runs inline via
+`executionContext.waitUntil` instead of only enqueueing to the `api-command`
+Cloudflare Queue (`max_batch_timeout = 5`, `apps/api/wrangler.toml`). The queue
+enqueue stays as a durable fallback; the `queued→booting` CAS in dispatch makes
+it exactly-once. Removes up to ~5 s of queue-batch wait from cold-run TTFT.
 
-### O2 — first-token fast flush (up to −150 ms + one D1 write)
-The viewer delivery buffer flushes on a 150 ms timer / 4 KB / 64 events, and
-delta delivery is additionally gated behind the D1 persistence commit
-(`session-viewer-event-delivery-buffer.ts:15-17`). So the first visible token
-waits for a timer tick and a durable write. Fix: flush the first text delta of a
-run immediately and decouple delta broadcast from persistence
-(broadcast-before-persist). Expected: removes ~150 ms + one D1 round-trip from
-first-token latency.
+### O2 — first-token fast flush (up to −150 ms) — IMPLEMENTED
+The viewer delivery buffer now flushes the first delta of each run immediately
+(armed on `RUN_STARTED`) instead of waiting out the 150 ms timer, then resumes
+per-delta batching (`session-viewer-event-delivery-buffer.ts`). Unit test covers
+first-delta-immediate + subsequent-delta-batched. Removes up to ~150 ms from
+first-token latency without increasing write amplification for the rest of the
+stream.
 
-### O4 — opencode models.dev fetch (up to −10 s, opencode cold start)
+### O4 — opencode models.dev fetch (up to −10 s, opencode cold start) — projected
 OpenCode blocks startup on a `models.dev/api.json` fetch (10 s timeout) when the
 cache/embedded snapshot is cold. Fix: pre-seed `models.json` in the image or set
 `OPENCODE_DISABLE_MODELS_FETCH=1`. Expected: removes up to ~10 s from opencode

--- a/pkgs/ag-ui-session/src/ag-ui-session-events.ts
+++ b/pkgs/ag-ui-session/src/ag-ui-session-events.ts
@@ -192,3 +192,7 @@ export function isAgUiSessionRunTerminalEvent(event: AgUiSessionEvent): boolean 
     isTerminalSessionRunStatus(event.value.run.status)
   );
 }
+
+export function isAgUiSessionRunStartedEvent(event: AgUiSessionEvent): boolean {
+  return event.type === EventType.RUN_STARTED;
+}


### PR DESCRIPTION
## What

Threads a first-class **`permissionPolicy`** (`full_access` | `supervised`) from the agent profile into the driver boot payload, and bumps the driver submodule to the matching implementation (langgenius/mosoo-agent-driver#29).

- `DriverProfileConfig` + `DriverExecutionSpec` carry `permissionPolicy`; `createAgentRuntimeProfile` defaults it to `full_access` (the sandbox is the isolation boundary).
- The raw `permissionMode` / `approval_policy` / `sandbox_mode` keys stay **blocked** in `SECURITY_BOUNDARY_SETTING_KEYS` — this sanctioned enum sits above that boundary rather than relaxing it. Per product decision, full-access is the fixed default (no per-agent opt-in UI for now); `supervised` remains the latent interactive-broker path.
- `docs/perf-permission-work/00-findings.md`: the reference-map research (15 repos, P0/P1/P2 — all 7 P0 default to full-access), latest SDK/protocol facts, current-state evidence, and the optimization backlog.

## Why it matters (measured)

The old default routed every tool call to the control plane and auto-rejected when non-interactive. On a tool-writing task that meant **0% success at ~16.5s**; full-access is **100% at ~11.6s**. The driver PR additionally cuts first-token TTFT **−30% p50 / −41% p95** via CLI prewarm. See langgenius/mosoo-agent-driver#29.

## Notes

- Depends on langgenius/mosoo-agent-driver#29 (submodule pinned to its head; re-pin to the merge commit after it lands).
- Control-plane TTFT optimizations (inline queue dispatch, first-token flush) are tracked separately — they need a staging CF deploy for faithful measurement (local Queues/DO ≠ CF).
