### PR TITLE
feat(mcp): add edit support for app MCP servers

### DIFF
--- a/apps/api/src/adapters/graphql/graphql-module-specs.ts
+++ b/apps/api/src/adapters/graphql/graphql-module-specs.ts
@@ -97,6 +97,7 @@ export const mcpGraphQLSpec = {
     "revokeMcpCredential(appId: ULID!, serverId: ULID!): McpServerWithCredential!",
     "setMcpServerEnabled(appId: ULID!, serverId: ULID!, enabled: Boolean!): McpServerWithCredential!",
     "startMcpOAuth(input: StartMcpOAuthInput!): StartMcpOAuthPayload!",
+    "updateAppMcpServer(input: UpdateAppMcpServerInput!): McpServerWithCredential!",
   ],
   queryFields: [
     "mcpOAuthFlowStatus(flowId: ULID!): McpOAuthFlowState!",

--- a/apps/api/src/adapters/graphql/schema.generated.graphql
+++ b/apps/api/src/adapters/graphql/schema.generated.graphql
@@ -1288,6 +1288,7 @@ type Mutation {
   unarchiveAgentSession(appId: ULID!, sessionId: ULID!): OperationResult!
   unpublishAgent(agentId: ULID!, appId: ULID!): Agent!
   updateAgentConfig(input: UpdateAgentConfigInput!): Agent!
+  updateAppMcpServer(input: UpdateAppMcpServerInput!): McpServerWithCredential!
   updateEnvironment(input: UpdateEnvironmentInput!): EnvironmentDetail!
   updateProfile(input: UpdateAccountProfileInput!): Account!
   updateVendorCredential(input: UpdateVendorCredentialInput!): VendorCredential!
@@ -1833,6 +1834,15 @@ input UpdateAgentConfigInput {
   providerOptions: JsonObject!
   runtimeId: String!
   skillIds: [ULID!]!
+}
+
+input UpdateAppMcpServerInput {
+  appId: ULID!
+  description: String
+  iconUrl: String
+  name: String!
+  serverId: ULID!
+  url: String!
 }
 
 input UpdateEnvironmentInput {

--- a/apps/api/src/adapters/graphql/schema/mcp-schema.ts
+++ b/apps/api/src/adapters/graphql/schema/mcp-schema.ts
@@ -147,6 +147,15 @@ export const mcpSchema = /* GraphQL */ `
     url: String!
   }
 
+  input UpdateAppMcpServerInput {
+    appId: ULID!
+    description: String
+    iconUrl: String
+    name: String!
+    serverId: ULID!
+    url: String!
+  }
+
   input ConnectMcpBearerInput {
     appId: ULID!
     serverId: ULID!

--- a/apps/api/src/modules/mcp/application/mcp-server-management.service.ts
+++ b/apps/api/src/modules/mcp/application/mcp-server-management.service.ts
@@ -1,4 +1,8 @@
-import type { CreateAppMcpServerInput, McpServerWithCredential } from "@mosoo/contracts/mcp";
+import type {
+  CreateAppMcpServerInput,
+  McpServerWithCredential,
+  UpdateAppMcpServerInput,
+} from "@mosoo/contracts/mcp";
 import { agentMcpBindingsTable, mcpServersTable } from "@mosoo/db";
 import type { McpServerId, AppId } from "@mosoo/id";
 import { eq } from "drizzle-orm";
@@ -10,9 +14,11 @@ import { ensureAppOwnership } from "../../apps/application/app.service";
 import type { AuthenticatedViewer } from "../../auth/application/viewer-auth.service";
 import {
   deleteCredentialArtifactsBatch,
+  getAppCredentialRow,
   hasAppCredential,
   listCredentialRowsByServerId,
   resolveRegistryCredential,
+  revokeCredential,
 } from "./mcp-credential.repository";
 import { parseHttpsUrl, toServerWithCredential } from "./mcp-mappers";
 import {
@@ -99,6 +105,48 @@ export async function createAppMcpServer(
 
   const server = await getServerRow(bindings.DB, serverId);
   return toServerWithCredential(server, null, false);
+}
+
+export async function updateAppMcpServer(
+  database: D1Database,
+  viewer: AuthenticatedViewer,
+  input: UpdateAppMcpServerInput,
+): Promise<McpServerWithCredential> {
+  const { server: existing } = await ensureServerManageAccess(
+    database,
+    viewer,
+    input.appId,
+    input.serverId,
+  );
+  const nextUrl = parseHttpsUrl(input.url);
+  // A stored credential is bound to the previous endpoint, so a URL change
+  // revokes it and drops cached OAuth discovery metadata for re-discovery.
+  const urlChanged = nextUrl !== existing.url;
+
+  if (urlChanged) {
+    await revokeCredential(database, await getAppCredentialRow(database, existing.id));
+  }
+
+  await getAppDatabase(database)
+    .update(mcpServersTable)
+    .set({
+      description: input.description ?? null,
+      iconUrl: input.iconUrl ?? null,
+      name: input.name,
+      updatedAt: currentTimestampMs(),
+      url: nextUrl,
+      ...(urlChanged && { oauthMetadataJson: null }),
+    })
+    .where(eq(mcpServersTable.id, input.serverId))
+    .run();
+
+  const server = await getServerRow(database, input.serverId);
+  const [credential, hasCredential] = await Promise.all([
+    resolveRegistryCredential(database, server),
+    hasAppCredential(database, server.id),
+  ]);
+
+  return toServerWithCredential(server, credential, hasCredential);
 }
 
 export async function setMcpServerEnabled(

--- a/apps/api/src/modules/mcp/graphql/mcp-graphql.ts
+++ b/apps/api/src/modules/mcp/graphql/mcp-graphql.ts
@@ -9,6 +9,7 @@ import {
   getMcpRegistry,
   revokeMcpCredential,
   setMcpServerEnabled,
+  updateAppMcpServer,
 } from "../application/mcp-server.service";
 
 interface AppIdArgs {
@@ -40,6 +41,10 @@ interface ConnectMcpBearerArgs {
 
 interface StartMcpOAuthArgs {
   input: Parameters<typeof startMcpOAuth>[3];
+}
+
+interface UpdateAppMcpServerArgs {
+  input: Parameters<typeof updateAppMcpServer>[2];
 }
 
 export const mcpGraphQLModule = {
@@ -82,6 +87,12 @@ export const mcpGraphQLModule = {
       ),
     startMcpOAuth: async (_parent, args: StartMcpOAuthArgs, context) =>
       startMcpOAuth(context.bindings, context.request.url, context.viewer, {
+        ...args.input,
+        appId: readAppId(args.input.appId),
+        serverId: readMcpServerId(args.input.serverId),
+      }),
+    updateAppMcpServer: async (_parent, args: UpdateAppMcpServerArgs, context) =>
+      updateAppMcpServer(context.bindings.DB, context.viewer, {
         ...args.input,
         appId: readAppId(args.input.appId),
         serverId: readMcpServerId(args.input.serverId),

--- a/apps/api/tests/mcp-server-update.test.ts
+++ b/apps/api/tests/mcp-server-update.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AuthenticatedViewer } from "../src/modules/auth/application/viewer-auth.service";
+import { updateAppMcpServer } from "../src/modules/mcp/application/mcp-server-management.service";
+import { SqliteD1Database } from "./helpers/sqlite-d1";
+
+const OWNER_ID = "01J00000000000000000000001";
+const MEMBER_ID = "01J00000000000000000000002";
+const APP_ID = "01J00000000000000000000006";
+const APP_MCP_SERVER_ID = "01J0000000000000000000000A";
+const APP_CREDENTIAL_ID = "01J0000000000000000000000D";
+const APP_SECRET_ID = "01J0000000000000000000000F";
+
+function createMcpServerUpdateDatabase(): SqliteD1Database {
+  const database = new SqliteD1Database({ foreignKeys: false });
+
+  database.execute(`
+    CREATE TABLE organization (
+      id text PRIMARY KEY NOT NULL
+    );
+
+    CREATE TABLE app (
+      id text PRIMARY KEY NOT NULL,
+      organization_id text NOT NULL,
+      owner_account_id text NOT NULL,
+      name text NOT NULL,
+      default_environment_id text,
+      created_at integer NOT NULL,
+      updated_at integer NOT NULL
+    );
+
+    CREATE TABLE account (
+      id text PRIMARY KEY NOT NULL,
+      email text,
+      image_url text,
+      name text
+    );
+
+    CREATE TABLE mcp_server (
+      id text PRIMARY KEY NOT NULL,
+      auth_type text NOT NULL,
+      byo_client_id text,
+      byo_client_secret_secret_id text,
+      created_at integer NOT NULL,
+      credential_scope text NOT NULL,
+      description text,
+      enabled integer NOT NULL,
+      icon_url text,
+      name text NOT NULL,
+      oauth_metadata_json text,
+      owner_account_id text NOT NULL,
+      app_id text NOT NULL,
+      source text NOT NULL,
+      updated_at integer NOT NULL,
+      url text NOT NULL
+    );
+
+    CREATE TABLE mcp_credential (
+      id text PRIMARY KEY NOT NULL,
+      account_id text,
+      agent_id text,
+      auth_type text NOT NULL,
+      created_at integer NOT NULL,
+      expires_at integer,
+      last_refreshed_at integer,
+      oauth_client_id text,
+      oauth_client_secret_secret_id text,
+      app_id text NOT NULL,
+      refresh_secret_id text,
+      scope text NOT NULL,
+      scope_values_json text,
+      secret_id text NOT NULL,
+      server_id text NOT NULL,
+      status text NOT NULL,
+      subject_label text,
+      updated_at integer NOT NULL
+    );
+
+    INSERT INTO organization (id)
+    VALUES ('01J00000000000000000000007');
+
+    INSERT INTO app (
+      id,
+      organization_id,
+      owner_account_id,
+      name,
+      created_at,
+      updated_at
+    )
+    VALUES ('${APP_ID}', '01J00000000000000000000007', '${OWNER_ID}', 'App', 1, 1);
+
+    INSERT INTO account (id, email, image_url, name)
+    VALUES
+      ('${OWNER_ID}', 'owner@example.com', NULL, 'Owner'),
+      ('${MEMBER_ID}', 'member@example.com', NULL, 'Member');
+
+    INSERT INTO mcp_server (
+      id,
+      auth_type,
+      created_at,
+      credential_scope,
+      description,
+      enabled,
+      icon_url,
+      name,
+      oauth_metadata_json,
+      owner_account_id,
+      app_id,
+      source,
+      updated_at,
+      url
+    )
+    VALUES
+      ('${APP_MCP_SERVER_ID}', 'bearer', 1, 'app', 'Old description', 1, 'https://icons.example.com/old.png', 'App MCP', '{"cached":true}', '${OWNER_ID}', '${APP_ID}', 'app', 1, 'https://app.example.com/mcp');
+
+    INSERT INTO mcp_credential (
+      id,
+      account_id,
+      agent_id,
+      auth_type,
+      created_at,
+      expires_at,
+      last_refreshed_at,
+      app_id,
+      scope,
+      scope_values_json,
+      secret_id,
+      server_id,
+      status,
+      subject_label,
+      updated_at
+    )
+    VALUES
+      ('${APP_CREDENTIAL_ID}', NULL, NULL, 'bearer', 1, NULL, NULL, '${APP_ID}', 'app', '[]', '${APP_SECRET_ID}', '${APP_MCP_SERVER_ID}', 'active', 'App token', 1);
+  `);
+
+  return database;
+}
+
+function createViewer(id: string): AuthenticatedViewer {
+  return {
+    email: `${id}@mosoo.ai`,
+    emailVerified: true,
+    id,
+    imageUrl: null,
+    name: id,
+  };
+}
+
+describe("MCP server update", () => {
+  test("updates editable fields and keeps the credential when the URL is unchanged", async () => {
+    const database = createMcpServerUpdateDatabase();
+
+    const server = await updateAppMcpServer(database, createViewer(OWNER_ID), {
+      appId: APP_ID,
+      description: "New description",
+      iconUrl: "https://icons.example.com/new.png",
+      name: "Renamed MCP",
+      serverId: APP_MCP_SERVER_ID,
+      url: "https://app.example.com/mcp",
+    });
+
+    expect(server.name).toBe("Renamed MCP");
+    expect(server.description).toBe("New description");
+    expect(server.iconUrl).toBe("https://icons.example.com/new.png");
+    expect(server.url).toBe("https://app.example.com/mcp");
+    expect(server.credentialStatus).toBe("active");
+    expect(server.hasCredential).toBe(true);
+  });
+
+  test("clears description and icon when omitted", async () => {
+    const database = createMcpServerUpdateDatabase();
+
+    const server = await updateAppMcpServer(database, createViewer(OWNER_ID), {
+      appId: APP_ID,
+      name: "App MCP",
+      serverId: APP_MCP_SERVER_ID,
+      url: "https://app.example.com/mcp",
+    });
+
+    expect(server.description).toBeNull();
+
+    const statement = database
+      .prepare("SELECT icon_url FROM mcp_server WHERE id = ?")
+      .bind(APP_MCP_SERVER_ID);
+    const record = await statement.first<{ icon_url: string | null }>();
+    expect(record?.icon_url).toBeNull();
+  });
+
+  test("revokes the app credential and clears cached OAuth metadata when the URL changes", async () => {
+    const database = createMcpServerUpdateDatabase();
+
+    const server = await updateAppMcpServer(database, createViewer(OWNER_ID), {
+      appId: APP_ID,
+      description: "Old description",
+      iconUrl: "https://icons.example.com/old.png",
+      name: "App MCP",
+      serverId: APP_MCP_SERVER_ID,
+      url: "https://moved.example.com/mcp",
+    });
+
+    expect(server.url).toBe("https://moved.example.com/mcp");
+    expect(server.credentialStatus).toBe("revoked");
+    expect(server.hasCredential).toBe(false);
+
+    const row = database
+      .prepare("SELECT oauth_metadata_json FROM mcp_server WHERE id = ?")
+      .bind(APP_MCP_SERVER_ID);
+    const record = await row.first<{ oauth_metadata_json: string | null }>();
+    expect(record?.oauth_metadata_json).toBeNull();
+  });
+
+  test("rejects a non-https URL", async () => {
+    const database = createMcpServerUpdateDatabase();
+
+    await expect(
+      updateAppMcpServer(database, createViewer(OWNER_ID), {
+        appId: APP_ID,
+        name: "App MCP",
+        serverId: APP_MCP_SERVER_ID,
+        url: "http://app.example.com/mcp",
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("denies non-owner updates", async () => {
+    const database = createMcpServerUpdateDatabase();
+
+    await expect(
+      updateAppMcpServer(database, createViewer(MEMBER_ID), {
+        appId: APP_ID,
+        name: "Hijacked MCP",
+        serverId: APP_MCP_SERVER_ID,
+        url: "https://app.example.com/mcp",
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/web/src/domains/mcp/api/mcp-client.ts
+++ b/apps/web/src/domains/mcp/api/mcp-client.ts
@@ -7,6 +7,7 @@ import type {
   McpServerWithCredential,
   StartMcpOAuthInput,
   StartMcpOAuthPayload,
+  UpdateAppMcpServerInput,
 } from "@mosoo/contracts/mcp";
 
 import type {
@@ -17,6 +18,7 @@ import type {
   RevokeMcpCredentialMutation,
   SetMcpServerEnabledMutation,
   StartMcpOAuthMutation,
+  UpdateAppMcpServerMutation,
 } from "@/gql/graphql";
 import { requestGraphQL } from "@/platform/http/graphql-client";
 import {
@@ -36,6 +38,7 @@ import {
   REVOKE_MCP_CREDENTIAL_MUTATION,
   SET_MCP_SERVER_ENABLED_MUTATION,
   START_MCP_OAUTH_MUTATION,
+  UPDATE_APP_MCP_SERVER_MUTATION,
 } from "./mcp-graphql-documents";
 
 type GraphQLMcpServerWithCredential = McpRegistryQuery["mcpRegistry"]["servers"][number];
@@ -43,7 +46,8 @@ type GraphQLMcpServerMutationResult =
   | CreateAppMcpServerMutation["createAppMcpServer"]
   | ConnectMcpBearerMutation["connectMcpBearer"]
   | RevokeMcpCredentialMutation["revokeMcpCredential"]
-  | SetMcpServerEnabledMutation["setMcpServerEnabled"];
+  | SetMcpServerEnabledMutation["setMcpServerEnabled"]
+  | UpdateAppMcpServerMutation["updateAppMcpServer"];
 
 function toMcpServerWithCredential(
   server: GraphQLMcpServerWithCredential | GraphQLMcpServerMutationResult,
@@ -134,6 +138,14 @@ export async function setMcpServerEnabled(
   });
 
   return toMcpServerWithCredential(payload.setMcpServerEnabled);
+}
+
+export async function updateAppMcpServer(
+  input: UpdateAppMcpServerInput,
+): Promise<McpServerWithCredential> {
+  const payload = await requestGraphQL(UPDATE_APP_MCP_SERVER_MUTATION, { input });
+
+  return toMcpServerWithCredential(payload.updateAppMcpServer);
 }
 
 export async function deleteMcpServer(appId: AppId, serverId: McpServerId): Promise<void> {

--- a/apps/web/src/domains/mcp/api/mcp-graphql-documents.ts
+++ b/apps/web/src/domains/mcp/api/mcp-graphql-documents.ts
@@ -89,6 +89,14 @@ export const SET_MCP_SERVER_ENABLED_MUTATION = graphql(/* GraphQL */ `
   }
 `);
 
+export const UPDATE_APP_MCP_SERVER_MUTATION = graphql(/* GraphQL */ `
+  mutation UpdateAppMcpServer($input: UpdateAppMcpServerInput!) {
+    updateAppMcpServer(input: $input) {
+      ...McpServerFields
+    }
+  }
+`);
+
 export const DELETE_MCP_SERVER_MUTATION = graphql(/* GraphQL */ `
   mutation DeleteMcpServer($appId: ULID!, $serverId: ULID!) {
     deleteMcpServer(appId: $appId, serverId: $serverId) {

--- a/apps/web/src/gql/gql.ts
+++ b/apps/web/src/gql/gql.ts
@@ -81,6 +81,7 @@ type Documents = {
     "\n  mutation ConnectMcpBearer($input: ConnectMcpBearerInput!) {\n    connectMcpBearer(input: $input) {\n      ...McpServerFields\n    }\n  }\n": typeof types.ConnectMcpBearerDocument,
     "\n  mutation RevokeMcpCredential($appId: ULID!, $serverId: ULID!) {\n    revokeMcpCredential(appId: $appId, serverId: $serverId) {\n      ...McpServerFields\n    }\n  }\n": typeof types.RevokeMcpCredentialDocument,
     "\n  mutation SetMcpServerEnabled($appId: ULID!, $serverId: ULID!, $enabled: Boolean!) {\n    setMcpServerEnabled(appId: $appId, serverId: $serverId, enabled: $enabled) {\n      ...McpServerFields\n    }\n  }\n": typeof types.SetMcpServerEnabledDocument,
+    "\n  mutation UpdateAppMcpServer($input: UpdateAppMcpServerInput!) {\n    updateAppMcpServer(input: $input) {\n      ...McpServerFields\n    }\n  }\n": typeof types.UpdateAppMcpServerDocument,
     "\n  mutation DeleteMcpServer($appId: ULID!, $serverId: ULID!) {\n    deleteMcpServer(appId: $appId, serverId: $serverId) {\n      ok\n    }\n  }\n": typeof types.DeleteMcpServerDocument,
     "\n  mutation StartMcpOAuth($input: StartMcpOAuthInput!) {\n    startMcpOAuth(input: $input) {\n      authorizationUrl\n      flowId\n    }\n  }\n": typeof types.StartMcpOAuthDocument,
     "\n  query McpOAuthFlowStatus($flowId: ULID!) {\n    mcpOAuthFlowStatus(flowId: $flowId) {\n      authorizationState\n      errorMessage\n      flowId\n      serverId\n      status\n      subjectLabel\n    }\n  }\n": typeof types.McpOAuthFlowStatusDocument,
@@ -184,6 +185,7 @@ const documents: Documents = {
     "\n  mutation ConnectMcpBearer($input: ConnectMcpBearerInput!) {\n    connectMcpBearer(input: $input) {\n      ...McpServerFields\n    }\n  }\n": types.ConnectMcpBearerDocument,
     "\n  mutation RevokeMcpCredential($appId: ULID!, $serverId: ULID!) {\n    revokeMcpCredential(appId: $appId, serverId: $serverId) {\n      ...McpServerFields\n    }\n  }\n": types.RevokeMcpCredentialDocument,
     "\n  mutation SetMcpServerEnabled($appId: ULID!, $serverId: ULID!, $enabled: Boolean!) {\n    setMcpServerEnabled(appId: $appId, serverId: $serverId, enabled: $enabled) {\n      ...McpServerFields\n    }\n  }\n": types.SetMcpServerEnabledDocument,
+    "\n  mutation UpdateAppMcpServer($input: UpdateAppMcpServerInput!) {\n    updateAppMcpServer(input: $input) {\n      ...McpServerFields\n    }\n  }\n": types.UpdateAppMcpServerDocument,
     "\n  mutation DeleteMcpServer($appId: ULID!, $serverId: ULID!) {\n    deleteMcpServer(appId: $appId, serverId: $serverId) {\n      ok\n    }\n  }\n": types.DeleteMcpServerDocument,
     "\n  mutation StartMcpOAuth($input: StartMcpOAuthInput!) {\n    startMcpOAuth(input: $input) {\n      authorizationUrl\n      flowId\n    }\n  }\n": types.StartMcpOAuthDocument,
     "\n  query McpOAuthFlowStatus($flowId: ULID!) {\n    mcpOAuthFlowStatus(flowId: $flowId) {\n      authorizationState\n      errorMessage\n      flowId\n      serverId\n      status\n      subjectLabel\n    }\n  }\n": types.McpOAuthFlowStatusDocument,
@@ -485,6 +487,10 @@ export function graphql(source: "\n  mutation RevokeMcpCredential($appId: ULID!,
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  mutation SetMcpServerEnabled($appId: ULID!, $serverId: ULID!, $enabled: Boolean!) {\n    setMcpServerEnabled(appId: $appId, serverId: $serverId, enabled: $enabled) {\n      ...McpServerFields\n    }\n  }\n"): typeof import('./graphql').SetMcpServerEnabledDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  mutation UpdateAppMcpServer($input: UpdateAppMcpServerInput!) {\n    updateAppMcpServer(input: $input) {\n      ...McpServerFields\n    }\n  }\n"): typeof import('./graphql').UpdateAppMcpServerDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/apps/web/src/gql/graphql.ts
+++ b/apps/web/src/gql/graphql.ts
@@ -631,6 +631,15 @@ export type UpdateAgentConfigInput = {
   skillIds: Array<PlatformId>;
 };
 
+export type UpdateAppMcpServerInput = {
+  appId: PlatformId;
+  description?: string | null | undefined;
+  iconUrl?: string | null | undefined;
+  name: string;
+  serverId: PlatformId;
+  url: string;
+};
+
 export type UpdateEnvironmentInput = {
   allowMcpServers: boolean;
   allowPackageManagers: boolean;
@@ -1052,6 +1061,13 @@ export type SetMcpServerEnabledMutationVariables = Exact<{
 
 
 export type SetMcpServerEnabledMutation = { setMcpServerEnabled: { authType: McpAuthType, authorizationState: McpAuthorizationState, createdAt: string, credentialScope: McpCredentialScope, credentialStatus: McpCredentialStatus, description: string | null, enabled: boolean, hasCredential: boolean, iconUrl: string | null, id: PlatformId, name: string, ownerId: PlatformId, ownerName: string, appId: PlatformId, source: McpServerSource, updatedAt: string, url: string, credential: { authType: McpAuthType, createdAt: string, expiresAt: string | null, id: PlatformId, scope: McpCredentialRecordScope, scopeValues: Array<string>, status: McpCredentialStatus, subjectLabel: string | null, updatedAt: string } | null } };
+
+export type UpdateAppMcpServerMutationVariables = Exact<{
+  input: UpdateAppMcpServerInput;
+}>;
+
+
+export type UpdateAppMcpServerMutation = { updateAppMcpServer: { authType: McpAuthType, authorizationState: McpAuthorizationState, createdAt: string, credentialScope: McpCredentialScope, credentialStatus: McpCredentialStatus, description: string | null, enabled: boolean, hasCredential: boolean, iconUrl: string | null, id: PlatformId, name: string, ownerId: PlatformId, ownerName: string, appId: PlatformId, source: McpServerSource, updatedAt: string, url: string, credential: { authType: McpAuthType, createdAt: string, expiresAt: string | null, id: PlatformId, scope: McpCredentialRecordScope, scopeValues: Array<string>, status: McpCredentialStatus, subjectLabel: string | null, updatedAt: string } | null } };
 
 export type DeleteMcpServerMutationVariables = Exact<{
   appId: PlatformId;
@@ -3414,6 +3430,45 @@ fragment McpServerFields on McpServerWithCredential {
     ...McpCredentialFields
   }
 }`) as unknown as TypedDocumentString<SetMcpServerEnabledMutation, SetMcpServerEnabledMutationVariables>;
+export const UpdateAppMcpServerDocument = /*#__PURE__*/ new TypedDocumentString(`
+    mutation UpdateAppMcpServer($input: UpdateAppMcpServerInput!) {
+  updateAppMcpServer(input: $input) {
+    ...McpServerFields
+  }
+}
+    fragment McpCredentialFields on McpCredentialSummary {
+  authType
+  createdAt
+  expiresAt
+  id
+  scope
+  scopeValues
+  status
+  subjectLabel
+  updatedAt
+}
+fragment McpServerFields on McpServerWithCredential {
+  authType
+  authorizationState
+  createdAt
+  credentialScope
+  credentialStatus
+  description
+  enabled
+  hasCredential
+  iconUrl
+  id
+  name
+  ownerId
+  ownerName
+  appId
+  source
+  updatedAt
+  url
+  credential {
+    ...McpCredentialFields
+  }
+}`) as unknown as TypedDocumentString<UpdateAppMcpServerMutation, UpdateAppMcpServerMutationVariables>;
 export const DeleteMcpServerDocument = /*#__PURE__*/ new TypedDocumentString(`
     mutation DeleteMcpServer($appId: ULID!, $serverId: ULID!) {
   deleteMcpServer(appId: $appId, serverId: $serverId) {

--- a/apps/web/src/routes/integrations/mcp/edit-mcp-dialog.tsx
+++ b/apps/web/src/routes/integrations/mcp/edit-mcp-dialog.tsx
@@ -1,0 +1,225 @@
+import { useReducer } from "react";
+
+import { Button } from "@/shared/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
+import { Input } from "@/shared/ui/input";
+import { Label } from "@/shared/ui/label";
+import { Textarea } from "@/shared/ui/textarea";
+
+import { isTruthy } from "../../../shared/lib/truthiness";
+import { authTypeLabel } from "./format";
+import { IconAvatar } from "./icon-avatar";
+import type { McpServerWithCredential } from "./mcp-types";
+
+interface EditMcpInput {
+  name: string;
+  url: string;
+  description: string | null;
+  iconUrl: string | null;
+}
+
+interface Props {
+  server: McpServerWithCredential;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (input: EditMcpInput) => Promise<void> | void;
+}
+
+interface EditMcpDialogState {
+  description: string;
+  iconUrl: string;
+  name: string;
+  submitError: string | null;
+  submitting: boolean;
+  url: string;
+}
+
+type EditMcpDialogAction =
+  | { type: "changeDescription"; description: string }
+  | { type: "changeIconUrl"; iconUrl: string }
+  | { type: "changeName"; name: string }
+  | { type: "changeUrl"; url: string }
+  | { type: "setSubmitError"; error: string | null }
+  | { type: "setSubmitting"; submitting: boolean };
+
+function createInitialState(server: McpServerWithCredential): EditMcpDialogState {
+  return {
+    description: server.description ?? "",
+    iconUrl: server.iconUrl ?? "",
+    name: server.name,
+    submitError: null,
+    submitting: false,
+    url: server.url,
+  };
+}
+
+function editMcpDialogReducer(
+  state: EditMcpDialogState,
+  action: EditMcpDialogAction,
+): EditMcpDialogState {
+  switch (action.type) {
+    case "changeDescription":
+      return { ...state, description: action.description };
+    case "changeIconUrl":
+      return { ...state, iconUrl: action.iconUrl };
+    case "changeName":
+      return { ...state, name: action.name };
+    case "changeUrl":
+      return { ...state, url: action.url };
+    case "setSubmitError":
+      return { ...state, submitError: action.error };
+    case "setSubmitting":
+      return { ...state, submitting: action.submitting };
+  }
+}
+
+export function EditMcpDialog({ server, onOpenChange, onSubmit }: Props) {
+  const [state, dispatch] = useReducer(editMcpDialogReducer, server, createInitialState);
+  const { description, iconUrl, name, submitError, submitting, url } = state;
+
+  const urlValid = url.trim().startsWith("https://");
+  const canSubmit = name.trim().length > 0 && urlValid;
+  const urlChanged = url.trim() !== server.url;
+  const disconnectsOnSave = urlChanged && server.credentialStatus === "active";
+
+  async function handleSubmit() {
+    if (!canSubmit || submitting) {
+      return;
+    }
+    const trimmedDesc = description.trim();
+    const trimmedIcon = iconUrl.trim();
+    dispatch({ error: null, type: "setSubmitError" });
+    dispatch({ submitting: true, type: "setSubmitting" });
+
+    try {
+      await onSubmit({
+        description: trimmedDesc.length > 0 ? trimmedDesc : null,
+        iconUrl: trimmedIcon.length > 0 ? trimmedIcon : null,
+        name: name.trim(),
+        url: url.trim(),
+      });
+      onOpenChange(false);
+    } catch (error) {
+      dispatch({
+        error: error instanceof Error ? error.message : "Failed to update MCP connection.",
+        type: "setSubmitError",
+      });
+    } finally {
+      dispatch({ submitting: false, type: "setSubmitting" });
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit MCP connection</DialogTitle>
+          <DialogDescription>
+            Update this MCP server. Authorization type ({authTypeLabel(server.authType)}) cannot be
+            changed.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Name + icon preview */}
+          <div className="flex items-start gap-3">
+            <IconAvatar
+              url={iconUrl.trim() || undefined}
+              serverUrl={url.trim() || undefined}
+              name={name || "?"}
+              size={44}
+            />
+            <div className="flex-1 space-y-1.5">
+              <Label htmlFor="mcp-edit-name">Name</Label>
+              <Input
+                id="mcp-edit-name"
+                value={name}
+                onChange={(e) => {
+                  dispatch({ name: e.target.value, type: "changeName" });
+                }}
+                placeholder="For example: Figma"
+              />
+            </div>
+          </div>
+
+          {/* URL */}
+          <div className="space-y-1.5">
+            <Label htmlFor="mcp-edit-url">Server URL</Label>
+            <Input
+              id="mcp-edit-url"
+              value={url}
+              onChange={(e) => {
+                dispatch({ type: "changeUrl", url: e.target.value });
+              }}
+              placeholder="https://mcp.figma.com/mcp"
+            />
+            {url.length > 0 && !urlValid && (
+              <p className="text-destructive text-[11px]">URL must start with https://</p>
+            )}
+            {disconnectsOnSave && (
+              <p className="text-amber-fg text-[11px]">
+                Changing the URL disconnects the current credential. You will need to connect again.
+              </p>
+            )}
+          </div>
+
+          {/* Icon URL */}
+          <div className="space-y-1.5">
+            <Label htmlFor="mcp-edit-icon">Icon URL (optional)</Label>
+            <Input
+              id="mcp-edit-icon"
+              value={iconUrl}
+              onChange={(e) => {
+                dispatch({ iconUrl: e.target.value, type: "changeIconUrl" });
+              }}
+              placeholder="https://logo.clearbit.com/example.com"
+            />
+            <p className="text-muted-foreground text-[10px]">
+              Leave empty to use the initial as the icon.
+            </p>
+          </div>
+
+          {/* Description */}
+          <div className="space-y-1.5">
+            <Label htmlFor="mcp-edit-desc">Description (optional)</Label>
+            <Textarea
+              id="mcp-edit-desc"
+              value={description}
+              onChange={(e) => {
+                dispatch({ description: e.target.value, type: "changeDescription" });
+              }}
+              rows={2}
+              placeholder="What capabilities does this MCP server provide?"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          {isTruthy(submitError) ? (
+            <div className="border-destructive/30 bg-destructive/5 text-destructive w-full rounded-md border px-3 py-2 text-xs">
+              {submitError}
+            </div>
+          ) : null}
+          <Button
+            variant="outline"
+            onClick={() => {
+              onOpenChange(false);
+            }}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button disabled={!canSubmit || submitting} onClick={() => void handleSubmit()}>
+            {submitting ? "Saving..." : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/routes/integrations/mcp/mcp-list-item.tsx
+++ b/apps/web/src/routes/integrations/mcp/mcp-list-item.tsx
@@ -1,4 +1,4 @@
-import { MoreHorizontal, Trash2, Unplug } from "lucide-react";
+import { MoreHorizontal, Pencil, Trash2, Unplug } from "lucide-react";
 
 import { cn } from "@/shared/lib/class-names";
 import { Button } from "@/shared/ui/button";
@@ -17,12 +17,20 @@ import type { McpServerWithCredential } from "./mcp-types";
 interface Props {
   server: McpServerWithCredential;
   onConnect: () => void;
+  onEdit: () => void;
   onRevoke: () => void;
   onDelete: () => void;
   onToggleEnabled: () => void;
 }
 
-export function McpListItem({ server, onConnect, onRevoke, onDelete, onToggleEnabled }: Props) {
+export function McpListItem({
+  server,
+  onConnect,
+  onEdit,
+  onRevoke,
+  onDelete,
+  onToggleEnabled,
+}: Props) {
   const status = server.credentialStatus;
   const isAuthorized = status === "active";
   const metaParts = [authTypeLabel(server.authType)];
@@ -77,6 +85,10 @@ export function McpListItem({ server, onConnect, onRevoke, onDelete, onToggleEna
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={onEdit}>
+              <Pencil />
+              Edit
+            </DropdownMenuItem>
             {isAuthorized && (
               <DropdownMenuItem onClick={onRevoke}>
                 <Unplug />

--- a/apps/web/src/routes/integrations/mcp/mcp-tab.tsx
+++ b/apps/web/src/routes/integrations/mcp/mcp-tab.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/shared/ui/input";
 import { PageHeader } from "@/shared/ui/page-header";
 
 import { AddMcpDialog } from "./add-mcp-dialog";
+import { EditMcpDialog } from "./edit-mcp-dialog";
 import { McpListItem } from "./mcp-list-item";
 import type { McpServerWithCredential } from "./mcp-types";
 import { OAuthConnectDialog } from "./oauth-connect-dialog";
@@ -14,17 +15,20 @@ import { useMcpRegistry } from "./use-mcp-registry";
 
 interface McpTabState {
   addOpen: boolean;
+  editServer: McpServerWithCredential | null;
   oauthServer: McpServerWithCredential | null;
   search: string;
 }
 
 type McpTabAction =
   | { type: "setAddOpen"; open: boolean }
+  | { type: "setEditServer"; server: McpServerWithCredential | null }
   | { type: "setOauthServer"; server: McpServerWithCredential | null }
   | { type: "setSearch"; search: string };
 
 const MCP_TAB_INITIAL_STATE: McpTabState = {
   addOpen: false,
+  editServer: null,
   oauthServer: null,
   search: "",
 };
@@ -33,6 +37,8 @@ function mcpTabReducer(state: McpTabState, action: McpTabAction): McpTabState {
   switch (action.type) {
     case "setAddOpen":
       return { ...state, addOpen: action.open };
+    case "setEditServer":
+      return { ...state, editServer: action.server };
     case "setOauthServer":
       return { ...state, oauthServer: action.server };
     case "setSearch":
@@ -43,7 +49,7 @@ function mcpTabReducer(state: McpTabState, action: McpTabAction): McpTabState {
 export function McpTab() {
   const registry = useMcpRegistry();
   const [state, dispatch] = useReducer(mcpTabReducer, MCP_TAB_INITIAL_STATE);
-  const { addOpen, oauthServer, search } = state;
+  const { addOpen, editServer, oauthServer, search } = state;
 
   const list: McpServerWithCredential[] = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -134,6 +140,9 @@ export function McpTab() {
                   onConnect={() => {
                     dispatch({ server, type: "setOauthServer" });
                   }}
+                  onEdit={() => {
+                    dispatch({ server, type: "setEditServer" });
+                  }}
                   onDelete={() => void registry.deleteServer(server.id)}
                   onRevoke={() => void registry.revokeCredential(server.id)}
                   onToggleEnabled={() => void registry.setServerEnabled(server.id, !server.enabled)}
@@ -151,6 +160,23 @@ export function McpTab() {
         }}
         onSubmit={handleAddSubmit}
       />
+      {editServer !== null && (
+        <EditMcpDialog
+          key={editServer.id}
+          server={editServer}
+          onOpenChange={(next) => {
+            if (!next) {
+              dispatch({ server: null, type: "setEditServer" });
+            }
+          }}
+          onSubmit={async (input) => {
+            await registry.updateServer({
+              serverId: editServer.id,
+              ...input,
+            });
+          }}
+        />
+      )}
       <OAuthConnectDialog
         open={oauthServer !== null}
         server={oauthServer}

--- a/apps/web/src/routes/integrations/mcp/use-mcp-registry.ts
+++ b/apps/web/src/routes/integrations/mcp/use-mcp-registry.ts
@@ -4,6 +4,7 @@ import type {
   McpRegistry,
   McpServerWithCredential,
   StartMcpOAuthPayload,
+  UpdateAppMcpServerInput,
 } from "@mosoo/contracts/mcp";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -17,6 +18,7 @@ import {
   revokeMcpCredential,
   setMcpServerEnabled,
   startMcpOAuth,
+  updateAppMcpServer,
 } from "@/domains/mcp/api/mcp-client";
 import { mcpKeys, useMcpRegistryQuery } from "@/domains/mcp/query/mcp-queries";
 import { toMcpOAuthFlowId, toMcpServerId, toAppId } from "@/routes/typed-id";
@@ -61,6 +63,21 @@ export function useMcpRegistry() {
     });
     await refresh();
     return created;
+  }
+
+  async function updateServer(
+    input: Omit<UpdateAppMcpServerInput, "appId">,
+  ): Promise<McpServerWithCredential> {
+    if (!isTruthy(appId)) {
+      throw new Error("MCP registry is not ready.");
+    }
+
+    const updated = await updateAppMcpServer({
+      ...input,
+      appId: toAppId(appId),
+    });
+    await refresh();
+    return updated;
   }
 
   async function connectBearerCredential(
@@ -141,5 +158,6 @@ export function useMcpRegistry() {
     servers: registry?.servers ?? [],
     setServerEnabled: toggleServerEnabled,
     startOAuth: startOAuthFlow,
+    updateServer,
   };
 }

--- a/pkgs/contracts/src/mcp/mcp.contract.ts
+++ b/pkgs/contracts/src/mcp/mcp.contract.ts
@@ -156,6 +156,15 @@ export interface CreateAppMcpServerInput {
   url: string;
 }
 
+export interface UpdateAppMcpServerInput {
+  appId: AppId;
+  description?: string | null;
+  iconUrl?: string | null;
+  name: string;
+  serverId: McpServerId;
+  url: string;
+}
+
 export interface ConnectMcpBearerInput {
   appId: AppId;
   serverId: McpServerId;


### PR DESCRIPTION
## Summary

- Add an **Edit** entry to the MCP server "..." action menu (previously only Disable/Delete were available, so servers could not be edited after creation).
- New `updateAppMcpServer` GraphQL mutation + `updateAppMcpServer` service that lets the owner update an app MCP server's name, URL, icon URL, and description.
- New `EditMcpDialog` in the web app, prefilled with the current server values; auth type is shown but immutable.
- Changing the server URL revokes the stored app credential and clears cached OAuth discovery metadata, since both are bound to the previous endpoint. The dialog warns about this before saving.

## Why

- MCP servers could only be disabled or deleted after creation. Fixing a typo in the URL or renaming a server required delete + recreate, losing the credential. Reported as YEF-797 ("MCP Server 无法编辑").

## Verification

- Commands: `bun run tc`, `bun run lint`, `bun run test` (814 pass, includes `graphql:codegen:check`), new `apps/api/tests/mcp-server-update.test.ts` (5 cases: field update keeps credential, clears optional fields, URL change revokes credential + clears OAuth metadata cache, rejects non-https URL, denies non-owner).
- Manual steps: ran `wrangler dev` + web dev locally, logged in via the loopback dev backdoor, added a Bearer MCP server, opened "..." → Edit, changed name/description, saved, and confirmed the list refreshed with the new values (screenshots in the linked issue).
- Not run: OAuth end-to-end reconnect after URL change (requires a live OAuth provider).

## Impact

- User/API/contract changes: new `updateAppMcpServer` mutation and `UpdateAppMcpServerInput` in `@mosoo/contracts/mcp`; additive only, no existing operation changed.
- Generated files / GraphQL / DB / lockfile: regenerated `schema.generated.graphql` and `apps/web/src/gql/*` via `bun run graphql:codegen`; no DB schema change.
- Env or config changes: N/A
- Risk and rollback: low, additive endpoint + UI entry; revert the single commit to roll back.

## Review

- Closest review areas: `apps/api/src/modules/mcp/application/mcp-server-management.service.ts` (URL-change credential revocation semantics), `apps/web/src/routes/integrations/mcp/edit-mcp-dialog.tsx`.
- Known trade-offs: auth type is intentionally not editable (switching oauth/bearer entangles credential and client-secret lifecycles); URL edits always require reconnecting rather than trying to keep a possibly-invalid credential.
