### PR TITLE
fix(runtime): make run dispatch acquire exclusive

### DIFF
--- a/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
@@ -22,6 +22,7 @@ import type { HydratedSessionRunContext } from "../session-definition/session-ex
 import { cleanupDispatchedDriver } from "./dispatch-run-cleanup.service";
 import { persistSessionRunSkills } from "./session-run-skill-snapshot.repository";
 import {
+  acquireSessionRunDispatch,
   SessionRunNoLongerActiveError,
   ensureSessionRunIsActive,
   getSessionRunState,
@@ -125,10 +126,7 @@ export async function dispatchSessionRun(
 
     await persistSessionRunSkills(bindings.DB, input.sessionRunId, input.resolvedSkills);
 
-    const bootingRun = await updateSessionRunStatusIfActive(bindings.DB, {
-      runId: input.sessionRunId,
-      status: "booting",
-    });
+    const bootingRun = await acquireSessionRunDispatch(bindings.DB, input.sessionRunId);
 
     if (!bootingRun) {
       const state = await getSessionRunState(bindings.DB, input.sessionRunId);

--- a/apps/api/src/modules/runtime/application/session-runs/session-run-state.repository.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/session-run-state.repository.ts
@@ -88,3 +88,28 @@ export async function updateSessionRunStatusIfActive(
     }
   }
 }
+
+export async function acquireSessionRunDispatch(
+  database: D1Database,
+  runId: SessionRunId,
+): Promise<SessionRunSummary | null> {
+  const outcome = await setSessionRunStatus(database, {
+    runId,
+    source: "api",
+    status: "booting",
+  });
+
+  switch (outcome.kind) {
+    case "applied": {
+      return outcome.run;
+    }
+    case "duplicate":
+    case "rejected":
+    case "stale": {
+      return null;
+    }
+    case "repair_needed": {
+      throw new Error("Session lifecycle projection needs repair.");
+    }
+  }
+}

--- a/apps/api/tests/session-run-state.test.ts
+++ b/apps/api/tests/session-run-state.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { updateSessionRunStatusIfActive } from "../src/modules/runtime/application/session-runs/session-run-state.repository";
+import {
+  acquireSessionRunDispatch,
+  updateSessionRunStatusIfActive,
+} from "../src/modules/runtime/application/session-runs/session-run-state.repository";
 import {
   createPublicHttpContractDatabase,
   insertNonOwnerSession,
@@ -61,6 +64,25 @@ describe("session run state", () => {
 
     expect(run?.id).toBe("run-active-transition");
     expect(run?.status).toBe("booting");
+
+    const stored = await database
+      .prepare("SELECT status FROM session_run WHERE id = ?")
+      .bind("run-active-transition")
+      .first<{ status: string }>();
+    expect(stored).toEqual({ status: "booting" });
+  });
+
+  test("only the first dispatch acquire can continue a run", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertNonOwnerSession(database);
+    await insertQueuedSessionRun(database);
+
+    const first = await acquireSessionRunDispatch(database, "run-active-transition");
+    const second = await acquireSessionRunDispatch(database, "run-active-transition");
+
+    expect(first?.id).toBe("run-active-transition");
+    expect(first?.status).toBe("booting");
+    expect(second).toBeNull();
 
     const stored = await database
       .prepare("SELECT status FROM session_run WHERE id = ?")


### PR DESCRIPTION
## Summary

- Add `acquireSessionRunDispatch` so only the first applied `queued -> booting` transition can continue into driver dispatch.
- Make duplicate, stale, or rejected dispatch acquisitions skip instead of continuing through prepare/driver dispatch.
- Add focused API coverage that a second dispatch acquire for the same run returns `null` and leaves the run in `booting`.

## User Journeys

Before this PR, a normal user journey could fail when a user sent the first message into a cold or newly-created Agent session, especially in Preview/UI paths that have an `ExecutionContext` available. The API would enqueue the durable `session_run_dispatch` fallback and also start inline dispatch through `waitUntil`. If inline dispatch moved the run from `queued` to `booting`, and the queue consumer or a queue retry arrived while the run was still `booting`, the generic status helper treated that duplicate `booting` transition as success. Both paths could then prepare and dispatch the same run, producing duplicate `run.dispatched` events and interrupting the driver before the first turn settled.

After this PR, the user journey that should no longer fail from this root cause is: user sends one message once through Preview, UI Threads, or the public/API-backed session path; inline dispatch, durable queue fallback, or a queue retry may race, but only the first applied `queued -> booting` acquire can continue to driver dispatch. Later duplicate attempts skip instead of sending the same run to the driver again. This means a single submitted user message should no longer be lost because the same run was double-dispatched.

This does not claim every first-turn failure is impossible. Independent provider errors, missing credentials, driver binary/provisioning failures, container crashes, network issues, or a separate driver-ready bug can still fail a run; they should now show up as their own failure mode instead of being masked by duplicate dispatch.

## Evidence

Production D1 read-only investigation for `2026-07-02 14:50-18:50 UTC` found run `01KWHXVGP8AZ8S2NN9QE09MGK0` with duplicate `run.dispatched` events at `17:26:06` and `17:26:09 UTC`. The durable `session_run_dispatch` command had `attempt_count=2`, and the driver instance stopped before processing commands (`command_seq_cursor=0`, `heartbeat_count=0`).

Local GraphQL smoke on run `01KWKJAV26GKVF4WSENJJ0JQ42` after the fix showed dispatch count `1`, driver `input.start` count `1`, queue fallback skipped once, run completed, and assistant message persisted.

## Verification

- `bun test apps/api/tests/session-run-state.test.ts`
- `bun run fmt:check:path -- apps/api/src/modules/runtime/application/session-runs/session-run-state.repository.ts apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts apps/api/tests/session-run-state.test.ts`
- `just tc-package @mosoo/api`
- `git diff --check`
- `just commit-check`

GraphQL codegen not run: no GraphQL schema, document, or scalar changes.
DB regen/migrate not run: no DB schema, migration, or baseline changes.
