### PR TITLE
refactor(web): migrate UI primitives from Radix to Base UI

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,7 +35,6 @@
     "lucide-react": "^1.16.0",
     "motion": "^12.40.0",
     "qrcode.react": "^4.2.0",
-    "radix-ui": "^1.4.3",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-markdown": "^10.1.0",

--- a/apps/web/src/domains/environment/components/environment-form-controls.tsx
+++ b/apps/web/src/domains/environment/components/environment-form-controls.tsx
@@ -47,7 +47,7 @@ export function NetworkPolicySelect({
       <SelectButton disabled={disabled} label={NETWORK_POLICY_LABELS[value]} />
       <DropdownMenuContent
         align="start"
-        className="environment-scroll-area max-h-64 w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto"
+        className="environment-scroll-area max-h-64 w-[var(--anchor-width)] overflow-y-auto"
       >
         {(["limited", "full"] as const).map((policy) => (
           <DropdownMenuItem
@@ -80,7 +80,7 @@ export function PackageManagerSelect({
       <SelectButton disabled={disabled} label={value ? PACKAGE_MANAGER_LABELS[value] : "Manager"} />
       <DropdownMenuContent
         align="start"
-        className="environment-scroll-area max-h-56 w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto"
+        className="environment-scroll-area max-h-56 w-[var(--anchor-width)] overflow-y-auto"
       >
         {PACKAGE_MANAGERS.map((manager) => (
           <DropdownMenuItem

--- a/apps/web/src/features/help/help-docs-dialog.tsx
+++ b/apps/web/src/features/help/help-docs-dialog.tsx
@@ -72,10 +72,7 @@ function HelpDocsDialogContent({ onOpenChange }: { onOpenChange: (open: boolean)
     <DialogContent
       showCloseButton={false}
       className="gap-0 overflow-hidden p-0 sm:max-w-xl"
-      onOpenAutoFocus={(event) => {
-        event.preventDefault();
-        inputRef.current?.focus();
-      }}
+      initialFocus={inputRef}
     >
       <DialogHeader className="sr-only">
         <DialogTitle>Help &amp; docs</DialogTitle>

--- a/apps/web/src/routes/agent/components/editor/mcp-bindings-field.tsx
+++ b/apps/web/src/routes/agent/components/editor/mcp-bindings-field.tsx
@@ -73,7 +73,7 @@ function McpAddDropdown({
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="start"
-        className="max-h-[320px] w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto"
+        className="max-h-[320px] w-[var(--anchor-width)] overflow-y-auto"
       >
         {nothingLeft ? (
           <div className="text-muted-foreground p-3 text-[12px]">

--- a/apps/web/src/routes/agent/components/editor/model-picker-field.tsx
+++ b/apps/web/src/routes/agent/components/editor/model-picker-field.tsx
@@ -77,7 +77,7 @@ export function ModelPickerField({
             <ChevronDown className="text-muted-foreground size-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-[var(--radix-dropdown-menu-trigger-width)]">
+        <DropdownMenuContent align="start" className="w-[var(--anchor-width)]">
           <DropdownMenuLabel>Available models</DropdownMenuLabel>
           <DropdownMenuSeparator />
           <div className="max-h-[280px] overflow-y-auto">

--- a/apps/web/src/routes/agent/components/editor/skills-field.tsx
+++ b/apps/web/src/routes/agent/components/editor/skills-field.tsx
@@ -118,7 +118,7 @@ export function AgentSkillsField({
             </DropdownMenuTrigger>
             <DropdownMenuContent
               align="start"
-              className="max-h-[320px] w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto"
+              className="max-h-[320px] w-[var(--anchor-width)] overflow-y-auto"
             >
               {dropdownContent}
               <DropdownMenuSeparator />

--- a/apps/web/src/routes/threads/compose/new-dialog.tsx
+++ b/apps/web/src/routes/threads/compose/new-dialog.tsx
@@ -233,7 +233,7 @@ function AgentAssignField({
               <ChevronDown className="text-fg-3 size-4 shrink-0" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent className="max-h-[320px] w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto">
+          <DropdownMenuContent className="max-h-[320px] w-[var(--anchor-width)] overflow-y-auto">
             {agents.map((agent) => {
               const isSelected = agent.id === selectedAgentId;
 

--- a/apps/web/src/shared/ui/avatar-fallback.tsx
+++ b/apps/web/src/shared/ui/avatar-fallback.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Avatar as AvatarPrimitive } from "radix-ui";
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar";
 import type { ComponentProps, ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";

--- a/apps/web/src/shared/ui/avatar-image.tsx
+++ b/apps/web/src/shared/ui/avatar-image.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Avatar as AvatarPrimitive } from "radix-ui";
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar";
 import type { ComponentProps, ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";

--- a/apps/web/src/shared/ui/avatar-root.tsx
+++ b/apps/web/src/shared/ui/avatar-root.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Avatar as AvatarPrimitive } from "radix-ui";
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar";
 import type { ComponentProps, ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";

--- a/apps/web/src/shared/ui/badge.tsx
+++ b/apps/web/src/shared/ui/badge.tsx
@@ -1,6 +1,7 @@
+import { useRender } from "@base-ui/react/use-render";
 import { cva } from "class-variance-authority";
 import type { VariantProps } from "class-variance-authority";
-import { Slot } from "radix-ui";
+import { isValidElement } from "react";
 import type { ComponentProps, ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";
@@ -32,25 +33,39 @@ const badgeVariants = cva(
   },
 );
 
+type BadgeProps = ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & {
+    /** Radix-style escape hatch: render the single child element as the badge. */
+    asChild?: boolean;
+    /** Base UI native composition: element (or render fn) to render instead of a span. */
+    render?: useRender.RenderProp;
+  };
+
 function Badge({
   className,
   variant = "default",
   asChild = false,
+  render,
+  children,
   ...props
-}: ComponentProps<"span"> &
-  VariantProps<typeof badgeVariants> & {
-    asChild?: boolean;
-  }): ReactElement {
-  const Comp = asChild ? Slot.Root : "span";
+}: BadgeProps): ReactElement {
+  // `asChild` uses the single child element AS the rendered element (its own
+  // children come with it); the native `render` prop instead keeps `children`
+  // as separate content Base UI merges into the render target.
+  const asChildElement =
+    asChild && isValidElement(children) ? (children as ReactElement) : undefined;
 
-  return (
-    <Comp
-      data-slot="badge"
-      data-variant={variant}
-      className={cn(badgeVariants({ variant }), className)}
-      {...props}
-    />
-  );
+  return useRender({
+    render: render ?? asChildElement,
+    defaultTagName: "span",
+    props: {
+      "data-slot": "badge",
+      "data-variant": variant,
+      className: cn(badgeVariants({ variant }), className),
+      ...props,
+      ...(asChildElement ? {} : { children }),
+    },
+  });
 }
 
 export { Badge };

--- a/apps/web/src/shared/ui/button.tsx
+++ b/apps/web/src/shared/ui/button.tsx
@@ -1,6 +1,7 @@
+import { useRender } from "@base-ui/react/use-render";
 import { cva } from "class-variance-authority";
 import type { VariantProps } from "class-variance-authority";
-import { Slot } from "radix-ui";
+import { isValidElement } from "react";
 import type { ComponentProps, ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";
@@ -39,27 +40,42 @@ const buttonVariants = cva(
   },
 );
 
+type ButtonProps = ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    /** Radix-style escape hatch: render the single child element as the button. */
+    asChild?: boolean;
+    /** Base UI native composition: element (or render fn) to render instead of a button. */
+    render?: useRender.RenderProp;
+  };
+
 function Button({
   className,
   variant = "default",
   size = "default",
   asChild = false,
+  render,
+  children,
   ...props
-}: ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
-  }): ReactElement {
-  const Comp = asChild ? Slot.Root : "button";
+}: ButtonProps): ReactElement {
+  // `asChild` uses the single child element AS the rendered element (its own
+  // children come with it), so they must not also be passed as a prop. The
+  // native `render` prop is different: `children` is separate content Base UI
+  // merges into the render target, so it must be forwarded.
+  const asChildElement =
+    asChild && isValidElement(children) ? (children as ReactElement) : undefined;
 
-  return (
-    <Comp
-      data-slot="button"
-      data-variant={variant}
-      data-size={size}
-      className={cn(buttonVariants({ className, size, variant }))}
-      {...props}
-    />
-  );
+  return useRender({
+    render: render ?? asChildElement,
+    defaultTagName: "button",
+    props: {
+      "data-slot": "button",
+      "data-variant": variant,
+      "data-size": size,
+      className: cn(buttonVariants({ className, size, variant })),
+      ...props,
+      ...(asChildElement ? {} : { children }),
+    },
+  });
 }
 
 export { Button };

--- a/apps/web/src/shared/ui/dialog.tsx
+++ b/apps/web/src/shared/ui/dialog.tsx
@@ -1,27 +1,23 @@
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { XIcon } from "lucide-react";
-import { Dialog as DialogPrimitive } from "radix-ui";
 import type { ComponentProps, ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";
 import { Button } from "@/shared/ui/button";
 
 function Dialog({ ...props }: ComponentProps<typeof DialogPrimitive.Root>): ReactElement {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
-}
-
-function DialogPortal({ ...props }: ComponentProps<typeof DialogPrimitive.Portal>): ReactElement {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+  return <DialogPrimitive.Root {...props} />;
 }
 
 function DialogOverlay({
   className,
   ...props
-}: ComponentProps<typeof DialogPrimitive.Overlay>): ReactElement {
+}: ComponentProps<typeof DialogPrimitive.Backdrop>): ReactElement {
   return (
-    <DialogPrimitive.Overlay
+    <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 bg-black/50 data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:animate-in data-[open]:fade-in-0",
         className,
       )}
       {...props}
@@ -34,16 +30,16 @@ function DialogContent({
   children,
   showCloseButton = true,
   ...props
-}: ComponentProps<typeof DialogPrimitive.Content> & {
+}: ComponentProps<typeof DialogPrimitive.Popup> & {
   showCloseButton?: boolean;
 }): ReactElement {
   return (
-    <DialogPortal data-slot="dialog-portal">
+    <DialogPrimitive.Portal>
       <DialogOverlay />
-      <DialogPrimitive.Content
+      <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[closed]:animate-out data-[closed]:fade-out-0 data-[closed]:zoom-out-95 data-[open]:animate-in data-[open]:fade-in-0 data-[open]:zoom-in-95 sm:max-w-lg",
           className,
         )}
         {...props}
@@ -52,14 +48,14 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[open]:bg-accent data-[open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>
         )}
-      </DialogPrimitive.Content>
-    </DialogPortal>
+      </DialogPrimitive.Popup>
+    </DialogPrimitive.Portal>
   );
 }
 
@@ -89,9 +85,7 @@ function DialogFooter({
     >
       {children}
       {showCloseButton && (
-        <DialogPrimitive.Close asChild>
-          <Button variant="outline">Close</Button>
-        </DialogPrimitive.Close>
+        <DialogPrimitive.Close render={<Button variant="outline">Close</Button>} />
       )}
     </div>
   );

--- a/apps/web/src/shared/ui/dropdown-menu.tsx
+++ b/apps/web/src/shared/ui/dropdown-menu.tsx
@@ -1,43 +1,59 @@
-import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
+import { Menu as MenuPrimitive } from "@base-ui/react/menu";
 import type { ComponentProps, ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";
+import { asChildRender } from "@/shared/ui/render-prop";
 
-function DropdownMenu({
-  ...props
-}: ComponentProps<typeof DropdownMenuPrimitive.Root>): ReactElement {
-  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+function DropdownMenu({ ...props }: ComponentProps<typeof MenuPrimitive.Root>): ReactElement {
+  return <MenuPrimitive.Root {...props} />;
 }
 
 function DropdownMenuTrigger({
+  asChild,
+  children,
   ...props
-}: ComponentProps<typeof DropdownMenuPrimitive.Trigger>): ReactElement {
-  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
-}
-
-function DropdownMenuPortal({
-  ...props
-}: ComponentProps<typeof DropdownMenuPrimitive.Portal>): ReactElement {
-  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
+}: ComponentProps<typeof MenuPrimitive.Trigger> & { asChild?: boolean }): ReactElement {
+  const render = asChildRender(asChild, children);
+  return (
+    <MenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...(render ? { render } : { children })}
+      {...props}
+    />
+  );
 }
 
 function DropdownMenuContent({
   className,
   sideOffset = 4,
+  side,
+  align,
+  alignOffset,
   ...props
-}: ComponentProps<typeof DropdownMenuPrimitive.Content>): ReactElement {
+}: ComponentProps<typeof MenuPrimitive.Popup> &
+  Pick<
+    ComponentProps<typeof MenuPrimitive.Positioner>,
+    "side" | "align" | "sideOffset" | "alignOffset"
+  >): ReactElement {
   return (
-    <DropdownMenuPortal>
-      <DropdownMenuPrimitive.Content
-        data-slot="dropdown-menu-content"
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        className="z-50"
+        side={side}
+        align={align}
         sideOffset={sideOffset}
-        className={cn(
-          "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-          className,
-        )}
-        {...props}
-      />
-    </DropdownMenuPortal>
+        alignOffset={alignOffset}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn(
+            "min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+            className,
+          )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
   );
 }
 
@@ -45,20 +61,41 @@ function DropdownMenuItem({
   className,
   inset,
   variant = "default",
+  asChild,
+  onSelect,
+  children,
   ...props
-}: ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+}: ComponentProps<typeof MenuPrimitive.Item> & {
   inset?: boolean;
   variant?: "default" | "destructive";
+  asChild?: boolean;
+  /** Radix compatibility: fires on click / keyboard select and closes the menu. */
+  onSelect?: (event: Event) => void;
 }): ReactElement {
+  const render = asChildRender(asChild, children);
   return (
-    <DropdownMenuPrimitive.Item
+    <MenuPrimitive.Item
       data-slot="dropdown-menu-item"
       data-inset={inset}
       data-variant={variant}
+      onClick={
+        onSelect
+          ? (event) => {
+              onSelect(event.nativeEvent);
+              // Preserve Radix's contract: calling preventDefault() inside onSelect
+              // keeps the menu open. Base UI closes on click unless its own handler
+              // is cancelled via preventBaseUIHandler().
+              if (event.nativeEvent.defaultPrevented) {
+                event.preventBaseUIHandler();
+              }
+            }
+          : undefined
+      }
       className={cn(
-        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive",
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:text-destructive data-[variant=destructive]:data-[highlighted]:bg-destructive/10 data-[variant=destructive]:data-[highlighted]:text-destructive",
         className,
       )}
+      {...(render ? { render } : { children })}
       {...props}
     />
   );
@@ -67,9 +104,9 @@ function DropdownMenuItem({
 function DropdownMenuSeparator({
   className,
   ...props
-}: ComponentProps<typeof DropdownMenuPrimitive.Separator>): ReactElement {
+}: ComponentProps<typeof MenuPrimitive.Separator>): ReactElement {
   return (
-    <DropdownMenuPrimitive.Separator
+    <MenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
       className={cn("-mx-1 my-1 h-px bg-muted", className)}
       {...props}
@@ -81,9 +118,9 @@ function DropdownMenuLabel({
   className,
   inset,
   ...props
-}: ComponentProps<typeof DropdownMenuPrimitive.Label> & { inset?: boolean }): ReactElement {
+}: ComponentProps<"div"> & { inset?: boolean }): ReactElement {
   return (
-    <DropdownMenuPrimitive.Label
+    <div
       data-slot="dropdown-menu-label"
       data-inset={inset}
       className={cn(

--- a/apps/web/src/shared/ui/label.tsx
+++ b/apps/web/src/shared/ui/label.tsx
@@ -1,11 +1,13 @@
-import { Label as LabelPrimitive } from "radix-ui";
 import type { ComponentProps, ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";
 
-function Label({ className, ...props }: ComponentProps<typeof LabelPrimitive.Root>): ReactElement {
+function Label({ className, ...props }: ComponentProps<"label">): ReactElement {
   return (
-    <LabelPrimitive.Root
+    // Design-system primitive: the control association is supplied by callers via
+    // `htmlFor` (or by wrapping a control), so it can't be asserted at this site.
+    // eslint-disable-next-line jsx-a11y/label-has-associated-control
+    <label
       data-slot="label"
       className={cn(
         "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",

--- a/apps/web/src/shared/ui/render-prop.ts
+++ b/apps/web/src/shared/ui/render-prop.ts
@@ -1,0 +1,16 @@
+import { isValidElement } from "react";
+import type { ReactElement, ReactNode } from "react";
+
+/**
+ * Base UI replaces Radix's `asChild` + child-merge convention with a `render`
+ * prop. This bridges the two so our wrapper primitives can keep accepting
+ * `asChild` without every call site changing: when `asChild` is set and the
+ * single child is an element, it becomes Base UI's `render` target and the
+ * wrapper's own props (data-slot, className, handlers) are merged onto it.
+ */
+export function asChildRender(
+  asChild: boolean | undefined,
+  children: ReactNode,
+): ReactElement | undefined {
+  return asChild && isValidElement(children) ? children : undefined;
+}

--- a/apps/web/src/shared/ui/scroll-area.tsx
+++ b/apps/web/src/shared/ui/scroll-area.tsx
@@ -1,4 +1,4 @@
-import { ScrollArea as ScrollAreaPrimitive } from "radix-ui";
+import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
 import type { ComponentProps, ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";
@@ -18,7 +18,9 @@ function ScrollArea({
         data-slot="scroll-area-viewport"
         className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
       >
-        {children}
+        <ScrollAreaPrimitive.Content data-slot="scroll-area-content">
+          {children}
+        </ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />
       <ScrollAreaPrimitive.Corner />
@@ -30,9 +32,9 @@ function ScrollBar({
   className,
   orientation = "vertical",
   ...props
-}: ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>): ReactElement {
+}: ComponentProps<typeof ScrollAreaPrimitive.Scrollbar>): ReactElement {
   return (
-    <ScrollAreaPrimitive.ScrollAreaScrollbar
+    <ScrollAreaPrimitive.Scrollbar
       data-slot="scroll-area-scrollbar"
       orientation={orientation}
       className={cn(
@@ -43,11 +45,11 @@ function ScrollBar({
       )}
       {...props}
     >
-      <ScrollAreaPrimitive.ScrollAreaThumb
+      <ScrollAreaPrimitive.Thumb
         data-slot="scroll-area-thumb"
         className="bg-border relative flex-1 rounded-full"
       />
-    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+    </ScrollAreaPrimitive.Scrollbar>
   );
 }
 

--- a/apps/web/src/shared/ui/separator.tsx
+++ b/apps/web/src/shared/ui/separator.tsx
@@ -1,4 +1,4 @@
-import { Separator as SeparatorPrimitive } from "radix-ui";
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
 import type { ComponentProps, ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";
@@ -6,13 +6,11 @@ import { cn } from "@/shared/lib/class-names";
 function Separator({
   className,
   orientation = "horizontal",
-  decorative = true,
   ...props
-}: ComponentProps<typeof SeparatorPrimitive.Root>): ReactElement {
+}: ComponentProps<typeof SeparatorPrimitive>): ReactElement {
   return (
-    <SeparatorPrimitive.Root
+    <SeparatorPrimitive
       data-slot="separator"
-      decorative={decorative}
       orientation={orientation}
       className={cn(
         "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",

--- a/apps/web/src/shared/ui/sheet.tsx
+++ b/apps/web/src/shared/ui/sheet.tsx
@@ -1,26 +1,22 @@
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { XIcon } from "lucide-react";
-import { Dialog as DialogPrimitive } from "radix-ui";
 import type { ComponentProps, ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";
 
 function Sheet({ ...props }: ComponentProps<typeof DialogPrimitive.Root>): ReactElement {
-  return <DialogPrimitive.Root data-slot="sheet" {...props} />;
-}
-
-function SheetPortal({ ...props }: ComponentProps<typeof DialogPrimitive.Portal>): ReactElement {
-  return <DialogPrimitive.Portal data-slot="sheet-portal" {...props} />;
+  return <DialogPrimitive.Root {...props} />;
 }
 
 function SheetOverlay({
   className,
   ...props
-}: ComponentProps<typeof DialogPrimitive.Overlay>): ReactElement {
+}: ComponentProps<typeof DialogPrimitive.Backdrop>): ReactElement {
   return (
-    <DialogPrimitive.Overlay
+    <DialogPrimitive.Backdrop
       data-slot="sheet-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 bg-black/50 data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:animate-in data-[open]:fade-in-0",
         className,
       )}
       {...props}
@@ -32,14 +28,14 @@ function SheetContent({
   className,
   children,
   ...props
-}: ComponentProps<typeof DialogPrimitive.Content>): ReactElement {
+}: ComponentProps<typeof DialogPrimitive.Popup>): ReactElement {
   return (
-    <SheetPortal>
+    <DialogPrimitive.Portal>
       <SheetOverlay />
-      <DialogPrimitive.Content
+      <DialogPrimitive.Popup
         data-slot="sheet-content"
         className={cn(
-          "fixed inset-y-0 right-0 z-50 flex w-[420px] max-w-[calc(100vw-2rem)] flex-col bg-background shadow-xl duration-300 outline-none data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=open]:animate-in data-[state=open]:slide-in-from-right",
+          "fixed inset-y-0 right-0 z-50 flex w-[420px] max-w-[calc(100vw-2rem)] flex-col bg-background shadow-xl duration-300 outline-none data-[closed]:animate-out data-[closed]:slide-out-to-right data-[open]:animate-in data-[open]:slide-in-from-right",
           className,
         )}
         {...props}
@@ -52,8 +48,8 @@ function SheetContent({
           <XIcon />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>
-      </DialogPrimitive.Content>
-    </SheetPortal>
+      </DialogPrimitive.Popup>
+    </DialogPrimitive.Portal>
   );
 }
 

--- a/apps/web/src/shared/ui/switch.tsx
+++ b/apps/web/src/shared/ui/switch.tsx
@@ -1,4 +1,4 @@
-import { Switch as SwitchPrimitive } from "radix-ui";
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch";
 import type { ComponentProps, ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";
@@ -11,7 +11,7 @@ function Switch({
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-green-600 data-[state=unchecked]:bg-input",
+        "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:bg-green-600 data-[unchecked]:bg-input",
         className,
       )}
       {...props}
@@ -19,7 +19,7 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+          "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[checked]:translate-x-4 data-[unchecked]:translate-x-0",
         )}
       />
     </SwitchPrimitive.Root>

--- a/apps/web/src/shared/ui/tooltip.tsx
+++ b/apps/web/src/shared/ui/tooltip.tsx
@@ -1,53 +1,71 @@
 "use client";
 
-import { Tooltip as TooltipPrimitive } from "radix-ui";
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 import type { ComponentProps, ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";
+import { asChildRender } from "@/shared/ui/render-prop";
 
 function TooltipProvider({
   delayDuration = 0,
   ...props
-}: ComponentProps<typeof TooltipPrimitive.Provider>): ReactElement {
+}: Omit<ComponentProps<typeof TooltipPrimitive.Provider>, "delay"> & {
+  delayDuration?: number;
+}): ReactElement {
+  return <TooltipPrimitive.Provider delay={delayDuration} {...props} />;
+}
+
+function Tooltip({ ...props }: ComponentProps<typeof TooltipPrimitive.Root>): ReactElement {
+  return <TooltipPrimitive.Root {...props} />;
+}
+
+function TooltipTrigger({
+  asChild,
+  children,
+  ...props
+}: ComponentProps<typeof TooltipPrimitive.Trigger> & { asChild?: boolean }): ReactElement {
+  const render = asChildRender(asChild, children);
   return (
-    <TooltipPrimitive.Provider
-      data-slot="tooltip-provider"
-      delayDuration={delayDuration}
+    <TooltipPrimitive.Trigger
+      data-slot="tooltip-trigger"
+      {...(render ? { render } : { children })}
       {...props}
     />
   );
 }
 
-function Tooltip({ ...props }: ComponentProps<typeof TooltipPrimitive.Root>): ReactElement {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
-}
-
-function TooltipTrigger({
-  ...props
-}: ComponentProps<typeof TooltipPrimitive.Trigger>): ReactElement {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
-}
-
 function TooltipContent({
   className,
   sideOffset = 0,
+  side,
+  align,
   children,
   ...props
-}: ComponentProps<typeof TooltipPrimitive.Content>): ReactElement {
+}: ComponentProps<typeof TooltipPrimitive.Popup> &
+  Pick<
+    ComponentProps<typeof TooltipPrimitive.Positioner>,
+    "side" | "sideOffset" | "align"
+  >): ReactElement {
   return (
     <TooltipPrimitive.Portal>
-      <TooltipPrimitive.Content
-        data-slot="tooltip-content"
+      <TooltipPrimitive.Positioner
+        className="z-50"
         sideOffset={sideOffset}
-        className={cn(
-          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
-          className,
-        )}
-        {...props}
+        side={side}
+        align={align}
       >
-        {children}
-        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
-      </TooltipPrimitive.Content>
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "relative w-fit origin-(--transform-origin) rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background data-[open]:animate-in data-[open]:fade-in-0 data-[open]:zoom-in-95 data-[closed]:animate-out data-[closed]:fade-out-0 data-[closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 rotate-45 rounded-[2px] data-[side=bottom]:top-[-3px] data-[side=left]:right-[-3px] data-[side=right]:left-[-3px] data-[side=top]:bottom-[-3px]" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>
   );
 }

--- a/apps/web/tests/providers-tab-dialog.test.tsx
+++ b/apps/web/tests/providers-tab-dialog.test.tsx
@@ -28,15 +28,18 @@ interface CapturedGraphQLBody {
 function installDom(): void {
   dom = new JSDOM("<!doctype html><html><body></body></html>", {
     url: "http://localhost/providers",
+    pretendToBeVisual: true,
   });
   const { window } = dom;
 
   globalThis.window = window as unknown as Window & typeof globalThis;
   globalThis.document = window.document;
+  globalThis.Element = window.Element;
   globalThis.HTMLElement = window.HTMLElement;
   globalThis.HTMLButtonElement = window.HTMLButtonElement;
   globalThis.HTMLInputElement = window.HTMLInputElement;
   globalThis.Node = window.Node;
+  globalThis.ShadowRoot = window.ShadowRoot;
   globalThis.NodeFilter = window.NodeFilter;
   globalThis.Event = window.Event;
   globalThis.MouseEvent = window.MouseEvent;
@@ -44,6 +47,8 @@ function installDom(): void {
   globalThis.KeyboardEvent = window.KeyboardEvent;
   globalThis.MutationObserver = window.MutationObserver;
   globalThis.getComputedStyle = window.getComputedStyle.bind(window);
+  globalThis.requestAnimationFrame = window.requestAnimationFrame.bind(window);
+  globalThis.cancelAnimationFrame = window.cancelAnimationFrame.bind(window);
   Object.defineProperty(globalThis, "navigator", {
     configurable: true,
     value: window.navigator,
@@ -73,10 +78,12 @@ function uninstallDom(): void {
   dom = null;
   delete globalThis.window;
   delete globalThis.document;
+  delete globalThis.Element;
   delete globalThis.HTMLElement;
   delete globalThis.HTMLButtonElement;
   delete globalThis.HTMLInputElement;
   delete globalThis.Node;
+  delete globalThis.ShadowRoot;
   delete globalThis.NodeFilter;
   delete globalThis.Event;
   delete globalThis.MouseEvent;
@@ -84,6 +91,8 @@ function uninstallDom(): void {
   delete globalThis.KeyboardEvent;
   delete globalThis.MutationObserver;
   delete globalThis.getComputedStyle;
+  delete globalThis.requestAnimationFrame;
+  delete globalThis.cancelAnimationFrame;
   Object.defineProperty(globalThis, "navigator", {
     configurable: true,
     value: undefined,

--- a/bun.lock
+++ b/bun.lock
@@ -101,7 +101,6 @@
         "lucide-react": "^1.16.0",
         "motion": "^12.40.0",
         "qrcode.react": "^4.2.0",
-        "radix-ui": "^1.4.3",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-markdown": "^10.1.0",


### PR DESCRIPTION
## What & why

Migrates the shadcn-style design system in `apps/web` off the unified **`radix-ui`** package onto **Base UI** (`@base-ui/react`, already a dependency at 1.6.0). The wrapper API is **fully preserved** — every `asChild` call site is unchanged; it's bridged to Base UI's `render` / `useRender` internally — so no product/page code moves.

**22 files** + a small `render-prop` bridge. Independent of any in-flight work; touches only the design-system primitives and 6 consumer call sites.

## Primitives migrated (13)
`button` · `badge` · `dialog` · `sheet` · `dropdown-menu` · `tooltip` · `switch` · `separator` · `label` · `scroll-area` · `avatar-{root,image,fallback}`

## Notable API translations (each verified against Base UI 1.6.0 source)
| Radix | Base UI |
|---|---|
| `asChild` | `render` (`useRender` for button/badge; `asChildRender` helper for parts) |
| `Overlay` / `Content` | `Backdrop` / `Popup` (+ `Portal › Positioner › Popup` for menu/tooltip) |
| `data-[state=open\|closed\|checked]` | `data-[open\|closed\|checked]`; `focus:`→`data-[highlighted]:` |
| `--radix-…-trigger-width` / `…-transform-origin` | `--anchor-width` / `--transform-origin` |
| `onSelect` | `onClick` — **Radix's `preventDefault()` keep-open contract preserved** via Base UI's `preventBaseUIHandler()` |
| `delayDuration` / `decorative` / `onOpenAutoFocus` | `delay` / (dropped) / `initialFocus` |

`radix-ui` is dropped as a **direct** dep (still present transitively via `@assistant-ui/react`, so `bun.lock` changes by a single line).

## Adversarial review — findings fixed
A 4-agent review ran against Base UI's actual source. Confirmed animation lifecycle is correct (`useAnimationsFinished` awaits `getAnimations().finished`, so `data-[closed]` exit keyframes play before unmount). Three findings were fixed:
- **[med]** `onSelect`+`preventDefault()` keep-open contract — restored at the wrapper via `preventBaseUIHandler()` (no consumer edits).
- **[med]** tooltip arrow was mis-placed under Base UI's Positioner-driven arrows — now anchored per `data-[side]`.
- **[low]** native `render` prop dropped separate `children` — now forwarded.

## Verification
`typecheck` ✅ · `lint` ✅ · `build` ✅ · **114 tests pass** (incl. `providers-tab-dialog.test.tsx` rendering the migrated Dialog end-to-end; added the DOM globals Base UI's floating-ui needs in jsdom: `Element`, `ShadowRoot`, `requestAnimationFrame`).

## One thing to eyeball
The tooltip arrow's per-side offset (`-3px`) is structurally correct but not visually pixel-verified — worth a quick hover check; trivial to nudge.