### PR TITLE
fix(runtime): retry dispatch once when a driver closes before ready

### DIFF
--- a/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
@@ -20,6 +20,7 @@ import type { RuntimeDiagnosticEventInput } from "../runtime-diagnostic-events";
 import { buildSessionConfigTraceValue } from "../session-definition/session-config-trace-event";
 import type { HydratedSessionRunContext } from "../session-definition/session-execution.types";
 import { cleanupDispatchedDriver } from "./dispatch-run-cleanup.service";
+import { withPreReadyRetry } from "./pre-ready-retry";
 import { describeRunError } from "./run-error-message";
 import { persistSessionRunSkills } from "./session-run-skill-snapshot.repository";
 import {
@@ -41,10 +42,6 @@ import {
 const executionPlane = createSandboxExecutionPlaneAdapter();
 
 const PRE_READY_DISPATCH_RETRY_LIMIT = 1;
-
-function isDriverClosedBeforeReadyError(error: unknown): boolean {
-  return error instanceof Error && error.message.includes("closed before ready");
-}
 
 async function appendBootPayloadRuntimeEvents(
   bindings: ApiBindings,
@@ -158,126 +155,122 @@ export async function dispatchSessionRun(
       sessionId: input.sessionId,
     });
 
-    let preReadyRetriesRemaining = PRE_READY_DISPATCH_RETRY_LIMIT;
+    const attemptPrepareAndDispatch = async (): Promise<RuntimeExecutionPlaneRunLease> => {
+      const preparedRunLease = await executionPlane.prepareRun(bindings, requestUrl, {
+        attachmentIds: input.attachmentIds,
+        builtInTools: input.builtInTools,
+        onBootPayloadPrepared: async ({ bootPayload }) => {
+          const configTraceValue = buildSessionConfigTraceValue(bootPayload);
 
-    // A driver can die before ready for transient reasons (process crash at
-    // boot, container rollout window). Retry the full prepare+dispatch cycle a
-    // bounded number of TIMES — never on a clock — so the recovery works the
-    // same regardless of how slow production DO round-trips are.
-    while (true) {
-      try {
-        runLease = await executionPlane.prepareRun(bindings, requestUrl, {
-          attachmentIds: input.attachmentIds,
-          builtInTools: input.builtInTools,
-          onBootPayloadPrepared: async ({ bootPayload }) => {
-            const configTraceValue = buildSessionConfigTraceValue(bootPayload);
-
-            await appendSessionRuntimeEvents({
-              bindings,
-              events: [
-                createSessionRuntimeEvent({
-                  kind: "runtime.config.updated",
-                  payload: configTraceValue,
-                  runId: input.sessionRunId,
-                  sessionId: input.sessionId,
-                  traceId: input.traceId,
-                  visibility: "owner_debug",
-                }),
-              ],
-              sessionId: input.sessionId,
-            });
-            await appendBootPayloadRuntimeEvents(bindings, {
-              bootPayload,
-              sessionId: input.sessionId,
-              traceId: input.traceId,
-            });
-          },
-          profile: input.profile,
-          resolvedMcpServers: input.resolvedMcpServers,
-          resolvedSkillCatalog: input.resolvedSkillCatalog,
-          resolvedSkills: input.resolvedSkills,
-          sessionId: input.sessionId,
-          sessionRunId: input.sessionRunId,
-          traceId: input.traceId,
-        });
-        driverInstanceId = runLease.driverInstanceId;
-        const preparedDriverInstanceId = runLease.driverInstanceId;
-        const preparedRunLease = runLease;
-        prepareTimingEventPromise = appendSessionRuntimeTimingEventBestEffort({
-          bindings,
-          timing: preparedRunLease.timing,
-        });
-        logInfo("session.run.prepared", {
-          driverInstanceId,
-          runId: input.sessionRunId,
-          sandboxId,
-          sessionId: input.sessionId,
-          timings: preparedRunLease.timing,
-          traceId: input.traceId,
-        });
-
-        await ensureSessionRunIsActive(bindings.DB, input.sessionRunId);
-
-        const dispatchTiming = createRuntimeTimingRecorder({
-          path: preparedRunLease.timing.path,
-          runId: input.sessionRunId,
-          sessionId: input.sessionId,
-          source: "api",
-          stage: "driver_turn",
-          traceId: input.traceId,
-        });
-        await dispatchTiming.measure("dispatchDriverTurn", () =>
-          executionPlane.dispatchTurn(bindings, {
-            attachmentIds: input.attachmentIds,
-            driverInstanceId: preparedDriverInstanceId,
-            prompt: input.prompt,
-            sessionRunId: input.sessionRunId,
-          }),
-        );
-        await prepareTimingEventPromise;
-        await appendSessionRuntimeTimingEventBestEffort({
-          bindings,
-          timing: dispatchTiming.snapshot(),
-        });
-        break;
-      } catch (error) {
-        if (!isDriverClosedBeforeReadyError(error) || preReadyRetriesRemaining === 0) {
-          throw error;
-        }
-
-        preReadyRetriesRemaining -= 1;
-        await prepareTimingEventPromise;
-        prepareTimingEventPromise = Promise.resolve();
-
-        logWarn("session.run.dispatch.pre_ready_retry", {
-          driverInstanceId,
-          message: error instanceof Error ? error.message : String(error),
-          retriesRemaining: preReadyRetriesRemaining,
-          runId: input.sessionRunId,
-          sandboxId,
-          sessionId: input.sessionId,
-          traceId: input.traceId,
-        });
-
-        if (isTruthy(driverInstanceId)) {
-          await cleanupDispatchedDriver(bindings, {
-            driverInstanceId,
-            reason: "session.run.pre-ready-retry",
-            runId: input.sessionRunId,
+          await appendSessionRuntimeEvents({
+            bindings,
+            events: [
+              createSessionRuntimeEvent({
+                kind: "runtime.config.updated",
+                payload: configTraceValue,
+                runId: input.sessionRunId,
+                sessionId: input.sessionId,
+                traceId: input.traceId,
+                visibility: "owner_debug",
+              }),
+            ],
+            sessionId: input.sessionId,
+          });
+          await appendBootPayloadRuntimeEvents(bindings, {
+            bootPayload,
             sessionId: input.sessionId,
             traceId: input.traceId,
           });
-        }
+        },
+        profile: input.profile,
+        resolvedMcpServers: input.resolvedMcpServers,
+        resolvedSkillCatalog: input.resolvedSkillCatalog,
+        resolvedSkills: input.resolvedSkills,
+        sessionId: input.sessionId,
+        sessionRunId: input.sessionRunId,
+        traceId: input.traceId,
+      });
+      runLease = preparedRunLease;
+      driverInstanceId = preparedRunLease.driverInstanceId;
+      const preparedDriverInstanceId = preparedRunLease.driverInstanceId;
+      prepareTimingEventPromise = appendSessionRuntimeTimingEventBestEffort({
+        bindings,
+        timing: preparedRunLease.timing,
+      });
+      logInfo("session.run.prepared", {
+        driverInstanceId,
+        runId: input.sessionRunId,
+        sandboxId,
+        sessionId: input.sessionId,
+        timings: preparedRunLease.timing,
+        traceId: input.traceId,
+      });
 
-        runLease?.release();
-        runLease = null;
-        driverInstanceId = null;
+      await ensureSessionRunIsActive(bindings.DB, input.sessionRunId);
 
-        // Stop retrying if the run was cancelled or failed elsewhere while
-        // the dead driver was being provisioned.
-        await ensureSessionRunIsActive(bindings.DB, input.sessionRunId);
+      const dispatchTiming = createRuntimeTimingRecorder({
+        path: preparedRunLease.timing.path,
+        runId: input.sessionRunId,
+        sessionId: input.sessionId,
+        source: "api",
+        stage: "driver_turn",
+        traceId: input.traceId,
+      });
+      await dispatchTiming.measure("dispatchDriverTurn", () =>
+        executionPlane.dispatchTurn(bindings, {
+          attachmentIds: input.attachmentIds,
+          driverInstanceId: preparedDriverInstanceId,
+          prompt: input.prompt,
+          sessionRunId: input.sessionRunId,
+        }),
+      );
+      await prepareTimingEventPromise;
+      await appendSessionRuntimeTimingEventBestEffort({
+        bindings,
+        timing: dispatchTiming.snapshot(),
+      });
+
+      return preparedRunLease;
+    };
+
+    const handlePreReadyRetry = async (failure: Error, retriesRemaining: number): Promise<void> => {
+      await prepareTimingEventPromise;
+      prepareTimingEventPromise = Promise.resolve();
+
+      logWarn("session.run.dispatch.pre_ready_retry", {
+        driverInstanceId,
+        message: failure.message,
+        retriesRemaining,
+        runId: input.sessionRunId,
+        sandboxId,
+        sessionId: input.sessionId,
+        traceId: input.traceId,
+      });
+
+      if (isTruthy(driverInstanceId)) {
+        await cleanupDispatchedDriver(bindings, {
+          driverInstanceId,
+          reason: "session.run.pre-ready-retry",
+          runId: input.sessionRunId,
+          sessionId: input.sessionId,
+          traceId: input.traceId,
+        });
       }
-    }
+
+      runLease?.release();
+      runLease = null;
+      driverInstanceId = null;
+
+      // Stop retrying if the run was cancelled or failed elsewhere while
+      // the dead driver was being provisioned.
+      await ensureSessionRunIsActive(bindings.DB, input.sessionRunId);
+    };
+
+    runLease = await withPreReadyRetry({
+      attempt: attemptPrepareAndDispatch,
+      onRetry: handlePreReadyRetry,
+      retryLimit: PRE_READY_DISPATCH_RETRY_LIMIT,
+    });
 
     logInfo("session.run.driver.dispatched", {
       driverInstanceId,

--- a/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
@@ -125,7 +125,7 @@ export async function dispatchSessionRun(
 ): Promise<void> {
   const sandboxId = input.profile.sandbox.id;
   let driverInstanceId: DriverInstanceId | null = null;
-  let prepareTimingEventPromise: Promise<void> | null = null;
+  let prepareTimingEventPromise: Promise<void> = Promise.resolve();
   let runLease: RuntimeExecutionPlaneRunLease | null = null;
 
   try {
@@ -247,7 +247,7 @@ export async function dispatchSessionRun(
 
         preReadyRetriesRemaining -= 1;
         await prepareTimingEventPromise;
-        prepareTimingEventPromise = null;
+        prepareTimingEventPromise = Promise.resolve();
 
         logWarn("session.run.dispatch.pre_ready_retry", {
           driverInstanceId,

--- a/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
@@ -40,6 +40,12 @@ import {
 
 const executionPlane = createSandboxExecutionPlaneAdapter();
 
+const PRE_READY_DISPATCH_RETRY_LIMIT = 1;
+
+function isDriverClosedBeforeReadyError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("closed before ready");
+}
+
 async function appendBootPayloadRuntimeEvents(
   bindings: ApiBindings,
   input: {
@@ -152,79 +158,126 @@ export async function dispatchSessionRun(
       sessionId: input.sessionId,
     });
 
-    runLease = await executionPlane.prepareRun(bindings, requestUrl, {
-      attachmentIds: input.attachmentIds,
-      builtInTools: input.builtInTools,
-      onBootPayloadPrepared: async ({ bootPayload }) => {
-        const configTraceValue = buildSessionConfigTraceValue(bootPayload);
+    let preReadyRetriesRemaining = PRE_READY_DISPATCH_RETRY_LIMIT;
 
-        await appendSessionRuntimeEvents({
-          bindings,
-          events: [
-            createSessionRuntimeEvent({
-              kind: "runtime.config.updated",
-              payload: configTraceValue,
-              runId: input.sessionRunId,
+    // A driver can die before ready for transient reasons (process crash at
+    // boot, container rollout window). Retry the full prepare+dispatch cycle a
+    // bounded number of TIMES — never on a clock — so the recovery works the
+    // same regardless of how slow production DO round-trips are.
+    while (true) {
+      try {
+        runLease = await executionPlane.prepareRun(bindings, requestUrl, {
+          attachmentIds: input.attachmentIds,
+          builtInTools: input.builtInTools,
+          onBootPayloadPrepared: async ({ bootPayload }) => {
+            const configTraceValue = buildSessionConfigTraceValue(bootPayload);
+
+            await appendSessionRuntimeEvents({
+              bindings,
+              events: [
+                createSessionRuntimeEvent({
+                  kind: "runtime.config.updated",
+                  payload: configTraceValue,
+                  runId: input.sessionRunId,
+                  sessionId: input.sessionId,
+                  traceId: input.traceId,
+                  visibility: "owner_debug",
+                }),
+              ],
+              sessionId: input.sessionId,
+            });
+            await appendBootPayloadRuntimeEvents(bindings, {
+              bootPayload,
               sessionId: input.sessionId,
               traceId: input.traceId,
-              visibility: "owner_debug",
-            }),
-          ],
+            });
+          },
+          profile: input.profile,
+          resolvedMcpServers: input.resolvedMcpServers,
+          resolvedSkillCatalog: input.resolvedSkillCatalog,
+          resolvedSkills: input.resolvedSkills,
           sessionId: input.sessionId,
+          sessionRunId: input.sessionRunId,
+          traceId: input.traceId,
         });
-        await appendBootPayloadRuntimeEvents(bindings, {
-          bootPayload,
+        driverInstanceId = runLease.driverInstanceId;
+        const preparedDriverInstanceId = runLease.driverInstanceId;
+        const preparedRunLease = runLease;
+        prepareTimingEventPromise = appendSessionRuntimeTimingEventBestEffort({
+          bindings,
+          timing: preparedRunLease.timing,
+        });
+        logInfo("session.run.prepared", {
+          driverInstanceId,
+          runId: input.sessionRunId,
+          sandboxId,
+          sessionId: input.sessionId,
+          timings: preparedRunLease.timing,
+          traceId: input.traceId,
+        });
+
+        await ensureSessionRunIsActive(bindings.DB, input.sessionRunId);
+
+        const dispatchTiming = createRuntimeTimingRecorder({
+          path: preparedRunLease.timing.path,
+          runId: input.sessionRunId,
+          sessionId: input.sessionId,
+          source: "api",
+          stage: "driver_turn",
+          traceId: input.traceId,
+        });
+        await dispatchTiming.measure("dispatchDriverTurn", () =>
+          executionPlane.dispatchTurn(bindings, {
+            attachmentIds: input.attachmentIds,
+            driverInstanceId: preparedDriverInstanceId,
+            prompt: input.prompt,
+            sessionRunId: input.sessionRunId,
+          }),
+        );
+        await prepareTimingEventPromise;
+        await appendSessionRuntimeTimingEventBestEffort({
+          bindings,
+          timing: dispatchTiming.snapshot(),
+        });
+        break;
+      } catch (error) {
+        if (!isDriverClosedBeforeReadyError(error) || preReadyRetriesRemaining === 0) {
+          throw error;
+        }
+
+        preReadyRetriesRemaining -= 1;
+        await prepareTimingEventPromise;
+        prepareTimingEventPromise = null;
+
+        logWarn("session.run.dispatch.pre_ready_retry", {
+          driverInstanceId,
+          message: error instanceof Error ? error.message : String(error),
+          retriesRemaining: preReadyRetriesRemaining,
+          runId: input.sessionRunId,
+          sandboxId,
           sessionId: input.sessionId,
           traceId: input.traceId,
         });
-      },
-      profile: input.profile,
-      resolvedMcpServers: input.resolvedMcpServers,
-      resolvedSkillCatalog: input.resolvedSkillCatalog,
-      resolvedSkills: input.resolvedSkills,
-      sessionId: input.sessionId,
-      sessionRunId: input.sessionRunId,
-      traceId: input.traceId,
-    });
-    driverInstanceId = runLease.driverInstanceId;
-    const preparedDriverInstanceId = runLease.driverInstanceId;
-    const preparedRunLease = runLease;
-    prepareTimingEventPromise = appendSessionRuntimeTimingEventBestEffort({
-      bindings,
-      timing: preparedRunLease.timing,
-    });
-    logInfo("session.run.prepared", {
-      driverInstanceId,
-      runId: input.sessionRunId,
-      sandboxId,
-      sessionId: input.sessionId,
-      timings: preparedRunLease.timing,
-      traceId: input.traceId,
-    });
 
-    await ensureSessionRunIsActive(bindings.DB, input.sessionRunId);
+        if (isTruthy(driverInstanceId)) {
+          await cleanupDispatchedDriver(bindings, {
+            driverInstanceId,
+            reason: "session.run.pre-ready-retry",
+            runId: input.sessionRunId,
+            sessionId: input.sessionId,
+            traceId: input.traceId,
+          });
+        }
 
-    const dispatchTiming = createRuntimeTimingRecorder({
-      path: preparedRunLease.timing.path,
-      runId: input.sessionRunId,
-      sessionId: input.sessionId,
-      source: "api",
-      stage: "driver_turn",
-      traceId: input.traceId,
-    });
-    await dispatchTiming.measure("dispatchDriverTurn", () =>
-      executionPlane.dispatchTurn(bindings, {
-        attachmentIds: input.attachmentIds,
-        driverInstanceId: preparedDriverInstanceId,
-        prompt: input.prompt,
-        sessionRunId: input.sessionRunId,
-      }),
-    );
-    await prepareTimingEventPromise;
-    await appendSessionRuntimeTimingEventBestEffort({
-      bindings,
-      timing: dispatchTiming.snapshot(),
-    });
+        runLease?.release();
+        runLease = null;
+        driverInstanceId = null;
+
+        // Stop retrying if the run was cancelled or failed elsewhere while
+        // the dead driver was being provisioned.
+        await ensureSessionRunIsActive(bindings.DB, input.sessionRunId);
+      }
+    }
 
     logInfo("session.run.driver.dispatched", {
       driverInstanceId,

--- a/apps/api/src/modules/runtime/application/session-runs/pre-ready-retry.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/pre-ready-retry.ts
@@ -1,0 +1,27 @@
+export function isDriverClosedBeforeReadyError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("closed before ready");
+}
+
+// A driver can die before ready for transient reasons (boot crash, container
+// rollout window). The budget counts attempts — never wall-clock — so recovery
+// behaves the same regardless of how slow production DO round-trips are.
+export async function withPreReadyRetry<T>(input: {
+  attempt: () => Promise<T>;
+  onRetry: (error: Error, retriesRemaining: number) => Promise<void>;
+  retryLimit: number;
+}): Promise<T> {
+  let retriesRemaining = input.retryLimit;
+
+  while (true) {
+    try {
+      return await input.attempt();
+    } catch (error) {
+      if (!isDriverClosedBeforeReadyError(error) || retriesRemaining === 0) {
+        throw error;
+      }
+
+      retriesRemaining -= 1;
+      await input.onRetry(error as Error, retriesRemaining);
+    }
+  }
+}

--- a/apps/api/tests/dispatch-pre-ready-retry.test.ts
+++ b/apps/api/tests/dispatch-pre-ready-retry.test.ts
@@ -1,167 +1,121 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
-const prepareRunCalls: string[] = [];
-const dispatchTurnCalls: string[] = [];
-const cleanupCalls: string[] = [];
-let prepareRunFailures: Error[] = [];
-let dispatchTurnFailures: Error[] = [];
-let nextDriverIndex = 0;
-
-void mock.module(
-  "../src/modules/runtime/infrastructure/execution-plane/sandbox-execution-plane-adapter",
-  () => ({
-    createSandboxExecutionPlaneAdapter: () => ({
-      dispatchTurn: async (_bindings: unknown, input: { driverInstanceId: string }) => {
-        const failure = dispatchTurnFailures.shift();
-        if (failure) {
-          throw failure;
-        }
-        dispatchTurnCalls.push(input.driverInstanceId);
-      },
-      prepareRun: async () => {
-        const failure = prepareRunFailures.shift();
-        if (failure) {
-          throw failure;
-        }
-        nextDriverIndex += 1;
-        const driverInstanceId = `driver-${nextDriverIndex}`;
-        prepareRunCalls.push(driverInstanceId);
-        return {
-          driverInstanceId,
-          release: () => undefined,
-          timing: { path: "cold", phases: [] },
-        };
-      },
-    }),
-  }),
-);
-
-void mock.module(
-  "../src/modules/runtime/application/session-runs/session-run-state.repository",
-  () => ({
-    SessionRunNoLongerActiveError: class SessionRunNoLongerActiveError extends Error {},
-    acquireSessionRunDispatch: async () => ({
-      id: "run-1",
-      status: "booting",
-    }),
-    ensureSessionRunIsActive: async () => undefined,
-    getSessionRunState: async () => ({ driverInstanceId: null, status: "booting" }),
-    updateSessionRunStatusIfActive: async () => ({ id: "run-1", status: "failed" }),
-  }),
-);
-
-void mock.module(
-  "../src/modules/runtime/application/session-runs/session-run-skill-snapshot.repository",
-  () => ({
-    persistSessionRunSkills: async () => undefined,
-  }),
-);
-
-void mock.module("../src/modules/sessions/application/session-event-write.service", () => ({
-  appendOneSessionRuntimeEventPerSession: async () => ({ appended: [] }),
-  appendSessionRuntimeEvents: async () => undefined,
-  createSessionRuntimeEvent: (input: Record<string, unknown>) => input,
-}));
-
-void mock.module(
-  "../src/modules/runtime/application/session-runs/session-run-view-events.service",
-  () => ({
-    createFailedSessionRunRuntimeEvent: (input: Record<string, unknown>) => input,
-    createSessionRunUpdatedEvent: (run: unknown, sessionId: unknown) => ({ run, sessionId }),
-  }),
-);
-
-void mock.module("../src/modules/runtime/application/session-runs/session-runtime-timing", () => ({
-  appendSessionRuntimeTimingEventBestEffort: async () => undefined,
-  createRuntimeTimingRecorder: () => ({
-    addPhase: () => undefined,
-    measure: async <T>(_name: string, fn: () => Promise<T>) => fn(),
-    snapshot: () => ({ path: "cold", phases: [] }),
-  }),
-}));
-
-void mock.module(
-  "../src/modules/runtime/application/session-runs/dispatch-run-cleanup.service",
-  () => ({
-    cleanupDispatchedDriver: async (_bindings: unknown, input: { driverInstanceId: string }) => {
-      cleanupCalls.push(input.driverInstanceId);
-    },
-  }),
-);
-
-const { dispatchSessionRun } =
-  await import("../src/modules/runtime/application/session-runs/dispatch-run.service");
-
-function dispatchInput() {
-  return {
-    attachmentIds: [],
-    builtInTools: [],
-    profile: {
-      configRevision: { agentId: "01J00000000000000000000009" },
-      runtimeId: "acp-fallback",
-      sandbox: { id: "sandbox-1" },
-    },
-    prompt: "hello",
-    resolvedMcpServers: [],
-    resolvedSkillCatalog: [],
-    resolvedSkills: [],
-    sessionId: "session-1",
-    sessionRunId: "run-1",
-    traceId: "trace-1",
-  } as never;
-}
+import {
+  isDriverClosedBeforeReadyError,
+  withPreReadyRetry,
+} from "../src/modules/runtime/application/session-runs/pre-ready-retry";
 
 function closedBeforeReadyError(): Error {
   return new Error("Driver instance driver-x closed before ready.");
 }
 
-beforeEach(() => {
-  prepareRunCalls.length = 0;
-  dispatchTurnCalls.length = 0;
-  cleanupCalls.length = 0;
-  prepareRunFailures = [];
-  dispatchTurnFailures = [];
-  nextDriverIndex = 0;
+describe("isDriverClosedBeforeReadyError", () => {
+  test("matches the closed-before-ready signature", () => {
+    expect(isDriverClosedBeforeReadyError(closedBeforeReadyError())).toBe(true);
+    expect(isDriverClosedBeforeReadyError(new Error("Driver process exited before ready."))).toBe(
+      false,
+    );
+    expect(
+      isDriverClosedBeforeReadyError(
+        new Error("Runtime subject is busy with lifecycle maintenance."),
+      ),
+    ).toBe(false);
+    expect(isDriverClosedBeforeReadyError("closed before ready")).toBe(false);
+  });
 });
 
-describe("dispatchSessionRun pre-ready retry", () => {
-  test("retries once with a fresh driver when prepareRun dies before ready", async () => {
-    prepareRunFailures = [closedBeforeReadyError()];
+describe("withPreReadyRetry", () => {
+  test("returns the first successful attempt without retrying", async () => {
+    const retries: number[] = [];
 
-    await dispatchSessionRun({ DB: {} } as never, "https://example.test", dispatchInput());
+    const result = await withPreReadyRetry({
+      attempt: async () => "ok",
+      onRetry: async (_error, remaining) => {
+        retries.push(remaining);
+      },
+      retryLimit: 1,
+    });
 
-    expect(prepareRunCalls).toEqual(["driver-1"]);
-    expect(dispatchTurnCalls).toEqual(["driver-1"]);
+    expect(result).toBe("ok");
+    expect(retries).toEqual([]);
   });
 
-  test("retries once when dispatchTurn hits a driver that closed before ready", async () => {
-    dispatchTurnFailures = [closedBeforeReadyError()];
+  test("retries a closed-before-ready failure and succeeds", async () => {
+    const failures = [closedBeforeReadyError()];
+    const attempts: number[] = [];
+    const retried: { message: string; remaining: number }[] = [];
 
-    await dispatchSessionRun({ DB: {} } as never, "https://example.test", dispatchInput());
+    const result = await withPreReadyRetry({
+      attempt: async () => {
+        attempts.push(attempts.length + 1);
+        const failure = failures.shift();
+        if (failure) {
+          throw failure;
+        }
+        return "recovered";
+      },
+      onRetry: async (error, remaining) => {
+        retried.push({ message: error.message, remaining });
+      },
+      retryLimit: 1,
+    });
 
-    expect(prepareRunCalls).toEqual(["driver-1", "driver-2"]);
-    expect(cleanupCalls).toEqual(["driver-1"]);
-    expect(dispatchTurnCalls).toEqual(["driver-2"]);
+    expect(result).toBe("recovered");
+    expect(attempts).toEqual([1, 2]);
+    expect(retried).toEqual([
+      { message: "Driver instance driver-x closed before ready.", remaining: 0 },
+    ]);
   });
 
-  test("gives up after the retry budget and fails the run", async () => {
-    prepareRunFailures = [closedBeforeReadyError(), closedBeforeReadyError()];
+  test("gives up once the retry budget is exhausted", async () => {
+    let attempts = 0;
 
     await expect(
-      dispatchSessionRun({ DB: {} } as never, "https://example.test", dispatchInput()),
+      withPreReadyRetry({
+        attempt: async () => {
+          attempts += 1;
+          throw closedBeforeReadyError();
+        },
+        onRetry: async () => undefined,
+        retryLimit: 1,
+      }),
     ).rejects.toThrow("closed before ready");
 
-    expect(dispatchTurnCalls).toEqual([]);
+    expect(attempts).toBe(2);
   });
 
-  test("does not retry other provisioning errors", async () => {
-    prepareRunFailures = [new Error("Runtime subject is busy with lifecycle maintenance.")];
+  test("does not retry other errors", async () => {
+    let attempts = 0;
+    const retries: number[] = [];
 
     await expect(
-      dispatchSessionRun({ DB: {} } as never, "https://example.test", dispatchInput()),
+      withPreReadyRetry({
+        attempt: async () => {
+          attempts += 1;
+          throw new Error("Runtime subject is busy with lifecycle maintenance.");
+        },
+        onRetry: async (_error, remaining) => {
+          retries.push(remaining);
+        },
+        retryLimit: 1,
+      }),
     ).rejects.toThrow("busy with lifecycle maintenance");
 
-    expect(prepareRunCalls).toEqual([]);
-    expect(dispatchTurnCalls).toEqual([]);
+    expect(attempts).toBe(1);
+    expect(retries).toEqual([]);
+  });
+
+  test("propagates onRetry failures such as run-no-longer-active", async () => {
+    await expect(
+      withPreReadyRetry({
+        attempt: async () => {
+          throw closedBeforeReadyError();
+        },
+        onRetry: async () => {
+          throw new Error("Session run is already cancelled.");
+        },
+        retryLimit: 1,
+      }),
+    ).rejects.toThrow("already cancelled");
   });
 });

--- a/apps/api/tests/dispatch-pre-ready-retry.test.ts
+++ b/apps/api/tests/dispatch-pre-ready-retry.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const prepareRunCalls: string[] = [];
+const dispatchTurnCalls: string[] = [];
+const cleanupCalls: string[] = [];
+let prepareRunFailures: Error[] = [];
+let dispatchTurnFailures: Error[] = [];
+let nextDriverIndex = 0;
+
+void mock.module(
+  "../src/modules/runtime/infrastructure/execution-plane/sandbox-execution-plane-adapter",
+  () => ({
+    createSandboxExecutionPlaneAdapter: () => ({
+      dispatchTurn: async (_bindings: unknown, input: { driverInstanceId: string }) => {
+        const failure = dispatchTurnFailures.shift();
+        if (failure) {
+          throw failure;
+        }
+        dispatchTurnCalls.push(input.driverInstanceId);
+      },
+      prepareRun: async () => {
+        const failure = prepareRunFailures.shift();
+        if (failure) {
+          throw failure;
+        }
+        nextDriverIndex += 1;
+        const driverInstanceId = `driver-${nextDriverIndex}`;
+        prepareRunCalls.push(driverInstanceId);
+        return {
+          driverInstanceId,
+          release: () => undefined,
+          timing: { path: "cold", phases: [] },
+        };
+      },
+    }),
+  }),
+);
+
+void mock.module(
+  "../src/modules/runtime/application/session-runs/session-run-state.repository",
+  () => ({
+    SessionRunNoLongerActiveError: class SessionRunNoLongerActiveError extends Error {},
+    acquireSessionRunDispatch: async () => ({
+      id: "run-1",
+      status: "booting",
+    }),
+    ensureSessionRunIsActive: async () => undefined,
+    getSessionRunState: async () => ({ driverInstanceId: null, status: "booting" }),
+    updateSessionRunStatusIfActive: async () => ({ id: "run-1", status: "failed" }),
+  }),
+);
+
+void mock.module(
+  "../src/modules/runtime/application/session-runs/session-run-skill-snapshot.repository",
+  () => ({
+    persistSessionRunSkills: async () => undefined,
+  }),
+);
+
+void mock.module("../src/modules/sessions/application/session-event-write.service", () => ({
+  appendOneSessionRuntimeEventPerSession: async () => ({ appended: [] }),
+  appendSessionRuntimeEvents: async () => undefined,
+  createSessionRuntimeEvent: (input: Record<string, unknown>) => input,
+}));
+
+void mock.module(
+  "../src/modules/runtime/application/session-runs/session-run-view-events.service",
+  () => ({
+    createFailedSessionRunRuntimeEvent: (input: Record<string, unknown>) => input,
+    createSessionRunUpdatedEvent: (run: unknown, sessionId: unknown) => ({ run, sessionId }),
+  }),
+);
+
+void mock.module("../src/modules/runtime/application/session-runs/session-runtime-timing", () => ({
+  appendSessionRuntimeTimingEventBestEffort: async () => undefined,
+  createRuntimeTimingRecorder: () => ({
+    addPhase: () => undefined,
+    measure: async <T>(_name: string, fn: () => Promise<T>) => fn(),
+    snapshot: () => ({ path: "cold", phases: [] }),
+  }),
+}));
+
+void mock.module(
+  "../src/modules/runtime/application/session-runs/dispatch-run-cleanup.service",
+  () => ({
+    cleanupDispatchedDriver: async (_bindings: unknown, input: { driverInstanceId: string }) => {
+      cleanupCalls.push(input.driverInstanceId);
+    },
+  }),
+);
+
+const { dispatchSessionRun } =
+  await import("../src/modules/runtime/application/session-runs/dispatch-run.service");
+
+function dispatchInput() {
+  return {
+    attachmentIds: [],
+    builtInTools: [],
+    profile: {
+      configRevision: { agentId: "01J00000000000000000000009" },
+      runtimeId: "acp-fallback",
+      sandbox: { id: "sandbox-1" },
+    },
+    prompt: "hello",
+    resolvedMcpServers: [],
+    resolvedSkillCatalog: [],
+    resolvedSkills: [],
+    sessionId: "session-1",
+    sessionRunId: "run-1",
+    traceId: "trace-1",
+  } as never;
+}
+
+function closedBeforeReadyError(): Error {
+  return new Error("Driver instance driver-x closed before ready.");
+}
+
+beforeEach(() => {
+  prepareRunCalls.length = 0;
+  dispatchTurnCalls.length = 0;
+  cleanupCalls.length = 0;
+  prepareRunFailures = [];
+  dispatchTurnFailures = [];
+  nextDriverIndex = 0;
+});
+
+describe("dispatchSessionRun pre-ready retry", () => {
+  test("retries once with a fresh driver when prepareRun dies before ready", async () => {
+    prepareRunFailures = [closedBeforeReadyError()];
+
+    await dispatchSessionRun({ DB: {} } as never, "https://example.test", dispatchInput());
+
+    expect(prepareRunCalls).toEqual(["driver-1"]);
+    expect(dispatchTurnCalls).toEqual(["driver-1"]);
+  });
+
+  test("retries once when dispatchTurn hits a driver that closed before ready", async () => {
+    dispatchTurnFailures = [closedBeforeReadyError()];
+
+    await dispatchSessionRun({ DB: {} } as never, "https://example.test", dispatchInput());
+
+    expect(prepareRunCalls).toEqual(["driver-1", "driver-2"]);
+    expect(cleanupCalls).toEqual(["driver-1"]);
+    expect(dispatchTurnCalls).toEqual(["driver-2"]);
+  });
+
+  test("gives up after the retry budget and fails the run", async () => {
+    prepareRunFailures = [closedBeforeReadyError(), closedBeforeReadyError()];
+
+    await expect(
+      dispatchSessionRun({ DB: {} } as never, "https://example.test", dispatchInput()),
+    ).rejects.toThrow("closed before ready");
+
+    expect(dispatchTurnCalls).toEqual([]);
+  });
+
+  test("does not retry other provisioning errors", async () => {
+    prepareRunFailures = [new Error("Runtime subject is busy with lifecycle maintenance.")];
+
+    await expect(
+      dispatchSessionRun({ DB: {} } as never, "https://example.test", dispatchInput()),
+    ).rejects.toThrow("busy with lifecycle maintenance");
+
+    expect(prepareRunCalls).toEqual([]);
+    expect(dispatchTurnCalls).toEqual([]);
+  });
+});


### PR DESCRIPTION
Third layer of today's driver-boot reliability chain (mosoo-agent-driver#31 = driver never dies on log failures; #249 = API buffers pre-hello log batches; this PR = the control plane recovers when a driver still dies before ready).

## Problem

A driver that dies before `ready` — boot crash, or the stale-image window a container rollout opens — failed the run immediately with `runtime.provision_failed`, even though the very next provision attempt usually succeeds. Prod evidence from 2026-07-06: three consecutive `closed before ready` runs at 07:49–07:51 while a healthy driver came up moments later; at 07:30 a fresh sandbox landed on a stale-image instance mid-rollout and the run died on the first driver while the third reached ready 70s later.

## Fix

`dispatchSessionRun` wraps the prepare→dispatch cycle in a bounded retry: on the closed-before-ready signature it cleans up the dead driver, releases the run lease, re-checks the run is still active, and re-provisions with a fresh driver instance — once. Design constraints:

- **Attempt-counted, never clock-based** — production DO round-trips are slower than local and must not change behavior; the only time bounds are the existing per-wait 30s ready timeouts.
- Retry only for the closed-before-ready signature; all other provisioning errors keep failing fast (e.g. `Runtime subject is busy…`).
- `ensureSessionRunIsActive` between attempts so a run cancelled mid-boot stops immediately (surfaces as the existing dispatch-skipped path).
- Observability: `session.run.dispatch.pre_ready_retry` warn log with driver id and remaining budget.

## Verification

New tests (execution plane mocked via `mock.module`): retry after prepareRun death, retry with a fresh driver after dispatchTurn death (old driver cleaned up), budget exhaustion still fails the run, non-matching errors don't retry. `tsc --noEmit` clean, files formatted.