### PR TITLE
fix(web): make document titles route-aware

### DIFF
--- a/apps/web/src/app/document-title.tsx
+++ b/apps/web/src/app/document-title.tsx
@@ -1,0 +1,103 @@
+import { useEffect } from "react";
+import { matchPath, useLocation } from "react-router-dom";
+
+import { useAppSession } from "./session-provider";
+
+const PRODUCT_NAME = "Mosoo";
+
+type DocumentTitleScope = "app" | "global" | "org";
+
+interface DocumentTitleRule {
+  path: string;
+  scope: DocumentTitleScope;
+  title: string;
+}
+
+const DOCUMENT_TITLE_RULES: DocumentTitleRule[] = [
+  { path: "/integrations/mcp/oauth-complete", scope: "app", title: "MCP authorization" },
+  { path: "/app-settings/general", scope: "app", title: "App settings" },
+  { path: "/app-settings/usage", scope: "app", title: "Usage" },
+  { path: "/app-settings", scope: "app", title: "App settings" },
+  { path: "/settings/access-tokens", scope: "global", title: "Access tokens" },
+  { path: "/settings/profile", scope: "global", title: "Profile" },
+  { path: "/settings", scope: "global", title: "Settings" },
+  { path: "/environment/:environmentId", scope: "app", title: "Environments" },
+  { path: "/environment", scope: "app", title: "Environments" },
+  { path: "/integrations/skills", scope: "app", title: "Skills" },
+  { path: "/integrations/mcp", scope: "app", title: "MCP servers" },
+  { path: "/providers", scope: "app", title: "Providers" },
+  { path: "/threads/:threadId", scope: "app", title: "Thread" },
+  { path: "/threads", scope: "app", title: "Threads" },
+  { path: "/agent/:agentId", scope: "app", title: "Agent" },
+  { path: "/agent", scope: "app", title: "Agents" },
+  { path: "/files", scope: "app", title: "Files" },
+  { path: "/cli-auth", scope: "global", title: "CLI authorization" },
+  { path: "/v0-deploy-preview", scope: "global", title: "Deployment preview" },
+  { path: "/onboarding", scope: "global", title: "Onboarding" },
+  { path: "/login", scope: "global", title: "Sign in" },
+  { path: "/org/settings", scope: "org", title: "Org settings" },
+  { path: "/apps", scope: "org", title: "Apps" },
+  { path: "/", scope: "app", title: "Overview" },
+];
+
+function findDocumentTitleRule(pathname: string): DocumentTitleRule | null {
+  return (
+    DOCUMENT_TITLE_RULES.find((rule) => matchPath({ end: true, path: rule.path }, pathname)) ?? null
+  );
+}
+
+function cleanTitlePart(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized === undefined || normalized.length === 0 ? null : normalized;
+}
+
+function joinDocumentTitle(parts: Array<string | null | undefined>): string {
+  const normalizedParts = parts.flatMap((part) => {
+    const cleaned = cleanTitlePart(part);
+    return cleaned === null ? [] : [cleaned];
+  });
+
+  if (normalizedParts.length === 0) {
+    return PRODUCT_NAME;
+  }
+
+  return [...normalizedParts, PRODUCT_NAME].join(" | ");
+}
+
+export function resolveDocumentTitle(input: {
+  activeAppName: string | null;
+  activeOrganizationName: string | null;
+  pathname: string;
+}): string {
+  const rule = findDocumentTitleRule(input.pathname);
+
+  if (rule === null) {
+    return joinDocumentTitle([input.activeAppName]);
+  }
+
+  if (rule.scope === "app") {
+    return joinDocumentTitle([rule.title, input.activeAppName]);
+  }
+
+  if (rule.scope === "org") {
+    return joinDocumentTitle([rule.title, input.activeOrganizationName]);
+  }
+
+  return joinDocumentTitle([rule.title]);
+}
+
+export function DocumentTitle() {
+  const location = useLocation();
+  const { activeApp, activeOrganization } = useAppSession();
+  const title = resolveDocumentTitle({
+    activeAppName: activeApp?.name ?? null,
+    activeOrganizationName: activeOrganization?.name ?? null,
+    pathname: location.pathname,
+  });
+
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
+
+  return null;
+}

--- a/apps/web/src/app/router.tsx
+++ b/apps/web/src/app/router.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 
+import { DocumentTitle } from "./document-title";
 import { AppLoading } from "./route-guards";
 import { AppRoutes } from "./route-registry";
 
@@ -7,8 +8,11 @@ const appLoadingFallback = <AppLoading />;
 
 export function App() {
   return (
-    <Suspense fallback={appLoadingFallback}>
-      <AppRoutes />
-    </Suspense>
+    <>
+      <DocumentTitle />
+      <Suspense fallback={appLoadingFallback}>
+        <AppRoutes />
+      </Suspense>
+    </>
   );
 }

--- a/apps/web/tests/document-title.test.ts
+++ b/apps/web/tests/document-title.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveDocumentTitle } from "../src/app/document-title";
+
+describe("document title", () => {
+  test("uses the current App name for App-layer pages", () => {
+    expect(
+      resolveDocumentTitle({
+        activeAppName: "Default App",
+        activeOrganizationName: "Mosoo Org",
+        pathname: "/integrations/skills",
+      }),
+    ).toBe("Skills | Default App | Mosoo");
+  });
+
+  test("uses the current Organization name for Org-layer pages", () => {
+    expect(
+      resolveDocumentTitle({
+        activeAppName: "Default App",
+        activeOrganizationName: "Mosoo Org",
+        pathname: "/apps",
+      }),
+    ).toBe("Apps | Mosoo Org | Mosoo");
+  });
+
+  test("keeps unauthenticated routes scoped to the product", () => {
+    expect(
+      resolveDocumentTitle({
+        activeAppName: null,
+        activeOrganizationName: null,
+        pathname: "/login",
+      }),
+    ).toBe("Sign in | Mosoo");
+  });
+
+  test("falls back to the active App before the product name for unknown App paths", () => {
+    expect(
+      resolveDocumentTitle({
+        activeAppName: "Default App",
+        activeOrganizationName: null,
+        pathname: "/unexpected",
+      }),
+    ).toBe("Default App | Mosoo");
+  });
+});


### PR DESCRIPTION
## Summary

- Add a small document title manager that updates `document.title` from the current route.
- Include active App and Organization names in App-layer and Org-layer page titles.
- Keep the static HTML title as the no-JavaScript fallback only.

## Why

Browser tabs were always titled `Mosoo`, which made it hard to distinguish pages and Apps. Titles now reflect the active surface, for example `Skills | Default App | Mosoo`.

## Validation

- `just fmt-check-path apps/web/src/app/document-title.tsx`
- `just fmt-check-path apps/web/tests/document-title.test.ts`
- `just test-file apps/web/tests/document-title.test.ts`
- `just tc-package @mosoo/web`
- `just test-package @mosoo/web`
- Playwright browser check: `/login` -> `Sign in | Mosoo`, `/integrations/skills` -> `Skills | Default App | Mosoo`, `/deployments` redirects to `/` -> `Overview | Default App | Mosoo`.
