### PR TITLE
fix(web): remove preview cost filter

### DIFF
--- a/apps/web/src/routes/agent/components/cost-tab.tsx
+++ b/apps/web/src/routes/agent/components/cost-tab.tsx
@@ -5,32 +5,26 @@ import type { ReactElement, ReactNode } from "react";
 import { Link } from "react-router-dom";
 
 import { fetchAgentCost } from "@/domains/cost/api/cost-client";
-import type { CostRunPurpose } from "@/domains/cost/api/cost-client";
 import { exportAttributionCostCsv } from "@/routes/cost/cost-csv";
 import {
   COST_RANGES,
+  RUN_PURPOSE_FILTERS,
   cacheHitRate,
   formatCompactNumber,
   formatCurrency,
   formatPlainPercent,
   rangeToInput,
+  runPurposeToQuery,
   tokensTotal,
 } from "@/routes/cost/cost-model";
-import type { CostRange } from "@/routes/cost/cost-model";
+import type { CostRange, CostRunPurpose } from "@/routes/cost/cost-model";
 import { toAgentId, toAppId } from "@/routes/typed-id";
 import { cn } from "@/shared/lib/class-names";
-
-const RUN_PURPOSES: { label: string; value: CostRunPurpose | "all" }[] = [
-  { label: "All", value: "all" },
-  { label: "Production", value: "production" },
-  { label: "Debug", value: "debug" },
-  { label: "Preview", value: "preview" },
-];
 
 export function AgentCostTab({ agentId, appId }: { agentId: string; appId: string }): ReactElement {
   const [range, setRange] = useState<CostRange>("30d");
   const [purpose, setPurpose] = useState<CostRunPurpose | "all">("all");
-  const runPurposes = purpose === "all" ? [] : [purpose];
+  const runPurposes = runPurposeToQuery(purpose);
   const { data: card, isLoading } = useQuery({
     queryFn: async () =>
       fetchAgentCost({
@@ -93,7 +87,7 @@ export function AgentCostTab({ agentId, appId }: { agentId: string; appId: strin
         </div>
 
         <div className="flex flex-wrap gap-2">
-          {RUN_PURPOSES.map((item) => (
+          {RUN_PURPOSE_FILTERS.map((item) => (
             <button
               key={item.value}
               type="button"
@@ -211,7 +205,7 @@ export function AgentCostTab({ agentId, appId }: { agentId: string; appId: strin
 
         <div className="border-border bg-card text-muted-foreground flex items-center gap-2 rounded-lg border px-4 py-3 text-xs">
           <BarChart3 className="size-3.5" />
-          Agent cost includes production, debug, and preview run purposes.
+          Agent cost separates production usage from debug usage.
         </div>
       </div>
     </div>

--- a/apps/web/tests/app-settings-boundary.test.ts
+++ b/apps/web/tests/app-settings-boundary.test.ts
@@ -66,6 +66,15 @@ describe("App settings boundary", () => {
     expect(routeRegistry).not.toContain("OrganizationGeneralTab");
   });
 
+  test("keeps Agent Cost run-purpose filters aligned with App Usage", () => {
+    const agentCostTab = readSource("../src/routes/agent/components/cost-tab.tsx");
+
+    expect(agentCostTab).toContain("RUN_PURPOSE_FILTERS.map");
+    expect(agentCostTab).toContain("runPurposeToQuery(purpose)");
+    expect(agentCostTab).not.toContain('label: "Preview"');
+    expect(agentCostTab).not.toContain("preview run purposes");
+  });
+
   test("uses Agent API Endpoint wording for API tokens and API reference help", () => {
     const accessTokens = readSource("../src/routes/settings/access-tokens-tab.tsx");
     const helpDocs = readSource("../src/shared/config/help-docs.ts");


### PR DESCRIPTION
## Summary

- Removed the standalone `Preview` run-purpose filter from the Agent Cost tab.
- Reused the App Usage run-purpose filter/query mapping so `Debug` still includes backend preview usage.
- Added a boundary test to keep the Agent Cost filter aligned with App Usage.

## Why

- Closes YEF-785.
- The App Usage route already hides `Preview` as a separate public filter, but the Agent Cost tab still exposed it.

## Verification

- Commands:
  - `bun test apps/web/tests/app-settings-boundary.test.ts`
  - `bun test apps/web/tests`
  - `bun run --filter @mosoo/web tc`
  - `bun run fmt:check:path apps/web/src/routes/agent/components/cost-tab.tsx apps/web/tests/app-settings-boundary.test.ts`
  - `bun run --filter @mosoo/web lint`
  - `bun run commit:check`
- Manual steps:
  - Reviewed the attached issue screenshot and confirmed the highlighted `Preview` filter was on the Agent Cost tab.
- Not run:
  - Full repository `bun run check`; this change is scoped to the web Cost tab, and the web tests/type-check/lint passed.

## Impact

- User/API/contract changes:
  - Agent Cost UI now exposes `All`, `Production`, and `Debug` run-purpose filters, matching App Usage.
  - Selecting `Debug` continues querying both backend `debug` and `preview` purposes.
- Generated files / GraphQL / DB / lockfile:
  - N/A
- Env or config changes:
  - N/A
- Risk and rollback:
  - Low; rollback restores the prior separate `Preview` filter.

## Review

- Closest review areas:
  - `apps/web/src/routes/agent/components/cost-tab.tsx`
  - `apps/web/src/routes/cost/cost-model.ts`
- Known trade-offs:
  - N/A

