### PR TITLE
refactor(api)!: simplify public file uploads

### DIFF
--- a/apps/api/src/adapters/http/routes/public-api-openapi.ts
+++ b/apps/api/src/adapters/http/routes/public-api-openapi.ts
@@ -5,7 +5,6 @@ import {
   PUBLIC_THREAD_API_THREADS_MAX_LIMIT,
   PUBLIC_THREAD_EVENTS_DEFAULT_LIMIT,
   PUBLIC_THREAD_EVENTS_MAX_LIMIT,
-  PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES,
   PUBLIC_API_VERSION,
 } from "@mosoo/contracts/public-api";
 
@@ -49,7 +48,6 @@ interface PublicApiOpenApiDocument {
 const EXAMPLE_AGENT_ID = "01J00000000000000000000001";
 const EXAMPLE_THREAD_ID = "01J00000000000000000000009";
 const EXAMPLE_FILE_ID = "01J0000000000000000000000J";
-const EXAMPLE_ACCOUNT_ID = "01J00000000000000000000002";
 const ACCESS_TOKEN_SECURITY: Array<Record<string, []>> = [{ accessToken: [] }];
 
 const EXAMPLE_SESSION_FILE = {
@@ -62,31 +60,12 @@ const EXAMPLE_SESSION_FILE = {
   size: 19,
 };
 
-const EXAMPLE_FILE_UPLOAD_SUMMARY = {
-  contentType: "text/plain",
-  expectedSize: 19,
-  expiresAt: "2026-05-20T00:02:00.000Z",
-  fileId: EXAMPLE_FILE_ID,
-  partSize: null,
-  path: `session-files/${EXAMPLE_FILE_ID}/brief.txt`,
-  status: "pending",
-  strategy: "single_put",
-};
-
-const EXAMPLE_FILE_ENTRY = {
+const EXAMPLE_PUBLIC_FILE = {
   createdAt: "2026-05-19T00:02:00.000Z",
-  createdBy: EXAMPLE_ACCOUNT_ID,
-  etag: "etag-1",
-  expiresAt: null,
   id: EXAMPLE_FILE_ID,
   mimeType: "text/plain",
   name: "brief.txt",
-  path: `session-files/${EXAMPLE_FILE_ID}/brief.txt`,
-  sessionKind: "attachment",
   size: 19,
-  status: "ready",
-  updatedAt: "2026-05-19T00:03:00.000Z",
-  version: 1,
 };
 
 function platformIdPathParameter(input: {
@@ -212,17 +191,24 @@ function jsonRequestBodyExamples(
   };
 }
 
-function binaryRequestBody(description: string) {
+function multipartFileRequestBody() {
   return {
     content: {
-      "application/octet-stream": {
+      "multipart/form-data": {
         schema: {
-          format: "binary",
-          type: "string",
+          additionalProperties: false,
+          properties: {
+            file: {
+              description: "File bytes to upload before attaching them to a Thread.",
+              format: "binary",
+              type: "string",
+            },
+          },
+          required: ["file"],
+          type: "object",
         },
       },
     },
-    description,
     required: true,
   };
 }
@@ -327,24 +313,21 @@ function operation(
 
 export function createPublicApiOpenApiDocument(origin: string): PublicApiOpenApiDocument {
   const paths = {
-    "/files/{fileId}/complete": {
+    "/agents/{agentId}/files": {
       post: operation({
         description:
-          "Completes a pending single PUT Thread file upload. The file must have been created through POST /threads/{threadId}/files/uploads, uploaded through PUT /files/{fileId}/content, and belong to a public Thread visible to the Access Token caller.",
-        parameters: [fileIdParameter],
-        requestBody: jsonRequestBody(
-          { $ref: "#/components/schemas/CompleteFileUploadRequest" },
-          {},
-        ),
+          "Uploads a file into the Agent API Endpoint's App draft scope before a Thread exists. Use the returned file ID in create-thread or send-events resources.",
+        parameters: [exampleAgentIdParameter],
+        requestBody: multipartFileRequestBody(),
         security: ACCESS_TOKEN_SECURITY,
         success: {
-          "200": jsonResponse(
-            "Completed files API upload.",
-            { $ref: "#/components/schemas/CompleteFileUploadResponse" },
-            { file: EXAMPLE_FILE_ENTRY },
+          "201": jsonResponse(
+            "Uploaded file.",
+            { $ref: "#/components/schemas/PublicFileResponse" },
+            { file: EXAMPLE_PUBLIC_FILE },
           ),
         },
-        summary: "Complete Thread file upload",
+        summary: "Upload an Agent file",
       }),
     },
     "/files/{fileId}/content": {
@@ -358,16 +341,31 @@ export function createPublicApiOpenApiDocument(origin: string): PublicApiOpenApi
         },
         summary: "Download Thread file content",
       }),
-      put: operation({
+    },
+    "/files/{fileId}": {
+      delete: operation({
         description:
-          "Uploads raw bytes for a pending single PUT Thread file upload. The file must have been created through POST /threads/{threadId}/files/uploads and belong to a public Thread visible to the Access Token caller.",
+          "Deletes a pre-Thread uploaded file or a file attached to a public Thread visible to the Access Token caller.",
         parameters: [fileIdParameter],
-        requestBody: binaryRequestBody("Raw file bytes for the upload session."),
         security: ACCESS_TOKEN_SECURITY,
         success: {
-          "200": okResponse("Uploaded."),
+          "200": okResponse("Deleted."),
         },
-        summary: "Upload Thread file content",
+        summary: "Delete a file",
+      }),
+      get: operation({
+        description:
+          "Returns public file metadata for a pre-Thread uploaded file or a file attached to a public Thread visible to the Access Token caller.",
+        parameters: [fileIdParameter],
+        security: ACCESS_TOKEN_SECURITY,
+        success: {
+          "200": jsonResponse(
+            "File metadata.",
+            { $ref: "#/components/schemas/PublicFileResponse" },
+            { file: EXAMPLE_PUBLIC_FILE },
+          ),
+        },
+        summary: "Retrieve file metadata",
       }),
     },
     "/agents/{agentId}/threads": {
@@ -416,7 +414,6 @@ export function createPublicApiOpenApiDocument(origin: string): PublicApiOpenApi
               summary: "Access Token with an uploaded file",
               value: {
                 client_external_ref: "linear-ENG-123",
-                files: [{ file_id: EXAMPLE_FILE_ID }],
                 input: {
                   content: [
                     {
@@ -426,6 +423,7 @@ export function createPublicApiOpenApiDocument(origin: string): PublicApiOpenApi
                   ],
                   type: "user.message",
                 },
+                resources: [{ file_id: EXAMPLE_FILE_ID, type: "file" }],
               },
             },
             accessTokenBasic: {
@@ -553,55 +551,6 @@ export function createPublicApiOpenApiDocument(origin: string): PublicApiOpenApi
           ),
         },
         summary: "List Thread files",
-      }),
-      post: operation({
-        description:
-          "Claims a ready draft file handle into this Thread. Upload file bytes through the files data plane first, then pass the resulting fileId here.",
-        parameters: [threadIdParameter],
-        security: ACCESS_TOKEN_SECURITY,
-        requestBody: jsonRequestBody(
-          {
-            $ref: "#/components/schemas/CreateThreadFileRequest",
-          },
-          {
-            fileId: EXAMPLE_SESSION_FILE.id,
-          },
-        ),
-        success: {
-          "201": jsonResponse(
-            "Created Thread file.",
-            { $ref: "#/components/schemas/ThreadFileResponse" },
-            { file: EXAMPLE_SESSION_FILE },
-          ),
-        },
-        summary: "Add a Thread file",
-      }),
-    },
-    "/threads/{threadId}/files/uploads": {
-      post: operation({
-        description: `Creates a files API upload session scoped to this Thread. The request only supplies file metadata; Mosoo resolves the backing App and Session from the Thread and creates a session attachment upload. MVP public uploads must be ${PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES} bytes or fewer and use single PUT.`,
-        parameters: [threadIdParameter],
-        security: ACCESS_TOKEN_SECURITY,
-        requestBody: jsonRequestBody(
-          {
-            $ref: "#/components/schemas/CreateThreadFileUploadRequest",
-          },
-          {
-            file: {
-              contentType: "text/plain",
-              name: "brief.txt",
-              size: 19,
-            },
-          },
-        ),
-        success: {
-          "201": jsonResponse(
-            "Created files API upload session.",
-            { $ref: "#/components/schemas/FileUploadSummary" },
-            EXAMPLE_FILE_UPLOAD_SUMMARY,
-          ),
-        },
-        summary: "Create a Thread file upload",
       }),
     },
     "/threads/{threadId}/files/{fileId}": {

--- a/apps/api/src/adapters/http/routes/public-api-route.ts
+++ b/apps/api/src/adapters/http/routes/public-api-route.ts
@@ -1,4 +1,3 @@
-import type { CompleteFileUploadRequest } from "@mosoo/contracts/file";
 import { PUBLIC_API_VERSION_PREFIX } from "@mosoo/contracts/public-api";
 import type { PublicThreadId } from "@mosoo/id";
 import { Hono } from "hono";
@@ -7,6 +6,7 @@ import type { Context } from "hono";
 import type { PersonalAccessTokenCaller } from "../../../modules/auth/application/personal-access-token.service";
 import { parseBoundAgentCallBody } from "../../../modules/public-api/app-agent-bound-call";
 import { renderBoundAgentCallError } from "../../../modules/public-api/app-agent-bound-errors";
+import { publicInvalidRequest } from "../../../modules/public-api/public-api-errors";
 import { hashPublicApiIdempotencyBody } from "../../../modules/public-api/public-api-idempotency.service";
 import { listAgentApiEndpointThreads } from "../../../modules/public-api/public-thread-session-query.service";
 import type { ApiGatewayEnvironment } from "../../../platform/cloudflare/worker-types";
@@ -28,13 +28,14 @@ import {
   parseThreadEventsLimit,
   readBoundAgentCallRequestBody,
   readCreateThreadRequest,
-  readCreateThreadFileRequest,
-  readCreateThreadFileUploadRequest,
   readSendEventsRequest,
 } from "./public-thread-api-request";
 import type { ParsedCreateThreadRequest } from "./public-thread-api-request";
 
 type PublicApiRouteContext = Context<ApiGatewayEnvironment>;
+interface PublicAgentFileUploadRequest {
+  file: File;
+}
 type PublicThreadFileService = Awaited<ReturnType<typeof loadPublicThreadFileService>>;
 
 async function loadPublicThreadCommandService() {
@@ -82,6 +83,19 @@ async function hashCreateThreadIdempotencyBody(
     fileIds: body.fileIds,
     inputText: body.inputText ?? null,
   });
+}
+
+async function readPublicAgentFileUploadRequest(
+  c: PublicApiRouteContext,
+): Promise<PublicAgentFileUploadRequest> {
+  const formData = await c.req.raw.formData();
+  const file = formData.get("file");
+
+  if (!(file instanceof File)) {
+    throw publicInvalidRequest("multipart/form-data field `file` is required.");
+  }
+
+  return { file };
 }
 
 export function registerPublicApiRoute(app: Hono<ApiGatewayEnvironment>) {
@@ -133,6 +147,21 @@ export function registerPublicApiRoute(app: Hono<ApiGatewayEnvironment>) {
       status: 201,
     });
   });
+
+  v1.post("/agents/:agentId/files", async (c) =>
+    runPublicApiThreadMutation(c, {
+      agentId: () => parseAgentIdParam(c.req.param("agentId")),
+      operation: async ({ agentId, caller, prepared }) => {
+        const service = await loadPublicThreadFileService();
+        return service.createPublicAgentFile(c.env, caller, {
+          agentId,
+          file: prepared.file,
+        });
+      },
+      prepare: async () => readPublicAgentFileUploadRequest(c),
+      status: 201,
+    }),
+  );
 
   v1.get("/threads/:threadId", async (c) =>
     runPublicApiThreadReadJson(c, {
@@ -206,24 +235,22 @@ export function registerPublicApiRoute(app: Hono<ApiGatewayEnvironment>) {
     }),
   );
 
-  v1.put("/files/:fileId/content", async (c) =>
+  v1.get("/files/:fileId", async (c) =>
     runPublicApiAuthenticatedJson(c, async (caller) => {
       const service = await loadPublicThreadFileService();
-      await service.putPublicThreadFileContent(c.env, caller.viewer, {
-        body: c.req.raw.body,
-        fileId: parseFileIdParam(c.req.param("fileId")),
-      });
-      return { ok: true };
+      return service.retrievePublicFile(
+        c.env,
+        caller.viewer,
+        parseFileIdParam(c.req.param("fileId")),
+      );
     }),
   );
 
-  v1.post("/files/:fileId/complete", async (c) =>
+  v1.delete("/files/:fileId", async (c) =>
     runPublicApiAuthenticatedJson(c, async (caller) => {
       const service = await loadPublicThreadFileService();
-      return service.completePublicThreadFileUpload(c.env, caller.viewer, {
-        fileId: parseFileIdParam(c.req.param("fileId")),
-        request: await c.req.json<CompleteFileUploadRequest>(),
-      });
+      await service.deletePublicFile(c.env, caller.viewer, parseFileIdParam(c.req.param("fileId")));
+      return { ok: true };
     }),
   );
 
@@ -300,34 +327,6 @@ export function registerPublicApiRoute(app: Hono<ApiGatewayEnvironment>) {
   v1.get("/threads/:threadId/files", async (c) =>
     runPublicThreadFileRoute(c, async ({ caller, service, threadId }) =>
       service.listPublicThreadFiles(c.env, caller.viewer, threadId),
-    ),
-  );
-
-  v1.post("/threads/:threadId/files", async (c) =>
-    runPublicThreadFileRoute(
-      c,
-      async ({ caller, service, threadId }) =>
-        service.createPublicThreadFile(
-          c.env,
-          caller.viewer,
-          threadId,
-          await readCreateThreadFileRequest(c),
-        ),
-      201,
-    ),
-  );
-
-  v1.post("/threads/:threadId/files/uploads", async (c) =>
-    runPublicThreadFileRoute(
-      c,
-      async ({ caller, service, threadId }) =>
-        service.createPublicThreadFileUpload(
-          c.env,
-          caller.viewer,
-          threadId,
-          await readCreateThreadFileUploadRequest(c),
-        ),
-      201,
     ),
   );
 

--- a/apps/api/src/adapters/http/routes/public-thread-api-request.ts
+++ b/apps/api/src/adapters/http/routes/public-thread-api-request.ts
@@ -1,14 +1,9 @@
-import type {
-  CreatePublicThreadFileUploadRequest,
-  CreatePublicThreadFileRequest,
-  PublicThreadApiSendEventsRequest,
-} from "@mosoo/contracts/public-api";
+import type { PublicThreadApiSendEventsRequest } from "@mosoo/contracts/public-api";
 import {
   PUBLIC_THREAD_EVENTS_DEFAULT_LIMIT,
   PUBLIC_THREAD_EVENTS_MAX_LIMIT,
   PUBLIC_THREAD_CLIENT_EXTERNAL_REF_MAX_LENGTH,
   PUBLIC_THREAD_FILE_ID_MAX_LENGTH,
-  PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES,
   PUBLIC_THREAD_INPUT_TEXT_MAX_LENGTH,
   PUBLIC_THREAD_JSON_BODY_MAX_BYTES,
 } from "@mosoo/contracts/public-api";
@@ -32,14 +27,14 @@ interface RawJsonRequestContext {
   };
 }
 
-const CREATE_THREAD_FILE_FIELDS: ReadonlySet<string> = new Set(["file_id"]);
+const CREATE_THREAD_RESOURCE_FIELDS: ReadonlySet<string> = new Set(["type", "file_id"]);
 const CREATE_THREAD_INPUT_FIELDS: ReadonlySet<string> = new Set(["type", "content"]);
 const CREATE_THREAD_INPUT_CONTENT_FIELDS: ReadonlySet<string> = new Set(["type", "text"]);
 const SEND_EVENTS_REQUEST_FIELDS: ReadonlySet<string> = new Set(["events"]);
 const THREAD_EVENT_USER_MESSAGE_FIELDS: ReadonlySet<string> = new Set([
   "type",
   "text",
-  "attachmentIds",
+  "resources",
   "clientRequestId",
 ]);
 const THREAD_EVENT_PERMISSION_DECISION_FIELDS: ReadonlySet<string> = new Set([
@@ -48,16 +43,9 @@ const THREAD_EVENT_PERMISSION_DECISION_FIELDS: ReadonlySet<string> = new Set([
   "decision",
 ]);
 const THREAD_EVENT_USER_INTERRUPT_FIELDS: ReadonlySet<string> = new Set(["type", "runId"]);
-const THREAD_FILE_REQUEST_FIELDS: ReadonlySet<string> = new Set(["fileId"]);
-const THREAD_FILE_UPLOAD_REQUEST_FIELDS: ReadonlySet<string> = new Set(["file"]);
-const THREAD_FILE_UPLOAD_FILE_FIELDS: ReadonlySet<string> = new Set([
-  "name",
-  "contentType",
-  "size",
-]);
 const CREATE_THREAD_REQUEST_FIELDS: ReadonlySet<string> = new Set([
   "input",
-  "files",
+  "resources",
   "client_external_ref",
 ]);
 
@@ -231,16 +219,6 @@ function readStringField(input: Record<string, unknown>, field: string): string 
   return value;
 }
 
-function readSafeIntegerField(input: Record<string, unknown>, field: string): number {
-  const value = input[field];
-
-  if (typeof value !== "number" || !Number.isSafeInteger(value)) {
-    throw publicInvalidRequest(`${field} must be an integer.`);
-  }
-
-  return value;
-}
-
 function readLimitedStringField(
   input: Record<string, unknown>,
   field: string,
@@ -284,23 +262,6 @@ function readOptionalStringOrNull(
   throw publicInvalidRequest(`${field} must be a string or null.`);
 }
 
-function readOptionalStringArray(
-  input: Record<string, unknown>,
-  field: string,
-): string[] | undefined {
-  const value = input[field];
-
-  if (value === undefined) {
-    return undefined;
-  }
-
-  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
-    throw publicInvalidRequest(`${field} must be an array of strings.`);
-  }
-
-  return value;
-}
-
 function readOptionalLimitedStringField(
   input: Record<string, unknown>,
   field: string,
@@ -323,34 +284,46 @@ function readOptionalLimitedStringField(
   return value;
 }
 
-function readCreateThreadFileIds(input: Record<string, unknown>): FileId[] {
-  const files = input["files"];
+function readPublicThreadResourceFileIds(
+  input: Record<string, unknown>,
+  fieldName: "resources",
+): FileId[] | undefined {
+  const resources = input[fieldName];
 
-  if (files === undefined) {
-    return [];
+  if (resources === undefined) {
+    return undefined;
   }
 
-  if (!Array.isArray(files)) {
-    throw publicInvalidRequest("files must be an array.");
+  if (!Array.isArray(resources)) {
+    throw publicInvalidRequest(`${fieldName} must be an array.`);
   }
 
   const fileIds: FileId[] = [];
 
-  for (const file of files) {
-    if (!isRecord(file)) {
-      throw publicInvalidRequest("files entries must be objects.");
+  for (const resource of resources) {
+    if (!isRecord(resource)) {
+      throw publicInvalidRequest(`${fieldName} entries must be objects.`);
     }
 
-    assertOnlyFields(file, CREATE_THREAD_FILE_FIELDS, "create thread file");
+    assertOnlyFields(resource, CREATE_THREAD_RESOURCE_FIELDS, "file resource");
+
+    if (resource["type"] !== "file") {
+      throw publicInvalidRequest("resource.type must be file.");
+    }
+
     fileIds.push(
       parsePublicPlatformId(
-        readLimitedStringField(file, "file_id", PUBLIC_THREAD_FILE_ID_MAX_LENGTH),
+        readLimitedStringField(resource, "file_id", PUBLIC_THREAD_FILE_ID_MAX_LENGTH),
         "file_id",
       ) as FileId,
     );
   }
 
   return fileIds;
+}
+
+function readCreateThreadFileIds(input: Record<string, unknown>): FileId[] {
+  return readPublicThreadResourceFileIds(input, "resources") ?? [];
 }
 
 function readCreateThreadInputText(input: Record<string, unknown>): string | undefined {
@@ -419,13 +392,14 @@ function readPublicThreadEvent(input: unknown): PublicThreadApiSendEventsRequest
         text: readStringField(input, "text"),
         type: "user_message",
       };
-      const attachmentIds = readOptionalStringArray(input, "attachmentIds");
+      const resourceFileIds = readPublicThreadResourceFileIds(input, "resources");
       const clientRequestId = readOptionalStringOrNull(input, "clientRequestId");
 
-      if (attachmentIds !== undefined) {
-        event.attachmentIds = attachmentIds.map(
-          (attachmentId) => parsePublicPlatformId(attachmentId, "attachmentIds entry") as FileId,
-        );
+      if (resourceFileIds !== undefined) {
+        event.resources = resourceFileIds.map((fileId) => ({
+          file_id: fileId,
+          type: "file",
+        }));
       }
 
       if (clientRequestId !== undefined) {
@@ -497,63 +471,6 @@ export async function readSendEventsRequest(
 
   return {
     events: parsedEvents,
-  };
-}
-
-export async function readCreateThreadFileRequest(
-  c: RawJsonRequestContext,
-): Promise<CreatePublicThreadFileRequest> {
-  const body = await readJsonBodyWithLimit(c, PUBLIC_THREAD_JSON_BODY_MAX_BYTES);
-
-  if (!isRecord(body)) {
-    throw publicInvalidRequest("Request body must be an object.");
-  }
-
-  assertOnlyFields(body, THREAD_FILE_REQUEST_FIELDS, "thread file request");
-
-  return {
-    fileId: parsePublicPlatformId(
-      readLimitedStringField(body, "fileId", PUBLIC_THREAD_FILE_ID_MAX_LENGTH),
-      "fileId",
-    ) as FileId,
-  };
-}
-
-export async function readCreateThreadFileUploadRequest(
-  c: RawJsonRequestContext,
-): Promise<CreatePublicThreadFileUploadRequest> {
-  const body = await readJsonBodyWithLimit(c, PUBLIC_THREAD_JSON_BODY_MAX_BYTES);
-
-  if (!isRecord(body)) {
-    throw publicInvalidRequest("Request body must be an object.");
-  }
-
-  assertOnlyFields(body, THREAD_FILE_UPLOAD_REQUEST_FIELDS, "thread file upload request");
-  const file = body["file"];
-
-  if (!isRecord(file)) {
-    throw publicInvalidRequest("file must be an object.");
-  }
-
-  assertOnlyFields(file, THREAD_FILE_UPLOAD_FILE_FIELDS, "thread file upload file");
-  const size = readSafeIntegerField(file, "size");
-
-  if (size < 0) {
-    throw publicInvalidRequest("file.size must be a non-negative integer.");
-  }
-
-  if (size > PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES) {
-    throw publicInvalidRequest(
-      `file.size must be ${PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES} bytes or fewer.`,
-    );
-  }
-
-  return {
-    file: {
-      contentType: readStringField(file, "contentType"),
-      name: readStringField(file, "name"),
-      size,
-    },
   };
 }
 

--- a/apps/api/src/modules/public-api/public-thread-api-command.service.ts
+++ b/apps/api/src/modules/public-api/public-thread-api-command.service.ts
@@ -1,7 +1,9 @@
 import type {
+  PublicThreadEventInput,
   PublicThreadApiSendEventsRequest,
   PublicThreadApiSendEventsResponse,
 } from "@mosoo/contracts/public-api";
+import type { AgentSessionEventInput } from "@mosoo/contracts/session";
 import { accountsTable } from "@mosoo/db";
 import { parsePlatformId } from "@mosoo/id";
 import type { AccountId, PublicThreadId } from "@mosoo/id";
@@ -21,6 +23,7 @@ import {
   toPublicThreadEventBatch,
   toPublicThreadSessionSummary,
 } from "./public-thread-api-presenter";
+import { claimPublicThreadFiles } from "./public-thread-file-api.service";
 import { toBackingSessionId } from "./public-thread-ids";
 import { toPublicThreadSummary } from "./public-thread-presenter";
 import { admitPublicSessionCaller } from "./public-thread-session-query.service";
@@ -77,6 +80,29 @@ export interface UnarchivePublicThreadSessionRequest {
   threadId: PublicThreadId;
 }
 
+async function toAgentSessionEventInput(input: {
+  bindings: ApiBindings;
+  caller: AuthenticatedViewer;
+  event: PublicThreadEventInput;
+  threadId: PublicThreadId;
+}): Promise<AgentSessionEventInput> {
+  if (input.event.type !== "user_message") {
+    return input.event;
+  }
+
+  const fileIds = (input.event.resources ?? []).map((resource) => resource.file_id);
+  const attachmentIds = await claimPublicThreadFiles(input.bindings, input.caller, {
+    fileIds,
+    threadId: input.threadId,
+  });
+  const { resources: _resources, ...event } = input.event;
+
+  return {
+    ...event,
+    ...(attachmentIds.length === 0 ? {} : { attachmentIds }),
+  };
+}
+
 export async function sendPublicThreadSessionEvents(
   request: SendPublicThreadSessionEventsRequest,
 ): Promise<PublicThreadApiSendEventsResponse> {
@@ -87,11 +113,21 @@ export async function sendPublicThreadSessionEvents(
     request.threadId,
   );
   const accessViewer = await getAccountViewer(request.bindings.DB, admission.agent.ownerId);
+  const events = await Promise.all(
+    request.input.events.map((event) =>
+      toAgentSessionEventInput({
+        bindings: request.bindings,
+        caller: request.caller,
+        event,
+        threadId: request.threadId,
+      }),
+    ),
+  );
   const batch = await sendAgentSessionEvents({
     bindings: request.bindings,
     executionContext: request.executionContext,
     input: {
-      events: request.input.events,
+      events,
       appId: admission.session.app_id,
       sessionId,
     },

--- a/apps/api/src/modules/public-api/public-thread-file-api.service.ts
+++ b/apps/api/src/modules/public-api/public-thread-file-api.service.ts
@@ -1,26 +1,21 @@
+import type { FileEntry, FileRecord } from "@mosoo/contracts/file";
+import { PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES } from "@mosoo/contracts/public-api";
 import type {
-  CompleteFileUploadRequest,
-  CompleteFileUploadResponse,
-  CreateFileUploadResponse,
-  FileEntry,
-  FileRecord,
-} from "@mosoo/contracts/file";
-import type { PublicThreadFile } from "@mosoo/contracts/public-api";
-import type {
-  CreatePublicThreadFileUploadRequest,
-  CreatePublicThreadFileRequest,
+  PublicFile,
+  PublicFileResponse,
+  PublicThreadFile,
   PublicThreadFileListResponse,
-  PublicThreadFileResponse,
 } from "@mosoo/contracts/public-api";
 import { parsePlatformId } from "@mosoo/id";
-import type { AppId, FileId, PublicThreadId, SessionId } from "@mosoo/id";
+import type { AgentId, AppId, FileId, PublicThreadId, SessionId } from "@mosoo/id";
 
 import type { ApiBindings } from "../../platform/cloudflare/worker-types";
+import type { PublicApiCaller } from "../auth/application/public-api-caller.service";
 import type { AuthenticatedViewer } from "../auth/application/viewer-auth.service";
 import { FileControlError } from "../files/application/file-control-errors";
 import { fileStore } from "../files/application/file-store";
-import type { ContentBody } from "../files/application/file-store";
 import { publishSessionResourceDelete } from "../sessions/application/session-resource-events.service";
+import { admitPublicThreadCreator } from "./public-thread-admission";
 import { toBackingSessionId, toPublicThreadId } from "./public-thread-ids";
 import { admitPublicSessionCaller } from "./public-thread-session-query.service";
 
@@ -58,14 +53,6 @@ function requirePublicThreadFile(file: FileRecord): PublicThreadId {
   return toPublicThreadId(parsePlatformId<SessionId>(file.scope.id, "File session ID"));
 }
 
-function requirePublicThreadAttachment(file: FileRecord): PublicThreadId {
-  if (file.sessionKind !== "attachment") {
-    throw new FileControlError(404, "file_not_found", `Thread file ${file.id} was not found.`);
-  }
-
-  return requirePublicThreadFile(file);
-}
-
 function toPublicThreadFile(file: FileEntry | FileRecord): PublicThreadFile {
   return {
     committed: true,
@@ -76,6 +63,36 @@ function toPublicThreadFile(file: FileEntry | FileRecord): PublicThreadFile {
     name: file.name,
     size: file.size,
   };
+}
+
+function toPublicFile(file: FileEntry | FileRecord): PublicFile {
+  return {
+    createdAt: file.createdAt,
+    id: parsePlatformId<FileId>(file.id, "File ID"),
+    mimeType: file.mimeType,
+    name: file.name,
+    size: file.size,
+  };
+}
+
+async function admitPublicFileRecord(
+  bindings: ApiBindings,
+  caller: AuthenticatedViewer,
+  fileId: FileId,
+): Promise<FileRecord> {
+  const file = await fileStore.getRecord(bindings, caller, fileId);
+
+  if (file.scope.kind === "session") {
+    const threadId = requirePublicThreadFile(file);
+    await admitPublicSessionCaller(bindings.DB, caller, threadId);
+    return file;
+  }
+
+  if (file.scope.kind === "app_draft") {
+    return file;
+  }
+
+  throw new FileControlError(404, "file_not_found", `File ${file.id} was not found.`);
 }
 
 export async function listPublicThreadFiles(
@@ -94,53 +111,98 @@ export async function listPublicThreadFiles(
   };
 }
 
-export async function createPublicThreadFileUpload(
+export async function createPublicAgentFile(
   bindings: ApiBindings,
-  caller: AuthenticatedViewer,
-  threadId: PublicThreadId,
-  input: CreatePublicThreadFileUploadRequest,
-): Promise<CreateFileUploadResponse> {
-  const { appId, sessionId } = await admitPublicThreadFileAccess(bindings, caller, threadId);
-  return fileStore.createSessionResourceUpload(bindings, caller, {
-    appId,
-    file: input.file,
-    sessionId,
+  caller: PublicApiCaller,
+  input: {
+    agentId: AgentId;
+    file: File;
+  },
+): Promise<PublicFileResponse> {
+  if (input.file.size > PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES) {
+    throw new FileControlError(
+      400,
+      "file_invalid_request",
+      `file.size must be ${PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES} bytes or fewer.`,
+    );
+  }
+
+  const admission = await admitPublicThreadCreator(bindings.DB, caller, {
+    agentId: input.agentId,
   });
-}
+  const upload = await fileStore.createUpload(bindings, admission.fileViewer, {
+    file: {
+      contentType: input.file.type || "application/octet-stream",
+      name: input.file.name,
+      size: input.file.size,
+    },
+    overwrite: false,
+    purpose: "app_draft",
+    target: {
+      id: admission.appId,
+      kind: "app_draft",
+      name: input.file.name,
+    },
+  });
 
-export async function putPublicThreadFileContent(
-  bindings: ApiBindings,
-  caller: AuthenticatedViewer,
-  input: {
-    body: ContentBody;
-    fileId: FileId;
-  },
-): Promise<void> {
-  const file = await fileStore.getRecord(bindings, caller, input.fileId);
-  const threadId = requirePublicThreadAttachment(file);
-
-  await admitPublicSessionCaller(bindings.DB, caller, threadId);
-  await fileStore.putContent(bindings, caller, input.fileId, input.body);
-}
-
-export async function completePublicThreadFileUpload(
-  bindings: ApiBindings,
-  caller: AuthenticatedViewer,
-  input: {
-    fileId: FileId;
-    request: CompleteFileUploadRequest;
-  },
-): Promise<CompleteFileUploadResponse> {
-  const file = await fileStore.getRecord(bindings, caller, input.fileId);
-  const threadId = requirePublicThreadAttachment(file);
-
-  await admitPublicSessionCaller(bindings.DB, caller, threadId);
-  return fileStore.completeUpload({
+  await fileStore.putContent(bindings, admission.fileViewer, upload.fileId, input.file.stream());
+  const completed = await fileStore.completeUpload({
     bindings,
-    fileId: input.fileId,
-    input: input.request,
-    viewer: caller,
+    fileId: upload.fileId,
+    input: {},
+    viewer: admission.fileViewer,
   });
+
+  return {
+    file: toPublicFile(completed.file),
+  };
+}
+
+export async function retrievePublicFile(
+  bindings: ApiBindings,
+  caller: AuthenticatedViewer,
+  fileId: FileId,
+): Promise<PublicFileResponse> {
+  const file = await admitPublicFileRecord(bindings, caller, fileId);
+  return {
+    file: toPublicFile(file),
+  };
+}
+
+export async function claimPublicThreadFiles(
+  bindings: ApiBindings,
+  caller: AuthenticatedViewer,
+  input: {
+    fileIds: FileId[];
+    threadId: PublicThreadId;
+  },
+): Promise<FileId[]> {
+  if (input.fileIds.length === 0) {
+    return [];
+  }
+
+  const { sessionId } = await admitPublicThreadFileAccess(bindings, caller, input.threadId);
+  const claimedFiles = await fileStore.claimToSession(bindings, caller, sessionId, input.fileIds);
+
+  return claimedFiles.map((file) => parsePlatformId<FileId>(file.id, "File ID"));
+}
+
+export async function deletePublicFile(
+  bindings: ApiBindings,
+  caller: AuthenticatedViewer,
+  fileId: FileId,
+): Promise<void> {
+  const file = await admitPublicFileRecord(bindings, caller, fileId);
+
+  await fileStore.delete(bindings, caller, fileId);
+
+  if (file.scope.kind === "session" && file.scope.id !== null) {
+    await publishSessionResourceDelete({
+      bindings,
+      resourceId: fileId,
+      sessionId: parsePlatformId<SessionId>(file.scope.id, "File session ID"),
+    });
+  }
 }
 
 export async function downloadPublicThreadFileContent(
@@ -163,31 +225,6 @@ export async function downloadPublicThreadFileContent(
     status: response.status,
     statusText: response.statusText,
   });
-}
-
-export async function createPublicThreadFile(
-  bindings: ApiBindings,
-  caller: AuthenticatedViewer,
-  threadId: PublicThreadId,
-  input: CreatePublicThreadFileRequest,
-): Promise<PublicThreadFileResponse> {
-  const { sessionId } = await admitPublicThreadFileAccess(bindings, caller, threadId);
-  const claimedFiles = await fileStore.claimToSession(bindings, caller, sessionId, [input.fileId]);
-  const claimedFile = claimedFiles[0];
-
-  return {
-    file: toPublicThreadFile(
-      claimedFile === undefined ? toFileRecordMissing(input.fileId) : claimedFile,
-    ),
-  };
-}
-
-function toFileRecordMissing(fileId: FileId): never {
-  throw new FileControlError(
-    404,
-    "file_not_found",
-    `Thread file ${fileId} was not found after claim.`,
-  );
 }
 
 export async function deletePublicThreadFile(

--- a/apps/api/tests/api-web-boundary-fixtures.ts
+++ b/apps/api/tests/api-web-boundary-fixtures.ts
@@ -1,5 +1,4 @@
-import type { CompleteFileUploadResponse, CreateFileUploadResponse } from "@mosoo/contracts/file";
-import type { PublicThreadSummary } from "@mosoo/contracts/public-api";
+import type { PublicFile, PublicThreadSummary } from "@mosoo/contracts/public-api";
 import type { SessionFile, SessionSummary } from "@mosoo/contracts/session";
 import type { SessionRunSummary } from "@mosoo/contracts/session-run";
 
@@ -192,35 +191,12 @@ export function createSessionFile(): SessionFile {
   };
 }
 
-export function createFileUploadSummary(): CreateFileUploadResponse {
+export function createPublicFile(): PublicFile {
   return {
-    contentType: "text/plain",
-    expectedSize: 19,
-    expiresAt: "2026-05-20T00:02:00.000Z",
-    fileId: PUBLIC_API_TEST_IDS.file,
-    partSize: null,
-    path: `session-files/${PUBLIC_API_TEST_IDS.file}/brief.txt`,
-    status: "pending",
-    strategy: "single_put",
-  };
-}
-
-export function createCompleteFileUploadResponse(): CompleteFileUploadResponse {
-  return {
-    file: {
-      createdAt: "2026-05-19T00:02:00.000Z",
-      createdBy: PUBLIC_API_TEST_IDS.nonOwnerAccount,
-      etag: "etag-1",
-      expiresAt: null,
-      id: PUBLIC_API_TEST_IDS.file,
-      mimeType: "text/plain",
-      name: "brief.txt",
-      path: `session-files/${PUBLIC_API_TEST_IDS.file}/brief.txt`,
-      sessionKind: "attachment",
-      size: 19,
-      status: "ready",
-      updatedAt: "2026-05-19T00:03:00.000Z",
-      version: 1,
-    },
+    createdAt: "2026-05-19T00:02:00.000Z",
+    id: PUBLIC_API_TEST_IDS.file,
+    mimeType: "text/plain",
+    name: "brief.txt",
+    size: 19,
   };
 }

--- a/apps/api/tests/api-web-boundary.test.ts
+++ b/apps/api/tests/api-web-boundary.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-  PUBLIC_API_ERROR_CODES,
-  PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES,
-} from "@mosoo/contracts/public-api";
+import { PUBLIC_API_ERROR_CODES } from "@mosoo/contracts/public-api";
 import type { AgentSessionEventBatch } from "@mosoo/contracts/session";
 import { PLATFORM_ID_INPUT_PATTERN } from "@mosoo/id";
 import { isEnumType, isInputObjectType, isObjectType } from "graphql";
@@ -14,21 +11,17 @@ import {
   parseFileContentDisposition,
   parseOptionalBoolean,
   readCreateThreadRequest,
-  readCreateThreadFileRequest,
-  readCreateThreadFileUploadRequest,
   readSendEventsRequest,
 } from "../src/adapters/http/routes/public-thread-api-request";
 import { PublicApiError } from "../src/modules/public-api/public-api-errors";
 import { toPublicThreadEventBatch } from "../src/modules/public-api/public-thread-api-presenter";
 import {
   createChunkedJsonRequest,
-  createCompleteFileUploadResponse,
-  createFileUploadSummary,
+  createPublicFile,
   createRunSummary,
   createSessionFile,
   createSessionSummary,
   createThreadSummary,
-  openApiJsonRequestExample,
   openApiJsonResponseExample,
   openApiSchemaProperties,
   publicThreadRequestExamples,
@@ -285,18 +278,52 @@ describe("API to web boundary", () => {
     expect(document.openapi).toBe("3.1.0");
     expect(document.servers).toEqual([{ url: "https://api.example.com/api/v1" }]);
     expectProperties(document.paths, [
-      "/files/{fileId}/complete",
+      "/agents/{agentId}/files",
       "/files/{fileId}/content",
+      "/files/{fileId}",
       "/agents/{agentId}/threads",
       "/threads/{threadId}",
       "/threads/{threadId}/archive",
       "/threads/{threadId}/events",
       "/threads/{threadId}/events/stream",
       "/threads/{threadId}/files",
-      "/threads/{threadId}/files/uploads",
       "/threads/{threadId}/files/{fileId}",
       "/threads/{threadId}/unarchive",
     ]);
+    expect(document.paths["/files/{fileId}/complete"]).toBeUndefined();
+    expect(document.paths["/threads/{threadId}/files/uploads"]).toBeUndefined();
+    expect(document.paths["/threads/{threadId}/files"]?.post).toBeUndefined();
+
+    const agentFileUploadOperation = document.paths["/agents/{agentId}/files"]?.post;
+    expect(agentFileUploadOperation?.parameters?.map((parameter) => parameter.name)).toEqual([
+      "agentId",
+    ]);
+    expect(agentFileUploadOperation?.requestBody).toMatchObject({
+      content: {
+        "multipart/form-data": {
+          schema: {
+            properties: {
+              file: {
+                format: "binary",
+                type: "string",
+              },
+            },
+            required: ["file"],
+            type: "object",
+          },
+        },
+      },
+      required: true,
+    });
+    expect(agentFileUploadOperation?.responses["201"]).toMatchObject({
+      content: {
+        "application/json": {
+          schema: {
+            $ref: "#/components/schemas/PublicFileResponse",
+          },
+        },
+      },
+    });
 
     const downloadContentOperation = document.paths["/files/{fileId}/content"]?.get;
     expect(downloadContentOperation?.parameters?.map((parameter) => parameter.name)).toEqual([
@@ -332,22 +359,23 @@ describe("API to web boundary", () => {
       },
     });
 
-    const uploadContentOperation = document.paths["/files/{fileId}/content"]?.put;
-    expect(uploadContentOperation?.parameters?.map((parameter) => parameter.name)).toContain(
+    const fileMetadataOperation = document.paths["/files/{fileId}"]?.get;
+    expect(fileMetadataOperation?.parameters?.map((parameter) => parameter.name)).toEqual([
       "fileId",
-    );
-    expect(uploadContentOperation?.requestBody).toMatchObject({
+    ]);
+    expect(fileMetadataOperation?.responses["200"]).toMatchObject({
       content: {
-        "application/octet-stream": {
+        "application/json": {
           schema: {
-            format: "binary",
-            type: "string",
+            $ref: "#/components/schemas/PublicFileResponse",
           },
         },
       },
-      required: true,
     });
-    expect(uploadContentOperation?.responses["200"]).toMatchObject({
+
+    const deleteFileOperation = document.paths["/files/{fileId}"]?.delete;
+    expect(deleteFileOperation?.parameters?.map((parameter) => parameter.name)).toEqual(["fileId"]);
+    expect(deleteFileOperation?.responses["200"]).toMatchObject({
       content: {
         "application/json": {
           schema: {
@@ -356,31 +384,6 @@ describe("API to web boundary", () => {
             },
             required: ["ok"],
             type: "object",
-          },
-        },
-      },
-    });
-
-    const completeUploadOperation = document.paths["/files/{fileId}/complete"]?.post;
-    expect(completeUploadOperation?.parameters?.map((parameter) => parameter.name)).toContain(
-      "fileId",
-    );
-    expect(completeUploadOperation?.requestBody).toMatchObject({
-      content: {
-        "application/json": {
-          example: {},
-          schema: {
-            $ref: "#/components/schemas/CompleteFileUploadRequest",
-          },
-        },
-      },
-      required: true,
-    });
-    expect(completeUploadOperation?.responses["200"]).toMatchObject({
-      content: {
-        "application/json": {
-          schema: {
-            $ref: "#/components/schemas/CompleteFileUploadResponse",
           },
         },
       },
@@ -424,20 +427,20 @@ describe("API to web boundary", () => {
     const fileIdParameter = document.paths[
       "/threads/{threadId}/files/{fileId}"
     ]?.delete?.parameters?.find((parameter) => parameter.name === "fileId");
-    const uploadContentFileIdParameter = document.paths[
+    const downloadContentFileIdParameter = document.paths[
       "/files/{fileId}/content"
-    ]?.put?.parameters?.find((parameter) => parameter.name === "fileId");
-    const completeUploadFileIdParameter = document.paths[
-      "/files/{fileId}/complete"
-    ]?.post?.parameters?.find((parameter) => parameter.name === "fileId");
+    ]?.get?.parameters?.find((parameter) => parameter.name === "fileId");
+    const metadataFileIdParameter = document.paths["/files/{fileId}"]?.get?.parameters?.find(
+      (parameter) => parameter.name === "fileId",
+    );
 
     expect(document.info.description).toContain("v1 resource identifiers are bare ULIDs");
     for (const parameter of [
       agentIdParameter,
       threadIdParameter,
       fileIdParameter,
-      completeUploadFileIdParameter,
-      uploadContentFileIdParameter,
+      downloadContentFileIdParameter,
+      metadataFileIdParameter,
     ]) {
       expect(parameter?.description).toContain("v1 IDs are bare ULIDs");
       expect(parameter?.schema).toMatchObject({
@@ -551,43 +554,29 @@ describe("API to web boundary", () => {
     expectProperties(fileProperties, ["committed", "createdAt", "id", "kind", "name", "size"]);
     expectNoProperties(fileProperties, ["objectKey", "path", "scopeId", "scopeKind"]);
 
-    const uploadProperties = openApiSchemaProperties("FileUploadSummary");
-    expectProperties(uploadProperties, [
-      "contentType",
-      "expectedSize",
-      "expiresAt",
-      "fileId",
-      "partSize",
-      "path",
-      "status",
-      "strategy",
-    ]);
-    expectNoProperties(uploadProperties, ["purpose", "scopeId", "scopeKind", "target"]);
-
-    const fileEntryProperties = openApiSchemaProperties("FileEntry");
-    expectProperties(fileEntryProperties, [
-      "createdAt",
+    const publicFileProperties = openApiSchemaProperties("PublicFile");
+    expectProperties(publicFileProperties, ["createdAt", "id", "mimeType", "name", "size"]);
+    expectNoProperties(publicFileProperties, [
+      "committed",
       "createdBy",
       "etag",
       "expiresAt",
-      "id",
-      "mimeType",
-      "name",
-      "path",
-      "sessionKind",
-      "size",
-      "status",
-      "updatedAt",
-      "version",
-    ]);
-    expectNoProperties(fileEntryProperties, [
       "objectKey",
       "owner",
+      "path",
       "purpose",
       "scope",
       "scopeId",
       "scopeKind",
+      "sessionKind",
+      "status",
+      "updatedAt",
+      "version",
     ]);
+
+    const fileResourceProperties = openApiSchemaProperties("FileResource");
+    expectProperties(fileResourceProperties, ["file_id", "type"]);
+    expectNoProperties(fileResourceProperties, ["mountPath", "purpose", "scopeKind"]);
   });
 
   test("parses the Public Thread API create-work body shape", async () => {
@@ -619,11 +608,11 @@ describe("API to web boundary", () => {
             {
               body: JSON.stringify({
                 client_external_ref: "linear-ENG-123",
-                files: [{ file_id: PUBLIC_API_TEST_IDS.file }],
                 input: {
                   content: [{ text: "Summarize the launch plan.", type: "text" }],
                   type: "user.message",
                 },
+                resources: [{ file_id: PUBLIC_API_TEST_IDS.file, type: "file" }],
               }),
               headers: { "Content-Type": "application/json" },
               method: "POST",
@@ -692,9 +681,9 @@ describe("API to web boundary", () => {
         raw: createChunkedJsonRequest(
           `https://api.example.com/api/v1/agents/${PUBLIC_API_TEST_IDS.agent}/threads`,
           {
-            files: [
-              { file_id: PUBLIC_API_TEST_IDS.file },
-              { file_id: PUBLIC_API_TEST_IDS.fileAlt },
+            resources: [
+              { file_id: PUBLIC_API_TEST_IDS.file, type: "file" },
+              { file_id: PUBLIC_API_TEST_IDS.fileAlt, type: "file" },
             ],
             input: {
               content: [
@@ -747,65 +736,19 @@ describe("API to web boundary", () => {
     expect(hasFileExample).toBe(true);
   });
 
-  test("keeps Public Thread file OpenAPI examples aligned with public readers and responses", async () => {
-    const requestExample = openApiJsonRequestExample("/threads/{threadId}/files", "post");
-    const uploadRequestExample = openApiJsonRequestExample(
-      "/threads/{threadId}/files/uploads",
-      "post",
-    );
-    const uploadSummary = createFileUploadSummary();
+  test("keeps Public Thread file OpenAPI examples aligned with public responses", () => {
+    const publicFile = createPublicFile();
     const sessionFile = createSessionFile();
 
-    await expect(
-      readCreateThreadFileRequest({
-        req: {
-          raw: new Request(
-            `https://api.example.com/api/v1/threads/${PUBLIC_API_TEST_IDS.nonOwnerSession}/files`,
-            {
-              body: JSON.stringify(requestExample),
-              headers: { "Content-Type": "application/json" },
-              method: "POST",
-            },
-          ),
-        },
-      }),
-    ).resolves.toEqual({
-      fileId: PUBLIC_API_TEST_IDS.file,
+    expect(openApiJsonResponseExample("/agents/{agentId}/files", "post", "201")).toEqual({
+      file: publicFile,
     });
-
-    await expect(
-      readCreateThreadFileUploadRequest({
-        req: {
-          raw: new Request(
-            `https://api.example.com/api/v1/threads/${PUBLIC_API_TEST_IDS.nonOwnerSession}/files/uploads`,
-            {
-              body: JSON.stringify(uploadRequestExample),
-              headers: { "Content-Type": "application/json" },
-              method: "POST",
-            },
-          ),
-        },
-      }),
-    ).resolves.toEqual({
-      file: {
-        contentType: "text/plain",
-        name: "brief.txt",
-        size: 19,
-      },
+    expect(openApiJsonResponseExample("/files/{fileId}", "get", "200")).toEqual({
+      file: publicFile,
     });
-
     expect(openApiJsonResponseExample("/threads/{threadId}/files", "get", "200")).toEqual({
       files: [sessionFile],
     });
-    expect(openApiJsonResponseExample("/threads/{threadId}/files", "post", "201")).toEqual({
-      file: sessionFile,
-    });
-    expect(openApiJsonResponseExample("/threads/{threadId}/files/uploads", "post", "201")).toEqual(
-      uploadSummary,
-    );
-    expect(openApiJsonResponseExample("/files/{fileId}/complete", "post", "200")).toEqual(
-      createCompleteFileUploadResponse(),
-    );
   });
 
   test("accepts the three public thread event input shapes", async () => {
@@ -815,8 +758,8 @@ describe("API to web boundary", () => {
           json: async () => ({
             events: [
               {
-                attachmentIds: [PUBLIC_API_TEST_IDS.file],
                 clientRequestId: "client-1",
+                resources: [{ file_id: PUBLIC_API_TEST_IDS.file, type: "file" }],
                 text: "hello",
                 type: "user_message",
               },
@@ -836,8 +779,8 @@ describe("API to web boundary", () => {
     ).resolves.toEqual({
       events: [
         {
-          attachmentIds: [PUBLIC_API_TEST_IDS.file],
           clientRequestId: "client-1",
+          resources: [{ file_id: PUBLIC_API_TEST_IDS.file, type: "file" }],
           text: "hello",
           type: "user_message",
         },
@@ -880,6 +823,25 @@ describe("API to web boundary", () => {
           json: async () => ({
             events: [
               {
+                attachmentIds: [PUBLIC_API_TEST_IDS.file],
+                text: "hello",
+                type: "user_message",
+              },
+            ],
+          }),
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_request",
+      status: 400,
+    });
+
+    await expect(
+      readSendEventsRequest({
+        req: {
+          json: async () => ({
+            events: [
+              {
                 mountPath: "/workspace/brief.txt",
                 text: "hello",
                 type: "user_message",
@@ -894,39 +856,16 @@ describe("API to web boundary", () => {
     });
 
     await expect(
-      readCreateThreadFileRequest({
+      readCreateThreadRequest({
         req: {
           raw: new Request(
-            `https://api.example.com/api/v1/threads/${PUBLIC_API_TEST_IDS.nonOwnerSession}/files`,
+            `https://api.example.com/api/v1/agents/${PUBLIC_API_TEST_IDS.agent}/threads`,
             {
               body: JSON.stringify({
-                contentBase64: "SGVsbG8=",
-                contentType: "text/plain",
-                mountPath: "/workspace/brief.txt",
-                name: "brief.txt",
-              }),
-              headers: { "Content-Type": "application/json" },
-              method: "POST",
-            },
-          ),
-        },
-      }),
-    ).rejects.toMatchObject({
-      code: "invalid_request",
-      status: 400,
-    });
-
-    await expect(
-      readCreateThreadFileUploadRequest({
-        req: {
-          raw: new Request(
-            `https://api.example.com/api/v1/threads/${PUBLIC_API_TEST_IDS.nonOwnerSession}/files/uploads`,
-            {
-              body: JSON.stringify({
-                file: {
-                  contentType: "text/plain",
-                  name: "too-large.txt",
-                  size: PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES + 1,
+                files: [{ file_id: PUBLIC_API_TEST_IDS.file }],
+                input: {
+                  content: [{ text: "Do the work.", type: "text" }],
+                  type: "user.message",
                 },
               }),
               headers: { "Content-Type": "application/json" },
@@ -941,20 +880,13 @@ describe("API to web boundary", () => {
     });
 
     await expect(
-      readCreateThreadFileUploadRequest({
+      readCreateThreadRequest({
         req: {
           raw: new Request(
-            `https://api.example.com/api/v1/threads/${PUBLIC_API_TEST_IDS.nonOwnerSession}/files/uploads`,
+            `https://api.example.com/api/v1/agents/${PUBLIC_API_TEST_IDS.agent}/threads`,
             {
               body: JSON.stringify({
-                file: {
-                  contentType: "text/plain",
-                  name: "brief.txt",
-                  size: 19,
-                },
-                target: {
-                  kind: "session",
-                },
+                resources: [{ file_id: PUBLIC_API_TEST_IDS.file, type: "mount" }],
               }),
               headers: { "Content-Type": "application/json" },
               method: "POST",

--- a/apps/api/tests/public-thread-api.e2e.test.ts
+++ b/apps/api/tests/public-thread-api.e2e.test.ts
@@ -212,16 +212,22 @@ async function insertPublicThread(
     .run();
 }
 
-async function expectThreadFileClaimRejected(input: {
+async function expectCreateThreadFileClaimRejected(input: {
   fileId: string;
   message: string;
   requestThreadApi: (request: Request) => Promise<Response>;
   threadId: string;
 }): Promise<void> {
   const response = await input.requestThreadApi(
-    new Request(`https://api.example.com/api/v1/threads/${input.threadId}/files`, {
+    new Request(`https://api.example.com/api/v1/threads/${input.threadId}/events`, {
       body: JSON.stringify({
-        fileId: input.fileId,
+        events: [
+          {
+            resources: [{ file_id: input.fileId, type: "file" }],
+            text: "Read the file.",
+            type: "user_message",
+          },
+        ],
       }),
       headers: {
         Authorization: bearer(TOKENS.owner),
@@ -927,10 +933,7 @@ describe("Public Thread API e2e", () => {
       const createThreadResponse = await requestThreadApi(
         new Request(`https://api.example.com/api/v1/agents/${PUBLIC_API_TEST_IDS.agent}/threads`, {
           body: JSON.stringify({
-            input: {
-              content: [{ text: "Read the attached launch note.", type: "text" }],
-              type: "user.message",
-            },
+            client_external_ref: "thread-files-lifecycle",
           }),
           headers: {
             Authorization: bearer(TOKENS.owner),
@@ -952,16 +955,42 @@ describe("Public Thread API e2e", () => {
       expect(emptyFilesResponse.status).toBe(200);
       expect(await readJson(emptyFilesResponse)).toEqual({ files: [] });
 
-      const draftFileId = await createReadyAppDraftFile({
-        body: "Launch note.\n",
-        bucket,
-        database,
-        name: "launch-note.txt",
-      });
-      const createFileResponse = await requestThreadApi(
-        new Request(`https://api.example.com/api/v1/threads/${threadId}/files`, {
+      const formData = new FormData();
+      formData.set(
+        "file",
+        new File([new TextEncoder().encode("Launch note.\n")], "launch-note.txt", {
+          type: "text/plain",
+        }),
+      );
+      const uploadFileResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/agents/${PUBLIC_API_TEST_IDS.agent}/files`, {
+          body: formData,
+          headers: { Authorization: bearer(TOKENS.owner) },
+          method: "POST",
+        }),
+      );
+      expect(uploadFileResponse.status).toBe(201);
+      const fileId = expectString(
+        expectRecord(expectRecord(await readJson(uploadFileResponse))["file"])["id"],
+      );
+      const appDraftFileRow = await database
+        .prepare("SELECT object_key FROM file_record WHERE id = ?")
+        .bind(fileId)
+        .first<{ object_key: string }>();
+      if (!appDraftFileRow) {
+        throw new Error("Expected Agent draft file row.");
+      }
+
+      const sendEventResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/threads/${threadId}/events`, {
           body: JSON.stringify({
-            fileId: draftFileId,
+            events: [
+              {
+                resources: [{ file_id: fileId, type: "file" }],
+                text: "Read the attached launch note.",
+                type: "user_message",
+              },
+            ],
           }),
           headers: {
             Authorization: bearer(TOKENS.owner),
@@ -970,16 +999,12 @@ describe("Public Thread API e2e", () => {
           method: "POST",
         }),
       );
-      expect(createFileResponse.status).toBe(201);
-      const file = expectRecord(expectRecord(await readJson(createFileResponse))["file"]);
-      const fileId = expectString(file["id"]);
-      expect(file).toMatchObject({
-        committed: true,
-        kind: "attachment",
-        mimeType: "text/plain",
-        name: "launch-note.txt",
-        size: 13,
-      });
+      expect(sendEventResponse.status).toBe(200);
+      const sendEvent = expectRecord(
+        expectArray(expectRecord(await readJson(sendEventResponse))["events"])[0],
+      );
+      expect(sendEvent["type"]).toBe("user_message");
+      expect(["queued", "running"]).toContain(expectRecord(sendEvent["run"])["status"]);
 
       const readyFileRow = await database
         .prepare(
@@ -1016,6 +1041,7 @@ describe("Public Thread API e2e", () => {
       expectString(readyFileRow.object_key);
       expectString(readyFileRow.path);
       expect(bucket.objects.has(readyFileRow.object_key)).toBe(true);
+      expect(bucket.objects.has(appDraftFileRow.object_key)).toBe(false);
 
       const artifactObjectKey = `session/${threadId}/artifact/${PUBLIC_API_TEST_IDS.fileAlt}/summary.md`;
 
@@ -1113,7 +1139,7 @@ describe("Public Thread API e2e", () => {
       );
       expect(downloadAttachmentResponse.status).toBe(200);
       expect(downloadAttachmentResponse.headers.get("cache-control")).toBe("no-store");
-      expect(downloadAttachmentResponse.headers.get("content-type")).toBe("text/plain");
+      expect(downloadAttachmentResponse.headers.get("content-type")).toStartWith("text/plain");
       expect(downloadAttachmentResponse.headers.get("content-disposition")).toContain(
         'attachment; filename="launch-note.txt"',
       );
@@ -1220,7 +1246,7 @@ describe("Public Thread API e2e", () => {
     });
   });
 
-  test("creates a Thread file upload through the public files API contract", async () => {
+  test("uploads an Agent file and attaches it to the first Thread message", async () => {
     const database = await createPublicHttpContractDatabase();
     const app = createPublicThreadApiTestApp();
     const bucket = new PublicApiMemoryFileBucket();
@@ -1228,10 +1254,112 @@ describe("Public Thread API e2e", () => {
       requestPublicApi(app, database, request, { fileBucket: bucket as unknown as R2Bucket });
 
     await withProviderProbeMock(async () => {
+      const fileBody = "Launch note.\n";
+      const fileBytes = new TextEncoder().encode(fileBody);
+      const fileSize = fileBytes.byteLength;
+      const formData = new FormData();
+      formData.set("file", new File([fileBytes], "launch-note.txt", { type: "text/plain" }));
+
+      const uploadFileResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/agents/${PUBLIC_API_TEST_IDS.agent}/files`, {
+          body: formData,
+          headers: {
+            Authorization: bearer(TOKENS.owner),
+          },
+          method: "POST",
+        }),
+      );
+      expect(uploadFileResponse.status).toBe(201);
+      const uploadedFile = expectRecord(expectRecord(await readJson(uploadFileResponse))["file"]);
+      const fileId = expectString(uploadedFile["id"]);
+      expect(uploadedFile).toMatchObject({
+        name: "launch-note.txt",
+        size: fileSize,
+      });
+      expectString(uploadedFile["createdAt"]);
+      expect(expectString(uploadedFile["mimeType"])).toStartWith("text/plain");
+      expectNoProperties(uploadedFile, [
+        "committed",
+        "createdBy",
+        "etag",
+        "objectKey",
+        "path",
+        "purpose",
+        "scope",
+        "status",
+        "version",
+      ]);
+
+      const appDraftFileRow = await database
+        .prepare(
+          `SELECT committed, object_key, owner_id, owner_kind, purpose, scope_id, scope_kind, session_kind, status
+             FROM file_record
+            WHERE id = ?`,
+        )
+        .bind(fileId)
+        .first<{
+          committed: number;
+          object_key: string;
+          owner_id: string;
+          owner_kind: string;
+          purpose: string;
+          scope_id: string;
+          scope_kind: string;
+          session_kind: string | null;
+          status: string;
+        }>();
+      expect(appDraftFileRow).toMatchObject({
+        committed: 0,
+        owner_id: PUBLIC_API_TEST_IDS.app,
+        owner_kind: "app",
+        purpose: "app_draft",
+        scope_id: PUBLIC_API_TEST_IDS.app,
+        scope_kind: "app_draft",
+        session_kind: "attachment",
+        status: "ready",
+      });
+      if (!appDraftFileRow) {
+        throw new Error("Expected ready Agent draft file row.");
+      }
+      expect(await bucket.get(appDraftFileRow.object_key).then((object) => object?.text())).toBe(
+        fileBody,
+      );
+
+      const retrieveDraftResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/files/${fileId}`, {
+          headers: { Authorization: bearer(TOKENS.owner) },
+        }),
+      );
+      expect(retrieveDraftResponse.status).toBe(200);
+      const retrievedDraftFile = expectRecord(
+        expectRecord(await readJson(retrieveDraftResponse))["file"],
+      );
+      expect(retrievedDraftFile).toMatchObject({
+        id: fileId,
+        name: "launch-note.txt",
+        size: fileSize,
+      });
+      expect(expectString(retrievedDraftFile["mimeType"])).toStartWith("text/plain");
+
+      const draftDownloadResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/files/${fileId}/content`, {
+          headers: { Authorization: bearer(TOKENS.owner) },
+        }),
+      );
+      expect(draftDownloadResponse.status).toBe(404);
+      expect(expectRecord(await readJson(draftDownloadResponse))["error"]).toMatchObject({
+        code: "not_found",
+      });
+
       const createThreadResponse = await requestThreadApi(
         new Request(`https://api.example.com/api/v1/agents/${PUBLIC_API_TEST_IDS.agent}/threads`, {
           body: JSON.stringify({
-            client_external_ref: "thread-upload-contract",
+            client_external_ref: "thread-upload-first-message",
+            input: {
+              content: [{ text: "Read the attached launch note.", type: "text" }],
+              type: "user.message",
+            },
+            resources: [{ file_id: fileId, type: "file" }],
           }),
           headers: {
             Authorization: bearer(TOKENS.owner),
@@ -1241,51 +1369,20 @@ describe("Public Thread API e2e", () => {
         }),
       );
       expect(createThreadResponse.status).toBe(201);
-      const threadId = expectString(
-        expectRecord(expectRecord(await readJson(createThreadResponse))["thread"])["id"],
-      );
+      const createThreadPayload = expectRecord(await readJson(createThreadResponse));
+      const threadId = expectString(expectRecord(createThreadPayload["thread"])["id"]);
+      expect(["queued", "running"]).toContain(expectRecord(createThreadPayload["run"])["status"]);
 
-      const fileBody = "Launch note.\n";
-      const fileSize = new TextEncoder().encode(fileBody).byteLength;
-      const createUploadResponse = await requestThreadApi(
-        new Request(`https://api.example.com/api/v1/threads/${threadId}/files/uploads`, {
-          body: JSON.stringify({
-            file: {
-              contentType: "text/plain",
-              name: "launch-note.txt",
-              size: fileSize,
-            },
-          }),
-          headers: {
-            Authorization: bearer(TOKENS.owner),
-            "Content-Type": "application/json",
-          },
-          method: "POST",
-        }),
-      );
-      expect(createUploadResponse.status).toBe(201);
-
-      const upload = expectRecord(await readJson(createUploadResponse));
-      const fileId = expectString(upload["fileId"]);
-      expect(upload).toMatchObject({
-        contentType: "text/plain",
-        expectedSize: fileSize,
-        partSize: null,
-        path: `session-files/${fileId}/launch-note.txt`,
-        status: "pending",
-        strategy: "single_put",
-      });
-      expectNoProperties(upload, ["purpose", "scopeId", "scopeKind", "target", "upload"]);
-
-      const pendingFileRow = await database
+      const claimedFileRow = await database
         .prepare(
-          `SELECT mime_type, object_key, owner_id, owner_kind, path, purpose, scope_id, scope_kind, session_kind, size, status
+          `SELECT committed, expires_at, object_key, owner_id, owner_kind, path, purpose, scope_id, scope_kind, session_kind, status
              FROM file_record
             WHERE id = ?`,
         )
         .bind(fileId)
         .first<{
-          mime_type: string | null;
+          committed: number;
+          expires_at: number | null;
           object_key: string;
           owner_id: string;
           owner_kind: string;
@@ -1294,149 +1391,28 @@ describe("Public Thread API e2e", () => {
           scope_id: string;
           scope_kind: string;
           session_kind: string;
-          size: number;
           status: string;
         }>();
-      expect(pendingFileRow).toEqual({
-        mime_type: "text/plain",
-        object_key: `staging/session/${threadId}/${fileId}`,
+      expect(claimedFileRow).toMatchObject({
+        committed: 1,
+        expires_at: null,
         owner_id: threadId,
         owner_kind: "session",
-        path: `attachment/${fileId}/launch-note.txt`,
         purpose: "session_attachment",
         scope_id: threadId,
         scope_kind: "session",
         session_kind: "attachment",
-        size: fileSize,
-        status: "pending",
-      });
-
-      const uploadRow = await database
-        .prepare(
-          `SELECT expected_size, file_id, part_size, scope_id, scope_kind, status, strategy
-             FROM file_upload
-            WHERE file_id = ?`,
-        )
-        .bind(fileId)
-        .first<{
-          expected_size: number;
-          file_id: string;
-          part_size: number | null;
-          scope_id: string;
-          scope_kind: string;
-          status: string;
-          strategy: string;
-        }>();
-      expect(uploadRow).toEqual({
-        expected_size: fileSize,
-        file_id: fileId,
-        part_size: null,
-        scope_id: threadId,
-        scope_kind: "session",
-        status: "pending",
-        strategy: "single_put",
-      });
-
-      const uploadContentResponse = await requestThreadApi(
-        new Request(`https://api.example.com/api/v1/files/${fileId}/content`, {
-          body: fileBody,
-          headers: {
-            Authorization: bearer(TOKENS.owner),
-            "Content-Type": "text/plain",
-          },
-          method: "PUT",
-        }),
-      );
-      expect(uploadContentResponse.status).toBe(200);
-      expect(await readJson(uploadContentResponse)).toEqual({ ok: true });
-
-      if (!pendingFileRow) {
-        throw new Error("Expected pending public Thread file row.");
-      }
-      const stagingObject = await bucket.get(pendingFileRow.object_key);
-      expect(await stagingObject?.text()).toBe(fileBody);
-
-      const uploadedRow = await database
-        .prepare("SELECT status FROM file_upload WHERE file_id = ?")
-        .bind(fileId)
-        .first<{ status: string }>();
-      expect(uploadedRow).toEqual({ status: "uploading" });
-
-      const pendingDownloadResponse = await requestThreadApi(
-        new Request(`https://api.example.com/api/v1/files/${fileId}/content`, {
-          headers: { Authorization: bearer(TOKENS.owner) },
-        }),
-      );
-      expect(pendingDownloadResponse.status).toBe(400);
-      expect(expectRecord(await readJson(pendingDownloadResponse))["error"]).toMatchObject({
-        code: "invalid_request",
-        message: "Only a ready file can be downloaded.",
-      });
-
-      const nonOwnerUploadResponse = await requestThreadApi(
-        new Request(`https://api.example.com/api/v1/files/${fileId}/content`, {
-          body: "non-owner overwrite\n",
-          headers: {
-            Authorization: bearer(TOKENS.nonOwner),
-            "Content-Type": "text/plain",
-          },
-          method: "PUT",
-        }),
-      );
-      expect(nonOwnerUploadResponse.status).toBe(404);
-      expect(expectRecord(await readJson(nonOwnerUploadResponse))["error"]).toMatchObject({
-        code: "not_found",
-      });
-
-      const nonOwnerCompleteResponse = await requestThreadApi(
-        new Request(`https://api.example.com/api/v1/files/${fileId}/complete`, {
-          body: JSON.stringify({}),
-          headers: {
-            Authorization: bearer(TOKENS.nonOwner),
-            "Content-Type": "application/json",
-          },
-          method: "POST",
-        }),
-      );
-      expect(nonOwnerCompleteResponse.status).toBe(404);
-      expect(expectRecord(await readJson(nonOwnerCompleteResponse))["error"]).toMatchObject({
-        code: "not_found",
-      });
-
-      const completeUploadResponse = await requestThreadApi(
-        new Request(`https://api.example.com/api/v1/files/${fileId}/complete`, {
-          body: JSON.stringify({}),
-          headers: {
-            Authorization: bearer(TOKENS.owner),
-            "Content-Type": "application/json",
-          },
-          method: "POST",
-        }),
-      );
-      expect(completeUploadResponse.status).toBe(200);
-      const completedFile = expectRecord(
-        expectRecord(await readJson(completeUploadResponse))["file"],
-      );
-      expect(completedFile).toMatchObject({
-        createdBy: PUBLIC_API_TEST_IDS.ownerAccount,
-        expiresAt: null,
-        id: fileId,
-        mimeType: "text/plain",
-        name: "launch-note.txt",
-        path: `session-files/${fileId}/launch-note.txt`,
-        sessionKind: "attachment",
-        size: fileSize,
         status: "ready",
-        version: 1,
       });
-      expectString(completedFile["createdAt"]);
-      expectString(completedFile["etag"]);
-      expectString(completedFile["updatedAt"]);
-
-      const finalObjectKey = `session/${threadId}/attachment/${fileId}/launch-note.txt`;
-      const finalObject = await bucket.get(finalObjectKey);
-      expect(await finalObject?.text()).toBe(fileBody);
-      expect(await bucket.get(pendingFileRow.object_key)).toBeNull();
+      if (!claimedFileRow) {
+        throw new Error("Expected claimed public Thread file row.");
+      }
+      expectString(claimedFileRow.object_key);
+      expectString(claimedFileRow.path);
+      expect(bucket.objects.has(appDraftFileRow.object_key)).toBe(false);
+      expect(await bucket.get(claimedFileRow.object_key).then((object) => object?.text())).toBe(
+        fileBody,
+      );
 
       const downloadContentResponse = await requestThreadApi(
         new Request(`https://api.example.com/api/v1/files/${fileId}/content?disposition=inline`, {
@@ -1446,7 +1422,7 @@ describe("Public Thread API e2e", () => {
       expect(downloadContentResponse.status).toBe(200);
       expect(downloadContentResponse.headers.get("cache-control")).toBe("no-store");
       expect(downloadContentResponse.headers.get("content-length")).toBe(String(fileSize));
-      expect(downloadContentResponse.headers.get("content-type")).toBe("text/plain");
+      expect(downloadContentResponse.headers.get("content-type")).toStartWith("text/plain");
       expect(downloadContentResponse.headers.get("content-disposition")).toContain(
         'inline; filename="launch-note.txt"',
       );
@@ -1463,83 +1439,30 @@ describe("Public Thread API e2e", () => {
         message: "File content disposition must be attachment or inline.",
       });
 
-      const completedFileRow = await database
-        .prepare(
-          `SELECT committed, expires_at, object_key, status
-             FROM file_record
-            WHERE id = ?`,
-        )
-        .bind(fileId)
-        .first<{
-          committed: number;
-          expires_at: number | null;
-          object_key: string;
-          status: string;
-        }>();
-      expect(completedFileRow).toEqual({
-        committed: 1,
-        expires_at: null,
-        object_key: finalObjectKey,
-        status: "ready",
-      });
-
-      const completedUploadRow = await database
-        .prepare("SELECT status FROM file_upload WHERE file_id = ?")
-        .bind(fileId)
-        .first<{ status: string }>();
-      expect(completedUploadRow).toEqual({ status: "completed" });
-
-      const appDraftFileId = await createPendingAppDraftFile({
-        body: "App draft upload.\n",
-        bucket,
-        database,
-        name: "app-draft.txt",
-      });
-      const appDraftUploadResponse = await requestThreadApi(
-        new Request(`https://api.example.com/api/v1/files/${appDraftFileId}/content`, {
-          body: "blocked app draft content\n",
-          headers: {
-            Authorization: bearer(TOKENS.owner),
-            "Content-Type": "text/plain",
-          },
-          method: "PUT",
-        }),
-      );
-      expect(appDraftUploadResponse.status).toBe(404);
-      expect(expectRecord(await readJson(appDraftUploadResponse))["error"]).toMatchObject({
-        code: "not_found",
-      });
-
-      const appDraftCompleteResponse = await requestThreadApi(
-        new Request(`https://api.example.com/api/v1/files/${appDraftFileId}/complete`, {
-          body: JSON.stringify({}),
-          headers: {
-            Authorization: bearer(TOKENS.owner),
-            "Content-Type": "application/json",
-          },
-          method: "POST",
-        }),
-      );
-      expect(appDraftCompleteResponse.status).toBe(404);
-      expect(expectRecord(await readJson(appDraftCompleteResponse))["error"]).toMatchObject({
-        code: "not_found",
-      });
-
-      const readyAppDraftFileId = await createReadyAppDraftFile({
-        body: "Ready app draft.\n",
-        bucket,
-        database,
-        name: "ready-app-draft.txt",
-      });
-      const appDraftDownloadResponse = await requestThreadApi(
-        new Request(`https://api.example.com/api/v1/files/${readyAppDraftFileId}/content`, {
+      const listedFilesResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/threads/${threadId}/files`, {
           headers: { Authorization: bearer(TOKENS.owner) },
         }),
       );
-      expect(appDraftDownloadResponse.status).toBe(404);
-      expect(expectRecord(await readJson(appDraftDownloadResponse))["error"]).toMatchObject({
-        code: "not_found",
-      });
+      expect(listedFilesResponse.status).toBe(200);
+      expect(expectArray(expectRecord(await readJson(listedFilesResponse))["files"])).toEqual([
+        expect.objectContaining({
+          id: fileId,
+          kind: "attachment",
+          name: "launch-note.txt",
+          size: fileSize,
+        }),
+      ]);
+
+      const deleteFileResponse = await requestThreadApi(
+        new Request(`https://api.example.com/api/v1/files/${fileId}`, {
+          headers: { Authorization: bearer(TOKENS.owner) },
+          method: "DELETE",
+        }),
+      );
+      expect(deleteFileResponse.status).toBe(200);
+      expect(await readJson(deleteFileResponse)).toEqual({ ok: true });
+      expect(bucket.objects.has(claimedFileRow.object_key)).toBe(false);
     });
   });
 
@@ -1567,7 +1490,7 @@ describe("Public Thread API e2e", () => {
       .prepare("UPDATE file_record SET created_by_account_id = ? WHERE id = ?")
       .bind(PUBLIC_API_TEST_IDS.nonOwnerAccount, wrongCreatorFileId)
       .run();
-    await expectThreadFileClaimRejected({
+    await expectCreateThreadFileClaimRejected({
       fileId: wrongCreatorFileId,
       message: `Attachment ${wrongCreatorFileId} was not found.`,
       requestThreadApi,
@@ -1585,7 +1508,7 @@ describe("Public Thread API e2e", () => {
       .prepare("UPDATE file_record SET owner_id = ?, scope_id = ? WHERE id = ?")
       .bind(wrongAppId, wrongAppId, wrongAppFileId)
       .run();
-    await expectThreadFileClaimRejected({
+    await expectCreateThreadFileClaimRejected({
       fileId: wrongAppFileId,
       message: `Attachment ${wrongAppFileId} is not a draft attachment.`,
       requestThreadApi,
@@ -1598,20 +1521,21 @@ describe("Public Thread API e2e", () => {
       database,
       name: "claimed-draft.txt",
     });
-    const firstClaimResponse = await requestThreadApi(
-      new Request(`https://api.example.com/api/v1/threads/${threadId}/files`, {
-        body: JSON.stringify({
-          fileId: nonDraftFileId,
-        }),
-        headers: {
-          Authorization: bearer(TOKENS.owner),
-          "Content-Type": "application/json",
-        },
-        method: "POST",
-      }),
-    );
-    expect(firstClaimResponse.status).toBe(201);
-    await expectThreadFileClaimRejected({
+    await database
+      .prepare(
+        `UPDATE file_record
+            SET committed = 1,
+                owner_id = ?,
+                owner_kind = 'session',
+                purpose = 'session_attachment',
+                scope_id = ?,
+                scope_kind = 'session',
+                session_kind = 'attachment'
+          WHERE id = ?`,
+      )
+      .bind(threadId, threadId, nonDraftFileId)
+      .run();
+    await expectCreateThreadFileClaimRejected({
       fileId: nonDraftFileId,
       message: `Attachment ${nonDraftFileId} is not a draft attachment.`,
       requestThreadApi,
@@ -1624,7 +1548,7 @@ describe("Public Thread API e2e", () => {
       database,
       name: "pending-draft.txt",
     });
-    await expectThreadFileClaimRejected({
+    await expectCreateThreadFileClaimRejected({
       fileId: notReadyFileId,
       message: `Attachment ${notReadyFileId} is not ready.`,
       requestThreadApi,

--- a/apps/web/src/features/session-chat/session-resource-mentions.ts
+++ b/apps/web/src/features/session-chat/session-resource-mentions.ts
@@ -6,6 +6,11 @@ export interface SessionResourceMention {
 
 export type DraftSessionResourceMentions = Record<string, SessionResourceMention[]>;
 
+export interface SessionResourceMentionMessagePayload {
+  attachmentIds: string[];
+  text: string;
+}
+
 function uniqueMentions(mentions: SessionResourceMention[]): SessionResourceMention[] {
   const seen = new Set<string>();
   const unique: SessionResourceMention[] = [];
@@ -43,6 +48,16 @@ export function appendSessionResourceMentionsToMessage(
   }
 
   return `${trimmedMessage}\n\n${paths.join("\n")}`;
+}
+
+export function createSessionResourceMentionMessagePayload(input: {
+  mentions: SessionResourceMention[];
+  message: string;
+}): SessionResourceMentionMessagePayload {
+  return {
+    attachmentIds: input.mentions.map((mention) => mention.id),
+    text: appendSessionResourceMentionsToMessage(input.message, input.mentions),
+  };
 }
 
 export function appendDraftSessionResourceMention(

--- a/apps/web/src/routes/agent/components/use-agent-session-panel-model.ts
+++ b/apps/web/src/routes/agent/components/use-agent-session-panel-model.ts
@@ -7,7 +7,7 @@ import type { KeyboardEvent } from "react";
 import { useSessionStream } from "@/domains/runtime/use-session-stream";
 import type { PermissionRequest } from "@/domains/runtime/use-session-stream";
 import { listAgentSessions } from "@/domains/session/api/agent-session";
-import { appendSessionResourceMentionsToMessage } from "@/features/session-chat/session-resource-mentions";
+import { createSessionResourceMentionMessagePayload } from "@/features/session-chat/session-resource-mentions";
 import { useSessionChatLayoutState } from "@/features/session-chat/use-session-chat-layout-state";
 import { toAgentId, toAppId, toSessionId } from "@/routes/typed-id";
 
@@ -272,10 +272,10 @@ export function useAgentSessionPanelModel(
 
   async function handleSend(options: SendOptions = {}): Promise<boolean> {
     const typedText = (options.text ?? inputValue).trim();
-    const text = appendSessionResourceMentionsToMessage(
-      typedText,
-      options.sessionResourceMentions ?? [],
-    );
+    const payload = createSessionResourceMentionMessagePayload({
+      mentions: options.sessionResourceMentions ?? [],
+      message: typedText,
+    });
 
     if (
       isComposerSendBlocked({
@@ -303,9 +303,10 @@ export function useAgentSessionPanelModel(
       const sessionId = await ensureActiveSession();
 
       await stream.sendUserMessage({
+        attachmentIds: payload.attachmentIds,
         clientRequestId: crypto.randomUUID(),
         sessionId,
-        text,
+        text: payload.text,
       });
       setInputValue("");
 

--- a/apps/web/tests/session-resource-mentions.test.ts
+++ b/apps/web/tests/session-resource-mentions.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
-import { appendSessionResourceMentionsToMessage } from "../src/features/session-chat/session-resource-mentions";
+import {
+  appendSessionResourceMentionsToMessage,
+  createSessionResourceMentionMessagePayload,
+} from "../src/features/session-chat/session-resource-mentions";
 import type { SessionResourceMention } from "../src/features/session-chat/session-resource-mentions";
 
-function mention(path: string, name = path): SessionResourceMention {
-  return { id: path, name, path };
+function mention(path: string, name = path, id = path): SessionResourceMention {
+  return { id, name, path };
 }
 
 describe("appendSessionResourceMentionsToMessage", () => {
@@ -41,5 +44,22 @@ describe("appendSessionResourceMentionsToMessage", () => {
 
   test("leaves the message untouched when there are no mentions", () => {
     expect(appendSessionResourceMentionsToMessage("hello", [])).toBe("hello");
+  });
+});
+
+describe("createSessionResourceMentionMessagePayload", () => {
+  test("keeps the readable paths and includes attachment ids for the stream event", () => {
+    const payload = createSessionResourceMentionMessagePayload({
+      mentions: [
+        mention("session-files/file-a/one.txt", "one.txt", "file-a"),
+        mention("session-files/file-b/two.txt", "two.txt", "file-b"),
+      ],
+      message: "summarize these",
+    });
+
+    expect(payload).toEqual({
+      attachmentIds: ["file-a", "file-b"],
+      text: "summarize these\n\nsession-files/file-a/one.txt\nsession-files/file-b/two.txt",
+    });
   });
 });

--- a/docs/prd/files-api-contract.md
+++ b/docs/prd/files-api-contract.md
@@ -250,7 +250,9 @@ A public résumé-editing bot. End user uploads `resume.pdf` and asks the agent 
 ### Explicit non-goals for this MVP
 
 - No `MemoryStore`, `Memory`, `MemoryVersion`, or Dreams contract.
-- No generic `resources[]` union.
+- No generic `resources[]` union in the Files Library or runtime mount model. The
+  Public Thread API may expose a file-only `resources` array as request syntax
+  for draft files that are immediately claimed into a Thread.
 - No generic `Mount` contract.
 - No Claude `file_id` adapter contract.
 - No end-user save-to-library flow.

--- a/docs/prd/public-thread-api-surface.md
+++ b/docs/prd/public-thread-api-surface.md
@@ -135,6 +135,7 @@ The current route family is:
 
 | Capability                  | Route shape                                     | Product meaning                              |
 | --------------------------- | ----------------------------------------------- | -------------------------------------------- |
+| Upload Agent file           | `POST /api/v1/agents/{agentId}/files`           | Upload a ready file before a Thread exists.  |
 | Create Thread               | `POST /api/v1/agents/{agentId}/threads`         | Create a Thread for one Agent API Endpoint.  |
 | List endpoint Threads       | `GET /api/v1/agents/{agentId}/threads`          | List Threads for that endpoint and caller.   |
 | Retrieve Thread             | `GET /api/v1/threads/{threadId}`                | Read one Thread by public Thread ID.         |
@@ -145,17 +146,18 @@ The current route family is:
 | Unarchive Thread            | `POST /api/v1/threads/{threadId}/unarchive`     | Restore an archived Thread for the caller.   |
 | Delete Thread               | `DELETE /api/v1/threads/{threadId}`             | Delete the Thread through the public API.    |
 | List Thread files           | `GET /api/v1/threads/{threadId}/files`          | List files attached to the Thread.           |
-| Create Thread file upload   | `POST /api/v1/threads/{threadId}/files/uploads` | Open a Thread-scoped upload for raw bytes.   |
-| Upload Thread file bytes    | `PUT /api/v1/files/{fileId}/content`            | Send the file bytes for a pending upload.    |
+| Retrieve file metadata      | `GET /api/v1/files/{fileId}`                    | Read public metadata for a draft or Thread file. |
 | Download Thread file bytes  | `GET /api/v1/files/{fileId}/content`            | Read the bytes of a ready Thread file.       |
-| Complete Thread file upload | `POST /api/v1/files/{fileId}/complete`          | Finalize a pending upload into a ready file. |
-| Attach Thread file          | `POST /api/v1/threads/{threadId}/files`         | Claim a ready file handle into the Thread.   |
+| Delete file                 | `DELETE /api/v1/files/{fileId}`                 | Delete a pre-Thread draft file or Thread file. |
 | Delete Thread file          | `DELETE /api/v1/threads/{threadId}/files/{id}`  | Remove a file from the Thread.               |
 | Machine-readable API schema | `GET /api/v1/openapi.json`                      | Describe the Public Thread API for tooling.  |
 
-Attaching a file is a two-stage flow: upload the bytes through the files data
-plane first (create upload → `PUT` content → complete), then claim the resulting
-`fileId` into the Thread. MVP public uploads are single `PUT` and size-capped.
+Attaching a file is a single public upload plus a later reference: upload bytes
+to the Agent endpoint with `multipart/form-data` field `file`, receive a ready
+`file_id`, then pass it as `resources: [{ type: "file", file_id }]` when creating
+the Thread or posting a `user_message` event. The API service claims the draft
+file into the Thread before queueing the run. The old public create-upload →
+`PUT` content → complete state machine is not part of this contract.
 
 The public schema should keep runtime implementation details out of responses:
 driver ids, deployment internals, trace ids, vendor resume pointers, raw event
@@ -170,8 +172,8 @@ payloads, and sandbox paths are not part of the public contract.
 - Create Thread callers must use `response.thread.id` as the Thread ID for every
   later retrieve, events, stream, file, archive, and delete request.
 - Creating a Thread may omit `input`; that creates an idle Thread with no Run.
-- Thread creation accepts only the public input fields: initial input, file
-  handles, and caller external reference.
+- Thread creation accepts only the public input fields: initial input,
+  file-only `resources`, and caller external reference.
 - Thread events accept only user messages, permission decisions, and user
   interrupts.
 - Public event reads expose the stable `ThreadEventLogEntry` projection only; raw

--- a/pkgs/contracts/src/http/public-api-core.contract.ts
+++ b/pkgs/contracts/src/http/public-api-core.contract.ts
@@ -11,7 +11,6 @@ import type {
 
 import type { AgentKind } from "../agent/agent.contract";
 import { SINGLE_PUT_THRESHOLD_BYTES } from "../file/file.contract";
-import type { CreateFileUploadRequest } from "../file/file.contract";
 import type { UserWarning } from "../session/session-run.contract";
 import {
   SESSION_PROCESS_EVENT_STATUSES,
@@ -111,10 +110,15 @@ export type PublicThreadEventType = "permission_decision" | "user_interrupt" | "
 
 export type PublicThreadPermissionDecision = "allow_once" | "reject_once";
 
+export interface PublicThreadFileResourceInput {
+  file_id: FileId;
+  type: "file";
+}
+
 export type PublicThreadEventInput =
   | {
-      attachmentIds?: FileId[];
       clientRequestId?: string | null;
+      resources?: PublicThreadFileResourceInput[];
       text: string;
       type: "user_message";
     }
@@ -207,12 +211,16 @@ export interface PublicThreadApiListThreadEventsResponse {
   truncated: boolean;
 }
 
-export interface CreatePublicThreadFileRequest {
-  fileId: FileId;
+export interface PublicFile {
+  createdAt: string;
+  id: FileId;
+  mimeType: string | null;
+  name: string;
+  size: number;
 }
 
-export interface CreatePublicThreadFileUploadRequest {
-  file: CreateFileUploadRequest["file"];
+export interface PublicFileResponse {
+  file: PublicFile;
 }
 
 export interface PublicThreadFile {
@@ -223,10 +231,6 @@ export interface PublicThreadFile {
   mimeType: string | null;
   name: string;
   size: number;
-}
-
-export interface PublicThreadFileResponse {
-  file: PublicThreadFile;
 }
 
 export interface PublicThreadFileListResponse {

--- a/pkgs/contracts/src/http/public-api-openapi.contract.ts
+++ b/pkgs/contracts/src/http/public-api-openapi.contract.ts
@@ -2,18 +2,11 @@ import { PLATFORM_ID_INPUT_PATTERN } from "@mosoo/id";
 
 import { AGENT_KIND_VALUES } from "../agent/agent.contract.ts";
 import {
-  FILE_SESSION_KINDS,
-  FILE_STATUSES,
-  FILE_UPLOAD_STATUSES,
-  FILE_UPLOAD_STRATEGIES,
-} from "../file/file.contract";
-import {
   PUBLIC_API_ERROR_CODES,
   PUBLIC_THREAD_CLIENT_EXTERNAL_REF_MAX_LENGTH,
   PUBLIC_THREAD_EVENT_LOG_STATUSES,
   PUBLIC_THREAD_EVENT_LOG_TYPES,
   PUBLIC_THREAD_FILE_ID_MAX_LENGTH,
-  PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES,
   PUBLIC_THREAD_INPUT_TEXT_MAX_LENGTH,
   PUBLIC_THREAD_RUN_TERMINAL_STATUSES,
 } from "./public-api-core.contract";
@@ -50,10 +43,10 @@ export const PUBLIC_API_OPENAPI_SCHEMAS = {
         additionalProperties: false,
         description: "Send a new user message into the Thread, optionally with file attachments.",
         properties: {
-          attachmentIds: {
+          resources: {
             description:
-              "File IDs (bare ULIDs) to attach to this message. Each file must already be uploaded and claimed into this Thread.",
-            items: PLATFORM_ID_SCHEMA,
+              "Files to attach to this message. Each file must be a ready draft file uploaded through the Agent file endpoint by the same Access Token caller.",
+            items: { $ref: "#/components/schemas/FileResource" },
             type: "array",
           },
           clientRequestId: {
@@ -131,235 +124,65 @@ export const PUBLIC_API_OPENAPI_SCHEMAS = {
     required: ["events"],
     type: "object",
   },
-  CreateThreadFileRequest: {
+  FileResource: {
     additionalProperties: false,
-    description: "Request body for claiming a previously uploaded draft file handle into a Thread.",
+    description: "A file resource to mount into a Thread or user message.",
     properties: {
-      fileId: {
+      file_id: {
         ...createPublicApiPlatformIdSchema({
           maxLength: PUBLIC_THREAD_FILE_ID_MAX_LENGTH,
           minLength: 1,
         }),
-        description:
-          "ID of a ready draft file (bare ULID) previously uploaded through the files data plane by the same Access Token caller.",
+        description: "ID of a ready draft file uploaded through the Agent file endpoint.",
+      },
+      type: {
+        const: "file",
+        description: "Resource discriminator. Only `file` is supported today.",
       },
     },
-    required: ["fileId"],
+    required: ["type", "file_id"],
     type: "object",
   },
-  CreateThreadFileUploadRequest: {
+  PublicFile: {
     additionalProperties: false,
-    description: "Request body for creating a files API upload session scoped to this Thread.",
-    properties: {
-      file: {
-        additionalProperties: false,
-        description: "Metadata for the file bytes that will be uploaded.",
-        properties: {
-          contentType: {
-            description: "MIME type for the file bytes.",
-            minLength: 1,
-            type: "string",
-          },
-          name: {
-            description: "Original file name to record for this Thread attachment.",
-            minLength: 1,
-            type: "string",
-          },
-          size: {
-            description:
-              "File size in bytes. Public Thread upload creation currently accepts single-put uploads only.",
-            maximum: PUBLIC_THREAD_FILE_UPLOAD_MAX_BYTES,
-            minimum: 0,
-            type: "integer",
-          },
-        },
-        required: ["name", "contentType", "size"],
-        type: "object",
-      },
-    },
-    required: ["file"],
-    type: "object",
-  },
-  FileUploadSummary: {
-    additionalProperties: false,
-    description: "Files API upload session summary returned after creating an upload target.",
-    properties: {
-      contentType: {
-        description: "Normalized MIME type the upload expects.",
-        type: "string",
-      },
-      expectedSize: {
-        description: "Expected file size in bytes for integrity validation.",
-        minimum: 0,
-        type: "integer",
-      },
-      expiresAt: {
-        description: "Timestamp (RFC 3339) when this upload session expires.",
-        format: "date-time",
-        type: "string",
-      },
-      fileId: {
-        ...createPublicApiPlatformIdSchema({
-          maxLength: PUBLIC_THREAD_FILE_ID_MAX_LENGTH,
-          minLength: 1,
-        }),
-        description: "File ID (bare ULID) for this upload session.",
-      },
-      partSize: {
-        description: "Multipart part size in bytes, or null when the upload uses single PUT.",
-        minimum: 1,
-        type: ["integer", "null"],
-      },
-      path: {
-        description: "Materialized file path exposed by the files API upload summary.",
-        minLength: 1,
-        type: "string",
-      },
-      status: {
-        description: "Current files API upload session status.",
-        enum: FILE_UPLOAD_STATUSES,
-      },
-      strategy: {
-        description: "Files API upload transfer strategy selected for the file size.",
-        enum: FILE_UPLOAD_STRATEGIES,
-      },
-    },
-    required: [
-      "contentType",
-      "expectedSize",
-      "expiresAt",
-      "fileId",
-      "partSize",
-      "path",
-      "status",
-      "strategy",
-    ],
-    type: "object",
-  },
-  CompleteFileUploadPart: {
-    additionalProperties: false,
-    description:
-      "A completed multipart upload part. Public Thread MVP uploads use single PUT and do not send parts.",
-    properties: {
-      etag: {
-        description: "ETag returned by the uploaded multipart part.",
-        minLength: 1,
-        type: "string",
-      },
-      partNumber: {
-        description: "One-based multipart part number for completion ordering.",
-        minimum: 1,
-        type: "integer",
-      },
-    },
-    required: ["etag", "partNumber"],
-    type: "object",
-  },
-  CompleteFileUploadRequest: {
-    additionalProperties: false,
-    description:
-      "Request body for completing a files API upload session. Public Thread MVP single PUT uploads send an empty object.",
-    properties: {
-      parts: {
-        description:
-          "Multipart completion parts. Omit this field for public MVP single PUT uploads.",
-        items: { $ref: "#/components/schemas/CompleteFileUploadPart" },
-        type: "array",
-      },
-    },
-    required: [],
-    type: "object",
-  },
-  FileEntry: {
-    additionalProperties: false,
-    description: "Files API file entry returned after an upload completes.",
+    description: "Public file metadata.",
     properties: {
       createdAt: {
         description: "Timestamp (RFC 3339) at which the file record was created.",
         format: "date-time",
         type: "string",
       },
-      createdBy: {
-        ...PLATFORM_ID_SCHEMA,
-        description: "Account ID (bare ULID) that created the file record.",
-      },
-      etag: {
-        description: "Storage ETag for the finalized object, or null when unavailable.",
-        type: ["string", "null"],
-      },
-      expiresAt: {
-        description: "Expiration timestamp for temporary files, or null for durable Thread files.",
-        format: "date-time",
-        type: ["string", "null"],
-      },
       id: {
         ...createPublicApiPlatformIdSchema({
           maxLength: PUBLIC_THREAD_FILE_ID_MAX_LENGTH,
           minLength: 1,
         }),
-        description: "File ID (bare ULID) for the finalized file.",
+        description: "File ID (bare ULID).",
       },
       mimeType: {
-        description: "Stored MIME type for the file bytes, or null when unknown.",
+        description: "Detected MIME type of the file, or null when unknown.",
         type: ["string", "null"],
       },
       name: {
-        description: "Original file name recorded for this file.",
+        description: "Original file name.",
         type: "string",
-      },
-      path: {
-        description: "Files API record path for the finalized file.",
-        minLength: 1,
-        type: "string",
-      },
-      sessionKind: {
-        description: "Session file kind for Thread-scoped files, or null for non-session files.",
-        enum: [...FILE_SESSION_KINDS, null],
       },
       size: {
-        description: "Finalized file size in bytes.",
+        description: "File size in bytes.",
         minimum: 0,
         type: "integer",
       },
-      status: {
-        description: "Current files API file lifecycle status.",
-        enum: FILE_STATUSES,
-      },
-      updatedAt: {
-        description: "Timestamp (RFC 3339) at which the file record was last updated.",
-        format: "date-time",
-        type: "string",
-      },
-      version: {
-        description: "Monotonic file version number within its path.",
-        minimum: 1,
-        type: "integer",
-      },
     },
-    required: [
-      "createdAt",
-      "createdBy",
-      "etag",
-      "expiresAt",
-      "id",
-      "mimeType",
-      "name",
-      "path",
-      "sessionKind",
-      "size",
-      "status",
-      "updatedAt",
-      "version",
-    ],
+    required: ["createdAt", "id", "mimeType", "name", "size"],
     type: "object",
   },
-  CompleteFileUploadResponse: {
+  PublicFileResponse: {
     additionalProperties: false,
-    description: "Result of completing a files API upload session.",
+    description: "A single public file.",
     properties: {
       file: {
-        $ref: "#/components/schemas/FileEntry",
-        description: "Completed files API file entry.",
+        $ref: "#/components/schemas/PublicFile",
+        description: "Public file metadata.",
       },
     },
     required: ["file"],
@@ -515,23 +338,10 @@ export const PUBLIC_API_OPENAPI_SCHEMAS = {
         maxLength: PUBLIC_THREAD_CLIENT_EXTERNAL_REF_MAX_LENGTH,
         type: "string",
       },
-      files: {
-        description: "Draft file handles uploaded by the same Access Token caller.",
-        items: {
-          additionalProperties: false,
-          description: "Reference to a single uploaded draft file to attach to the Thread.",
-          properties: {
-            file_id: {
-              ...createPublicApiPlatformIdSchema({
-                maxLength: PUBLIC_THREAD_FILE_ID_MAX_LENGTH,
-                minLength: 1,
-              }),
-              description: "ID (bare ULID) of a ready draft file uploaded by the same caller.",
-            },
-          },
-          required: ["file_id"],
-          type: "object",
-        },
+      resources: {
+        description:
+          "Files uploaded through the Agent file endpoint and mounted into the first Run.",
+        items: { $ref: "#/components/schemas/FileResource" },
         type: "array",
       },
       input: {

--- a/pkgs/public-api-client/src/index.ts
+++ b/pkgs/public-api-client/src/index.ts
@@ -4,6 +4,7 @@ import {
 } from "@mosoo/contracts/public-api";
 import type {
   PublicApiErrorCode,
+  PublicFileResponse,
   PublicThreadApiCreateThreadResponse,
   PublicThreadApiListThreadEventsResponse,
   PublicThreadApiRetrieveThreadResponse,
@@ -21,11 +22,11 @@ type FetchFunction = typeof fetch;
 
 interface CreateThreadRequestBody {
   client_external_ref?: string;
-  files?: { file_id: string }[];
   input?: {
     content: { text: string; type: "text" }[];
     type: "user.message";
   };
+  resources?: { file_id: string; type: "file" }[];
 }
 
 interface SseMessage {
@@ -48,6 +49,13 @@ export interface MosooCreateThreadInput {
   fileIds?: string[];
   idempotencyKey?: string;
   input?: string;
+  signal?: AbortSignal | undefined;
+}
+
+export interface MosooUploadAgentFileInput {
+  agentId: string;
+  file: Blob;
+  filename?: string | undefined;
   signal?: AbortSignal | undefined;
 }
 
@@ -222,7 +230,7 @@ function createCreateThreadBody(input: MosooCreateThreadInput): CreateThreadRequ
   }
 
   if (input.fileIds !== undefined && input.fileIds.length > 0) {
-    body.files = input.fileIds.map((fileId) => ({ file_id: fileId }));
+    body.resources = input.fileIds.map((fileId) => ({ file_id: fileId, type: "file" }));
   }
 
   if (input.input !== undefined) {
@@ -500,6 +508,22 @@ export class MosooPublicThreadClient {
     });
   }
 
+  async uploadAgentFile(input: MosooUploadAgentFileInput): Promise<PublicFileResponse> {
+    const formData = new FormData();
+
+    if (input.filename === undefined) {
+      formData.append("file", input.file);
+    } else {
+      formData.append("file", input.file, input.filename);
+    }
+
+    return this.requestJson("POST", `/agents/${input.agentId}/files`, {
+      body: formData,
+      signal: input.signal,
+      status: 201,
+    });
+  }
+
   async retrieveThread(
     threadId: string,
     options: { signal?: AbortSignal | undefined } = {},
@@ -768,8 +792,12 @@ export class MosooPublicThreadClient {
     };
 
     if (options.body !== undefined) {
-      headers.set("Content-Type", "application/json");
-      init.body = JSON.stringify(options.body);
+      if (options.body instanceof FormData) {
+        init.body = options.body;
+      } else {
+        headers.set("Content-Type", "application/json");
+        init.body = JSON.stringify(options.body);
+      }
     }
 
     if (options.idempotencyKey !== undefined) {

--- a/pkgs/public-api-client/tests/public-api-client.test.ts
+++ b/pkgs/public-api-client/tests/public-api-client.test.ts
@@ -20,6 +20,7 @@ interface RecordedRequest {
 
 const THREAD_ID = "01J00000000000000000000009";
 const RUN_ID = "01J0000000000000000000000A";
+const FILE_ID = "01J0000000000000000000000J";
 
 function threadResponse(status: "RUNNING" | "IDLE" = "RUNNING") {
   return {
@@ -70,6 +71,91 @@ function jsonResponse(value: unknown, status = 200): Response {
 }
 
 describe("MosooPublicThreadClient", () => {
+  test("maps createThread fileIds to public file resources", async () => {
+    const requests: RecordedRequest[] = [];
+    const fetchMock: typeof fetch = async (input, init) => {
+      const request = new Request(input, init);
+      requests.push({
+        body: await readRequestBody(request.clone()),
+        headers: request.headers,
+        method: request.method,
+        url: request.url,
+      });
+
+      return jsonResponse(
+        {
+          links: { thread: `/api/v1/threads/${THREAD_ID}` },
+          run: null,
+          thread: threadResponse("IDLE"),
+        } satisfies PublicThreadApiCreateThreadResponse,
+        201,
+      );
+    };
+    const client = new MosooPublicThreadClient({
+      baseUrl: "https://api.example.com",
+      fetch: fetchMock,
+      token: "mst_test",
+    });
+
+    await client.createThread({
+      agentId: "agent-1",
+      fileIds: [FILE_ID],
+      input: "Summarize the file.",
+    });
+
+    expect(requests[0]?.body).toEqual({
+      input: {
+        content: [{ text: "Summarize the file.", type: "text" }],
+        type: "user.message",
+      },
+      resources: [{ file_id: FILE_ID, type: "file" }],
+    });
+  });
+
+  test("uploads Agent files through multipart/form-data", async () => {
+    const fetchMock: typeof fetch = async (input, init) => {
+      const request = new Request(input, init);
+      const formData = await request.formData();
+      const file = formData.get("file");
+
+      expect(request.method).toBe("POST");
+      expect(request.url).toBe("https://api.example.com/api/v1/agents/agent-1/files");
+      expect(request.headers.get("Authorization")).toBe("Bearer mst_test");
+      expect(request.headers.get("Content-Type")).toStartWith("multipart/form-data;");
+      expect(file).toBeInstanceOf(File);
+      expect(file).toMatchObject({
+        name: "brief.txt",
+        size: 12,
+      });
+
+      return jsonResponse(
+        {
+          file: {
+            createdAt: "2026-05-19T00:00:00.000Z",
+            id: FILE_ID,
+            mimeType: "text/plain",
+            name: "brief.txt",
+            size: 12,
+          },
+        },
+        201,
+      );
+    };
+    const client = new MosooPublicThreadClient({
+      baseUrl: "https://api.example.com",
+      fetch: fetchMock,
+      token: "mst_test",
+    });
+
+    const response = await client.uploadAgentFile({
+      agentId: "agent-1",
+      file: new Blob([new TextEncoder().encode("Hello file.\n")], { type: "text/plain" }),
+      filename: "brief.txt",
+    });
+
+    expect(response.file.id).toBe(FILE_ID);
+  });
+
   test("creates a Thread, waits for completion, and reconstructs final output by run", async () => {
     const requests: RecordedRequest[] = [];
     const fetchMock: typeof fetch = async (input, init) => {


### PR DESCRIPTION
## Summary
- replace public Thread upload state machine with Agent-scoped multipart file upload
- use file-only `resources` on create-thread and send-events, then claim drafts into Threads before runs
- keep metadata/download/delete/list Thread file surfaces and update SDK/tests/PRDs

## Verification
- `just fmt-check`
- `just docs-check`
- `just tc-package @mosoo/api`
- `just tc-package @mosoo/contracts`
- `just tc-package @mosoo/public-api-client`
- `just test-file apps/api/tests/api-web-boundary.test.ts`
- `just test-file apps/api/tests/public-thread-api.e2e.test.ts`
- `just test-package @mosoo/public-api-client`
- `just graphql-codegen-check`
- `git diff --check`

## Notes
- no DB schema or migration changes
- no GraphQL schema changes; codegen check is clean