### PR TITLE
fix(sessions): make agent session delete idempotent for missing sessions

### DIFF
--- a/apps/api/src/modules/sessions/application/session-lifecycle-mutation.service.ts
+++ b/apps/api/src/modules/sessions/application/session-lifecycle-mutation.service.ts
@@ -6,6 +6,7 @@ import { and, eq, inArray } from "drizzle-orm";
 
 import type { ApiBindings } from "../../../platform/cloudflare/worker-types";
 import { getAppDatabase } from "../../../platform/db/drizzle";
+import { forbiddenError } from "../../../platform/errors";
 import { currentTimestampMs } from "../../../time";
 import type { AuthenticatedViewer } from "../../auth/application/viewer-auth.service";
 import { listLiveRuntimeDriverInstanceIdsForSession } from "../../runtime/application/runtime-driver-instance-query.service";
@@ -24,6 +25,7 @@ import type {
 } from "../domain/session-access.policy";
 import {
   getAppSessionParticipantCapabilityAccess,
+  lookupAppSessionParticipantCapabilityAccess,
   resolveSessionActionCreatorFlag,
 } from "../domain/session-access.policy";
 import {
@@ -312,14 +314,26 @@ export async function deleteAgentSession({
   sessionId,
   viewer,
 }: DeleteAgentSessionRequest): Promise<void> {
-  const session = await getAppSessionParticipantCapabilityAccess(bindings.DB, viewer.id, {
+  const lookup = await lookupAppSessionParticipantCapabilityAccess(bindings.DB, viewer.id, {
     appId,
     sessionId,
   });
+
+  // Delete must stay idempotent: clients can hold a session id that was
+  // already removed (stale tab, replaced preview session). Treat the missing
+  // row as deleted instead of reporting a permission error.
+  if (lookup.kind === "missing") {
+    return;
+  }
+
+  if (lookup.kind === "not_participant") {
+    throw forbiddenError();
+  }
+
   ensureLifecycleActionCapability({
     action: "delete_session",
     authorization,
-    session,
+    session: lookup.row,
   });
 
   await deleteSessionCascade(bindings, sessionId);

--- a/apps/api/src/modules/sessions/domain/session-access.policy.ts
+++ b/apps/api/src/modules/sessions/domain/session-access.policy.ts
@@ -138,6 +138,53 @@ export async function getAppSessionParticipantTimelineAccess(
   return row;
 }
 
+export type AppSessionParticipantCapabilityAccessLookup =
+  | { kind: "found"; row: SessionParticipantCapabilityAccessRow }
+  | { kind: "missing" }
+  | { kind: "not_participant" };
+
+export async function lookupAppSessionParticipantCapabilityAccess(
+  database: D1Database,
+  viewerId: AccountId,
+  input: {
+    appId: AppId;
+    sessionId: SessionId;
+  },
+): Promise<AppSessionParticipantCapabilityAccessLookup> {
+  await ensureAppOwnership(database, viewerId, input.appId);
+  const row =
+    (await getAppDatabase(database)
+      .select({
+        archived_at: sessionsTable.archivedAt,
+        is_participant: sessionParticipantFlag(viewerId).as("is_participant"),
+        is_session_creator: sessionCreatorFlag(viewerId).as("is_session_creator"),
+        runtime_id: sessionsTable.runtimeId,
+        status: sessionsTable.status,
+      })
+      .from(sessionsTable)
+      .where(and(eq(sessionsTable.id, input.sessionId), eq(sessionsTable.appId, input.appId)))
+      .limit(1)
+      .get()) ?? null;
+
+  if (!row) {
+    return { kind: "missing" };
+  }
+
+  if (row.is_participant !== 1) {
+    return { kind: "not_participant" };
+  }
+
+  return {
+    kind: "found",
+    row: {
+      archived_at: row.archived_at,
+      is_session_creator: row.is_session_creator,
+      runtime_id: row.runtime_id,
+      status: row.status,
+    },
+  };
+}
+
 export async function getAppSessionParticipantCapabilityAccess(
   database: D1Database,
   viewerId: AccountId,
@@ -146,31 +193,13 @@ export async function getAppSessionParticipantCapabilityAccess(
     sessionId: SessionId;
   },
 ): Promise<SessionParticipantCapabilityAccessRow> {
-  await ensureAppOwnership(database, viewerId, input.appId);
-  const row =
-    (await getAppDatabase(database)
-      .select({
-        archived_at: sessionsTable.archivedAt,
-        is_session_creator: sessionCreatorFlag(viewerId).as("is_session_creator"),
-        runtime_id: sessionsTable.runtimeId,
-        status: sessionsTable.status,
-      })
-      .from(sessionsTable)
-      .where(
-        and(
-          eq(sessionsTable.id, input.sessionId),
-          eq(sessionsTable.appId, input.appId),
-          sessionParticipantCondition(viewerId),
-        ),
-      )
-      .limit(1)
-      .get()) ?? null;
+  const lookup = await lookupAppSessionParticipantCapabilityAccess(database, viewerId, input);
 
-  if (!row) {
+  if (lookup.kind !== "found") {
     throw forbiddenError();
   }
 
-  return row;
+  return lookup.row;
 }
 
 export async function getActiveAppSessionParticipantAccess(

--- a/apps/api/tests/session-delete-idempotency.test.ts
+++ b/apps/api/tests/session-delete-idempotency.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
 import type { AuthenticatedViewer } from "../src/modules/auth/application/viewer-auth.service";
 import { deleteAgentSession } from "../src/modules/sessions/application/session-lifecycle-mutation.service";
 import { lookupAppSessionParticipantCapabilityAccess } from "../src/modules/sessions/domain/session-access.policy";
+import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
 import {
   PUBLIC_API_TEST_IDS,
   createPublicHttpContractDatabase,

--- a/apps/api/tests/session-delete-idempotency.test.ts
+++ b/apps/api/tests/session-delete-idempotency.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
+import type { AuthenticatedViewer } from "../src/modules/auth/application/viewer-auth.service";
+import { deleteAgentSession } from "../src/modules/sessions/application/session-lifecycle-mutation.service";
+import { lookupAppSessionParticipantCapabilityAccess } from "../src/modules/sessions/domain/session-access.policy";
+import {
+  PUBLIC_API_TEST_IDS,
+  createPublicHttpContractDatabase,
+  insertNonOwnerSession,
+  insertOwnerSession,
+} from "./helpers/public-api-http-test-fixture";
+
+const GHOST_SESSION_ID = "01J000000000000000000GHOST";
+
+function ownerViewer(): AuthenticatedViewer {
+  return { id: PUBLIC_API_TEST_IDS.ownerAccount } as AuthenticatedViewer;
+}
+
+describe("session delete idempotency", () => {
+  test("deleting a session that no longer exists succeeds", async () => {
+    const database = await createPublicHttpContractDatabase();
+
+    await expect(
+      deleteAgentSession({
+        bindings: { DB: database } as ApiBindings,
+        appId: PUBLIC_API_TEST_IDS.app,
+        sessionId: GHOST_SESSION_ID,
+        viewer: ownerViewer(),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("deleting another participant's session stays forbidden", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertNonOwnerSession(database);
+
+    await expect(
+      deleteAgentSession({
+        bindings: { DB: database } as ApiBindings,
+        appId: PUBLIC_API_TEST_IDS.app,
+        sessionId: PUBLIC_API_TEST_IDS.nonOwnerSession,
+        viewer: ownerViewer(),
+      }),
+    ).rejects.toThrow("You do not have permission to perform this action.");
+  });
+});
+
+describe("lookupAppSessionParticipantCapabilityAccess", () => {
+  test("distinguishes missing, not_participant, and found", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertOwnerSession(database);
+    await insertNonOwnerSession(database);
+
+    const missing = await lookupAppSessionParticipantCapabilityAccess(
+      database,
+      PUBLIC_API_TEST_IDS.ownerAccount,
+      { appId: PUBLIC_API_TEST_IDS.app, sessionId: GHOST_SESSION_ID },
+    );
+    expect(missing).toEqual({ kind: "missing" });
+
+    const notParticipant = await lookupAppSessionParticipantCapabilityAccess(
+      database,
+      PUBLIC_API_TEST_IDS.ownerAccount,
+      { appId: PUBLIC_API_TEST_IDS.app, sessionId: PUBLIC_API_TEST_IDS.nonOwnerSession },
+    );
+    expect(notParticipant).toEqual({ kind: "not_participant" });
+
+    const found = await lookupAppSessionParticipantCapabilityAccess(
+      database,
+      PUBLIC_API_TEST_IDS.ownerAccount,
+      { appId: PUBLIC_API_TEST_IDS.app, sessionId: PUBLIC_API_TEST_IDS.ownerSession },
+    );
+    expect(found.kind).toBe("found");
+    if (found.kind === "found") {
+      expect(found.row.is_session_creator).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Reset chat in the agent preview panel fails with **"You do not have permission to perform this action."** whenever the panel holds a session id that no longer exists server-side (long-lived tab, preview session replaced after an agent update). Locally reproduced: the panel kept reconnecting to a 3-day-old deleted session (53 ws attempts) and Reset chat 403'd, so the user could never recover without a hard refresh.

Root cause: `deleteAgentSession` resolves access through a participant-scoped lookup that reports a **missing row** as `ForbiddenError` — a 404 disguised as a 403 — and delete is the recovery path the UI offers.

## Fix

- `session-access.policy.ts`: new `lookupAppSessionParticipantCapabilityAccess` returns `found | not_participant | missing` from a single query (participant flag computed in SQL instead of filtering the row away). `getAppSessionParticipantCapabilityAccess` keeps its exact throwing behavior for all other callers.
- `deleteAgentSession`: missing session → **idempotent success** (already deleted); session that exists but the viewer does not participate in → forbidden as before; found → unchanged capability check + cascade.

With this, Reset chat always recovers a stale panel: deleting the ghost id succeeds, the panel clears local state and creates a fresh session.

## Follow-up (not in this PR)

The session-stream socket still retries a dead session id every 5s without a terminal state; it should stop after the server reports the session gone and surface Reset chat. Tracked as a UX follow-up.

## Verification

- new tests: ghost delete resolves; deleting another participant's session still forbidden; lookup distinguishes missing / not_participant / found
- `bun test` on session suites 9/9, `tsc --noEmit` clean