### PR TITLE
feat(web): support uploading a local skill folder

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "@mosoo/effects": "workspace:*",
     "@mosoo/id": "workspace:*",
     "@mosoo/runtime-catalog": "workspace:*",
+    "@mosoo/skill-package": "workspace:*",
     "@tailwindcss/vite": "^4.3.0",
     "@tanstack/react-query": "^5.100.10",
     "@xterm/addon-fit": "^0.11.0",

--- a/apps/web/src/domains/skill/lib/skill-folder-archive.ts
+++ b/apps/web/src/domains/skill/lib/skill-folder-archive.ts
@@ -1,0 +1,144 @@
+import { createZipArchive, normalizeSkillEntries } from "@mosoo/skill-package";
+
+// Mirrors the server-side upload limits in apps/api skill-package.shared.ts so
+// oversized folders fail fast in the dialog instead of after a full upload.
+const MAX_FOLDER_ENTRY_BYTES = 2 * 1024 * 1024;
+const MAX_FOLDER_TOTAL_BYTES = 25 * 1024 * 1024;
+
+const IGNORED_DIRECTORY_SEGMENTS = new Set([".git", "__MACOSX", "node_modules"]);
+const IGNORED_FILE_NAMES = new Set([".DS_Store", "Thumbs.db"]);
+
+export interface SkillFolderFile {
+  file: File;
+  path: string;
+}
+
+export interface SkillFolderSelection {
+  files: SkillFolderFile[];
+  folderName: string;
+}
+
+export function readFolderInputSelection(files: FileList | null): SkillFolderSelection | null {
+  if (!files || files.length === 0) {
+    return null;
+  }
+
+  const folderFiles = Array.from(files, (file) => ({
+    file,
+    path: file.webkitRelativePath.length > 0 ? file.webkitRelativePath : file.name,
+  }));
+  const [firstSegment] = folderFiles[0]!.path.split("/");
+
+  return {
+    files: folderFiles,
+    folderName: firstSegment !== undefined && firstSegment.length > 0 ? firstSegment : "skill",
+  };
+}
+
+export async function readDroppedFolderSelection(
+  directory: FileSystemDirectoryEntry,
+): Promise<SkillFolderSelection> {
+  const files: SkillFolderFile[] = [];
+  await collectDirectoryFiles(directory, directory.name, files);
+
+  return { files, folderName: directory.name };
+}
+
+export async function createSkillFolderArchiveFile(selection: SkillFolderSelection): Promise<File> {
+  const admitted = selection.files.filter((entry) => !isIgnoredFolderPath(entry.path));
+  let totalBytes = 0;
+
+  for (const { file, path } of admitted) {
+    if (file.size > MAX_FOLDER_ENTRY_BYTES) {
+      throw new Error(
+        `File exceeds the ${formatMegabytes(MAX_FOLDER_ENTRY_BYTES)} MB limit: ${path}`,
+      );
+    }
+
+    totalBytes += file.size;
+
+    if (totalBytes > MAX_FOLDER_TOTAL_BYTES) {
+      throw new Error(
+        `The folder exceeds the ${formatMegabytes(MAX_FOLDER_TOTAL_BYTES)} MB skill size limit.`,
+      );
+    }
+  }
+
+  const rawEntries: Record<string, { body: Uint8Array; entryKind: "file"; isExecutable: boolean }> =
+    {};
+
+  for (const { file, path } of admitted) {
+    rawEntries[path] = {
+      body: new Uint8Array(await file.arrayBuffer()),
+      entryKind: "file",
+      isExecutable: false,
+    };
+  }
+
+  const normalized = normalizeSkillEntries(rawEntries);
+  const archiveBytes = new Uint8Array(createZipArchive(normalized.entries));
+
+  return new File([archiveBytes.buffer], `${selection.folderName}.zip`, {
+    type: "application/zip",
+  });
+}
+
+function isIgnoredFolderPath(path: string): boolean {
+  const segments = path.split("/");
+  const fileName = segments.at(-1);
+
+  if (fileName !== undefined && IGNORED_FILE_NAMES.has(fileName)) {
+    return true;
+  }
+
+  return segments.some((segment) => IGNORED_DIRECTORY_SEGMENTS.has(segment));
+}
+
+async function collectDirectoryFiles(
+  directory: FileSystemDirectoryEntry,
+  parentPath: string,
+  out: SkillFolderFile[],
+): Promise<void> {
+  const entries = await readAllDirectoryEntries(directory.createReader());
+
+  for (const entry of entries) {
+    const path = `${parentPath}/${entry.name}`;
+
+    if (entry.isDirectory) {
+      await collectDirectoryFiles(entry as FileSystemDirectoryEntry, path, out);
+      continue;
+    }
+
+    if (entry.isFile) {
+      out.push({ file: await readEntryFile(entry as FileSystemFileEntry), path });
+    }
+  }
+}
+
+async function readAllDirectoryEntries(
+  reader: FileSystemDirectoryReader,
+): Promise<FileSystemEntry[]> {
+  const all: FileSystemEntry[] = [];
+
+  for (;;) {
+    const batch = await new Promise<FileSystemEntry[]>((resolve, reject) => {
+      reader.readEntries(resolve, reject);
+    });
+
+    if (batch.length === 0) {
+      return all;
+    }
+
+    all.push(...batch);
+  }
+}
+
+function readEntryFile(entry: FileSystemFileEntry): Promise<File> {
+  return new Promise((resolve, reject) => {
+    entry.file(resolve, reject);
+  });
+}
+
+function formatMegabytes(bytes: number): number {
+  return Math.floor(bytes / 1024 / 1024);
+}

--- a/apps/web/src/routes/integrations/skills/upload-skill-dialog.tsx
+++ b/apps/web/src/routes/integrations/skills/upload-skill-dialog.tsx
@@ -13,6 +13,12 @@ import {
 } from "@/shared/ui/dialog";
 import { Input } from "@/shared/ui/input";
 
+import type { SkillFolderSelection } from "../../../domains/skill/lib/skill-folder-archive";
+import {
+  createSkillFolderArchiveFile,
+  readDroppedFolderSelection,
+  readFolderInputSelection,
+} from "../../../domains/skill/lib/skill-folder-archive";
 import { isTruthy } from "../../../shared/lib/truthiness";
 import type { useSkillRegistry } from "./use-skill-registry";
 type Mode = "file" | "url";
@@ -85,6 +91,7 @@ interface Props {
 
 export function UploadSkillDialog({ onImportUrl, onOpenChange, onUpload, open, registry }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const folderInputRef = useRef<HTMLInputElement>(null);
   const [state, dispatch] = useReducer(uploadSkillReducer, UPLOAD_SKILL_INITIAL_STATE);
   const { dragOver, error, inspecting, mode, prepared, submitting, url } = state;
 
@@ -92,6 +99,9 @@ export function UploadSkillDialog({ onImportUrl, onOpenChange, onUpload, open, r
     dispatch({ type: "reset" });
     if (inputRef.current) {
       inputRef.current.value = "";
+    }
+    if (folderInputRef.current) {
+      folderInputRef.current.value = "";
     }
   }
 
@@ -102,6 +112,25 @@ export function UploadSkillDialog({ onImportUrl, onOpenChange, onUpload, open, r
     onOpenChange(next);
   }
 
+  async function inspectFile(file: File) {
+    const preview = registry ? await registry.inspectFile(file) : null;
+
+    if (!preview) {
+      throw new Error("Skill inspect service is unavailable.");
+    }
+
+    dispatch({ prepared: { kind: "file", file, preview }, type: "prepare" });
+  }
+
+  function dispatchInspectError(caughtError: unknown) {
+    dispatch({
+      error:
+        "Failed to inspect: " +
+        (caughtError instanceof Error ? caughtError.message : String(caughtError)),
+      type: "setError",
+    });
+  }
+
   async function handleFiles(files: FileList | null) {
     dispatch({ type: "clearError" });
     if (!files || files.length === 0) {
@@ -109,20 +138,25 @@ export function UploadSkillDialog({ onImportUrl, onOpenChange, onUpload, open, r
     }
     const file = files[0]!;
     try {
-      const preview = registry ? await registry.inspectFile(file) : null;
+      await inspectFile(file);
+    } catch (caughtError) {
+      dispatchInspectError(caughtError);
+    }
+  }
 
-      if (!preview) {
-        throw new Error("Skill inspect service is unavailable.");
+  async function handleFolder(loadSelection: () => Promise<SkillFolderSelection | null>) {
+    dispatch({ type: "clearError" });
+    try {
+      const selection = await loadSelection();
+
+      if (!selection) {
+        return;
       }
 
-      dispatch({ prepared: { kind: "file", file, preview }, type: "prepare" });
+      const archive = await createSkillFolderArchiveFile(selection);
+      await inspectFile(archive);
     } catch (caughtError) {
-      dispatch({
-        error:
-          "Failed to inspect: " +
-          (caughtError instanceof Error ? caughtError.message : String(caughtError)),
-        type: "setError",
-      });
+      dispatchInspectError(caughtError);
     }
   }
 
@@ -179,7 +213,8 @@ export function UploadSkillDialog({ onImportUrl, onOpenChange, onUpload, open, r
         <DialogHeader>
           <DialogTitle>Add skill</DialogTitle>
           <DialogDescription className="sr-only">
-            Upload a .md, .zip, or .skill file, or import a skill from a GitHub or skills.sh URL.
+            Upload a .md, .zip, or .skill file, upload a local skill folder, or import a skill from
+            a GitHub or skills.sh URL.
           </DialogDescription>
         </DialogHeader>
 
@@ -191,6 +226,22 @@ export function UploadSkillDialog({ onImportUrl, onOpenChange, onUpload, open, r
           className="sr-only"
           onChange={(e) => {
             void handleFiles(e.target.files);
+          }}
+        />
+
+        <input
+          ref={(element) => {
+            folderInputRef.current = element;
+            if (element !== null) {
+              element.webkitdirectory = true;
+            }
+          }}
+          type="file"
+          aria-label="Upload skill folder"
+          className="sr-only"
+          onChange={(e) => {
+            const files = e.target.files;
+            void handleFolder(() => Promise.resolve(readFolderInputSelection(files)));
           }}
         />
 
@@ -240,32 +291,58 @@ export function UploadSkillDialog({ onImportUrl, onOpenChange, onUpload, open, r
             ) : null}
           </div>
         ) : mode === "file" ? (
-          <button
-            className={cn(
-              "group flex cursor-pointer flex-col items-center justify-center gap-3 rounded-lg border border-dashed py-14 transition-colors",
-              dragOver
-                ? "border-primary bg-primary/5"
-                : "border-border hover:border-primary/60 hover:bg-muted/30",
-            )}
-            onDragOver={(e) => {
-              e.preventDefault();
-              dispatch({ dragOver: true, type: "setDragOver" });
-            }}
-            onDragLeave={() => {
-              dispatch({ dragOver: false, type: "setDragOver" });
-            }}
-            onDrop={(e) => {
-              e.preventDefault();
-              dispatch({ dragOver: false, type: "setDragOver" });
-              void handleFiles(e.dataTransfer.files);
-            }}
-            onClick={() => inputRef.current?.click()}
-            type="button"
-          >
-            <div className="text-foreground text-[15px] font-medium">
-              Drag and drop or click to upload
+          <div className="flex flex-col gap-2">
+            <button
+              className={cn(
+                "group flex cursor-pointer flex-col items-center justify-center gap-1.5 rounded-lg border border-dashed py-14 transition-colors",
+                dragOver
+                  ? "border-primary bg-primary/5"
+                  : "border-border hover:border-primary/60 hover:bg-muted/30",
+              )}
+              onDragOver={(e) => {
+                e.preventDefault();
+                dispatch({ dragOver: true, type: "setDragOver" });
+              }}
+              onDragLeave={() => {
+                dispatch({ dragOver: false, type: "setDragOver" });
+              }}
+              onDrop={(e) => {
+                e.preventDefault();
+                dispatch({ dragOver: false, type: "setDragOver" });
+                const entry =
+                  e.dataTransfer.items.length === 1
+                    ? e.dataTransfer.items[0]?.webkitGetAsEntry()
+                    : null;
+
+                if (entry?.isDirectory) {
+                  const directory = entry as FileSystemDirectoryEntry;
+                  void handleFolder(() => readDroppedFolderSelection(directory));
+                } else {
+                  void handleFiles(e.dataTransfer.files);
+                }
+              }}
+              onClick={() => inputRef.current?.click()}
+              type="button"
+            >
+              <div className="text-foreground text-[15px] font-medium">
+                Drag and drop or click to upload
+              </div>
+              <div className="text-muted-foreground text-xs">
+                Drop a file or a whole skill folder
+              </div>
+            </button>
+            <div className="text-muted-foreground text-center text-xs">
+              or{" "}
+              <button
+                type="button"
+                className="text-primary underline-offset-2 hover:underline"
+                onClick={() => folderInputRef.current?.click()}
+              >
+                select a folder
+              </button>{" "}
+              from your computer
             </div>
-          </button>
+          </div>
         ) : (
           <div className="flex flex-col gap-2">
             <div className="flex items-center gap-2">
@@ -308,6 +385,7 @@ export function UploadSkillDialog({ onImportUrl, onOpenChange, onUpload, open, r
             <ul className="text-muted-foreground marker:text-muted-foreground/60 list-disc space-y-1 pl-4 text-[12.5px]">
               <li>.md file must contain skill name and description formatted in YAML</li>
               <li>.zip or .skill file must include a SKILL.md file</li>
+              <li>A folder must include a SKILL.md file at its root</li>
             </ul>
           </div>
         ) : null}

--- a/apps/web/tests/skill-folder-archive.test.ts
+++ b/apps/web/tests/skill-folder-archive.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import { extractZipArchive } from "@mosoo/skill-package";
+
+import { createSkillFolderArchiveFile } from "../src/domains/skill/lib/skill-folder-archive";
+import type { SkillFolderFile } from "../src/domains/skill/lib/skill-folder-archive";
+
+const SKILL_MARKDOWN = ["---", "name: demo-skill", "description: Demo skill", "---", "", "Body"]
+  .join("\n")
+  .concat("\n");
+
+function folderFile(path: string, content: string): SkillFolderFile {
+  const name = path.split("/").at(-1) ?? path;
+
+  return { file: new File([content], name), path };
+}
+
+describe("createSkillFolderArchiveFile", () => {
+  test("zips a folder into a skill archive with the wrapper stripped", async () => {
+    const archive = await createSkillFolderArchiveFile({
+      files: [
+        folderFile("demo-skill/SKILL.md", SKILL_MARKDOWN),
+        folderFile("demo-skill/scripts/run.md", "helper"),
+      ],
+      folderName: "demo-skill",
+    });
+
+    expect(archive.name).toBe("demo-skill.zip");
+    expect(archive.type).toBe("application/zip");
+
+    const entries = extractZipArchive(new Uint8Array(await archive.arrayBuffer()));
+    const paths = entries.map((entry) => entry.path);
+
+    expect(paths).toContain("SKILL.md");
+    expect(paths).toContain("scripts/run.md");
+  });
+
+  test("drops junk files before packaging", async () => {
+    const archive = await createSkillFolderArchiveFile({
+      files: [
+        folderFile("demo-skill/SKILL.md", SKILL_MARKDOWN),
+        folderFile("demo-skill/.DS_Store", "junk"),
+        folderFile("demo-skill/.git/config", "junk"),
+        folderFile("demo-skill/node_modules/pkg/index.js", "junk"),
+      ],
+      folderName: "demo-skill",
+    });
+
+    const entries = extractZipArchive(new Uint8Array(await archive.arrayBuffer()));
+    const paths = entries.map((entry) => entry.path);
+
+    expect(paths).toEqual(["SKILL.md"]);
+  });
+
+  test("rejects a folder without a root SKILL.md", async () => {
+    await expect(
+      createSkillFolderArchiveFile({
+        files: [folderFile("demo-skill/notes.md", "notes")],
+        folderName: "demo-skill",
+      }),
+    ).rejects.toThrow("SKILL.md");
+  });
+
+  test("rejects a folder entry above the per-file limit", async () => {
+    const oversized = new Uint8Array(2 * 1024 * 1024 + 1);
+
+    await expect(
+      createSkillFolderArchiveFile({
+        files: [
+          folderFile("demo-skill/SKILL.md", SKILL_MARKDOWN),
+          { file: new File([oversized], "big.bin"), path: "demo-skill/big.bin" },
+        ],
+        folderName: "demo-skill",
+      }),
+    ).rejects.toThrow("File exceeds the 2 MB limit: demo-skill/big.bin");
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,5 @@
 {
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -90,6 +90,7 @@
         "@mosoo/effects": "workspace:*",
         "@mosoo/id": "workspace:*",
         "@mosoo/runtime-catalog": "workspace:*",
+        "@mosoo/skill-package": "workspace:*",
         "@tailwindcss/vite": "^4.3.0",
         "@tanstack/react-query": "^5.100.10",
         "@xterm/addon-fit": "^0.11.0",


### PR DESCRIPTION
Fill what changed. Use N/A for irrelevant or maintainer-only items. See `CONTRIBUTING.md` for branch, CLA, generated file, and CI rules.

## Summary

- Add local skill folder upload to the "Add skill" dialog: pick a folder via a new "select a folder" control, or drag and drop a whole folder onto the drop zone.
- New `skill-folder-archive` helper in `apps/web` packages the selected folder client-side with `@mosoo/skill-package` (`normalizeSkillEntries` + `createZipArchive`): junk entries (`.DS_Store`, `Thumbs.db`, `.git/`, `__MACOSX/`, `node_modules/`) are dropped, the wrapper directory is stripped, a root `SKILL.md` is required, and per-file (2 MB) / total (25 MB) limits mirroring the server are enforced before upload.
- The resulting `<folder>.zip` flows through the existing `/skill/inspect` preview and `/skill/package` publish endpoints — no backend changes.

## Why

- Users authoring multi-file skills (SKILL.md plus supporting files) previously had to zip the folder by hand before uploading; the dialog only accepted `.md`, `.zip`, or `.skill` files (YEF-828: 支持本地文件夹上传).

## Verification

- Commands: `just test-package @mosoo/web` (144 pass, includes new `skill-folder-archive.test.ts`), `just tc-package @mosoo/web`, `bun run lint` in `apps/web`, `just fmt`.
- Manual steps: ran the local stack, logged in via the loopback backdoor, uploaded a demo skill folder through both the folder picker and verified the preview (name/description parsed from `SKILL.md`) and skill creation end to end; `.DS_Store` in the folder was excluded.
- Not run: cross-browser drag-and-drop matrix (folder drop uses the widely supported `webkitGetAsEntry` API and falls back to plain file handling when the dropped item is not a directory).

## Impact

- User/API/contract changes: web-only UI addition; API contracts unchanged.
- Generated files / GraphQL / DB / lockfile: `bun.lock` updated for the new `@mosoo/skill-package` workspace dependency in `@mosoo/web`.
- Env or config changes: N/A
- Risk and rollback: low; the existing file/URL paths are untouched, so reverting the commit fully rolls back.

## Review

- Closest review areas: `apps/web/src/domains/skill/lib/skill-folder-archive.ts` (folder traversal, limits, ignore list) and the dialog wiring in `upload-skill-dialog.tsx`.
- Known trade-offs: executable bits cannot be detected from browser folder uploads, so all files are packaged non-executable; client-side size limits are mirrored constants of the server values in `apps/api` rather than a shared contract.
