### PR TITLE
feat(deploy): simplify user-facing deployment statuses

### DIFF
--- a/apps/web/src/routes/app-overview/deploy/components/deploy-actions.tsx
+++ b/apps/web/src/routes/app-overview/deploy/components/deploy-actions.tsx
@@ -18,7 +18,7 @@ import {
   DropdownMenuTrigger,
 } from "@/shared/ui/dropdown-menu";
 
-import type { DeploymentRunDisplayStatus } from "../deploy-console-data";
+import type { DeploymentRunOutcome } from "../deployment-status";
 import type { LocalDeploymentPreviewStatus } from "../local-preview-url";
 
 type DeployActionScope = "development" | "production";
@@ -31,7 +31,7 @@ type DeployActionScope = "development" | "production";
 export function DeployActions({
   appName,
   agentCount,
-  latestStatus,
+  latestOutcome,
   deploying,
   canDeploy,
   onRetry,
@@ -41,7 +41,7 @@ export function DeployActions({
 }: {
   appName: string;
   agentCount: number;
-  latestStatus: DeploymentRunDisplayStatus | null;
+  latestOutcome: DeploymentRunOutcome | null;
   deploying: boolean;
   canDeploy: boolean;
   onRetry: () => void;
@@ -60,7 +60,7 @@ export function DeployActions({
           : "Retry development"
       : deploying
         ? "Refreshing production…"
-        : latestStatus === "failed"
+        : latestOutcome === "failed"
           ? "Retry production"
           : "Refresh production";
 

--- a/apps/web/src/routes/app-overview/deploy/components/deploy-overview.tsx
+++ b/apps/web/src/routes/app-overview/deploy/components/deploy-overview.tsx
@@ -14,7 +14,6 @@ import { DeployUrlCard } from "./deploy-url-card";
 
 function previewUnavailableLabel(
   deployment: DeploymentVM,
-  live: boolean,
   localPreview: LocalDeploymentPreviewState,
 ): string {
   if (localPreview.status === "checking") {
@@ -23,7 +22,7 @@ function previewUnavailableLabel(
   if (localPreview.status === "offline") {
     return "Development preview offline";
   }
-  if (live && deployment.liveUrl !== null) {
+  if (deployment.liveUrl !== null) {
     return hostOf(deployment.liveUrl);
   }
   return "Preview unavailable";
@@ -31,20 +30,17 @@ function previewUnavailableLabel(
 
 function PreviewFrame({
   deployment,
-  latestRun,
   localPreview,
 }: {
   deployment: DeploymentVM;
-  latestRun: DeploymentRunVM | undefined;
   localPreview: LocalDeploymentPreviewState;
 }) {
-  const live = deployment.liveUrl !== null && latestRun?.status === "success";
   const localPreviewReady = localPreview.url !== null && localPreview.status === "online";
-  const previewLinkUrl = localPreviewReady ? localPreview.url : live ? deployment.liveUrl : null;
+  const previewLinkUrl = localPreviewReady ? localPreview.url : deployment.liveUrl;
   const previewLabel =
     localPreviewReady && localPreview.url !== null
       ? hostOf(localPreview.url)
-      : previewUnavailableLabel(deployment, live, localPreview);
+      : previewUnavailableLabel(deployment, localPreview);
 
   return (
     <div className="border-border bg-bg-sunken/60 rounded-xl border p-1.5 lg:h-[var(--deploy-preview-height)]">
@@ -181,7 +177,7 @@ export function DeployOverview({
 }) {
   return (
     <div className="grid grid-cols-1 items-start gap-x-12 gap-y-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(300px,0.9fr)] lg:[--deploy-preview-height:clamp(190px,22vw,300px)]">
-      <PreviewFrame deployment={deployment} latestRun={latestRun} localPreview={localPreview} />
+      <PreviewFrame deployment={deployment} localPreview={localPreview} />
 
       <div className="flex min-w-0 flex-col gap-5 lg:pt-1">
         <DeployUrlCard deployment={deployment} latestRun={latestRun} localPreview={localPreview} />

--- a/apps/web/src/routes/app-overview/deploy/components/deploy-status-badge.tsx
+++ b/apps/web/src/routes/app-overview/deploy/components/deploy-status-badge.tsx
@@ -1,38 +1,8 @@
-import { Loader2 } from "lucide-react";
+import { Check, Loader2 } from "lucide-react";
 
-import { cn } from "@/shared/lib/class-names";
 import { Badge } from "@/shared/ui/badge";
 
-import type { DeploymentRunDisplayStatus } from "../deploy-console-data";
-
-type StatusKind = "live" | "progress" | "failed" | "idle";
-
-interface StatusDescriptor {
-  kind: StatusKind;
-  label: string;
-}
-
-const PROGRESS_LABELS: Record<string, string> = {
-  activating: "Activating",
-  building: "Building",
-  preparing: "Preparing",
-  queued: "Queued",
-  submitted: "Submitted",
-  submitting: "Submitting",
-};
-
-function describeStatus(status: DeploymentRunDisplayStatus): StatusDescriptor {
-  if (status === "success") {
-    return { kind: "live", label: "Live" };
-  }
-  if (status === "failed") {
-    return { kind: "failed", label: "Failed" };
-  }
-  if (status === "superseded") {
-    return { kind: "idle", label: "Superseded" };
-  }
-  return { kind: "progress", label: `${PROGRESS_LABELS[status] ?? status}…` };
-}
+import type { DeploymentRunOutcome } from "../deployment-status";
 
 function withScope(label: string, scopeLabel: string | undefined): string {
   if (scopeLabel === undefined) {
@@ -43,20 +13,17 @@ function withScope(label: string, scopeLabel: string | undefined): string {
 }
 
 export function StatusBadge({
+  outcome,
   scopeLabel,
-  status,
 }: {
+  outcome: DeploymentRunOutcome;
   scopeLabel?: string | undefined;
-  status: DeploymentRunDisplayStatus;
 }) {
-  const { kind, label } = describeStatus(status);
+  const label =
+    outcome === "deploying" ? "Deploying…" : outcome === "failed" ? "Failed" : "Successful";
   const scopedLabel = withScope(label, scopeLabel);
 
-  if (kind === "idle") {
-    return <span className="text-fg-3 text-[12.5px] font-medium">{scopedLabel}</span>;
-  }
-
-  if (kind === "progress") {
+  if (outcome === "deploying") {
     return (
       <Badge variant="warning">
         <Loader2 className="size-3 animate-spin" />
@@ -65,17 +32,13 @@ export function StatusBadge({
     );
   }
 
-  if (kind === "failed") {
+  if (outcome === "failed") {
     return <Badge variant="danger">{scopedLabel}</Badge>;
   }
 
   return (
     <Badge variant="success">
-      <span
-        className={cn("size-1.5 rounded-full bg-current")}
-        style={{ animation: "pulse 900ms cubic-bezier(0.4,0,0.6,1) infinite" }}
-        aria-hidden
-      />
+      <Check className="size-3" />
       {scopedLabel}
     </Badge>
   );

--- a/apps/web/src/routes/app-overview/deploy/components/deploy-url-card.tsx
+++ b/apps/web/src/routes/app-overview/deploy/components/deploy-url-card.tsx
@@ -1,6 +1,5 @@
 import { ExternalLink } from "lucide-react";
 
-import { IN_FLIGHT_STATUSES } from "@/domains/app/query/app-deployment-queries";
 import { cn } from "@/shared/lib/class-names";
 
 import type { DeploymentRunVM, DeploymentVM } from "../deploy-console-data";
@@ -10,54 +9,7 @@ import type {
   LocalDeploymentPreviewStatus,
 } from "../local-preview-url";
 import { useNowTick } from "../use-now-tick";
-
-/**
- * The 8 backend run statuses collapsed into the 5 phases a user actually
- * watches: Queued → Build → Submit → Activate → Live.
- */
-const DEPLOY_PHASES = [
-  { label: "Queued", statuses: ["queued"] },
-  { label: "Build", statuses: ["preparing", "building"] },
-  { label: "Submit", statuses: ["submitting", "submitted"] },
-  { label: "Activate", statuses: ["activating"] },
-  { label: "Live", statuses: ["success"] },
-] as const;
-
-function PhaseStrip({ status }: { status: string }) {
-  const activeIndex = DEPLOY_PHASES.findIndex((phase) =>
-    (phase.statuses as readonly string[]).includes(status),
-  );
-
-  return (
-    <div aria-label="Deploy progress" className="flex items-center gap-0.5">
-      {DEPLOY_PHASES.map((phase, index) => {
-        const done = index < activeIndex;
-        const active = index === activeIndex;
-        return (
-          <span key={phase.label} className="flex items-center gap-0.5">
-            {index > 0 ? (
-              <span
-                aria-hidden
-                className={cn("h-px w-3", done || active ? "bg-amber-fg/50" : "bg-border")}
-              />
-            ) : null}
-            <span
-              className={cn(
-                "text-[12px] font-medium",
-                done && "text-fg-2",
-                active && "text-amber-fg animate-pulse font-semibold",
-                !done && !active && "text-fg-3/60",
-              )}
-            >
-              {done ? "✓ " : ""}
-              {phase.label}
-            </span>
-          </span>
-        );
-      })}
-    </div>
-  );
-}
+import { StatusBadge } from "./deploy-status-badge";
 
 function DomainLink({ url, large }: { url: string; large?: boolean | undefined }) {
   return (
@@ -145,11 +97,8 @@ export function DeployUrlCard({
   localPreview: LocalDeploymentPreviewState;
 }) {
   const now = useNowTick();
-  const inFlight =
-    latestRun !== undefined &&
-    latestRun.status !== "superseded" &&
-    IN_FLIGHT_STATUSES.has(latestRun.status);
-  const failed = latestRun !== undefined && latestRun.status === "failed";
+  const inFlight = latestRun?.outcome === "deploying";
+  const failed = latestRun?.outcome === "failed";
   const productionUrl = deployment.liveUrl ?? deployment.plannedUrl;
 
   return (
@@ -159,10 +108,7 @@ export function DeployUrlCard({
       {inFlight && latestRun !== undefined ? (
         <div className="flex flex-col gap-2.5">
           <DevelopmentPreviewRow status={localPreview.status} url={localPreview.url} />
-          <div className="flex min-w-0 flex-col gap-1">
-            <span className="text-fg-3 text-[13px]">Production deploy</span>
-            <PhaseStrip status={latestRun.status} />
-          </div>
+          <StatusBadge outcome={latestRun.outcome} scopeLabel="Production" />
           {deployment.liveUrl === null ? null : (
             <DomainRow label="Production still serving" url={deployment.liveUrl} />
           )}

--- a/apps/web/src/routes/app-overview/deploy/components/deployments-history.tsx
+++ b/apps/web/src/routes/app-overview/deploy/components/deployments-history.tsx
@@ -91,7 +91,7 @@ export function DeploymentsHistory({ runs }: { runs: DeploymentRunVM[] }) {
         <TableBody>
           {runs.map((run) => {
             const failedError =
-              run.status === "failed" ? (run.errorMessage ?? run.errorCode) : null;
+              run.outcome === "failed" ? (run.errorMessage ?? run.errorCode) : null;
             const expanded = expandedRunIds.has(run.id);
             return (
               <Fragment key={run.id}>
@@ -112,7 +112,7 @@ export function DeploymentsHistory({ runs }: { runs: DeploymentRunVM[] }) {
                     </div>
                   </TableCell>
                   <TableCell className="py-4 align-middle">
-                    <StatusBadge status={run.status} />
+                    <StatusBadge outcome={run.outcome} />
                   </TableCell>
                   <TableCell className="py-4 pr-5 align-middle">
                     <div className="flex min-w-0 items-start justify-between gap-3">

--- a/apps/web/src/routes/app-overview/deploy/deploy-console-data.ts
+++ b/apps/web/src/routes/app-overview/deploy/deploy-console-data.ts
@@ -1,4 +1,6 @@
-import type { AppDeploymentRunStatus, AppDeploymentTargetKind } from "@mosoo/contracts/app";
+import type { AppDeploymentTargetKind } from "@mosoo/contracts/app";
+
+import type { DeploymentRunOutcome } from "./deployment-status";
 
 /**
  * View models for the Deploy surface of the App Overview ("/") and its
@@ -31,9 +33,6 @@ export interface BoundAgentVM {
   envVar: string;
 }
 
-/** Run status plus the console-only "superseded" display state for old runs. */
-export type DeploymentRunDisplayStatus = AppDeploymentRunStatus | "superseded";
-
 /** Short console labels for the detected deploy target. */
 export const DEPLOY_TARGET_LABELS: Record<AppDeploymentTargetKind, string> = {
   cloudflare_pages: "static",
@@ -53,7 +52,7 @@ export interface DeploymentRunVM {
   commitSha: string;
   /** Detected deploy target; `null` while detection has not run yet. */
   targetKind: AppDeploymentTargetKind | null;
-  status: DeploymentRunDisplayStatus;
+  outcome: DeploymentRunOutcome;
   /** ISO timestamp the run was created — formatted relative at render time. */
   createdAt: string;
   liveUrl: string | null;
@@ -123,7 +122,7 @@ export function createDeployConsoleFixture(): DeployConsoleState {
         number: 4,
         commitSha: "a91c3f",
         targetKind: "cloudflare_worker",
-        status: "success",
+        outcome: "successful",
         createdAt: isoAgo(30_000),
         liveUrl,
         errorCode: null,
@@ -134,7 +133,7 @@ export function createDeployConsoleFixture(): DeployConsoleState {
         number: 3,
         commitSha: "7d20ab",
         targetKind: "cloudflare_worker",
-        status: "superseded",
+        outcome: "successful",
         createdAt: isoAgo(3 * 3_600_000),
         liveUrl: null,
         errorCode: null,
@@ -145,7 +144,7 @@ export function createDeployConsoleFixture(): DeployConsoleState {
         number: 2,
         commitSha: "1188ee",
         targetKind: "cloudflare_worker",
-        status: "superseded",
+        outcome: "successful",
         createdAt: isoAgo(26 * 3_600_000),
         liveUrl: null,
         errorCode: null,
@@ -156,7 +155,7 @@ export function createDeployConsoleFixture(): DeployConsoleState {
         number: 1,
         commitSha: "c0ffee",
         targetKind: "cloudflare_worker",
-        status: "superseded",
+        outcome: "successful",
         createdAt: isoAgo(50 * 3_600_000),
         liveUrl: null,
         errorCode: null,

--- a/apps/web/src/routes/app-overview/deploy/deploy-console-mapping.ts
+++ b/apps/web/src/routes/app-overview/deploy/deploy-console-mapping.ts
@@ -8,6 +8,7 @@ import type {
   DeploymentRunVM,
   DeploymentVM,
 } from "./deploy-console-data";
+import { toDeploymentRunOutcome } from "./deployment-status";
 
 /**
  * Pure mappers from the shared `@mosoo/contracts/app` deployment payloads onto
@@ -16,9 +17,9 @@ import type {
  *
  * Runs come from `appDeploymentRunList` newest-first: display numbers count
  * from the oldest fetched run (#1 = length - index, valid within the server's
- * 50-run window), and any success older than the newest success renders as
- * "superseded". Until the run list resolves, the overview's embedded latest
- * run renders WITHOUT a number — a lone run cannot know its place in history.
+ * 50-run window). Backend execution phases collapse into three user-facing
+ * outcomes. Until the run list resolves, the overview's embedded latest run
+ * renders WITHOUT a number — a lone run cannot know its place in history.
  */
 
 export function stripProtocol(url: string): string {
@@ -68,21 +69,13 @@ function toRunVM(run: AppDeploymentRun, number: number | null): DeploymentRunVM 
     id: run.id,
     liveUrl: run.liveUrl,
     number,
-    status: run.status,
+    outcome: toDeploymentRunOutcome(run.status),
     targetKind: run.targetKind,
   };
 }
 
 function toRunVMs(runs: AppDeploymentRun[], numbered: boolean): DeploymentRunVM[] {
-  let liveSeen = false;
-
-  return runs.map((run, index) => {
-    const superseded = run.status === "success" && liveSeen;
-    liveSeen = liveSeen || run.status === "success";
-    const vm = toRunVM(run, numbered ? runs.length - index : null);
-
-    return superseded ? { ...vm, liveUrl: null, status: "superseded" } : vm;
-  });
+  return runs.map((run, index) => toRunVM(run, numbered ? runs.length - index : null));
 }
 
 function toDeploymentVM(

--- a/apps/web/src/routes/app-overview/deploy/deploy-surface.tsx
+++ b/apps/web/src/routes/app-overview/deploy/deploy-surface.tsx
@@ -8,9 +8,10 @@ import { Badge } from "@/shared/ui/badge";
 import { DeployActions } from "./components/deploy-actions";
 import { DeployOverview } from "./components/deploy-overview";
 import { DeployRepoCard } from "./components/deploy-repo-card";
-import { StatusBadge } from "./components/deploy-status-badge";
 import { ActivitySection } from "./components/deployments-history";
 import type { DeployConsoleState } from "./deploy-console-data";
+import type { ProductionEnvironmentStatus } from "./deployment-status";
+import { toProductionEnvironmentStatus } from "./deployment-status";
 import type { LocalDeploymentPreviewState } from "./local-preview-url";
 import { useLocalDeploymentPreview } from "./local-preview-url";
 
@@ -59,6 +60,28 @@ function DevelopmentPreviewBadge({ localPreview }: { localPreview: LocalDeployme
   return <Badge variant="outline">Development offline</Badge>;
 }
 
+function ProductionEnvironmentBadge({ status }: { status: ProductionEnvironmentStatus }) {
+  if (status === "live") {
+    return (
+      <Badge variant="success">
+        <span className="size-1.5 rounded-full bg-current" aria-hidden />
+        Production live
+      </Badge>
+    );
+  }
+
+  if (status === "deploying") {
+    return (
+      <Badge variant="warning">
+        <Loader2 className="size-3 animate-spin" />
+        Production deploying
+      </Badge>
+    );
+  }
+
+  return <Badge variant="danger">Production unavailable</Badge>;
+}
+
 /**
  * The Overview deploy surface shared verbatim by the live "/" route and the
  * fixture-backed /v0-deploy-preview acceptance route — one composition, two
@@ -105,6 +128,10 @@ export function DeploySurface({
   const latestRun = runs[0];
   const localPreview = useLocalDeploymentPreview();
   const developmentMode = deployment !== null && localPreview.url !== null;
+  const productionStatus =
+    deployment === null
+      ? null
+      : toProductionEnvironmentStatus(deployment.liveUrl, latestRun?.outcome);
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -119,10 +146,10 @@ export function DeploySurface({
               {appName}
             </h1>
             <AppIdBadge appId={appId} />
+            {productionStatus === null ? null : (
+              <ProductionEnvironmentBadge status={productionStatus} />
+            )}
             {deployment !== null ? <DevelopmentPreviewBadge localPreview={localPreview} /> : null}
-            {deployment !== null && !developmentMode && latestRun !== undefined ? (
-              <StatusBadge scopeLabel="Production" status={latestRun.status} />
-            ) : null}
             {headerBadges}
           </div>
         </div>
@@ -131,7 +158,7 @@ export function DeploySurface({
             <DeployActions
               appName={appName}
               agentCount={agents.length}
-              latestStatus={developmentMode ? null : (latestRun?.status ?? null)}
+              latestOutcome={developmentMode ? null : (latestRun?.outcome ?? null)}
               deploying={developmentMode ? localPreview.status === "checking" : deploy.deploying}
               canDeploy={developmentMode ? true : deploy.canDeploy}
               onRetry={developmentMode ? localPreview.refresh : deploy.retryDeploy}

--- a/apps/web/src/routes/app-overview/deploy/deployment-status.ts
+++ b/apps/web/src/routes/app-overview/deploy/deployment-status.ts
@@ -1,0 +1,34 @@
+import type { AppDeploymentRunStatus } from "@mosoo/contracts/app";
+
+export type DeploymentRunOutcome = "deploying" | "failed" | "successful";
+
+export type ProductionEnvironmentStatus = "deploying" | "live" | "unavailable";
+
+/** Collapse executor phases into the outcomes users can understand and act on. */
+export function toDeploymentRunOutcome(status: AppDeploymentRunStatus): DeploymentRunOutcome {
+  switch (status) {
+    case "activating":
+    case "building":
+    case "preparing":
+    case "queued":
+    case "submitted":
+    case "submitting":
+      return "deploying";
+    case "failed":
+      return "failed";
+    case "success":
+      return "successful";
+  }
+}
+
+/** Production availability is independent from the latest deployment attempt. */
+export function toProductionEnvironmentStatus(
+  liveUrl: string | null,
+  latestOutcome: DeploymentRunOutcome | undefined,
+): ProductionEnvironmentStatus {
+  if (liveUrl !== null) {
+    return "live";
+  }
+
+  return latestOutcome === "deploying" ? "deploying" : "unavailable";
+}

--- a/apps/web/src/routes/app-overview/deploy/use-deploy-console.ts
+++ b/apps/web/src/routes/app-overview/deploy/use-deploy-console.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { createDeployConsoleFixture, DEPLOY_APP_IDENTITY } from "./deploy-console-data";
 import type { DeployConsoleState, DeploymentRunVM } from "./deploy-console-data";
 import { stripProtocol } from "./deploy-console-mapping";
+import { toDeploymentRunOutcome } from "./deployment-status";
 
 /**
  * Status steps a freshly triggered deploy walks through. This mirrors the real
@@ -86,7 +87,7 @@ export function useDeployConsole(): DeployConsole {
           number,
           commitSha,
           targetKind: null,
-          status: "queued",
+          outcome: "deploying",
           createdAt: new Date().toISOString(),
           liveUrl: null,
           errorCode: null,
@@ -115,15 +116,11 @@ export function useDeployConsole(): DeployConsole {
             setState((prev) => {
               const runs = prev.runs.map((run): DeploymentRunVM => {
                 if (run.id !== runId) {
-                  // The previous live run stays "success" (still serving) until
-                  // the new run actually goes live — then it is superseded.
-                  return status === "success" && run.status === "success"
-                    ? { ...run, status: "superseded", liveUrl: null }
-                    : run;
+                  return run;
                 }
                 return {
                   ...run,
-                  status,
+                  outcome: toDeploymentRunOutcome(status),
                   targetKind: status === "queued" ? null : "cloudflare_worker",
                   liveUrl: status === "success" ? DEPLOY_APP_IDENTITY.liveUrl : null,
                   ...(status === "failed" ? FAILURE_ERROR : null),

--- a/apps/web/tests/deployment-status.test.ts
+++ b/apps/web/tests/deployment-status.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+import type { AppDeployment, AppDeploymentRun, AppDeploymentRunStatus } from "@mosoo/contracts/app";
+
+import type { AppDeploymentOverview } from "../src/domains/app/api/app-deployment-client";
+import { toDeployConsoleState } from "../src/routes/app-overview/deploy/deploy-console-mapping";
+import {
+  toDeploymentRunOutcome,
+  toProductionEnvironmentStatus,
+} from "../src/routes/app-overview/deploy/deployment-status";
+
+function deploymentRun(id: string, status: AppDeploymentRunStatus): AppDeploymentRun {
+  return {
+    appId: "01APP000000000000000000000" as AppDeploymentRun["appId"],
+    createdAt: "2026-07-10T00:00:00.000Z",
+    deploymentId: "01DEPLOYMENT00000000000000" as AppDeploymentRun["deploymentId"],
+    errorCode: null,
+    errorMessage: null,
+    id: id as AppDeploymentRun["id"],
+    liveUrl: status === "success" ? "https://app.apps.mosoo.ai" : null,
+    plannedUrl: "https://app.apps.mosoo.ai",
+    sourceBranch: "main",
+    sourceCommitSha: "abcdef1234567890",
+    status,
+    targetKind: "cloudflare_worker",
+    updatedAt: "2026-07-10T00:00:00.000Z",
+  };
+}
+
+function readSource(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+describe("deployment status presentation", () => {
+  test("collapses executor phases into three user-facing outcomes", () => {
+    const cases: Array<[AppDeploymentRunStatus, ReturnType<typeof toDeploymentRunOutcome>]> = [
+      ["queued", "deploying"],
+      ["preparing", "deploying"],
+      ["building", "deploying"],
+      ["submitting", "deploying"],
+      ["submitted", "deploying"],
+      ["activating", "deploying"],
+      ["success", "successful"],
+      ["failed", "failed"],
+    ];
+
+    for (const [status, outcome] of cases) {
+      expect(toDeploymentRunOutcome(status)).toBe(outcome);
+    }
+  });
+
+  test("keeps production live when the latest attempt is deploying or failed", () => {
+    expect(toProductionEnvironmentStatus("https://app.apps.mosoo.ai", "deploying")).toBe("live");
+    expect(toProductionEnvironmentStatus("https://app.apps.mosoo.ai", "failed")).toBe("live");
+  });
+
+  test("keeps every successful history row successful", () => {
+    const newest = deploymentRun("01RUN0000000000000000000002", "success");
+    const older = deploymentRun("01RUN0000000000000000000001", "success");
+    const deployment: AppDeployment = {
+      appId: newest.appId,
+      createdAt: newest.createdAt,
+      defaultBranch: "main",
+      id: newest.deploymentId,
+      latestRun: newest,
+      liveUrl: newest.liveUrl,
+      plannedUrl: newest.plannedUrl,
+      repoName: "app",
+      repoOwner: "mosoo",
+      repoUrl: "https://github.com/mosoo/app.git",
+      updatedAt: newest.updatedAt,
+    };
+    const overview: AppDeploymentOverview = {
+      appName: "App",
+      boundAgents: [],
+      deployment,
+    };
+
+    const state = toDeployConsoleState(overview, [newest, older]);
+
+    expect(state.runs.map((run) => run.outcome)).toEqual(["successful", "successful"]);
+  });
+
+  test("reports deploying or unavailable before the first successful deploy", () => {
+    expect(toProductionEnvironmentStatus(null, "deploying")).toBe("deploying");
+    expect(toProductionEnvironmentStatus(null, "failed")).toBe("unavailable");
+    expect(toProductionEnvironmentStatus(null, undefined)).toBe("unavailable");
+  });
+
+  test("keeps internal phases and superseded out of presentation components", () => {
+    const badgeSource = readSource(
+      "../src/routes/app-overview/deploy/components/deploy-status-badge.tsx",
+    );
+    const urlCardSource = readSource(
+      "../src/routes/app-overview/deploy/components/deploy-url-card.tsx",
+    );
+
+    expect(badgeSource).toContain('"Deploying…"');
+    expect(badgeSource).toContain('"Successful"');
+    expect(badgeSource).toContain('"Failed"');
+    expect(badgeSource).not.toMatch(/Queued|Preparing|Building|Submitting|Submitted|Activating/u);
+    expect(badgeSource).not.toContain("Superseded");
+    expect(urlCardSource).not.toContain("DEPLOY_PHASES");
+    expect(urlCardSource).not.toContain("Deploy progress");
+  });
+});

--- a/docs/plans/2026-07-10-deployment-status-simplification-design.md
+++ b/docs/plans/2026-07-10-deployment-status-simplification-design.md
@@ -1,0 +1,83 @@
+# Deployment Status Simplification
+
+Status: approved on 2026-07-10.
+
+## Problem
+
+The App Overview exposes backend deployment phases as user-facing statuses and adds a Web-only
+`superseded` pseudo-status for older successful runs. This mixes two different questions:
+
+- Did this deployment run finish successfully?
+- Is a successful result currently serving production traffic?
+
+The result is a nine-label Activity vocabulary plus a five-step progress strip. The labels are more
+detailed than the decisions users need to make, and `Superseded` can be mistaken for a canceled run
+even though the persisted run outcome is `success`.
+
+Mintlify's public Activity design provides the product reference: the list exposes coarse run
+outcomes while build phases live in expanded deployment details. Mosoo does not yet expose a useful
+deployment log, so detailed phases should remain internal until that complete diagnostic surface
+exists.
+
+## Decision
+
+Keep the eight backend `AppDeploymentRunStatus` values unchanged for execution, retries,
+observability, and future diagnostics. Project them at the Web boundary into three user-facing run
+outcomes:
+
+| Backend status                                                             | User-facing outcome |
+| -------------------------------------------------------------------------- | ------------------- |
+| `queued`, `preparing`, `building`, `submitting`, `submitted`, `activating` | `Deploying`         |
+| `success`                                                                  | `Successful`        |
+| `failed`                                                                   | `Failed`            |
+
+Production availability is a separate environment state. A non-null deployment `liveUrl` is the
+source of truth for `Production live`, regardless of whether the latest attempt is deploying or
+failed. When there is no live URL, an active run shows `Production deploying`; a terminal failure
+shows `Production unavailable`.
+
+## User Experience
+
+- Activity shows only `Deploying`, `Successful`, and `Failed`.
+- All successful historical runs remain `Successful`; the UI does not show `Superseded`.
+- The five-step Queued/Build/Submit/Activate/Live strip is removed.
+- The header and environment section express production availability independently from the latest
+  run outcome.
+- If a redeploy fails while an older version is still serving, the page continues to show
+  `Production live`. The failed attempt remains visible in Activity with its error details.
+- If the first deployment fails, the environment is `Production unavailable` and the reserved URL
+  may still be shown.
+- The production preview uses `deployment.liveUrl` directly. A failed or active redeploy must not
+  hide a still-live production preview.
+
+## Architecture
+
+Add a Web-local `DeploymentRunOutcome` projection and keep the shared contract, GraphQL schema, D1
+schema, queue behavior, and executor transitions unchanged. Deployment view models expose the
+projected outcome to UI components; backend phases do not cross the final presentation boundary.
+
+Keep environment-state derivation pure and explicit so `liveUrl` takes precedence over the latest
+attempt's outcome. Do not infer production availability from whether the latest run succeeded.
+
+## Error Handling
+
+- Run errors remain attached only to `Failed` Activity rows.
+- A failed redeploy does not clear or downgrade a valid live environment.
+- A missing live URL after a reported successful run is treated as unavailable UI state rather than
+  inventing a fallback URL.
+
+## Verification
+
+- Add table-driven tests mapping all eight backend statuses to the three public outcomes.
+- Test that multiple successful runs all remain `Successful`.
+- Test environment precedence for live plus deploying, live plus failed, first deploy in progress,
+  and first deploy failed.
+- Run the Web package tests and typecheck.
+- Visually inspect the fixture-backed deployment preview at desktop and narrow widths.
+
+## Non-goals
+
+- No GraphQL or D1 schema change.
+- No production migration.
+- No change to retry, queue, executor, or Cloudflare deployment semantics.
+- No deployment-log or expandable phase-detail UI in this change.

--- a/docs/prd/app-deployment.md
+++ b/docs/prd/app-deployment.md
@@ -373,10 +373,27 @@ The initial response can include:
 - `runId`, for API callers only.
 - `status`.
 - `plannedUrl`, the Mosoo-owned URL reserved for this App.
-- `liveUrl`, null until the latest run succeeds.
+- `liveUrl`, null until the first run succeeds; later deploy attempts do not
+  clear the last successful URL.
 
-First-cut product clients should show status and URL, but should not require
-users to copy or pass a run ID.
+The API keeps detailed executor status for retries, diagnostics, and future
+deployment logs. Product clients should not expose those implementation phases
+as separate top-level states. Collapse them into the outcomes users can
+understand and act on:
+
+- `Deploying`: `queued`, `preparing`, `building`, `submitting`, `submitted`, or
+  `activating`
+- `Successful`: `success`
+- `Failed`: `failed`
+
+Production availability is a separate state. A non-null Deployment `liveUrl`
+means `Production live`, even when a newer run is deploying or failed. Historical
+successful runs remain `Successful`; do not relabel them as `Superseded`. Detailed
+executor phases belong in a future expanded deployment log rather than the
+Activity status column.
+
+First-cut product clients should show the projected outcome and URL, but should
+not require users to copy or pass a run ID.
 
 Statuses:
 
@@ -390,7 +407,8 @@ Statuses:
 - `failed`
 
 `submitted` means Mosoo has handed work to Cloudflare or the deployment queue.
-Only `success` means the URL is live.
+Only `success` may establish or update `liveUrl`. A later active or failed run
+does not take the last successful deployment offline.
 
 Delete removes the App's current deployment. It should remove or disable the
 Mosoo-owned route/subdomain and delete the corresponding Mosoo-managed


### PR DESCRIPTION
## Summary

- collapse the eight internal deployment phases into `Deploying`, `Successful`, and `Failed` outcomes at the Web boundary
- keep production availability independent so failed or active redeploys do not hide an existing live deployment
- remove the `Superseded` pseudo-status and five-step progress strip, and document the public state model

## Why

The console mixed execution progress with production availability. Historical successful runs were relabeled `Superseded`, and a failed redeploy could make an existing live production environment appear unavailable. The new projection follows Mintlify-style progressive disclosure: coarse outcomes in Activity; internal phases remain available for diagnostics.

## User impact

- Activity exposes only high-frequency, understandable outcomes.
- Production live remains accurate during later deploying or failed attempts.
- Historical successful runs remain `Successful`.

## Validation

- `just test-package @mosoo/web` — 126 pass, 551 assertions
- `bun run --filter @mosoo/web lint`
- `just docs-check`
- `bash ./init.sh acceptance`
- fixture browser checks at desktop and 390px, including active and failed redeploys; no console errors

## Generated artifacts

- GraphQL codegen: not required (no schema, document, or scalar changes)
- DB regeneration/migration: not required (no schema changes)
