### PR TITLE
fix(web): stop SPA fallback from passing through the index.html redirect

### DIFF
--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -19,10 +19,11 @@ export default {
     }
 
     // SPA route — react-router decides what to render client-side, so we
-    // intentionally return /index.html with 200.
-    const indexRes = await env.ASSETS.fetch(
-      new Request(new URL("/index.html", url.origin).href, request),
-    );
+    // intentionally return the index document with 200. Fetch "/" rather than
+    // "/index.html": the assets binding's default html_handling
+    // ("auto-trailing-slash") answers "/index.html" with a 307 to "/", and
+    // passing that redirect through breaks every deep link.
+    const indexRes = await env.ASSETS.fetch(new Request(new URL("/", url.origin).href, request));
     return indexRes;
   },
 };


### PR DESCRIPTION
## Summary

- Fix the web Worker SPA fallback so unknown console paths serve the index document with 200 instead of passing through a 307 redirect to `/`.

## Why

- In production (try.mosoo.ai) every non-asset path — `/login`, `/cli-auth`, any deep console route — answers `307 Location: /`, so direct visits, refreshes, and shared links always land on the homepage.
- Root cause: the fallback fetched `/index.html` through the assets binding, whose default `html_handling` (`auto-trailing-slash`) answers an explicit `/index.html` request with a 307 to `/`; the Worker returned that redirect verbatim. Fetching `/` serves the same document at 200.

## Verification

- Commands: `bun run check` (full gate: fmt, docs, lint, tc, test) exits 0.
- Manual steps: `wrangler dev` on the built assets — before: `GET /sign-in`, `/login`, `/index.html` → `307 -> /` (matches current prod behavior); after: `GET /sign-in`, `/login`, `/apps/some/deep/path` → `200` serving the SPA shell, `/favicon.svg` and hashed `/assets/*` still served directly.
- Not run: production deploy (change is not yet live; prod still reproduces the 307 as of 2026-07-06).

## Impact

- User/API/contract changes: deep links into the console work again on direct navigation and refresh; no API change.
- Generated files / GraphQL / DB / lockfile: N/A
- Env or config changes: N/A
- Risk and rollback: one-line Worker change scoped to the asset-miss path; rollback by reverting the commit.

## Review

- Closest review areas: `apps/web/src/worker.ts` SPA fallback; Workers Assets `html_handling` semantics with `not_found_handling = "none"`.
- Known trade-offs: SPA misses now return 200 with the shell (soft-404 for genuinely unknown URLs) — same behavior the fallback always intended.
