### PR TITLE
fix(runtime): sanitize provider-private citations

### DIFF
--- a/apps/api/src/modules/public-api/public-output-sanitization.ts
+++ b/apps/api/src/modules/public-api/public-output-sanitization.ts
@@ -1,0 +1,25 @@
+import type { PublicThreadFinalOutputWarning } from "@mosoo/contracts/public-api";
+
+import { sanitizeProviderPrivateMarkup } from "../sessions/domain/provider-private-markup";
+
+export interface SanitizedPublicOutput {
+  readonly text: string;
+  readonly warnings: PublicThreadFinalOutputWarning[];
+}
+
+export function sanitizePublicOutput(text: string): SanitizedPublicOutput {
+  const sanitized = sanitizeProviderPrivateMarkup(text);
+
+  return {
+    text: sanitized.text,
+    warnings:
+      sanitized.privateCitationCount === 0
+        ? []
+        : [
+            {
+              code: "unresolved_provider_citation",
+              count: sanitized.privateCitationCount,
+            },
+          ],
+  };
+}

--- a/apps/api/src/modules/public-api/public-thread-events.ts
+++ b/apps/api/src/modules/public-api/public-thread-events.ts
@@ -19,6 +19,7 @@ import { getAppDatabase } from "../../platform/db/drizzle";
 import { createSessionProcessEventsFromSessionEventRows } from "../sessions/application/session-process-events.service";
 import type { SessionEventProcessRow } from "../sessions/application/session-process-events.service";
 import { publicInternalError, publicInvalidRequest, toPublicApiError } from "./public-api-errors";
+import { sanitizePublicOutput } from "./public-output-sanitization";
 import { admitPublicThreadReader } from "./public-thread-admission";
 import { toBackingSessionId } from "./public-thread-ids";
 import { getThreadSnapshot } from "./public-thread-store";
@@ -69,7 +70,7 @@ function toPublicThreadEventLogEntry(input: {
   }
 
   return {
-    content: event.content,
+    content: sanitizePublicOutput(event.content).text,
     durationMs: event.durationMs,
     id: parsePlatformId(event.id, "Runtime event ID") as RuntimeEventId,
     occurredAt: event.occurredAt,
@@ -228,8 +229,11 @@ export async function readPublicThreadRunFinalOutput(input: {
     return null;
   }
 
+  const sanitizedOutput = sanitizePublicOutput(message.content);
+
   return {
-    text: message.content,
+    text: sanitizedOutput.text,
+    ...(sanitizedOutput.warnings.length === 0 ? {} : { warnings: sanitizedOutput.warnings }),
   };
 }
 

--- a/apps/api/src/modules/sessions/application/session-message-mappers.ts
+++ b/apps/api/src/modules/sessions/application/session-message-mappers.ts
@@ -3,6 +3,10 @@ import { parsePlatformId } from "@mosoo/id";
 import type { PlatformId, SessionMessageId } from "@mosoo/id";
 
 import { toIsoString } from "../../../time";
+import {
+  sanitizeAssistantMessageSegments,
+  sanitizeProviderPrivateMarkup,
+} from "../domain/provider-private-markup";
 import { parseStoredSessionMessageProjection } from "../domain/session-message-projection-parser";
 
 export interface SessionMessageRow {
@@ -22,12 +26,15 @@ export function toSessionMessage(row: SessionMessageRow): SessionMessage {
   });
 
   return {
-    content: row.content_text,
+    content:
+      row.role === "assistant"
+        ? sanitizeProviderPrivateMarkup(row.content_text).text
+        : row.content_text,
     createdAt: toIsoString(row.created_at),
     createdBy: parsePlatformId(row.created_by_account_id, "Session message creator ID"),
     id: parsePlatformId<SessionMessageId>(row.id, "Session message ID"),
     plan,
     role: row.role,
-    segments,
+    segments: row.role === "assistant" ? sanitizeAssistantMessageSegments(segments) : segments,
   };
 }

--- a/apps/api/src/modules/sessions/domain/provider-private-markup.ts
+++ b/apps/api/src/modules/sessions/domain/provider-private-markup.ts
@@ -1,0 +1,17 @@
+import type { SessionMessageSegment } from "@mosoo/contracts/session";
+import { filterOpenAiPrivateCitations } from "agent-driver/provider-output";
+
+export const sanitizeProviderPrivateMarkup = filterOpenAiPrivateCitations;
+
+export function sanitizeAssistantMessageSegments(
+  segments: SessionMessageSegment[],
+): SessionMessageSegment[] {
+  return segments.map((segment) =>
+    segment.kind === "text"
+      ? {
+          ...segment,
+          text: sanitizeProviderPrivateMarkup(segment.text).text,
+        }
+      : segment,
+  );
+}

--- a/apps/api/src/modules/sessions/infrastructure/session-message-snapshot.repository.ts
+++ b/apps/api/src/modules/sessions/infrastructure/session-message-snapshot.repository.ts
@@ -4,6 +4,10 @@ import { asc, eq } from "drizzle-orm";
 
 import { getAppDatabase } from "../../../platform/db/drizzle";
 import { toIsoString } from "../../../time";
+import {
+  sanitizeAssistantMessageSegments,
+  sanitizeProviderPrivateMarkup,
+} from "../domain/provider-private-markup";
 import { parseStoredSessionMessageProjection } from "../domain/session-message-projection-parser";
 import type { SessionLiveStateMessage } from "./session-live-state.types";
 
@@ -29,14 +33,17 @@ function toLiveStateMessage(row: StoredSessionMessageRow): SessionLiveStateMessa
     planJson: row.plan_json,
     segmentsJson: row.segments_json,
   });
+  const assistantMessage = row.role === "assistant";
 
   return {
-    content: row.content_text,
+    content: assistantMessage
+      ? sanitizeProviderPrivateMarkup(row.content_text).text
+      : row.content_text,
     createdAt: toIsoString(row.created_at),
     id: row.id,
     plan,
     role: row.role,
-    segments,
+    segments: assistantMessage ? sanitizeAssistantMessageSegments(segments) : segments,
   };
 }
 

--- a/apps/api/tests/public-output-sanitization.test.ts
+++ b/apps/api/tests/public-output-sanitization.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { sanitizePublicOutput } from "../src/modules/public-api/public-output-sanitization";
+
+const PRIVATE_CITATION = "\uE200cite\uE202turn2view0\uE202turn8view0\uE201";
+
+describe("public output sanitization", () => {
+  test("removes provider-private citation markup and reports a warning", () => {
+    expect(sanitizePublicOutput(`before${PRIVATE_CITATION}after`)).toEqual({
+      text: "beforeafter",
+      warnings: [
+        {
+          code: "unresolved_provider_citation",
+          count: 1,
+        },
+      ],
+    });
+  });
+
+  test("preserves text that contains no complete private citation envelope", () => {
+    expect(sanitizePublicOutput("before\uE200other\uE201after")).toEqual({
+      text: "before\uE200other\uE201after",
+      warnings: [],
+    });
+    expect(sanitizePublicOutput("before\uE200cite\uE202turn2view0")).toEqual({
+      text: "before\uE200cite\uE202turn2view0",
+      warnings: [],
+    });
+  });
+});

--- a/apps/api/tests/runtime-final-output-ingestion.test.ts
+++ b/apps/api/tests/runtime-final-output-ingestion.test.ts
@@ -476,6 +476,51 @@ describe("runtime final output ingestion", () => {
     expect(FINAL_TEXT.split("\n")).toContain("160|中文长文本校验-Aa9-表格字符|END160");
   });
 
+  test("removes provider-private citations at the public final-output boundary", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertRuntimeFixture(database);
+    const bindings = createPublicHttpTestBindings(database) as ApiBindings;
+    const finalMessageId = createPlatformId<SessionMessageId>();
+    const privateCitation = "\uE200cite\uE202turn2view0\uE202turn8view0\uE201";
+    const providerText = `before${privateCitation}after`;
+    const events = [
+      ...messageEvents({
+        messageId: finalMessageId,
+        sourcePrefix: "private-citation:final",
+        text: providerText,
+      }),
+      runtimeEvent({
+        kind: "run.completed",
+        payload: {
+          finalMessageId,
+          finalMessageText: providerText,
+          stopReason: "end_turn",
+        },
+        sourceEventId: "private-citation:run-completed",
+      }),
+    ];
+
+    await pushFreshController(bindings, events);
+
+    const persistedMessage = await database
+      .prepare("SELECT content_text FROM session_message WHERE id = ?")
+      .bind(finalMessageId)
+      .first<{ content_text: string }>();
+
+    expect(persistedMessage?.content_text).toBe(providerText);
+    await expect(
+      readPublicThreadRunFinalOutput({ database, runId: RUN_ID, sessionId: SESSION_ID }),
+    ).resolves.toEqual({
+      text: "beforeafter",
+      warnings: [
+        {
+          code: "unresolved_provider_citation",
+          count: 1,
+        },
+      ],
+    });
+  });
+
   test("fails closed when a cross-boot replay conflicts with the persisted final snapshot", async () => {
     const database = await createPublicHttpContractDatabase();
     await insertRuntimeFixture(database);

--- a/apps/api/tests/session-message-query.test.ts
+++ b/apps/api/tests/session-message-query.test.ts
@@ -192,4 +192,32 @@ describe("session message query", () => {
 
     expect(messages.map((message) => message.id)).toEqual([MESSAGE_ID_1, MESSAGE_ID_2]);
   });
+
+  test("removes provider-private citations from stored assistant message projections", async () => {
+    const database = createSessionMessageQueryDatabase();
+    const privateCitation = "\uE200cite\uE202turn2view0\uE202turn8view0\uE201";
+    const storedText = `before${privateCitation}after`;
+
+    await database
+      .prepare("UPDATE session_message SET content_text = ?, segments_json = ? WHERE id = ?")
+      .bind(storedText, JSON.stringify([{ kind: "text", text: storedText }]), MESSAGE_ID_2)
+      .run();
+
+    const [queryMessages, snapshotMessages] = await Promise.all([
+      getThreadSessionMessages(database, VIEWER, {
+        appId: APP_ID,
+        sessionId: SESSION_ID,
+      }),
+      loadStoredSessionMessages(database, SESSION_ID),
+    ]);
+
+    expect(queryMessages[1]).toMatchObject({
+      content: "beforeafter",
+      segments: [{ kind: "text", text: "beforeafter" }],
+    });
+    expect(snapshotMessages[1]).toMatchObject({
+      content: "beforeafter",
+      segments: [{ kind: "text", text: "beforeafter" }],
+    });
+  });
 });

--- a/pkgs/contracts/src/http/public-api-core.contract.ts
+++ b/pkgs/contracts/src/http/public-api-core.contract.ts
@@ -86,6 +86,12 @@ export type PublicThreadRunTerminalStatus = (typeof PUBLIC_THREAD_RUN_TERMINAL_S
 
 export interface PublicThreadFinalOutput {
   text: string;
+  warnings?: PublicThreadFinalOutputWarning[];
+}
+
+export interface PublicThreadFinalOutputWarning {
+  code: "unresolved_provider_citation";
+  count: number;
 }
 
 export interface PublicThreadRunError {

--- a/pkgs/contracts/src/http/public-api-openapi.contract.ts
+++ b/pkgs/contracts/src/http/public-api-openapi.contract.ts
@@ -628,7 +628,7 @@ export const PUBLIC_API_OPENAPI_SCHEMAS = {
       },
       finalOutput: {
         description:
-          "Canonical final assistant answer for a completed Run. This is the exact persisted final assistant message text, not a reconstruction of public `agent.message.delta` events. Null until that final message is persisted or when the Run has no final assistant answer.",
+          "Public-safe canonical final assistant answer for a completed Run. It is derived from the persisted final assistant message, not reconstructed from public `agent.message.delta` events. Null until that final message is persisted or when the Run has no final assistant answer.",
         oneOf: [{ $ref: "#/components/schemas/RunFinalOutput" }, { type: "null" }],
       },
       id: {
@@ -706,11 +706,34 @@ export const PUBLIC_API_OPENAPI_SCHEMAS = {
     properties: {
       text: {
         description:
-          "Exact text of the Run's persisted final assistant message. Public event entries are not a substitute for this value.",
+          "Public-safe text derived from the Run's persisted final assistant message. Provider-private control markup is omitted and reported through warnings.",
         type: "string",
+      },
+      warnings: {
+        description:
+          "Non-fatal warnings raised while making provider output safe for public consumption.",
+        items: { $ref: "#/components/schemas/RunFinalOutputWarning" },
+        type: "array",
       },
     },
     required: ["text"],
+    type: "object",
+  },
+  RunFinalOutputWarning: {
+    additionalProperties: false,
+    description: "A non-fatal warning attached to canonical final output.",
+    properties: {
+      code: {
+        const: "unresolved_provider_citation",
+        description: "Stable code identifying provider citation markup that could not be resolved.",
+      },
+      count: {
+        description: "Number of private citation envelopes removed from the public text.",
+        minimum: 1,
+        type: "integer",
+      },
+    },
+    required: ["code", "count"],
     type: "object",
   },
   UserWarning: {


### PR DESCRIPTION
## Summary
- sanitize provider-private citation envelopes at Public Thread API and event presentation boundaries
- return an additive `unresolved_provider_citation` warning with the removed envelope count
- sanitize historical assistant content and text segments for GraphQL/Web and live-state snapshots
- reuse the sanitizer exported by mosoo-agent-driver instead of maintaining a second parser

## Dependency
- depends on langgenius/mosoo-agent-driver#42
- advances the Driver submodule from `9466e68` to `1981191`; this range also includes already-merged Driver #39 Claude/ACP final-boundary hardening

## Validation
- API: 927 tests passed; lint and typecheck passed
- Driver: 193 non-live tests passed, 1 skipped; lint, typecheck, and type build passed
- Web: 121 tests passed; lint and typecheck passed
- Public API client: 9 tests passed; lint and typecheck passed
- Contracts: 14 tests passed; lint and typecheck passed

## Generated and schema changes
- no DB migration or baseline changes
- no GraphQL codegen changes
- no generated files
- Public API adds an optional `finalOutput.warnings` field and updates the handwritten OpenAPI contract