### PR TITLE
fix(runtime): keep the request port in container-reachable origins

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-sandbox-provisioning.paths.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-sandbox-provisioning.paths.ts
@@ -2,14 +2,15 @@ import { SANDBOX_CACHE_PATH, SANDBOX_MEMORY_PATH } from "agent-driver/paths";
 
 import type { DriverProfileConfig } from "../../domain/driver-snapshot";
 
-const WRANGLER_DEV_PORT = "8787";
-
 export function toContainerReachableOrigin(requestUrl: string): string {
   const url = new URL(requestUrl);
 
+  // Keep the original port: local requests reach the API through whichever
+  // dev server received them (vite on WEB_DEV_PORT or wrangler on
+  // WRANGLER_DEV_PORT), and both listen on all interfaces. Forcing a fixed
+  // port breaks any dev setup that does not run wrangler on that port.
   if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
     url.hostname = "host.docker.internal";
-    url.port = WRANGLER_DEV_PORT;
   }
 
   return url.toString();

--- a/apps/api/tests/runtime-sandbox-provisioning-paths.test.ts
+++ b/apps/api/tests/runtime-sandbox-provisioning-paths.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+import { toContainerReachableOrigin } from "../src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-sandbox-provisioning.paths";
+
+describe("toContainerReachableOrigin", () => {
+  test("rewrites localhost to host.docker.internal and keeps the port", () => {
+    expect(toContainerReachableOrigin("http://localhost:5173/api/graphql")).toBe(
+      "http://host.docker.internal:5173/api/graphql",
+    );
+    expect(toContainerReachableOrigin("http://localhost:8788/api/graphql")).toBe(
+      "http://host.docker.internal:8788/api/graphql",
+    );
+  });
+
+  test("rewrites 127.0.0.1 to host.docker.internal and keeps the port", () => {
+    expect(toContainerReachableOrigin("http://127.0.0.1:8787/api/graphql")).toBe(
+      "http://host.docker.internal:8787/api/graphql",
+    );
+  });
+
+  test("keeps a localhost URL without an explicit port on the default port", () => {
+    expect(toContainerReachableOrigin("http://localhost/api/graphql")).toBe(
+      "http://host.docker.internal/api/graphql",
+    );
+  });
+
+  test("leaves public origins untouched", () => {
+    expect(toContainerReachableOrigin("https://try.mosoo.ai/api/graphql")).toBe(
+      "https://try.mosoo.ai/api/graphql",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Local-dev only. `toContainerReachableOrigin` rewrites `localhost` request origins to `host.docker.internal` for URLs the driver fetches from inside the sandbox container (skill package downloads, MCP proxy), but it **hardcodes port 8787**. Any local stack that does not run wrangler on 8787 hands the driver dead callback URLs.

Observed while verifying #243 locally (WRANGLER_DEV_PORT=8788, an unrelated process squatting 8787):

- driver skill materialization failed every run with `Failed to download skill package for …: 502.`
- verified from inside the sandbox container: `host.docker.internal:8788` answers mosoo health, `host.docker.internal:8787` answers 404 from the squatter, `localhost:8788` unreachable (000)
- dispatch payload `requestUrl` was `http://localhost:5173/api/graphql` (vite origin) — the rewrite sent drivers to :8787 regardless

## Fix

Preserve the original request port; only swap the hostname. Both vite (`WEB_DEV_PORT`) and wrangler (`WRANGLER_DEV_PORT`) bind all interfaces, and vite proxies all of `/api`, so the original port is always container-reachable. Production URLs are public hostnames and take this branch never.

## Verification

- new unit tests for localhost/127.0.0.1 port preservation, default-port passthrough, and public-origin passthrough
- `bun test apps/api/tests/runtime-sandbox-provisioning-paths.test.ts` 4/4, `tsc --noEmit` clean