### PR TITLE
fix(runtime): prod availability + latency hotfix (prewarm OOM, hydration, prod logs)

### DIFF
--- a/apps/api/src/modules/environments/application/environment-config.ts
+++ b/apps/api/src/modules/environments/application/environment-config.ts
@@ -316,22 +316,28 @@ export async function decryptEnvironmentVariables(
     envVars: StoredEnvironmentVariable[];
   },
 ): Promise<Record<string, string>> {
-  const record: Record<string, string> = {};
+  // Decrypt all secrets concurrently. Each readEnvironmentVariableSecret does
+  // D1 reads + an AES-GCM unwrap; run serially this was N sequential D1
+  // round-trips per hydration (the dominant cause of the multi-second
+  // context_hydration tail on prod), and hydration runs on every run —
+  // including cache hits, since the volatile fields are re-resolved.
+  const entries = await Promise.all(
+    input.envVars.map(async (envVar) => {
+      if (envVar.secretId === null) {
+        throw new Error(`Environment variable ${envVar.key} is pending and has no secret value.`);
+      }
 
-  for (const envVar of input.envVars) {
-    if (envVar.secretId === null) {
-      throw new Error(`Environment variable ${envVar.key} is pending and has no secret value.`);
-    }
+      const value = await readEnvironmentVariableSecret(bindings, {
+        environmentId: input.environmentId,
+        envVarKey: envVar.key,
+        purpose: "runtime_snapshot_hydration",
+        secretId: envVar.secretId,
+      });
+      return [envVar.key, value] as const;
+    }),
+  );
 
-    record[envVar.key] = await readEnvironmentVariableSecret(bindings, {
-      environmentId: input.environmentId,
-      envVarKey: envVar.key,
-      purpose: "runtime_snapshot_hydration",
-      secretId: envVar.secretId,
-    });
-  }
-
-  return record;
+  return Object.fromEntries(entries);
 }
 
 export function serializeConfig(input: EnvironmentMutableConfig): {

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -109,6 +109,16 @@ dead_letter_queue = "channel-final-delivery-dlq"
 name = "mosoo-api-prod"
 workers_dev = false
 
+# Named envs do not inherit the top-level [observability] block, so prod had no
+# queryable Workers Logs (only traces). Enable logs so structured log lines
+# (e.g. "closed before ready", driver/ready/socket events) are retrievable.
+[env.prod.observability]
+enabled = true
+
+[env.prod.observability.logs]
+enabled = true
+head_sampling_rate = 1
+
 [env.prod.observability.traces]
 enabled = true
 head_sampling_rate = 0.1
@@ -190,7 +200,10 @@ queue = "channel-final-delivery"
 [[env.prod.queues.consumers]]
 queue = "api-command"
 max_batch_size = 10
-max_batch_timeout = 5
+# Interactive runs dispatch inline (executionContext.waitUntil); this queue is
+# the durable fallback for executionContext-less paths (replay, DO-originated).
+# Drop the batch window 5s -> 2s so those paths don't eat a 5s dispatch delay.
+max_batch_timeout = 2
 max_retries = 5
 dead_letter_queue = "api-command-dlq"
 


### PR DESCRIPTION
## Prod availability + latency hotfix (deployed to WH-2099, version 5e03cb79)

Follows a live prod test that showed recurring RUN FAILED "Driver instance closed before ready", reclaim "please resend", variable `context_hydration` (up to 5.8s), and slow message-to-screen.

### Availability — the crash
Bumps `apps/driver` to the prewarm fix (langgenius/mosoo-agent-driver#30): the Claude CLI prewarm spawned a **second CLI process** during `backend.start()` that **OOM-killed the 1 GiB "basic" container** before ready → "closed before ready". Prewarm is now default-off + non-blocking.

### Latency
- **Parallelize `decryptEnvironmentVariables`** (`Promise.all`). It was a sequential `for` loop — N secrets = N serialized D1 round-trips (+ AES-GCM) **on every run** (hydration re-resolves secrets even on cache hits). This was the dominant cause of the multi-second `context_hydration` tail.
- **api-command fallback queue window 5s → 2s.** Interactive runs already dispatch inline (`executionContext.waitUntil`, present in prod); this only helps `executionContext`-less paths (replay, DO-originated) that otherwise eat the full batch window.

### Observability
- **Enable prod Workers Logs** (was traces-only, so `console`/structured logs weren't queryable). Now log lines like "closed before ready" / driver / socket are retrievable via the observability API for the next incident.

### How this was diagnosed
CF GraphQL Analytics showed a DriverInstance-DO `scriptThrewException` + `clientDisconnected` spike at exactly the test hour; a 4-way code+log investigation localized the throw and confirmed the prewarm-OOM mechanism.

API suite: 806 pass. Deployed + verified (api/web HTTP 200).

### Follow-up (not in this PR)
The **slow message-to-screen** is a separate backend issue: each token is gated behind a D1 write before the viewer sees it (`rpc-event-ingestion-controller` awaits `persistProjectedRuntimeDriverEvents` before `viewerEventDelivery.enqueue`). Fix = deliver best-effort deltas optimistically and persist in `waitUntil`, keeping only terminal events commit-gated. Higher risk; landing separately with care.
