### PR TITLE
feat(runtime): reclaim recovery decision logic + unify retryable semantics

### DIFF
--- a/apps/api/src/modules/runtime/application/session-runs/stale-run-reconciliation.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/stale-run-reconciliation.service.ts
@@ -7,6 +7,7 @@ import { alias } from "drizzle-orm/sqlite-core";
 import { getAppDatabase } from "../../../../platform/db/drizzle";
 import { currentTimestampMs } from "../../../../time";
 import { RUNTIME_SOCKET_TIMEOUT_MS } from "../../domain/runtime-config";
+import { classifyReclaim } from "../../domain/session-run-reclaim-recovery";
 import { setSessionRunStatus } from "../../infrastructure/session-runs/session-run-store.repository";
 
 export interface ActiveRunDriverRow {
@@ -34,19 +35,18 @@ function latestRuntimeObservationMs(row: ActiveRunDriverRow): number {
 }
 
 function staleRunError(row: ActiveRunDriverRow): RunError {
-  const driverFailed = row.driver_status === "failed" || row.driver_status === "stopped";
-  const message =
-    row.driver_error_message ??
-    (driverFailed
-      ? "Runtime driver stopped before the run completed."
-      : "Runtime session became inactive before the run completed.");
+  // A run found stale by the sweep is the same physical event class as a
+  // synchronous socket-close reclaim, so classify it identically (retryable) —
+  // this removes the retryable:true (sync) vs retryable:false (sweep)
+  // contradiction for the same eviction.
+  const driverTerminalStatus =
+    row.driver_status === "failed" || row.driver_status === "stopped" ? row.driver_status : null;
 
-  return {
-    code: driverFailed ? "runtime.driver_stopped" : "runtime.inactive",
-    details: {},
-    message,
-    retryable: false,
-  };
+  return classifyReclaim({
+    driverErrorMessage: row.driver_error_message,
+    driverTerminalStatus,
+    reclaimReason: "heartbeat_stale",
+  });
 }
 
 function shouldFailActiveRunAsStale(row: ActiveRunDriverRow, nowMs: number): boolean {

--- a/apps/api/src/modules/runtime/domain/session-run-reclaim-recovery.ts
+++ b/apps/api/src/modules/runtime/domain/session-run-reclaim-recovery.ts
@@ -1,0 +1,146 @@
+import type { RunError, SessionRunStatus, SessionRunTrigger } from "@mosoo/contracts/session-run";
+
+import { isTerminalSessionRunStatus } from "./session-run-status";
+
+/**
+ * Involuntary-reclaim recovery decision logic.
+ *
+ * When the driver socket dies mid-run (sandbox reclaimed/evicted) the run is
+ * failed, but today nothing recovers it and the two failure paths disagree on
+ * whether the failure is retryable:
+ *   - the synchronous path (terminal-run-release) reports retryable: true
+ *   - the maintenance sweep (stale-run-reconciliation) reports retryable: false
+ * for the SAME physical event. This module is the single source of truth for
+ * both, so an eviction is classified identically everywhere, and it exposes the
+ * pure decision — requeue vs fail-clean — that the recovery wiring consumes.
+ *
+ * Design references (see docs/perf-permission-work/00-findings.md): OMA's
+ * `recoverInterruptedState`, agentos/opencomputer's "reclaim = lazy resume,
+ * fail cleanly, never loop", OpenHands's durable-pause-then-resume.
+ */
+
+/** Terminal status of the driver instance behind the reclaimed run. */
+export type DriverTerminalStatus = "failed" | "stopped";
+
+/**
+ * How the reclaim was observed:
+ *   - `socket_closed`   the driver WebSocket closed (synchronous finalize)
+ *   - `heartbeat_stale` the maintenance sweep found the run past its socket
+ *                       timeout with no live driver
+ */
+export type ReclaimReason = "socket_closed" | "heartbeat_stale";
+
+export interface ClassifyReclaimInput {
+  readonly reclaimReason: ReclaimReason;
+  /** Driver terminal status, or null when the driver never became terminal (inactive). */
+  readonly driverTerminalStatus: DriverTerminalStatus | null;
+  readonly driverInstanceId?: string;
+  /** Driver-reported error message, if any (used by the sweep path). */
+  readonly driverErrorMessage?: string | null;
+}
+
+/**
+ * The single reclaim classifier. An involuntary reclaim is ALWAYS retryable
+ * (a fresh run is safe) — `retryable` describes "is a retry safe?", decoupled
+ * from "did we auto-requeue?" (that is `decideReclaimRecovery`'s job). Distinct
+ * error codes are preserved because they carry real context, but the flag no
+ * longer contradicts across paths.
+ */
+export function classifyReclaim(input: ClassifyReclaimInput): RunError {
+  const details = input.driverInstanceId ? { driverInstanceId: input.driverInstanceId } : {};
+
+  if (input.reclaimReason === "socket_closed") {
+    if (input.driverTerminalStatus === "stopped") {
+      return {
+        code: "runtime.turn_interrupted",
+        details,
+        message:
+          "This turn was interrupted. Your workspace and context have been preserved — please resend your last request.",
+        retryable: true,
+      };
+    }
+
+    return {
+      code: "runtime.driver_failed",
+      details,
+      message: "Runtime driver failed before the run completed.",
+      retryable: true,
+    };
+  }
+
+  const driverFailed =
+    input.driverTerminalStatus === "failed" || input.driverTerminalStatus === "stopped";
+  const message =
+    input.driverErrorMessage ??
+    (driverFailed
+      ? "Runtime driver stopped before the run completed."
+      : "Runtime session became inactive before the run completed.");
+
+  return {
+    code: driverFailed ? "runtime.driver_stopped" : "runtime.inactive",
+    details,
+    message,
+    retryable: true,
+  };
+}
+
+/**
+ * How many times a reclaimed run may be auto-resumed before we stop and leave
+ * it to the user. Bounded to one so a run that is reclaimed, auto-resumed, then
+ * reclaimed again fails cleanly instead of looping.
+ */
+export const DEFAULT_MAX_RECLAIM_ATTEMPTS = 1;
+
+export interface ReclaimSignal {
+  /** Status of the run at reclaim time. */
+  readonly runStatus: SessionRunStatus;
+  readonly driverTerminalStatus: DriverTerminalStatus;
+  readonly reclaimReason: ReclaimReason;
+  /**
+   * Trigger of the reclaimed run — used as the attempt-budget proxy so no
+   * schema change is required: a run already triggered by `resume` has spent
+   * its one auto-resume.
+   */
+  readonly priorTrigger: SessionRunTrigger;
+  readonly maxReclaimAttempts?: number;
+}
+
+export type ReclaimRecoveryAction =
+  /** Run already terminal — nothing to recover. */
+  | { readonly kind: "noop" }
+  /** Auto-resume: create a fresh run and re-dispatch. */
+  | { readonly kind: "requeue"; readonly resumeTrigger: "resume"; readonly runError: RunError }
+  /** Attempt budget exhausted — fail cleanly (still retryable so the user may resend). */
+  | { readonly kind: "fail_clean"; readonly runError: RunError };
+
+/**
+ * Number of auto-resume attempts already spent on this run, inferred from its
+ * trigger. A `resume`-triggered run is itself the product of one auto-resume.
+ */
+function reclaimAttemptsSpent(priorTrigger: SessionRunTrigger): number {
+  return priorTrigger === "resume" ? 1 : 0;
+}
+
+/**
+ * Pure recovery decision. Terminal runs are a no-op; an active run within the
+ * attempt budget is requeued; an active run that has exhausted the budget fails
+ * cleanly (never loops).
+ */
+export function decideReclaimRecovery(signal: ReclaimSignal): ReclaimRecoveryAction {
+  const runError = classifyReclaim({
+    driverTerminalStatus: signal.driverTerminalStatus,
+    reclaimReason: signal.reclaimReason,
+  });
+
+  if (isTerminalSessionRunStatus(signal.runStatus)) {
+    return { kind: "noop" };
+  }
+
+  const maxAttempts = signal.maxReclaimAttempts ?? DEFAULT_MAX_RECLAIM_ATTEMPTS;
+
+  if (reclaimAttemptsSpent(signal.priorTrigger) < maxAttempts) {
+    return { kind: "requeue", resumeTrigger: "resume", runError };
+  }
+
+  return { kind: "fail_clean", runError };
+}

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/terminal-run-release.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/terminal-run-release.ts
@@ -3,11 +3,12 @@ import { sessionRunsTable } from "@mosoo/db";
 import type { DriverInstanceId, SessionId, SessionRunId } from "@mosoo/id";
 import { and, eq, inArray } from "drizzle-orm";
 
-import { logWarn } from "../../../../platform/cloudflare/logger";
+import { logInfo, logWarn } from "../../../../platform/cloudflare/logger";
 import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
 import { getAppDatabase } from "../../../../platform/db/drizzle";
 import { appendSessionRuntimeEvents } from "../../../sessions/application/session-event-write.service";
 import { createFailedSessionRunRuntimeEvent } from "../../application/session-runs/session-run-view-events.service";
+import { classifyReclaim, decideReclaimRecovery } from "../../domain/session-run-reclaim-recovery";
 import { isTerminalSessionRunStatus } from "../../domain/session-run-status";
 import { recordRuntimeRunLeaseReleasedOutcome } from "../runtime-subject-lifecycle/runtime-run-lease-store";
 import { failAcceptedRuntimeCommandsForTerminalDriver } from "../session-runs/runtime-command-store.repository";
@@ -25,32 +26,6 @@ interface LinkedSessionRunStatusRow {
 export interface TerminalDriverInstanceSessionRunReleaseResult {
   readonly link: RuntimeSessionLink | null;
   readonly released: boolean;
-}
-
-function createFinalizedDriverRunError(input: {
-  readonly driverInstanceId: DriverInstanceId;
-  readonly status: "failed" | "stopped";
-}): RunError {
-  if (input.status === "stopped") {
-    return {
-      code: "runtime.turn_interrupted",
-      details: {
-        driverInstanceId: input.driverInstanceId,
-      },
-      message:
-        "This turn was interrupted. Your workspace and context have been preserved — please resend your last request.",
-      retryable: true,
-    };
-  }
-
-  return {
-    code: "runtime.driver_failed",
-    details: {
-      driverInstanceId: input.driverInstanceId,
-    },
-    message: "Runtime driver failed before the run completed.",
-    retryable: true,
-  };
 }
 
 function toFinalizedDriverRunTransitionRun(
@@ -156,7 +131,11 @@ export async function repairFinalizedTerminalDriverRunState(
   }
 
   if (!isTerminalSessionRunStatus(link.sessionRunStatus)) {
-    const runError = createFinalizedDriverRunError(input);
+    const runError = classifyReclaim({
+      driverInstanceId: input.driverInstanceId,
+      driverTerminalStatus: input.status,
+      reclaimReason: "socket_closed",
+    });
     const outcome = await setSessionRunStatus(bindings.DB, {
       error: runError,
       runId: link.sessionRunId,
@@ -170,6 +149,25 @@ export async function repairFinalizedTerminalDriverRunState(
         driverInstanceId: input.driverInstanceId,
         run,
         runError,
+        sessionId: link.sessionId,
+      });
+
+      // Decide recovery for the reclaimed run. v1 records the decision so it is
+      // observable and unit-testable; executing the auto-requeue (a fresh
+      // `resume` run + re-dispatch) is a follow-up because this DO finalize
+      // context lacks the viewer + requestUrl that enqueueSessionRunDispatchCommand
+      // needs to rebuild the sandbox's action-token callback URLs.
+      const recovery = decideReclaimRecovery({
+        driverTerminalStatus: input.status,
+        priorTrigger: run.trigger,
+        reclaimReason: "socket_closed",
+        runStatus: link.sessionRunStatus,
+      });
+      logInfo("runtime.reclaim.recovery.decided", {
+        action: recovery.kind,
+        driverInstanceId: input.driverInstanceId,
+        priorTrigger: run.trigger,
+        runId: run.id,
         sessionId: link.sessionId,
       });
     }

--- a/apps/api/tests/session-run-reclaim-recovery.test.ts
+++ b/apps/api/tests/session-run-reclaim-recovery.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+
+import type { SessionRunStatus, SessionRunTrigger } from "@mosoo/contracts/session-run";
+
+import {
+  classifyReclaim,
+  decideReclaimRecovery,
+} from "../src/modules/runtime/domain/session-run-reclaim-recovery";
+import type {
+  DriverTerminalStatus,
+  ReclaimReason,
+} from "../src/modules/runtime/domain/session-run-reclaim-recovery";
+
+describe("classifyReclaim", () => {
+  const cases: Array<{
+    reclaimReason: ReclaimReason;
+    driverTerminalStatus: DriverTerminalStatus | null;
+    code: string;
+  }> = [
+    {
+      code: "runtime.turn_interrupted",
+      driverTerminalStatus: "stopped",
+      reclaimReason: "socket_closed",
+    },
+    {
+      code: "runtime.driver_failed",
+      driverTerminalStatus: "failed",
+      reclaimReason: "socket_closed",
+    },
+    { code: "runtime.driver_failed", driverTerminalStatus: null, reclaimReason: "socket_closed" },
+    {
+      code: "runtime.driver_stopped",
+      driverTerminalStatus: "failed",
+      reclaimReason: "heartbeat_stale",
+    },
+    {
+      code: "runtime.driver_stopped",
+      driverTerminalStatus: "stopped",
+      reclaimReason: "heartbeat_stale",
+    },
+    { code: "runtime.inactive", driverTerminalStatus: null, reclaimReason: "heartbeat_stale" },
+  ];
+
+  for (const { reclaimReason, driverTerminalStatus, code } of cases) {
+    test(`${reclaimReason} + ${driverTerminalStatus ?? "inactive"} -> ${code}`, () => {
+      const error = classifyReclaim({ driverTerminalStatus, reclaimReason });
+      expect(error.code).toBe(code);
+      // The whole point: every reclaim path is retryable, so the sync path and
+      // the sweep path no longer disagree for the same physical eviction.
+      expect(error.retryable).toBe(true);
+    });
+  }
+
+  test("prefers the driver-reported error message when present", () => {
+    const error = classifyReclaim({
+      driverErrorMessage: "container OOM-killed",
+      driverTerminalStatus: "failed",
+      reclaimReason: "heartbeat_stale",
+    });
+    expect(error.message).toBe("container OOM-killed");
+  });
+
+  test("carries the driver instance id into details", () => {
+    const error = classifyReclaim({
+      driverInstanceId: "driver-1",
+      driverTerminalStatus: "stopped",
+      reclaimReason: "socket_closed",
+    });
+    expect(error.details).toEqual({ driverInstanceId: "driver-1" });
+  });
+});
+
+describe("decideReclaimRecovery", () => {
+  const TERMINAL: SessionRunStatus[] = ["completed", "failed", "cancelled", "expired"];
+  const ACTIVE: SessionRunStatus[] = ["queued", "booting", "running", "waiting_input"];
+  const FIRST_ATTEMPT_TRIGGERS: SessionRunTrigger[] = ["user_prompt", "retry", "system"];
+
+  for (const runStatus of TERMINAL) {
+    test(`terminal run (${runStatus}) -> noop`, () => {
+      const action = decideReclaimRecovery({
+        driverTerminalStatus: "stopped",
+        priorTrigger: "user_prompt",
+        reclaimReason: "socket_closed",
+        runStatus,
+      });
+      expect(action.kind).toBe("noop");
+    });
+  }
+
+  for (const runStatus of ACTIVE) {
+    for (const priorTrigger of FIRST_ATTEMPT_TRIGGERS) {
+      test(`active run (${runStatus}), first reclaim (trigger=${priorTrigger}) -> requeue`, () => {
+        const action = decideReclaimRecovery({
+          driverTerminalStatus: "stopped",
+          priorTrigger,
+          reclaimReason: "socket_closed",
+          runStatus,
+        });
+        expect(action.kind).toBe("requeue");
+        if (action.kind === "requeue") {
+          expect(action.resumeTrigger).toBe("resume");
+          expect(action.runError.retryable).toBe(true);
+        }
+      });
+    }
+
+    test(`active run (${runStatus}) already resumed once -> fail_clean (no loop)`, () => {
+      const action = decideReclaimRecovery({
+        driverTerminalStatus: "failed",
+        priorTrigger: "resume",
+        reclaimReason: "heartbeat_stale",
+        runStatus,
+      });
+      expect(action.kind).toBe("fail_clean");
+      if (action.kind === "fail_clean") {
+        // fail_clean is still retryable so the user may resend — it only means
+        // we stop AUTO-resuming.
+        expect(action.runError.retryable).toBe(true);
+      }
+    });
+  }
+
+  test("respects a custom attempt budget", () => {
+    const twoAttempts = decideReclaimRecovery({
+      driverTerminalStatus: "stopped",
+      maxReclaimAttempts: 2,
+      priorTrigger: "resume",
+      reclaimReason: "socket_closed",
+      runStatus: "running",
+    });
+    // resume run has spent 1 attempt; budget of 2 still allows another requeue.
+    expect(twoAttempts.kind).toBe("requeue");
+  });
+});


### PR DESCRIPTION
## Problem

Involuntary reclaim (the driver socket dies mid-run because the sandbox was evicted) is a **dead-end** today, and the audit's three claims all check out at source level:

1. **Nothing recovers the run.** `terminal-run-release.ts` fails the run, surfaces a "please resend your last request" message, releases the lease — and stops. The `retryable: true` flag is **decorative**: every consumer of `.retryable` is a presenter/event; nothing reads it to trigger a retry.
2. **The two failure paths contradict.** The synchronous finalize reports `retryable: true`; the maintenance sweep (`stale-run-reconciliation.ts`) reports `retryable: false` — for the *same* physical eviction. Which one fires is a pure race.
3. **Zero recovery tests.** Existing tests assert the dead-end (run → `failed`, lease released); none assert requeue/resume (none existed to assert).

## This PR (v1 — the decision brain + the contradiction fix)

New pure module **`session-run-reclaim-recovery.ts`**:
- **`classifyReclaim`** — the single source of truth for the reclaim `RunError`, now called by **both** `terminal-run-release` and `stale-run-reconciliation`, so an eviction is classified identically (`retryable: true`) everywhere. Distinct error codes are preserved (they carry real context); only the contradicting flag is unified.
- **`decideReclaimRecovery`** — the pure recovery decision: `noop` (terminal run) | `requeue` (active run within budget) | `fail_clean` (budget exhausted, never loops). The **attempt budget uses the existing `trigger` field — no D1 migration**: a `user_prompt` run gets exactly one auto-`resume`; a `resume` run reclaimed again fails cleanly.

`terminal-run-release` now **decides + records** the recovery action (`runtime.reclaim.recovery.decided`), so the decision is observable in production and exercised by tests.

## Decision table

| run status | prior trigger (attempt budget) | action |
|---|---|---|
| terminal | any | `noop` |
| active | not `resume` (attempt 0) | **`requeue`** (as `resume`) |
| active | `resume` (attempt 1) | `fail_clean` |

Design references (see `docs/perf-permission-work/00-findings.md`): OMA's `recoverInterruptedState` (same CF Workers+DO substrate), agentos/opencomputer's "reclaim = lazy resume, fail cleanly, never loop", OpenHands's durable-pause-then-resume.

## Explicitly deferred (why this is v1)

**Executing the auto-requeue** (creating the fresh `resume` run + re-dispatch) is a follow-up: the DO finalize context lacks the `viewer` + `requestUrl` that `enqueueSessionRunDispatchCommand` needs to rebuild the sandbox's action-token callback URLs. That needs either storing resume-context on the run row or a synthesized system-dispatch path — a separate, riskier change. This PR lands the tested decision logic + the contradiction fix so the wiring has a verified foundation. Also deferred: hot warm-resume on the same sandbox (impossible on hard eviction), auto-requeue from the batch sweep (thundering-herd), full attachment-fidelity resume, a dedicated attempt-counter column, and the end-to-end DO test (needs the CF harness).

## Tests

API suite **801 pass**. New table-driven `session-run-reclaim-recovery.test.ts` fills the zero-reclaim-tests gap (classifier + decision, all branches). Existing finalization/reconciliation tests unchanged and green.
