### PR TITLE
fix(web): keep skill preview inside add-skill dialog bounds

### DIFF
--- a/apps/web/src/routes/integrations/skills/upload-skill-dialog.tsx
+++ b/apps/web/src/routes/integrations/skills/upload-skill-dialog.tsx
@@ -215,9 +215,9 @@ export function UploadSkillDialog({ onImportUrl, onOpenChange, onUpload, open, r
         ) : null}
 
         {prepared ? (
-          <div className="border-border bg-muted/30 flex flex-col gap-3 rounded-lg border p-4">
-            <div className="flex items-center gap-2 text-sm">
-              <span className="text-muted-foreground font-mono text-xs">
+          <div className="border-border bg-muted/30 flex min-w-0 flex-col gap-3 rounded-lg border p-4">
+            <div className="flex min-w-0 items-center gap-2 text-sm">
+              <span className="text-muted-foreground min-w-0 font-mono text-xs break-all">
                 {prepared.kind === "file" ? prepared.file.name : prepared.url}
               </span>
             </div>


### PR DESCRIPTION
## Summary

- Fix the "Add skill" dialog preview panel overflowing past the dialog's right edge when importing a skill from a long GitHub URL.
- The dialog content is a CSS grid, so the preview panel's `min-width: auto` let the unbreakable URL string force the panel wider than the dialog. Added `min-w-0` down the panel's flex chain and `break-all` on the URL/filename span so the source line wraps inside the panel.

## Why

- Importing a skill via a long URL (e.g. `https://github.com/mattpocock/skills/blob/main/skills/engineering/tdd/SKILL.md`) rendered a translucent panel spilling outside the modal with the URL text clipped.

## Verification

- Commands: `bun run fmt:check:path -- apps/web/src/routes/integrations/skills/upload-skill-dialog.tsx`, `bun run --filter @mosoo/web tc`, `bun run lint` — all pass.
- Manual steps: ran the local dev stack, signed in via the development backdoor, opened Integrations → Skills → Add skill → From URL, previewed the URL above, and confirmed via Playwright that the panel stays inside the dialog (panel right edge 25px inside the dialog content box) with the URL wrapped across two lines.

- Not run: full e2e suite. Before/after screenshots are attached on the tracking issue YEF-796.

## Impact

- User/API/contract changes: visual-only fix in the Add skill dialog; no behavior change.
- Generated files / GraphQL / DB / lockfile: N/A
- Env or config changes: N/A
- Risk and rollback: minimal — Tailwind class-only change; revert the single commit to roll back.

## Review

- Closest review areas: `apps/web/src/routes/integrations/skills/upload-skill-dialog.tsx` preview panel markup.
- Known trade-offs: `break-all` may break the URL mid-token; acceptable for monospace source paths and matches how long file names should wrap in the same slot.
