### PR TITLE
fix(runtime): canonicalize terminal run failures

### DIFF
--- a/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
@@ -28,12 +28,9 @@ import {
   SessionRunNoLongerActiveError,
   ensureSessionRunIsActive,
   getSessionRunState,
-  updateSessionRunStatusIfActive,
 } from "./session-run-state.repository";
-import {
-  createFailedSessionRunRuntimeEvent,
-  createSessionRunUpdatedEvent,
-} from "./session-run-view-events.service";
+import { recordCanonicalSessionRunFailure } from "./session-run-terminal-failure.service";
+import { createSessionRunUpdatedEvent } from "./session-run-view-events.service";
 import {
   appendSessionRuntimeTimingEventBestEffort,
   createRuntimeTimingRecorder,
@@ -325,35 +322,20 @@ export async function dispatchSessionRun(
       });
     }
 
-    const failedRun = await updateSessionRunStatusIfActive(bindings.DB, {
+    const failureOutcome = await recordCanonicalSessionRunFailure(bindings, {
       error: runError,
       runId: input.sessionRunId,
-      status: "failed",
+      sessionId: input.sessionId,
+      source: "api",
     });
-
-    if (!failedRun) {
-      const state = await getSessionRunState(bindings.DB, input.sessionRunId);
-
-      await appendSessionRuntimeEvents({
-        bindings,
-        events: [
-          createSessionRuntimeEvent({
-            kind: "run.failed",
-            payload: {
-              error: {
-                code: `${runError.code}.after_terminal`,
-                details: {},
-                message,
-                retryable: false,
-              },
-            },
-            runId: input.sessionRunId,
-            sessionId: input.sessionId,
-            traceId: input.traceId,
-          }),
-        ],
-        sessionId: input.sessionId,
+    if (failureOutcome.kind === "repair_needed") {
+      throw new Error("Session lifecycle projection needs repair.", {
+        cause: error,
       });
+    }
+
+    if (failureOutcome.kind === "not_failed") {
+      const state = await getSessionRunState(bindings.DB, input.sessionRunId);
 
       logWarn("session.run.provision.failed.after-terminal", {
         driverInstanceId,
@@ -366,18 +348,6 @@ export async function dispatchSessionRun(
 
       return;
     }
-
-    await appendSessionRuntimeEvents({
-      bindings,
-      events: [
-        createFailedSessionRunRuntimeEvent({
-          run: failedRun,
-          runError,
-          sessionId: input.sessionId,
-        }),
-      ],
-      sessionId: input.sessionId,
-    });
 
     logError("session.run.provision.failed", {
       message,

--- a/apps/api/src/modules/runtime/application/session-runs/session-run-terminal-failure.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/session-run-terminal-failure.service.ts
@@ -1,0 +1,70 @@
+import type { RunError } from "@mosoo/contracts/session-run";
+import type { SessionId, SessionRunId } from "@mosoo/id";
+
+import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
+import { appendSessionRuntimeEvents } from "../../../sessions/application/session-event-write.service";
+import { createSessionRunTerminalFailureSourceId } from "../../domain/session-run-terminal-event-id";
+import {
+  getSessionRunSummary,
+  setSessionRunStatus,
+} from "../../infrastructure/session-runs/session-run-store.repository";
+import type { SessionRunTransitionOutcome } from "../../infrastructure/session-runs/session-run-store.repository";
+import { createFailedSessionRunRuntimeEvent } from "./session-run-view-events.service";
+
+export type CanonicalSessionRunFailureOutcome =
+  | {
+      kind: "failed";
+    }
+  | {
+      kind: "not_failed";
+      transition: SessionRunTransitionOutcome;
+    }
+  | {
+      kind: "repair_needed";
+      transition: Extract<SessionRunTransitionOutcome, { kind: "repair_needed" }>;
+    };
+
+export async function recordCanonicalSessionRunFailure(
+  bindings: ApiBindings,
+  input: {
+    error: RunError;
+    runId: SessionRunId;
+    sessionId: SessionId;
+    source: "api" | "driver";
+  },
+): Promise<CanonicalSessionRunFailureOutcome> {
+  const outcome = await setSessionRunStatus(bindings.DB, {
+    error: input.error,
+    runId: input.runId,
+    source: input.source,
+    status: "failed",
+  });
+
+  if (outcome.kind === "repair_needed") {
+    return { kind: "repair_needed", transition: outcome };
+  }
+
+  const run =
+    outcome.kind === "applied" || outcome.kind === "duplicate"
+      ? outcome.run
+      : await getSessionRunSummary(bindings.DB, input.runId);
+
+  if (run?.status !== "failed" || run.error === null) {
+    return { kind: "not_failed", transition: outcome };
+  }
+
+  await appendSessionRuntimeEvents({
+    bindings,
+    events: [
+      createFailedSessionRunRuntimeEvent({
+        run,
+        runError: run.error,
+        sessionId: input.sessionId,
+        sourceEventId: createSessionRunTerminalFailureSourceId(input.runId),
+      }),
+    ],
+    sessionId: input.sessionId,
+  });
+
+  return { kind: "failed" };
+}

--- a/apps/api/src/modules/runtime/domain/session-run-terminal-event-id.ts
+++ b/apps/api/src/modules/runtime/domain/session-run-terminal-event-id.ts
@@ -1,0 +1,5 @@
+import type { SessionRunId } from "@mosoo/id";
+
+export function createSessionRunTerminalFailureSourceId(runId: SessionRunId): string {
+  return `session-run-terminal:${runId}:run.failed`;
+}

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/events.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/events.ts
@@ -37,6 +37,7 @@ import type {
   SessionLiveState,
 } from "../../../sessions/application/session-live-state.service";
 import { getRuntimeKindPolicy } from "../../domain/runtime-kind-policy";
+import { createSessionRunTerminalFailureSourceId } from "../../domain/session-run-terminal-event-id";
 import { upsertNativeResumeRef } from "../native-resume-ref.repository";
 import { getRuntimeSubjectKeepAliveHandle } from "../runtime-subject-lifecycle/runtime-subject-lifecycle.service";
 import { getRuntimeConversationSession } from "../runtime-subject-lifecycle/runtime-subject-store";
@@ -432,12 +433,13 @@ export async function appRuntimeDriverEvents(
         typeof source.occurredAt === "number" && Number.isFinite(source.occurredAt)
           ? source.occurredAt
           : null,
-      sourceEventId: source.eventId.trim().length > 0 ? source.eventId : null,
+      sourceEventId: resolveDriverEventPersistenceSourceId(source, event),
     });
   }
 
   function appendSessionDeliveryEvent(
     source: DriverEventEnvelope,
+    event: RuntimeEventEnvelope,
     deliveryEvent: SessionDeliveryEvent,
   ): void {
     sessionDeliveryEvents.push({
@@ -446,7 +448,7 @@ export async function appRuntimeDriverEvents(
         typeof source.occurredAt === "number" && Number.isFinite(source.occurredAt)
           ? source.occurredAt
           : null,
-      sourceEventId: source.eventId.trim().length > 0 ? source.eventId : null,
+      sourceEventId: resolveDriverEventPersistenceSourceId(source, event),
     });
   }
 
@@ -547,7 +549,7 @@ export async function appRuntimeDriverEvents(
         );
 
         nextLiveState = applyAgUiEventToSessionLiveState(nextLiveState, permissionsUpdatedEvent);
-        appendSessionDeliveryEvent(envelope, permissionsUpdatedEvent);
+        appendSessionDeliveryEvent(envelope, event, permissionsUpdatedEvent);
         liveStateChanged = true;
       }
 
@@ -572,7 +574,7 @@ export async function appRuntimeDriverEvents(
         );
 
         nextLiveState = applyAgUiEventToSessionLiveState(nextLiveState, permissionsUpdatedEvent);
-        appendSessionDeliveryEvent(envelope, permissionsUpdatedEvent);
+        appendSessionDeliveryEvent(envelope, event, permissionsUpdatedEvent);
         liveStateChanged = true;
       }
 
@@ -599,7 +601,7 @@ export async function appRuntimeDriverEvents(
 
     for (const liveEvent of liveEvents) {
       nextLiveState = applyAgUiEventToSessionLiveState(nextLiveState, liveEvent);
-      appendSessionDeliveryEvent(envelope, liveEvent);
+      appendSessionDeliveryEvent(envelope, event, liveEvent);
       liveStateChanged = true;
     }
   }
@@ -615,6 +617,17 @@ export async function appRuntimeDriverEvents(
     transitions,
     usage,
   };
+}
+
+function resolveDriverEventPersistenceSourceId(
+  source: DriverEventEnvelope,
+  event: RuntimeEventEnvelope,
+): string | null {
+  if (event.kind === "run.failed" && event.runId !== undefined) {
+    return createSessionRunTerminalFailureSourceId(event.runId);
+  }
+
+  return source.eventId.trim().length > 0 ? source.eventId : null;
 }
 
 function appendRuntimeDriverCanonicalSideEffects(

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/rpc-event-ingestion-controller.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/rpc-event-ingestion-controller.ts
@@ -12,6 +12,7 @@ import type {
 import { createErrorLogContext, logError } from "../../../../platform/cloudflare/logger";
 import type { SessionDeliveryEvent } from "../../../sessions/application/session-live-state.service";
 import { getSessionRuntimeEventSourceReceipts } from "../../../sessions/infrastructure/session-runtime-event-store.repository";
+import { createSessionRunTerminalFailureSourceId } from "../../domain/session-run-terminal-event-id";
 import { EVENT_BATCH_MAX_SIZE, LOG_BATCH_MAX_SIZE } from "./connections";
 import { DriverEventTerminalGate } from "./driver-event-terminal-gate";
 import { publishDriverLogBatch } from "./driver-log-batch-publisher";
@@ -56,6 +57,16 @@ function resolveEventSessionRunId(
   return eventRunId === undefined
     ? undefined
     : parsePlatformId<SessionRunId>(eventRunId, "driver event run id");
+}
+
+function resolveDriverEventPersistenceSourceId(event: DriverEventEnvelope): string {
+  if (event.event.kind === "run.failed" && event.event.runId !== undefined) {
+    return createSessionRunTerminalFailureSourceId(
+      parsePlatformId<SessionRunId>(event.event.runId, "driver failed event run id"),
+    );
+  }
+
+  return event.eventId;
 }
 
 const PRE_HELLO_LOG_BATCH_LIMIT = 16;
@@ -285,7 +296,7 @@ export class DriverInstanceRpcEventIngestionController {
     }
 
     const sourceEventIds = events
-      .map((event) => event.eventId)
+      .map(resolveDriverEventPersistenceSourceId)
       .filter((eventId) => eventId.length > 0);
 
     if (sourceEventIds.length === 0) {
@@ -309,13 +320,13 @@ export class DriverInstanceRpcEventIngestionController {
 
       seenEventIds.add(event.eventId);
 
-      const receipt = receiptsByEventId.get(event.eventId);
+      const receipt = receiptsByEventId.get(resolveDriverEventPersistenceSourceId(event));
 
       if (receipt === undefined) {
         continue;
       }
 
-      receipts.push(receipt);
+      receipts.push({ ...receipt, eventId: event.eventId });
     }
 
     return receipts;

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/rpc-run-terminal-controller.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/rpc-run-terminal-controller.ts
@@ -96,9 +96,13 @@ export class DriverInstanceRpcRunTerminalController {
 
     await viewerEventDelivery.flushSafely();
     context.assertActiveConnection();
+    const link = await this.#getRuntimeSessionLink({
+      refresh: runtimeSessionLinkNeedsRefresh(state.runtimeSessionLink),
+    });
     await recordDriverInstanceFailure(env, {
       driverInstanceId,
       error: input.error,
+      link,
     });
     context.assertActiveConnection();
 
@@ -123,9 +127,6 @@ export class DriverInstanceRpcRunTerminalController {
       await finalizeTerminalState();
     }
 
-    const link = await this.#getRuntimeSessionLink({
-      refresh: runtimeSessionLinkNeedsRefresh(state.runtimeSessionLink),
-    });
     await syncSessionViewerState(env, link.sessionId);
 
     return { ok: true };

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/terminal-driver-events.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/terminal-driver-events.ts
@@ -8,6 +8,7 @@ import { logWarn } from "../../../../platform/cloudflare/logger";
 import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
 import { appendSessionRuntimeEvents } from "../../../sessions/application/session-event-write.service";
 import { appRuntimeEventToSessionDeliveryEvents } from "../../../sessions/application/session-live-state.service";
+import { recordCanonicalSessionRunFailure } from "../../application/session-runs/session-run-terminal-failure.service";
 import { isTerminalSessionRunStatus } from "../../domain/session-run-status";
 import { recordRuntimeRunLeaseReleasedOutcome } from "../runtime-subject-lifecycle/runtime-run-lease-store";
 import { setSessionRunStatus } from "../session-runs/session-run-store.repository";
@@ -99,44 +100,23 @@ export async function recordDriverInstanceFailure(
   input: {
     error: DriverFailureInput["error"];
     driverInstanceId: DriverInstanceId;
+    link?: RuntimeSessionLink;
   },
 ): Promise<void> {
   const database = bindings.DB;
-  const link = await getRuntimeSessionLink(database, input.driverInstanceId);
+  const link = input.link ?? (await getRuntimeSessionLink(database, input.driverInstanceId));
 
-  if (
-    link.sessionRunId !== null &&
-    link.sessionRunStatus !== null &&
-    isTerminalSessionRunStatus(link.sessionRunStatus)
-  ) {
-    if (hasLinkedSessionRun(link) && link.sessionRunStatus === "failed") {
-      await appendCanonicalTerminalDriverEvent({
-        bindings,
-        event: createDriverRunFailedEvent({
-          driverInstanceId: input.driverInstanceId,
-          error: input.error,
-          link,
-        }),
-      });
-    }
-
-    const released = await releaseLinkedRunLease(bindings, {
-      driverInstanceId: input.driverInstanceId,
-      link,
-      sessionRunId: link.sessionRunId,
+  if (hasLinkedSessionRun(link)) {
+    const outcome = await recordCanonicalSessionRunFailure(bindings, {
+      error: input.error,
+      runId: link.sessionRunId,
+      sessionId: link.sessionId,
+      source: "driver",
     });
-    await recycleReleasedTerminalRuntimeLeaseIfNeeded(bindings, { link, released });
-    return;
-  }
-
-  if (link.sessionRunId !== null) {
-    const failedEvent = hasLinkedSessionRun(link)
-      ? createDriverRunFailedEvent({
-          driverInstanceId: input.driverInstanceId,
-          error: input.error,
-          link,
-        })
-      : null;
+    if (outcome.kind !== "failed") {
+      assertTerminalDriverSessionRunTransition(outcome.transition);
+    }
+  } else if (link.sessionRunId !== null) {
     const outcome = await setSessionRunStatus(database, {
       error: input.error,
       runId: link.sessionRunId,
@@ -144,16 +124,6 @@ export async function recordDriverInstanceFailure(
       status: "failed",
     });
     assertTerminalDriverSessionRunTransition(outcome);
-
-    if (
-      failedEvent !== null &&
-      (!isStaleTerminalRunTransition(outcome) || isStaleTerminalRunStatus(outcome, "failed"))
-    ) {
-      await appendCanonicalTerminalDriverEvent({
-        bindings,
-        event: failedEvent,
-      });
-    }
   }
 
   const released = await releaseLinkedRunLease(bindings, {
@@ -215,35 +185,6 @@ async function synthesizeDriverRunFinished(
   await appendCanonicalTerminalDriverEvent({
     bindings: input.bindings,
     event: runCompletedEvent,
-  });
-}
-
-function createDriverRunFailedEvent(input: {
-  readonly driverInstanceId: DriverInstanceId;
-  readonly error: DriverFailureInput["error"];
-  readonly link: RuntimeSessionLink & {
-    readonly sessionId: SessionId;
-    readonly sessionRunId: SessionRunId;
-  };
-}): RuntimeEventEnvelope {
-  const eventId = createTerminalDriverEventId({
-    driverInstanceId: input.driverInstanceId,
-    kind: "run.failed",
-    sessionRunId: input.link.sessionRunId,
-  });
-
-  return createRuntimeEvent({
-    driverInstanceId: input.driverInstanceId,
-    id: createPlatformId<RuntimeEventId>(),
-    kind: "run.failed",
-    occurredAt: new Date().toISOString(),
-    payload: {
-      error: input.error,
-      recoverable: false,
-    },
-    runId: input.link.sessionRunId,
-    sessionId: input.link.sessionId,
-    sourceEventId: eventId,
   });
 }
 

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/terminal-run-release.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/terminal-run-release.ts
@@ -10,6 +10,7 @@ import { appendSessionRuntimeEvents } from "../../../sessions/application/sessio
 import { createFailedSessionRunRuntimeEvent } from "../../application/session-runs/session-run-view-events.service";
 import { classifyReclaim, decideReclaimRecovery } from "../../domain/session-run-reclaim-recovery";
 import { isTerminalSessionRunStatus } from "../../domain/session-run-status";
+import { createSessionRunTerminalFailureSourceId } from "../../domain/session-run-terminal-event-id";
 import { recordRuntimeRunLeaseReleasedOutcome } from "../runtime-subject-lifecycle/runtime-run-lease-store";
 import { failAcceptedRuntimeCommandsForTerminalDriver } from "../session-runs/runtime-command-store.repository";
 import { setSessionRunStatus } from "../session-runs/session-run-store.repository";
@@ -51,17 +52,9 @@ function toFinalizedDriverRunTransitionRun(
   }
 }
 
-function finalizedDriverRunSourceEventId(input: {
-  readonly driverInstanceId: DriverInstanceId;
-  readonly sessionRunId: SessionRunId;
-}): string {
-  return `driver-terminal:${input.driverInstanceId}:${input.sessionRunId}:turn-interrupted`;
-}
-
 async function appendFinalizedDriverRunEvent(
   bindings: ApiBindings,
   input: {
-    readonly driverInstanceId: DriverInstanceId;
     readonly run: SessionRunSummary;
     readonly runError: RunError;
     readonly sessionId: SessionId;
@@ -74,10 +67,7 @@ async function appendFinalizedDriverRunEvent(
         run: input.run,
         runError: input.runError,
         sessionId: input.sessionId,
-        sourceEventId: finalizedDriverRunSourceEventId({
-          driverInstanceId: input.driverInstanceId,
-          sessionRunId: input.run.id,
-        }),
+        sourceEventId: createSessionRunTerminalFailureSourceId(input.run.id),
       }),
     ],
     sessionId: input.sessionId,
@@ -146,7 +136,6 @@ export async function repairFinalizedTerminalDriverRunState(
 
     if (link.sessionId !== null && run !== null) {
       await appendFinalizedDriverRunEvent(bindings, {
-        driverInstanceId: input.driverInstanceId,
         run,
         runError,
         sessionId: link.sessionId,

--- a/apps/api/tests/api-driver-boundary.test.ts
+++ b/apps/api/tests/api-driver-boundary.test.ts
@@ -558,7 +558,14 @@ describe("API to driver boundary", () => {
       events: batch.events,
       link,
     });
+    const canonicalFailureSourceId = `session-run-terminal:${API_DRIVER_BOUNDARY_IDS.sessionRun}:run.failed`;
 
+    expect(projection.runtimeEvents).toMatchObject([{ sourceEventId: canonicalFailureSourceId }]);
+    expect(projection.sessionDeliveryEvents.map((record) => record.sourceEventId)).toEqual([
+      canonicalFailureSourceId,
+      canonicalFailureSourceId,
+      canonicalFailureSourceId,
+    ]);
     expect(projection.sessionDeliveryEvents.map((record) => record.event.type)).toEqual([
       EventType.TOOL_CALL_RESULT,
       EventType.TOOL_CALL_END,

--- a/apps/api/tests/driver-finalization-repair.test.ts
+++ b/apps/api/tests/driver-finalization-repair.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { RuntimeCommand } from "@mosoo/contracts/runtime-command";
 import type { DriverCommandId, DriverInstanceId, SessionRunId } from "@mosoo/id";
 
+import { recordCanonicalSessionRunFailure } from "../src/modules/runtime/application/session-runs/session-run-terminal-failure.service";
 import { repairFinalizedTerminalDriverRunState } from "../src/modules/runtime/infrastructure/driver-instance/terminal-run-release";
 import {
   createRuntimeCommandRecord,
@@ -22,6 +23,12 @@ const FINALIZE_COMMAND_ID = "01J0000000000000000000000V" as DriverCommandId;
 const FINALIZE_CLOUDFLARE_SESSION_ID = "01J0000000000000000000000W";
 const TURN_INTERRUPTED_MESSAGE =
   "This turn was interrupted before it completed. Please resend your last request.";
+const PROVISION_ERROR = {
+  code: "runtime.provision_failed",
+  details: {},
+  message: "Driver command dispatch failed.",
+  retryable: false,
+} as const;
 
 interface TerminalEventRow {
   content_text: string;
@@ -382,11 +389,36 @@ describe("driver finalization repair", () => {
         run_id: FINALIZE_RUN_ID,
         seq: 1,
         source: "api",
-        source_event_id: `driver-terminal:${PUBLIC_API_TEST_IDS.driverOwner}:${FINALIZE_RUN_ID}:turn-interrupted`,
+        source_event_id: `session-run-terminal:${FINALIZE_RUN_ID}:run.failed`,
         trace_id: "trace-finalize",
         visibility: "all_consumers",
       },
     ]);
+  });
+
+  test("deduplicates dispatch repair after driver finalization", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertFinalizedDriverLeaseFixture(database);
+    const bindings = createPublicHttpTestBindings(database) as ApiBindings;
+
+    await repairFinalizedTerminalDriverRunState(bindings, {
+      driverInstanceId: PUBLIC_API_TEST_IDS.driverOwner as DriverInstanceId,
+      status: "failed",
+    });
+    await recordCanonicalSessionRunFailure(bindings, {
+      error: PROVISION_ERROR,
+      runId: FINALIZE_RUN_ID,
+      sessionId: PUBLIC_API_TEST_IDS.ownerSession,
+      source: "api",
+    });
+
+    const failureEvents = (await readTerminalEvents(database)).filter(
+      (event) => event.event_type === "run.failed",
+    );
+    expect(failureEvents).toHaveLength(1);
+    expect(failureEvents[0]?.source_event_id).toBe(
+      `session-run-terminal:${FINALIZE_RUN_ID}:run.failed`,
+    );
   });
 
   test("benchmarks driver interruption finalization over 20 fault injections", async () => {

--- a/apps/api/tests/session-run-terminal-failure.test.ts
+++ b/apps/api/tests/session-run-terminal-failure.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, test } from "bun:test";
+
+import type { DriverInstanceId, SessionRunId } from "@mosoo/id";
+
+import { recordCanonicalSessionRunFailure } from "../src/modules/runtime/application/session-runs/session-run-terminal-failure.service";
+import { getRuntimeSessionLink } from "../src/modules/runtime/infrastructure/driver-instance/session-link.repository";
+import { recordDriverInstanceFailure } from "../src/modules/runtime/infrastructure/driver-instance/terminal-driver-events";
+import { setSessionRunStatus } from "../src/modules/runtime/infrastructure/session-runs/session-run-store.repository";
+import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
+import {
+  createPublicHttpContractDatabase,
+  createPublicHttpTestBindings,
+  insertOwnerSession,
+  PUBLIC_API_TEST_IDS,
+} from "./helpers/public-api-http-test-fixture";
+import type { SqliteD1Database } from "./helpers/public-api-http-test-fixture";
+
+const RUN_ID = PUBLIC_API_TEST_IDS.run as SessionRunId;
+const DRIVER_ID = PUBLIC_API_TEST_IDS.driverOwner as DriverInstanceId;
+const CANONICAL_FAILURE_SOURCE_ID = `session-run-terminal:${RUN_ID}:run.failed`;
+const DRIVER_ERROR = {
+  code: "driver.command_failed",
+  details: {},
+  message: "OpenAi app-server exited with code 1.",
+  retryable: false,
+} as const;
+const PROVISION_ERROR = {
+  code: "runtime.provision_failed",
+  details: {},
+  message: "Driver command dispatch failed.",
+  retryable: false,
+} as const;
+
+interface FailureEventRow {
+  content_text: string;
+  event_type: string;
+  source_event_id: string;
+}
+
+async function insertLinkedRunFixture(
+  database: SqliteD1Database,
+  status: "booting" | "completed" | "cancelled" | "failed" = "booting",
+): Promise<void> {
+  await insertOwnerSession(database);
+  await database
+    .prepare(
+      `
+        INSERT INTO driver_instance (
+          id,
+          boot_token_expires_at,
+          boot_token_hash,
+          created_at,
+          expires_at,
+          heartbeat_count,
+          protocol,
+          protocol_version,
+          runtime,
+          sandbox_id,
+          sandbox_session_id,
+          status,
+          updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    )
+    .bind(
+      DRIVER_ID,
+      1,
+      new Uint8Array([1]),
+      1,
+      1,
+      0,
+      "orpc-ws",
+      1,
+      "openai-runtime",
+      PUBLIC_API_TEST_IDS.sandbox,
+      PUBLIC_API_TEST_IDS.ownerSession,
+      "ready",
+      1,
+    )
+    .run();
+  await database
+    .prepare(
+      `
+        INSERT INTO session_run (
+          id,
+          session_id,
+          agent_id,
+          created_by_account_id,
+          deployment_version_id,
+          deployment_version_number,
+          driver_instance_id,
+          trigger,
+          status,
+          provider,
+          model,
+          runtime_id,
+          trace_id,
+          started_at,
+          completed_at,
+          error_code,
+          error_message,
+          error_details_json,
+          created_at,
+          updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    )
+    .bind(
+      RUN_ID,
+      PUBLIC_API_TEST_IDS.ownerSession,
+      PUBLIC_API_TEST_IDS.agent,
+      PUBLIC_API_TEST_IDS.ownerAccount,
+      PUBLIC_API_TEST_IDS.deployment,
+      1,
+      DRIVER_ID,
+      "user_prompt",
+      status,
+      "openai",
+      "gpt-5.4",
+      "openai-runtime",
+      "trace-terminal-failure",
+      1,
+      status === "booting" ? null : 2,
+      status === "failed" ? DRIVER_ERROR.code : null,
+      status === "failed" ? DRIVER_ERROR.message : null,
+      status === "failed" ? "{}" : null,
+      1,
+      1,
+    )
+    .run();
+  await database
+    .prepare("UPDATE session SET last_run_id = ?, status = ? WHERE id = ?")
+    .bind(RUN_ID, status === "booting" ? "RUNNING" : "IDLE", PUBLIC_API_TEST_IDS.ownerSession)
+    .run();
+}
+
+async function readFailureEvents(database: SqliteD1Database): Promise<FailureEventRow[]> {
+  return database
+    .prepare(
+      `
+        SELECT content_text, event_type, source_event_id
+        FROM session_event
+        WHERE session_id = ? AND event_type = 'run.failed'
+        ORDER BY seq
+      `,
+    )
+    .bind(PUBLIC_API_TEST_IDS.ownerSession)
+    .all<FailureEventRow>()
+    .then((result) => result.results ?? []);
+}
+
+describe("canonical session run terminal failure", () => {
+  test("treats a concurrent failed transition as canonical success", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertLinkedRunFixture(database);
+    const bindings = createPublicHttpTestBindings(database) as ApiBindings;
+
+    const outcomes = await Promise.all([
+      recordCanonicalSessionRunFailure(bindings, {
+        error: DRIVER_ERROR,
+        runId: RUN_ID,
+        sessionId: PUBLIC_API_TEST_IDS.ownerSession,
+        source: "driver",
+      }),
+      recordCanonicalSessionRunFailure(bindings, {
+        error: PROVISION_ERROR,
+        runId: RUN_ID,
+        sessionId: PUBLIC_API_TEST_IDS.ownerSession,
+        source: "api",
+      }),
+    ]);
+
+    expect(outcomes.map((outcome) => outcome.kind)).toEqual(["failed", "failed"]);
+    expect(await readFailureEvents(database)).toHaveLength(1);
+  });
+
+  test("keeps one persisted driver failure when dispatch observes the terminal run", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertLinkedRunFixture(database);
+    const bindings = createPublicHttpTestBindings(database) as ApiBindings;
+
+    await recordDriverInstanceFailure(bindings, {
+      driverInstanceId: DRIVER_ID,
+      error: DRIVER_ERROR,
+    });
+    await recordCanonicalSessionRunFailure(bindings, {
+      error: PROVISION_ERROR,
+      runId: RUN_ID,
+      sessionId: PUBLIC_API_TEST_IDS.ownerSession,
+      source: "api",
+    });
+
+    const run = await database
+      .prepare("SELECT error_code, error_message, status FROM session_run WHERE id = ?")
+      .bind(RUN_ID)
+      .first<{ error_code: string; error_message: string; status: string }>();
+
+    expect(run).toEqual({
+      error_code: DRIVER_ERROR.code,
+      error_message: DRIVER_ERROR.message,
+      status: "failed",
+    });
+    expect(await readFailureEvents(database)).toEqual([
+      {
+        content_text: DRIVER_ERROR.message,
+        event_type: "run.failed",
+        source_event_id: CANONICAL_FAILURE_SOURCE_ID,
+      },
+    ]);
+  });
+
+  test("keeps one persisted provision failure when the driver reports terminal later", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertLinkedRunFixture(database);
+    const bindings = createPublicHttpTestBindings(database) as ApiBindings;
+
+    await recordCanonicalSessionRunFailure(bindings, {
+      error: PROVISION_ERROR,
+      runId: RUN_ID,
+      sessionId: PUBLIC_API_TEST_IDS.ownerSession,
+      source: "api",
+    });
+    await recordDriverInstanceFailure(bindings, {
+      driverInstanceId: DRIVER_ID,
+      error: DRIVER_ERROR,
+    });
+
+    const run = await database
+      .prepare("SELECT error_code, error_message, status FROM session_run WHERE id = ?")
+      .bind(RUN_ID)
+      .first<{ error_code: string; error_message: string; status: string }>();
+
+    expect(run).toEqual({
+      error_code: PROVISION_ERROR.code,
+      error_message: PROVISION_ERROR.message,
+      status: "failed",
+    });
+    expect(await readFailureEvents(database)).toEqual([
+      {
+        content_text: PROVISION_ERROR.message,
+        event_type: "run.failed",
+        source_event_id: CANONICAL_FAILURE_SOURCE_ID,
+      },
+    ]);
+  });
+
+  test("repairs a missing terminal failure event idempotently", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertLinkedRunFixture(database, "failed");
+    const bindings = createPublicHttpTestBindings(database) as ApiBindings;
+
+    await recordCanonicalSessionRunFailure(bindings, {
+      error: PROVISION_ERROR,
+      runId: RUN_ID,
+      sessionId: PUBLIC_API_TEST_IDS.ownerSession,
+      source: "api",
+    });
+    await recordCanonicalSessionRunFailure(bindings, {
+      error: PROVISION_ERROR,
+      runId: RUN_ID,
+      sessionId: PUBLIC_API_TEST_IDS.ownerSession,
+      source: "api",
+    });
+
+    expect(await readFailureEvents(database)).toEqual([
+      {
+        content_text: DRIVER_ERROR.message,
+        event_type: "run.failed",
+        source_event_id: CANONICAL_FAILURE_SOURCE_ID,
+      },
+    ]);
+  });
+
+  test("repairs an API failure event from the Driver cached run link", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertLinkedRunFixture(database);
+    const bindings = createPublicHttpTestBindings(database) as ApiBindings;
+    const link = await getRuntimeSessionLink(database, DRIVER_ID);
+
+    await setSessionRunStatus(database, {
+      error: PROVISION_ERROR,
+      runId: RUN_ID,
+      source: "api",
+      status: "failed",
+    });
+    expect(await readFailureEvents(database)).toEqual([]);
+
+    await recordDriverInstanceFailure(bindings, {
+      driverInstanceId: DRIVER_ID,
+      error: DRIVER_ERROR,
+      link,
+    });
+
+    expect(await readFailureEvents(database)).toEqual([
+      {
+        content_text: PROVISION_ERROR.message,
+        event_type: "run.failed",
+        source_event_id: CANONICAL_FAILURE_SOURCE_ID,
+      },
+    ]);
+  });
+
+  test("does not append a failure after a non-failed terminal outcome", async () => {
+    for (const status of ["completed", "cancelled"] as const) {
+      const database = await createPublicHttpContractDatabase();
+      await insertLinkedRunFixture(database, status);
+      const bindings = createPublicHttpTestBindings(database) as ApiBindings;
+
+      await recordCanonicalSessionRunFailure(bindings, {
+        error: PROVISION_ERROR,
+        runId: RUN_ID,
+        sessionId: PUBLIC_API_TEST_IDS.ownerSession,
+        source: "api",
+      });
+
+      expect(await readFailureEvents(database)).toEqual([]);
+    }
+  });
+});

--- a/apps/web/src/shared/ui/session-events/turns.ts
+++ b/apps/web/src/shared/ui/session-events/turns.ts
@@ -78,7 +78,7 @@ function finalizeTurns(turns: MutableSessionTurn[]): SessionTurn[] {
   }));
 }
 
-function createSessionTurns(events: readonly SessionProcessEvent[]): SessionTurn[] {
+export function projectSessionTurns(events: readonly SessionProcessEvent[]): SessionTurn[] {
   const turns: MutableSessionTurn[] = [];
   let pendingEvents: SessionProcessEvent[] = [];
   let current: MutableSessionTurn | null = null;
@@ -103,6 +103,18 @@ function createSessionTurns(events: readonly SessionProcessEvent[]): SessionTurn
 
     if (current === null) {
       pendingEvents.push(event);
+
+      if (event.type === "run.failed") {
+        const failedTurn = createPendingTurn(pendingEvents);
+
+        if (failedTurn !== null) {
+          failedTurn.endedAt = event.occurredAt;
+          failedTurn.status = "failed";
+          turns.push(failedTurn);
+          pendingEvents = [];
+        }
+      }
+
       continue;
     }
 
@@ -156,7 +168,7 @@ function createSessionTurns(events: readonly SessionProcessEvent[]): SessionTurn
 }
 
 export function useSessionTurns(events: readonly SessionProcessEvent[]): SessionTurn[] {
-  return useMemo(() => createSessionTurns(events), [events]);
+  return useMemo(() => projectSessionTurns(events), [events]);
 }
 
 export function countSessionTurnDomains(events: readonly SessionProcessEvent[]): SessionTurnCounts {

--- a/apps/web/tests/session-event-turns.test.ts
+++ b/apps/web/tests/session-event-turns.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+
+import type { SessionProcessEvent } from "@mosoo/contracts/session";
+
+import { projectSessionTurns } from "../src/shared/ui/session-events/turns";
+
+function eventOf(
+  id: string,
+  type: SessionProcessEvent["type"],
+  second: number,
+): SessionProcessEvent {
+  return {
+    content: type,
+    durationMs: 1,
+    id,
+    occurredAt: `2026-07-13T00:00:${String(second).padStart(2, "0")}.000Z`,
+    status: type === "run.failed" ? "error" : "available",
+    tokens: null,
+    type,
+  };
+}
+
+describe("session Turn projection", () => {
+  test("marks a Turn failed when a Run fails before run.started", () => {
+    const events = [
+      eventOf("event-1", "user.message", 1),
+      eventOf("event-2", "session.status", 2),
+      eventOf("event-3", "run.failed", 3),
+    ];
+
+    expect(projectSessionTurns(events)).toEqual([
+      expect.objectContaining({
+        endedAt: events[2]?.occurredAt,
+        events,
+        index: 1,
+        status: "failed",
+      }),
+    ]);
+  });
+
+  test("keeps consecutive Runs that fail before run.started in separate Turns", () => {
+    const events = [
+      eventOf("event-1", "user.message", 1),
+      eventOf("event-2", "run.failed", 2),
+      eventOf("event-3", "user.message", 3),
+      eventOf("event-4", "run.failed", 4),
+    ];
+
+    expect(
+      projectSessionTurns(events).map(({ events: turnEvents, index, status }) => ({
+        eventIds: turnEvents.map((event) => event.id),
+        index,
+        status,
+      })),
+    ).toEqual([
+      { eventIds: ["event-1", "event-2"], index: 1, status: "failed" },
+      { eventIds: ["event-3", "event-4"], index: 2, status: "failed" },
+    ]);
+  });
+
+  test("keeps the normal run.started to run.completed projection", () => {
+    const events = [
+      eventOf("event-1", "user.message", 1),
+      eventOf("event-2", "run.started", 2),
+      eventOf("event-3", "agent.message.delta", 3),
+      eventOf("event-4", "run.completed", 4),
+    ];
+
+    expect(projectSessionTurns(events)).toEqual([
+      expect.objectContaining({
+        endedAt: events[3]?.occurredAt,
+        events,
+        id: "event-2",
+        index: 1,
+        startedAt: events[0]?.occurredAt,
+        status: "completed",
+      }),
+    ]);
+  });
+
+  test("keeps unmatched trailing events in a pending Turn", () => {
+    const events = [eventOf("event-1", "user.message", 1), eventOf("event-2", "session.status", 2)];
+
+    expect(projectSessionTurns(events)).toEqual([
+      expect.objectContaining({
+        endedAt: null,
+        events,
+        id: "pending:event-1",
+        index: 1,
+        status: "pending",
+      }),
+    ]);
+  });
+});

--- a/docs/plans/2026-07-13-openai-runtime-session-failure-design.md
+++ b/docs/plans/2026-07-13-openai-runtime-session-failure-design.md
@@ -1,0 +1,64 @@
+# OpenAI Runtime Pre-Start Failure Repair
+
+## Decision
+
+Repair the user-visible failure at three existing boundaries without expanding
+the GraphQL or D1 schema:
+
+1. Fail the Driver image build when the bundled Codex runtime cannot start.
+2. Persist one canonical `run.failed` process event when Driver terminal and
+   dispatch provisioning failure paths race.
+3. Project a terminal event received before `run.started` as a terminal Turn
+   instead of leaving it in a provisional Pending Turn.
+
+`apps/driver` remains the runtime-image owner. The API remains the canonical
+Run/event owner. The Web projection remains responsible only for grouping
+persisted process events into Turn cards.
+
+## Driver Image
+
+Add `codex --version` and `codex app-server --help` to the same Docker `RUN`
+that installs native runtime packages. This invalidates the poisoned cache
+layer and makes a missing platform optional package fail closed. Mirror the
+smoke in Driver CI and lock the Dockerfile contract with a focused test.
+
+Do not hardcode `@openai/codex-linux-x64`: the same Dockerfile supports arm64
+local builds, and Codex already owns the platform-to-package mapping.
+
+## Canonical Run Failure
+
+Introduce one application service that ensures the canonical failed Run event
+after a status compare-and-set:
+
+- Read the persisted Run after either producer attempts its status update.
+- Emit only when the persisted terminal status is `failed` and carries an
+  error.
+- Build the payload from the persisted winning error, not the losing caller's
+  local error.
+- Use one stable source event identity for both producers so the existing
+  `(session_id, source_event_id)` uniqueness rule provides idempotency and
+  repair semantics.
+
+The after-terminal path must not simply stop writing: it is also the repair
+path when the status update succeeded but the first event append did not.
+
+## Pre-Start Turn Projection
+
+Keep the current event contract. When no Turn is active and a terminal event
+arrives, close the accumulated provisional events into a terminal Turn. Normal
+`run.started` grouping and genuinely unmatched trailing events remain
+unchanged.
+
+Do not deduplicate by adjacent text or timestamp in the Web layer; without a
+`runId` that can delete real independent events.
+
+## Verification
+
+- Red/green focused tests for the Driver artifact contract, both API race
+  orders plus repair/idempotency, and orphan terminal Turn grouping.
+- Driver/API/Web typechecks and relevant package tests.
+- No-cache linux/amd64 Driver image build and container-level Codex smoke.
+- Recreate only the local Sandbox, then run the configured OpenAI Agent twice
+  in the same Session and verify one successful terminal event per Run.
+- `just graphql-codegen` and DB generation are not applicable because the
+  cross-boundary schema and D1 schema do not change.


### PR DESCRIPTION
## Summary

- route dispatch, Driver ingestion, and Driver finalization failures through one canonical terminal-failure service and source identity
- project pre-start run.failed events as failed Turns instead of leaving the UI Pending
- update the Driver submodule with authoritative OpenAI terminal-event handling and app-server exit propagation

## Root cause

One runtime failure could enter through several callers, each with its own persistence and source-event identity. At the same time, the Driver treated advisory OpenAI notifications as terminal, while the Web projection required a started Turn. The result was duplicate failure rows, races, hangs on child exit, and Pending UI for failures before run.started.

## Verification

- just check (including 935 API tests and GraphQL codegen drift check)
- bash ./init.sh acceptance
- just commit-check
- credentialed live Run 01KXDHT5V2C5RVVNC24KAE8HE7 completed end to end
- D1 contains exactly one run.completed and zero run.failed for that Run
- live Web/API health: 5174/8788 both HTTP 200

## Dependency

- Driver: https://github.com/langgenius/mosoo-agent-driver/pull/45
- Keep this PR draft until the Driver PR is merged, then update the submodule pointer to the Driver main merge commit.

No GraphQL schema or database schema/migration changes.