### PR TITLE
fix(runtime): buffer pre-hello driver log batches instead of rejecting

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/rpc-controller.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/rpc-controller.ts
@@ -71,7 +71,11 @@ export class DriverInstanceRpcController implements DriverInstanceRpcHandler {
     input: DriverHelloInput,
     context: DriverInstanceRpcOperationContext,
   ): Promise<DriverHelloOutput> {
-    return this.#handshake.handleHello(input, context);
+    const result = await this.#handshake.handleHello(input, context);
+    // Publish batches the driver flushed while hello was still in flight
+    // without extending the hello round-trip that gates the driver's boot.
+    void this.#events.publishPendingPreHelloLogs();
+    return result;
   }
 
   async handleNextCommand(

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/rpc-event-ingestion-controller.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/rpc-event-ingestion-controller.ts
@@ -33,9 +33,13 @@ function summarizeDriverEvents(events: readonly DriverEventEnvelope[]) {
   };
 }
 
+const PRE_HELLO_LOG_BATCH_LIMIT = 16;
+
 export class DriverInstanceRpcEventIngestionController {
   readonly #dependencies: DriverInstanceRpcControllerDependencies;
   #driverEventGate: Promise<unknown> = Promise.resolve();
+  #droppedPreHelloLogBatches = 0;
+  readonly #pendingPreHelloLogBatches: DriverLogBatchInput[] = [];
   readonly #runtimeEventPersistenceCompactor = new RuntimeEventPersistenceCompactor();
 
   public constructor(dependencies: DriverInstanceRpcControllerDependencies) {
@@ -163,10 +167,6 @@ export class DriverInstanceRpcEventIngestionController {
   ): Promise<DriverLogBatchOutput> {
     const { env, state } = this.#dependencies;
 
-    if (!state.hello) {
-      throw new Error("Driver hello is required before pushLogs.");
-    }
-
     if (input.driverInstanceId !== state.requireDriverInstanceId()) {
       throw new Error("Driver instance id mismatch.");
     }
@@ -176,9 +176,50 @@ export class DriverInstanceRpcEventIngestionController {
     }
     context.assertActiveConnection();
 
+    if (!state.hello) {
+      // Drivers can flush their first batches while the hello round-trip is
+      // still in flight (production DO latency routinely exceeds the flush
+      // interval). Rejecting here used to kill boots; hold a bounded window
+      // instead and publish it once hello commits.
+      if (this.#pendingPreHelloLogBatches.length >= PRE_HELLO_LOG_BATCH_LIMIT) {
+        this.#pendingPreHelloLogBatches.shift();
+        this.#droppedPreHelloLogBatches += 1;
+      }
+
+      this.#pendingPreHelloLogBatches.push(input);
+
+      return { ok: true };
+    }
+
     await publishDriverLogBatch(env, state, input);
 
     return { ok: true };
+  }
+
+  public async publishPendingPreHelloLogs(): Promise<void> {
+    const { env, state } = this.#dependencies;
+    const pending = this.#pendingPreHelloLogBatches.splice(0);
+    const dropped = this.#droppedPreHelloLogBatches;
+    this.#droppedPreHelloLogBatches = 0;
+
+    if (dropped > 0) {
+      logError("runtime.driver.log.pre_hello_overflow", {
+        driverInstanceId: state.requireDriverInstanceId(),
+        droppedBatches: dropped,
+      });
+    }
+
+    for (const batch of pending) {
+      try {
+        await publishDriverLogBatch(env, state, batch);
+      } catch (error) {
+        logError("runtime.driver.log.pre_hello_publish_failed", {
+          ...createErrorLogContext(error),
+          batchSize: batch.logs.length,
+          driverInstanceId: state.requireDriverInstanceId(),
+        });
+      }
+    }
   }
 
   async #getRuntimeSessionLink(options: { refresh?: boolean } = {}): Promise<RuntimeSessionLink> {

--- a/apps/api/tests/driver-log-pre-hello-buffering.test.ts
+++ b/apps/api/tests/driver-log-pre-hello-buffering.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { DriverLogBatchInput } from "agent-driver/orpc";
+
+const publishedBatches: DriverLogBatchInput[] = [];
+
+void mock.module(
+  "../src/modules/runtime/infrastructure/driver-instance/driver-log-batch-publisher",
+  () => ({
+    publishDriverLogBatch: async (
+      _env: unknown,
+      _state: unknown,
+      input: DriverLogBatchInput,
+    ) => {
+      publishedBatches.push(input);
+    },
+  }),
+);
+
+const { DriverInstanceRpcEventIngestionController } = await import(
+  "../src/modules/runtime/infrastructure/driver-instance/rpc-event-ingestion-controller"
+);
+
+const DRIVER_INSTANCE_ID = "01J000000000000000000000DR";
+
+interface FakeState {
+  hello: { pid: number } | null;
+  requireDriverInstanceId: () => string;
+}
+
+function createController(state: FakeState) {
+  return new DriverInstanceRpcEventIngestionController({
+    env: {},
+    state,
+  } as never);
+}
+
+function createBatch(message: string): DriverLogBatchInput {
+  return {
+    driverInstanceId: DRIVER_INSTANCE_ID,
+    logs: [
+      {
+        level: "info",
+        message,
+        seq: 0,
+        timestamp: new Date(0).toISOString(),
+      },
+    ],
+  } as DriverLogBatchInput;
+}
+
+const activeContext = {
+  assertActiveConnection: () => undefined,
+  connectionId: "connection-1",
+} as never;
+
+beforeEach(() => {
+  publishedBatches.length = 0;
+});
+
+describe("pre-hello pushLogs buffering", () => {
+  test("buffers pre-hello batches and publishes them after hello", async () => {
+    const state: FakeState = {
+      hello: null,
+      requireDriverInstanceId: () => DRIVER_INSTANCE_ID,
+    };
+    const controller = createController(state);
+
+    const first = await controller.handlePushLogs(createBatch("boot.loaded"), activeContext);
+    const second = await controller.handlePushLogs(createBatch("hello.sending"), activeContext);
+
+    expect(first).toEqual({ ok: true });
+    expect(second).toEqual({ ok: true });
+    expect(publishedBatches).toHaveLength(0);
+
+    state.hello = { pid: 1 };
+    await controller.publishPendingPreHelloLogs();
+
+    expect(publishedBatches.map((batch) => batch.logs[0]?.message)).toEqual([
+      "boot.loaded",
+      "hello.sending",
+    ]);
+  });
+
+  test("publishes directly once hello is recorded", async () => {
+    const state: FakeState = {
+      hello: { pid: 1 },
+      requireDriverInstanceId: () => DRIVER_INSTANCE_ID,
+    };
+    const controller = createController(state);
+
+    await controller.handlePushLogs(createBatch("post.hello"), activeContext);
+
+    expect(publishedBatches.map((batch) => batch.logs[0]?.message)).toEqual(["post.hello"]);
+  });
+
+  test("bounds the pre-hello window by dropping the oldest batches", async () => {
+    const state: FakeState = {
+      hello: null,
+      requireDriverInstanceId: () => DRIVER_INSTANCE_ID,
+    };
+    const controller = createController(state);
+
+    for (let index = 0; index < 20; index += 1) {
+      await controller.handlePushLogs(createBatch(`batch-${index}`), activeContext);
+    }
+
+    state.hello = { pid: 1 };
+    await controller.publishPendingPreHelloLogs();
+
+    expect(publishedBatches).toHaveLength(16);
+    expect(publishedBatches[0]?.logs[0]?.message).toBe("batch-4");
+    expect(publishedBatches.at(-1)?.logs[0]?.message).toBe("batch-19");
+  });
+
+  test("still rejects a driver instance id mismatch before hello", async () => {
+    const state: FakeState = {
+      hello: null,
+      requireDriverInstanceId: () => DRIVER_INSTANCE_ID,
+    };
+    const controller = createController(state);
+
+    await expect(
+      controller.handlePushLogs(
+        { ...createBatch("mismatch"), driverInstanceId: "01J000000000000000000OTHER" },
+        activeContext,
+      ),
+    ).rejects.toThrow("Driver instance id mismatch.");
+  });
+});

--- a/apps/api/tests/driver-log-pre-hello-buffering.test.ts
+++ b/apps/api/tests/driver-log-pre-hello-buffering.test.ts
@@ -7,19 +7,14 @@ const publishedBatches: DriverLogBatchInput[] = [];
 void mock.module(
   "../src/modules/runtime/infrastructure/driver-instance/driver-log-batch-publisher",
   () => ({
-    publishDriverLogBatch: async (
-      _env: unknown,
-      _state: unknown,
-      input: DriverLogBatchInput,
-    ) => {
+    publishDriverLogBatch: async (_env: unknown, _state: unknown, input: DriverLogBatchInput) => {
       publishedBatches.push(input);
     },
   }),
 );
 
-const { DriverInstanceRpcEventIngestionController } = await import(
-  "../src/modules/runtime/infrastructure/driver-instance/rpc-event-ingestion-controller"
-);
+const { DriverInstanceRpcEventIngestionController } =
+  await import("../src/modules/runtime/infrastructure/driver-instance/rpc-event-ingestion-controller");
 
 const DRIVER_INSTANCE_ID = "01J000000000000000000000DR";
 


### PR DESCRIPTION
Second layer of the prod fix for OpenCode/acp boots dying `closed before ready` (see mosoo-agent-driver#31 for the driver-side layer and the full incident chain).

## Problem

`pushLogs` threw `Driver hello is required before pushLogs.` — an oRPC 500 — whenever a driver's first 200ms log flush raced the hello round-trip. Production DO latency makes that race common, and pre-#31 driver builds treat the failure as fatal (`reportError` under Bun) and exit before ready. Every container rollout re-opens this window for old images.

## Fix

- `handlePushLogs`: pre-hello batches are held in a bounded per-connection window (16 batches; overflow drops the oldest and logs `runtime.driver.log.pre_hello_overflow`) and `{ok:true}` is returned so old drivers don't die. Instance-id mismatch and batch-size violations stay hard errors.
- `handleHello`: after the handshake commits, pending batches publish via `publishDriverLogBatch` fire-and-forget — deliberately **not** awaited so buffered logs can never extend the hello round-trip that gates driver boot (slow-DO-RTT is the design constraint here).
- Publish failures are caught and logged per batch (`pre_hello_publish_failed`); log delivery must never affect connection lifecycle.

## Verification

- new tests (publisher stubbed via `mock.module`): pre-hello batches buffered then published in order after hello; direct publish post-hello; 16-batch bound drops oldest; instance-id mismatch still rejected
- `tsc --noEmit` clean

Defense-in-depth pairing: with driver#31 deployed, gated drivers never send pre-hello; this PR protects the fleet during rollouts and against any future early-flush regression.