### PR TITLE
fix(web): rename sidebar nav label from Threads to Runs

### DIFF
--- a/apps/web/src/app/navigation.tsx
+++ b/apps/web/src/app/navigation.tsx
@@ -41,7 +41,7 @@ const NAV_SECTIONS: AppNavSection[] = [
   {
     items: [
       { icon: createHugeicon(DashboardSquare01Icon, "OverviewIcon"), label: "Overview", path: "/" },
-      { icon: createHugeicon(InboxIcon, "ThreadsIcon"), label: "Threads", path: "/threads" },
+      { icon: createHugeicon(InboxIcon, "ThreadsIcon"), label: "Runs", path: "/threads" },
       { icon: createHugeicon(BotIcon, "AgentsIcon"), label: "Agents", path: "/agent" },
       {
         children: [

--- a/apps/web/tests/app-navigation-boundary.test.ts
+++ b/apps/web/tests/app-navigation-boundary.test.ts
@@ -9,11 +9,12 @@ describe("App navigation boundary", () => {
   test("puts App Overview before Agent-first surfaces", () => {
     const source = readSource("../src/app/navigation.tsx");
     const overviewIndex = source.indexOf('label: "Overview"');
-    const threadsIndex = source.indexOf('label: "Threads"');
+    const runsIndex = source.indexOf('label: "Runs"');
     const agentsIndex = source.indexOf('label: "Agents"');
 
     expect(overviewIndex).toBeGreaterThan(-1);
-    expect(overviewIndex).toBeLessThan(threadsIndex);
+    expect(runsIndex).toBeGreaterThan(-1);
+    expect(overviewIndex).toBeLessThan(runsIndex);
     expect(overviewIndex).toBeLessThan(agentsIndex);
     expect(source).toContain('path: "/"');
     expect(source).not.toContain('label: "Members"');


### PR DESCRIPTION
Fill what changed. Use N/A for irrelevant or maintainer-only items. See `CONTRIBUTING.md` for branch, CLA, generated file, and CI rules.

## Summary

- Rename the app sidebar nav label from "Threads" to "Runs" (`apps/web/src/app/navigation.tsx`).
- Update the navigation boundary test that pins the label ordering to assert on `label: "Runs"`.

## Why

- User request (YEF-804): the sidebar entry should read "Runs" instead of "Threads".

## Verification

- Commands: `bun test` in `apps/web` (118 pass), `vp exec tsc --noEmit`, `vp lint` and `vp fmt --check` on the changed files.
- Manual steps: ran the app locally, logged in via the development backdoor, and confirmed the sidebar shows "Runs" and still routes to `/threads` (screenshot attached on the issue).
- Not run: full e2e suite.

## Impact

- User/API/contract changes: sidebar label only. Routes (`/threads`), document title, and in-page copy ("Threads" page header, "New thread") are intentionally unchanged; renaming the rest of the thread terminology would be a follow-up.
- Generated files / GraphQL / DB / lockfile: N/A
- Env or config changes: N/A
- Risk and rollback: copy-only change; revert the commit to roll back.

## Review

- Closest review areas: `apps/web/src/app/navigation.tsx`, `apps/web/tests/app-navigation-boundary.test.ts`.
- Known trade-offs: sidebar now says "Runs" while the page it opens is still titled "Threads"; kept scope to the explicit request.
