### PR TITLE
docs(readme): add product positioning tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mosoo
 
+Mosoo is an open-source, cloud-native platform for turning AI app ideas into live agent apps: bring your PRD, run Codex, Claude Code, OpenCode, and other agent harnesses in isolated sandboxes, manage their lifecycle, and ship to production through a coding-agent-friendly CLI.
+
 ## Product Status
 
 Mosoo is still in alpha exploration. Product boundaries, data models, deployment methods, and management experience are all evolving quickly. During the App boundary cut, treat [SPEC.md](./docs/SPEC.md) and [App Boundary](./docs/prd/app-boundary.md) as newer than older Agent-first, Workspace, member-management, or team-governance language. This repository currently prioritizes fast validation and architectural convergence for the open-source version, with no promise of stable APIs or backward compatibility.


### PR DESCRIPTION
## Summary
- Add a product positioning sentence under the README title.
- Call out Codex, Claude Code, OpenCode, sandboxed execution, lifecycle management, and the coding-agent-friendly CLI.

## Verification
- `just fmt-check-path README.md`

## Generated files
- None

## GraphQL codegen
- Not required

## DB baseline
- Not changed