### PR TITLE
fix(runtime): stop duplicate dispatch from failing skill-bearing runs

### DIFF
--- a/apps/api/src/modules/runtime/application/session-runs/dispatch-queued-run.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/dispatch-queued-run.service.ts
@@ -11,6 +11,7 @@ import { getSupportedRuntimeId } from "../../domain/runtime-config";
 import { hydrateCachedRunContextFromSession } from "../session-definition/hydrate-run-context.service";
 import { appendSessionResourceContextToPrompt } from "../session-resources/session-resource-prompt.service";
 import { dispatchSessionRun } from "./dispatch-run.service";
+import { describeRunError } from "./run-error-message";
 import { getSessionRunState, updateSessionRunStatusIfActive } from "./session-run-state.repository";
 import { createFailedSessionRunRuntimeEvent } from "./session-run-view-events.service";
 import {
@@ -27,8 +28,7 @@ async function failQueuedSessionRunBeforeDispatch(
     traceId: string;
   },
 ): Promise<void> {
-  const message =
-    input.error instanceof Error ? input.error.message : "Session run context hydration failed.";
+  const message = describeRunError(input.error, "Session run context hydration failed.");
   const runError = {
     code: "runtime.context_hydration_failed",
     details: {},

--- a/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
@@ -20,6 +20,7 @@ import type { RuntimeDiagnosticEventInput } from "../runtime-diagnostic-events";
 import { buildSessionConfigTraceValue } from "../session-definition/session-config-trace-event";
 import type { HydratedSessionRunContext } from "../session-definition/session-execution.types";
 import { cleanupDispatchedDriver } from "./dispatch-run-cleanup.service";
+import { describeRunError } from "./run-error-message";
 import { persistSessionRunSkills } from "./session-run-skill-snapshot.repository";
 import {
   acquireSessionRunDispatch,
@@ -124,8 +125,6 @@ export async function dispatchSessionRun(
   try {
     await ensureSessionRunIsActive(bindings.DB, input.sessionRunId);
 
-    await persistSessionRunSkills(bindings.DB, input.sessionRunId, input.resolvedSkills);
-
     const bootingRun = await acquireSessionRunDispatch(bindings.DB, input.sessionRunId);
 
     if (!bootingRun) {
@@ -142,6 +141,10 @@ export async function dispatchSessionRun(
 
       return;
     }
+
+    // Only the dispatch winner writes run state; the losing path above must
+    // stay write-free so it cannot fail a run the winner is provisioning.
+    await persistSessionRunSkills(bindings.DB, input.sessionRunId, input.resolvedSkills);
 
     await appendSessionRuntimeEvents({
       bindings,
@@ -256,7 +259,7 @@ export async function dispatchSessionRun(
       return;
     }
 
-    const message = error instanceof Error ? error.message : "Session run provisioning failed.";
+    const message = describeRunError(error, "Session run provisioning failed.");
     const runError = {
       code: "runtime.provision_failed",
       details: {},

--- a/apps/api/src/modules/runtime/application/session-runs/run-error-message.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/run-error-message.ts
@@ -1,0 +1,25 @@
+export function describeRunError(error: unknown, fallback: string): string {
+  if (!(error instanceof Error)) {
+    return fallback;
+  }
+
+  const messages: string[] = [];
+  const seen = new Set<Error>();
+  let current: unknown = error;
+
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+
+    if (current.message.trim().length > 0) {
+      messages.push(current.message);
+    }
+
+    current = current.cause;
+  }
+
+  if (messages.length === 0) {
+    return fallback;
+  }
+
+  return messages.join("; caused by: ");
+}

--- a/apps/api/src/modules/runtime/application/session-runs/session-run-skill-snapshot.repository.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/session-run-skill-snapshot.repository.ts
@@ -15,6 +15,9 @@ export async function persistSessionRunSkills(
 
   const timestampMs = Date.now();
 
+  // A run can reach this insert more than once (inline dispatch, queue
+  // fallback, queue retry). The first writer wins; a duplicate (run, skill)
+  // pair must not fail the run.
   await getAppDatabase(database)
     .insert(sessionRunSkillsTable)
     .values(
@@ -32,5 +35,6 @@ export async function persistSessionRunSkills(
         warningCode: skill.warningCode,
       })),
     )
+    .onConflictDoNothing()
     .run();
 }

--- a/apps/api/tests/helpers/public-api-http-wechat-schema.sql
+++ b/apps/api/tests/helpers/public-api-http-wechat-schema.sql
@@ -154,6 +154,21 @@ CREATE TABLE session_run (
   updated_at integer
 );
 
+CREATE TABLE session_run_skill (
+  session_run_id text NOT NULL,
+  skill_id text NOT NULL,
+  skill_name text NOT NULL,
+  snapshot_id text,
+  blob_sha256 text,
+  mount_path text NOT NULL,
+  resolution_mode text NOT NULL,
+  materialization_status text NOT NULL,
+  warning_code text,
+  created_at integer NOT NULL,
+  updated_at integer NOT NULL,
+  PRIMARY KEY (session_run_id, skill_id)
+);
+
 CREATE TABLE session_execution_snapshot (
   session_id text PRIMARY KEY NOT NULL,
   plan_json text NOT NULL,

--- a/apps/api/tests/run-error-message.test.ts
+++ b/apps/api/tests/run-error-message.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+
+import { describeRunError } from "../src/modules/runtime/application/session-runs/run-error-message";
+
+describe("describeRunError", () => {
+  test("returns the fallback for non-error values", () => {
+    expect(describeRunError("boom", "Fallback message.")).toBe("Fallback message.");
+    expect(describeRunError(null, "Fallback message.")).toBe("Fallback message.");
+  });
+
+  test("returns the message for a plain error", () => {
+    expect(describeRunError(new Error("dispatch exploded"), "Fallback message.")).toBe(
+      "dispatch exploded",
+    );
+  });
+
+  test("appends the cause chain to the message", () => {
+    const sqlite = new Error(
+      "D1_ERROR: UNIQUE constraint failed: session_run_skill.session_run_id, session_run_skill.skill_id",
+    );
+    const query = new Error('Failed query: insert into "session_run_skill" (...)', {
+      cause: sqlite,
+    });
+
+    expect(describeRunError(query, "Fallback message.")).toBe(
+      'Failed query: insert into "session_run_skill" (...); caused by: D1_ERROR: UNIQUE constraint failed: session_run_skill.session_run_id, session_run_skill.skill_id',
+    );
+  });
+
+  test("survives cyclic cause chains", () => {
+    const first = new Error("first");
+    const second = new Error("second", { cause: first });
+    first.cause = second;
+
+    expect(describeRunError(first, "Fallback message.")).toBe("first; caused by: second");
+  });
+
+  test("falls back when every message in the chain is blank", () => {
+    expect(describeRunError(new Error(""), "Fallback message.")).toBe("Fallback message.");
+  });
+});

--- a/apps/api/tests/session-run-skill-persistence.test.ts
+++ b/apps/api/tests/session-run-skill-persistence.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+
+import { persistSessionRunSkills } from "../src/modules/runtime/application/session-runs/session-run-skill-snapshot.repository";
+import {
+  createPublicHttpContractDatabase,
+  insertNonOwnerSession,
+} from "./helpers/public-api-http-test-fixture";
+
+const RUN_ID = "run-skill-persistence";
+
+async function insertQueuedSessionRun(database: D1Database): Promise<void> {
+  await database
+    .prepare(
+      `
+        INSERT INTO session_run (
+          id,
+          session_id,
+          agent_id,
+          created_by_account_id,
+          trigger,
+          status,
+          provider,
+          model,
+          runtime_id,
+          trace_id,
+          created_at,
+          updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    )
+    .bind(
+      RUN_ID,
+      "01J0000000000000000000000B",
+      "01J00000000000000000000009",
+      "01J00000000000000000000002",
+      "user_prompt",
+      "queued",
+      "deepseek",
+      "deepseek-v4-pro",
+      "acp-fallback",
+      "trace-skill-persistence",
+      1,
+      1,
+    )
+    .run();
+}
+
+const tddSkill = {
+  archiveFormat: "zip",
+  blobSha256: "sha-tdd",
+  compression: "deflate",
+  materializationStatus: "pending",
+  mountPath: "/workspace/se/session/.mosoo/skill/skill-tdd",
+  resolutionMode: "explicit",
+  skillId: "01J00000000000000000000TDD",
+  skillName: "tdd",
+  snapshotId: "01J0000000000000000000SNAP",
+  warningCode: null,
+} as const;
+
+describe("session run skill persistence", () => {
+  test("persisting the same run skill twice keeps one row and does not throw", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertNonOwnerSession(database);
+    await insertQueuedSessionRun(database);
+
+    await persistSessionRunSkills(database, RUN_ID, [tddSkill]);
+    await persistSessionRunSkills(database, RUN_ID, [tddSkill]);
+
+    const stored = await database
+      .prepare(
+        "SELECT COUNT(*) AS row_count FROM session_run_skill WHERE session_run_id = ? AND skill_id = ?",
+      )
+      .bind(RUN_ID, tddSkill.skillId)
+      .first<{ row_count: number }>();
+    expect(stored).toEqual({ row_count: 1 });
+  });
+
+  test("a duplicate skill insert preserves the first writer's row", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertNonOwnerSession(database);
+    await insertQueuedSessionRun(database);
+
+    await persistSessionRunSkills(database, RUN_ID, [tddSkill]);
+    await persistSessionRunSkills(database, RUN_ID, [
+      { ...tddSkill, materializationStatus: "materialized" },
+    ]);
+
+    const stored = await database
+      .prepare(
+        "SELECT materialization_status FROM session_run_skill WHERE session_run_id = ? AND skill_id = ?",
+      )
+      .bind(RUN_ID, tddSkill.skillId)
+      .first<{ materialization_status: string }>();
+    expect(stored).toEqual({ materialization_status: "pending" });
+  });
+});


### PR DESCRIPTION
## Incident

Prod, 2026-07-06 03:10 UTC: both sessions on the first skill-bearing agent ever created on prod (`OpenCode`, acp-fallback + deepseek, skill `tdd`) failed with `runtime.provision_failed` and never produced a reply. D1 evidence (session `01KWTPFQ0FVRXBJ0E5PXEJK2Q0`, run `01KWTPFQEBZZMXF4S25QYNFRJA`, and its ui twin):

- run created 03:10:13; **inline dispatch** (O1 fast path) inserted the `session_run_skill` row at 03:10:15.8 and moved the run to `booting`, then started provisioning the driver (container boot 30s+)
- the **api-command queue fallback** delivered ~5s later (max_batch_timeout) and re-ran `dispatchSessionRun`; its `persistSessionRunSkills` insert hit the `(session_run_id, skill_id)` primary key at 03:10:22.3 and the catch marked the run **failed** while the winner was still provisioning
- the healthy driver was then cleaned up; queue retry (+30s) saw the terminal run, skipped, and marked the command succeeded at 03:10:55 — exactly matching `attempt_count=2`

#232 added the exclusive `acquireSessionRunDispatch`, but the skill insert ran **before** the acquire and was a plain insert, so skill-bearing runs still died deterministically.

## Changes

- `dispatch-run.service.ts`: move `persistSessionRunSkills` **after** `acquireSessionRunDispatch` — only the dispatch winner writes run state; the losing path stays write-free
- `session-run-skill-snapshot.repository.ts`: `.onConflictDoNothing()` on the insert as a second guard (queue retries, future re-entry)
- `run-error-message.ts` (new): join the `Error.cause` chain into run error messages so the underlying D1 error (`UNIQUE constraint failed: …`) is recorded instead of only drizzle's `Failed query: …` wrapper; used by both dispatch failure paths
- tests: `session_run_skill` idempotency (fails on the old plain insert), `describeRunError` unit tests; test schema gains the `session_run_skill` table with the real composite PK

## Verification

- `just check` green (fmt, docs, lint, tc, full test suite)
- new tests fail against the pre-fix insert (UNIQUE constraint) and pass with the fix