### PR TITLE
fix(skill-package): accept macOS-created skill zips

### DIFF
--- a/pkgs/skill-package/src/archive.ts
+++ b/pkgs/skill-package/src/archive.ts
@@ -58,13 +58,17 @@ export function extractZipArchive(
   options: SkillArchiveExtractOptions = {},
 ): SkillPackageEntry[] {
   const metadataByPath = listZipArchiveEntries(bytes, options);
-  const metadataLookup = new Map(metadataByPath.map((metadata) => [metadata.path, metadata]));
+  const metadataLookup = createZipMetadataLookup(metadataByPath);
   const extractedEntries = new Map<string, SkillPackageEntry>();
   const extractionState: { error: SkillPackageError | null } = { error: null };
   let totalExtractedBytes = 0;
   const unzip = new Unzip((file) => {
     if (extractionState.error !== null) {
       file.terminate();
+      return;
+    }
+
+    if (isIgnoredZipMetadataPath(file.name)) {
       return;
     }
 
@@ -204,6 +208,48 @@ export function extractZipArchive(
   });
 }
 
+function createZipMetadataLookup(
+  metadataByPath: ZipArchiveMetadata[],
+): Map<string, ZipArchiveMetadata> {
+  const metadataLookup = new Map<string, ZipArchiveMetadata>();
+
+  for (const metadata of metadataByPath) {
+    addZipMetadataLookupEntry(metadataLookup, metadata.path, metadata);
+
+    const byteStringPath = encodeUtf8PathAsByteString(metadata.path);
+
+    if (byteStringPath !== metadata.path) {
+      addZipMetadataLookupEntry(metadataLookup, byteStringPath, metadata);
+    }
+  }
+
+  return metadataLookup;
+}
+
+function addZipMetadataLookupEntry(
+  metadataLookup: Map<string, ZipArchiveMetadata>,
+  path: string,
+  metadata: ZipArchiveMetadata,
+): void {
+  const existing = metadataLookup.get(path);
+
+  if (existing === undefined || existing.path === metadata.path) {
+    metadataLookup.set(path, metadata);
+  }
+}
+
+function encodeUtf8PathAsByteString(path: string): string {
+  const bytes = new TextEncoder().encode(path);
+  const chunks: string[] = [];
+  const chunkSize = 0x80_00;
+
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    chunks.push(String.fromCharCode(...bytes.subarray(offset, offset + chunkSize)));
+  }
+
+  return chunks.join("");
+}
+
 export function looksLikeZipArchive(bytes: Uint8Array): boolean {
   if (bytes.byteLength < 4) {
     return false;
@@ -284,6 +330,17 @@ function listZipArchiveEntries(
     }
 
     const rawPath = decodeZipFileName(bytes.subarray(fileNameStart, fileNameEnd));
+    const nextOffset = fileNameEnd + extraLength + commentLength;
+
+    if (nextOffset > endOffset) {
+      throw new SkillPackageError("The skill zip archive central directory exceeds bounds.");
+    }
+
+    if (isIgnoredZipMetadataPath(rawPath)) {
+      offset = nextOffset;
+      continue;
+    }
+
     const entryKind = inferZipEntryKind(rawPath);
     const path = admission.admit(rawPath, entryKind).path;
 
@@ -317,14 +374,18 @@ function listZipArchiveEntries(
       uncompressedSize,
     });
 
-    offset = fileNameEnd + extraLength + commentLength;
-
-    if (offset > endOffset) {
-      throw new SkillPackageError("The skill zip archive central directory exceeds bounds.");
-    }
+    offset = nextOffset;
   }
 
   return metadata;
+}
+
+function isIgnoredZipMetadataPath(path: string): boolean {
+  const segments = path.replaceAll("\\", "/").split("/").filter(Boolean);
+
+  return segments.some(
+    (segment) => segment === "__MACOSX" || segment === ".DS_Store" || segment.startsWith("._"),
+  );
 }
 
 function isZipEntryExecutable(versionMadeBy: number, externalAttributes: number): boolean {

--- a/pkgs/skill-package/tests/path-admission.test.ts
+++ b/pkgs/skill-package/tests/path-admission.test.ts
@@ -9,6 +9,7 @@ import {
   parseSkillMarkdown,
   toEntryRecord,
 } from "@mosoo/skill-package";
+import { zipSync } from "fflate";
 
 const markdown = new TextEncoder().encode(
   "---\nname: Test\ndescription: Test skill.\n---\n# Test\n",
@@ -242,6 +243,38 @@ describe("skill package path admission", () => {
     );
   });
 
+  test("ignores macOS zip metadata before path admission", () => {
+    const archive = zipSync({
+      "._dify-brand-skills": data,
+      "__MACOSX/._dify-brand-skills": data,
+      "dify-brand-skills/.DS_Store": data,
+      "dify-brand-skills/._SKILL.md": data,
+      "dify-brand-skills/SKILL.md": markdown,
+      "dify-brand-skills/references/.DS_Store": data,
+      "dify-brand-skills/references/guide.md": data,
+    });
+    const normalized = normalizeSkillEntries(toEntryRecord(extractZipArchive(archive)));
+
+    expect(normalized.skillMarkdownPath).toBe("SKILL.md");
+    expect(normalized.entries.map((entry) => entry.path).toSorted()).toEqual(
+      ["references", "references/guide.md", "SKILL.md"].toSorted(),
+    );
+  });
+
+  test("matches UTF-8 zip filenames when the archive UTF-8 flag is missing", () => {
+    const archive = clearZipUtf8Flags(
+      zipSync({
+        "dify-brand-skills/SKILL.md": markdown,
+        "dify-brand-skills/assets/Söhne.otf": data,
+      }),
+    );
+    const normalized = normalizeSkillEntries(toEntryRecord(extractZipArchive(archive)));
+
+    expect(normalized.entries.map((entry) => entry.path).toSorted()).toEqual(
+      ["assets", "assets/Söhne.otf", "SKILL.md"].toSorted(),
+    );
+  });
+
   test("admits custom roots after stripping single wrapper zip archives", () => {
     const normalized = normalizeZipEntries([
       {
@@ -329,4 +362,52 @@ function normalizeZipEntries(entries: SkillPackageEntry[]) {
   const archive = createZipArchive(entries);
 
   return normalizeSkillEntries(toEntryRecord(extractZipArchive(archive)));
+}
+
+function clearZipUtf8Flags(archive: Uint8Array): Uint8Array {
+  const patched = new Uint8Array(archive);
+  let offset = 0;
+
+  while (offset + 4 <= patched.byteLength) {
+    const signature = readUint32LE(patched, offset);
+
+    if (signature === 0x04_03_4b_50) {
+      patched[offset + 7] = (patched[offset + 7] ?? 0) & ~0x08;
+      const compressedSize = readUint32LE(patched, offset + 18);
+      const fileNameLength = readUint16LE(patched, offset + 26);
+      const extraLength = readUint16LE(patched, offset + 28);
+      offset += 30 + fileNameLength + extraLength + compressedSize;
+      continue;
+    }
+
+    if (signature === 0x02_01_4b_50) {
+      patched[offset + 9] = (patched[offset + 9] ?? 0) & ~0x08;
+      const fileNameLength = readUint16LE(patched, offset + 28);
+      const extraLength = readUint16LE(patched, offset + 30);
+      const commentLength = readUint16LE(patched, offset + 32);
+      offset += 46 + fileNameLength + extraLength + commentLength;
+      continue;
+    }
+
+    if (signature === 0x06_05_4b_50) {
+      break;
+    }
+
+    offset += 1;
+  }
+
+  return patched;
+}
+
+function readUint16LE(bytes: Uint8Array, offset: number): number {
+  return (bytes[offset] ?? 0) + (bytes[offset + 1] ?? 0) * 0x01_00;
+}
+
+function readUint32LE(bytes: Uint8Array, offset: number): number {
+  return (
+    (bytes[offset] ?? 0) +
+    (bytes[offset + 1] ?? 0) * 0x01_00 +
+    (bytes[offset + 2] ?? 0) * 0x01_00 ** 2 +
+    (bytes[offset + 3] ?? 0) * 0x01_00 ** 3
+  );
 }


### PR DESCRIPTION
## Summary

- Ignore macOS archive metadata entries (`__MACOSX`, AppleDouble `._*` files, and `.DS_Store`) while extracting skill zip packages.
- Match stream unzip entries against both normalized UTF-8 paths and byte-string path variants so valid UTF-8 filenames still resolve when the ZIP UTF-8 flag is missing.
- Add regression coverage for Finder-created archive metadata and missing UTF-8 flags in skill package zips.

## Why

Fixes #259.

Skill uploads created on macOS can include Finder metadata entries that are not part of the skill package. Those entries currently flow through normal path admission and fail because dot-prefixed paths are reserved. A real reproduced archive also exposed a second failure where UTF-8 filename bytes without the ZIP UTF-8 flag caused the central-directory path and streaming unzip callback path to disagree, producing an `undeclared entry` error for valid assets.

## Verification

- Commands:
  - `git diff --check`
  - `npm exec --yes --package=bun -- bun test pkgs/skill-package/tests/path-admission.test.ts apps/api/tests/skill-package-source.test.ts`
  - `npm exec --yes --package=bun -- bun test pkgs/skill-package/tests`
  - `npm exec --yes --package=bun -- bun run --filter @mosoo/skill-package tc`
  - `npm exec --yes --package=bun -- bun run fmt:check:path pkgs/skill-package/src/archive.ts pkgs/skill-package/tests/path-admission.test.ts`
- Manual steps:
  - Ran the skill inspect path against a real macOS-created `dify-brand-skills.zip` containing `__MACOSX`, `._*`, `.DS_Store`, and `Söhne*.otf` asset filenames. Inspect now succeeds with `name: "dify-brand"` and `entryCount: 23`.
- Not run:
  - Full repository `just check`.

## Impact

- User/API/contract changes:
  - Skill zip uploads created by macOS Finder can inspect successfully when their actual package contents are valid.
  - Real hidden/reserved package paths remain rejected after normalized extraction.
- Generated files / GraphQL / DB / lockfile:
  - N/A
- Env or config changes:
  - N/A
- Risk and rollback:
  - Low. The change is limited to skill zip extraction and only ignores well-known archive metadata entries before package path admission. Rollback restores the prior strict behavior.

## Review

- Closest review areas:
  - `pkgs/skill-package/src/archive.ts`
  - `pkgs/skill-package/tests/path-admission.test.ts`
- Known trade-offs:
  - The extractor intentionally ignores AppleDouble and `.DS_Store` entries at any archive depth because they are archive metadata, not skill package content.
