### PR TITLE
docs(readme): add logo to heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mosoo
+# <img src="apps/web/public/brand/logo-mark.svg" alt="" width="32" height="32" /> Mosoo
 
 Mosoo is an open-source, cloud-native platform for turning AI app ideas into live agent apps: bring your PRD, run Codex, Claude Code, OpenCode, and other agent harnesses in isolated sandboxes, manage their lifecycle, and ship to production through a coding-agent-friendly CLI.
 


### PR DESCRIPTION
## Summary
- Add the existing Mosoo logo mark before the README title.
- Reuse `apps/web/public/brand/logo-mark.svg` instead of adding a new asset.

## Verification
- `just fmt-check-path README.md`
- `just docs-check`

## Generated files
- None

## GraphQL codegen
- Not required

## DB baseline
- Not changed