### PR TITLE
fix(apps): compensate deleted deployment resources

### DIFF
--- a/apps/api/src/modules/apps/application/app-deployment-executor.service.ts
+++ b/apps/api/src/modules/apps/application/app-deployment-executor.service.ts
@@ -2,7 +2,7 @@ import type { AppDeploymentRunStatus } from "@mosoo/contracts/app";
 import type { AppDeploymentRunRow, AppDeploymentRow } from "@mosoo/db";
 import { appDeploymentRunsTable, appDeploymentsTable } from "@mosoo/db";
 import type { AppDeploymentRunId } from "@mosoo/id";
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull } from "drizzle-orm";
 
 import { createErrorLogContext, logError } from "../../../platform/cloudflare/logger";
 import type { ApiBindings } from "../../../platform/cloudflare/worker-types";
@@ -25,7 +25,11 @@ import {
 } from "./app-agent-binding-resolution";
 import type { ResolvableAppAgent } from "./app-agent-binding-resolution";
 import type { CloudflareDeploymentClient } from "./app-deployment-cloudflare-client";
-import { createCloudflareDeploymentClient } from "./app-deployment-cloudflare-client";
+import {
+  createCloudflareDeploymentClient,
+  deleteCloudflareDeploymentResources,
+  logCloudflareDeploymentResourceDeleteFailures,
+} from "./app-deployment-cloudflare-client";
 import {
   APP_DEPLOYMENT_COMPATIBILITY_DATE,
   detectAppDeploymentPlan,
@@ -398,6 +402,73 @@ async function completeDeploymentRun(input: {
     .run();
 
   return getD1ChangeCount(runUpdate) > 0;
+}
+
+async function shouldCompensateDeletedDeployment(input: {
+  database: D1Database;
+  deployment: AppDeploymentRow;
+}): Promise<boolean> {
+  const deletedDeployment =
+    (await getAppDatabase(input.database)
+      .select({ id: appDeploymentsTable.id })
+      .from(appDeploymentsTable)
+      .where(
+        and(
+          eq(appDeploymentsTable.id, input.deployment.id),
+          isNotNull(appDeploymentsTable.deletedAt),
+        ),
+      )
+      .limit(1)
+      .get()) ?? null;
+
+  if (deletedDeployment === null) {
+    return false;
+  }
+
+  const replacement =
+    (await getAppDatabase(input.database)
+      .select({ id: appDeploymentsTable.id })
+      .from(appDeploymentsTable)
+      .where(
+        and(
+          eq(appDeploymentsTable.appId, input.deployment.appId),
+          isNull(appDeploymentsTable.deletedAt),
+        ),
+      )
+      .limit(1)
+      .get()) ?? null;
+
+  return replacement === null;
+}
+
+async function compensateDeletedDeploymentResources(input: {
+  bindings: ApiBindings;
+  cloudflareClient: CloudflareDeploymentClient | null;
+  deployment: AppDeploymentRow;
+}): Promise<void> {
+  if (
+    !(await shouldCompensateDeletedDeployment({
+      database: input.bindings.DB,
+      deployment: input.deployment,
+    }))
+  ) {
+    return;
+  }
+
+  const deleteFailures = await deleteCloudflareDeploymentResources(
+    input.cloudflareClient ?? createCloudflareDeploymentClient(input.bindings),
+    {
+      hostname: deploymentHostname(input.deployment, input.bindings.MOSOO_APP_DEPLOYMENT_DOMAIN),
+      resourceName: input.deployment.mosooSubdomain,
+    },
+  );
+
+  if (deleteFailures.length > 0) {
+    logCloudflareDeploymentResourceDeleteFailures(
+      "app-deployment.cloudflare_delete_after_deletion_failed",
+      deleteFailures,
+    );
+  }
 }
 
 function shouldIncludeSnapshotPath(path: string): boolean {
@@ -813,6 +884,7 @@ export async function dispatchAppDeploymentRun(
       bindings,
       cloudflareClient ?? createCloudflareDeploymentClient(bindings),
     );
+  let externallyAttemptedDeployment: AppDeploymentRow | null = null;
 
   try {
     const prepared = await runner.prepare(context);
@@ -875,6 +947,7 @@ export async function dispatchAppDeploymentRun(
       return;
     }
 
+    externallyAttemptedDeployment = context.deployment;
     const result = await runner.deploy({ ...context, envVars, plan, prepared });
 
     if (!(await updateRunStatus(bindings.DB, input.appDeploymentRunId, "submitted"))) {
@@ -913,6 +986,22 @@ export async function dispatchAppDeploymentRun(
       });
     }
   } finally {
+    if (externallyAttemptedDeployment !== null) {
+      try {
+        await compensateDeletedDeploymentResources({
+          bindings,
+          cloudflareClient,
+          deployment: externallyAttemptedDeployment,
+        });
+      } catch (error) {
+        logError("app-deployment.cloudflare_delete_after_deletion_check_failed", {
+          ...createErrorLogContext(error),
+          deploymentId: externallyAttemptedDeployment.id,
+          runId: input.appDeploymentRunId,
+        });
+      }
+    }
+
     await runner.cleanup?.();
   }
 }

--- a/apps/api/tests/app-deployment-service.test.ts
+++ b/apps/api/tests/app-deployment-service.test.ts
@@ -988,6 +988,118 @@ describe("app deployment service", () => {
     expect(runRow?.status).toBe("failed");
   });
 
+  test("compensates resources created after deployment deletion", async () => {
+    const database = createDatabase();
+    const { bindings } = createBindings(database);
+    const deleted: string[] = [];
+    const externallyCreated: string[] = [];
+    const cloudflareClient = createCloudflareDeleteRecorder(deleted);
+    const run = await deployApp(
+      bindings,
+      VIEWER,
+      { appId: APP_ID, repoUrl: "https://github.com/samzong/awire" },
+      { fetch: githubFetch, nowMs: () => NOW_MS },
+    );
+    const runner: AppDeploymentBuildRunner = {
+      async build() {},
+      async deploy() {
+        await deleteAppDeployment(bindings, VIEWER, { appId: APP_ID }, { cloudflareClient });
+        externallyCreated.push(`pages:${APP_ID}`);
+
+        return {
+          externalDeploymentId: "pages-deployment-after-delete",
+          externalProjectId: "pages-project-after-delete",
+          externalVersionId: null,
+          url: `https://app-${APP_ID.toLowerCase()}.apps.localhost`,
+        };
+      },
+      async prepare() {
+        return {
+          repoDir: "/repo",
+          snapshot: { files: { "index.html": "<main>Hello</main>" } },
+        };
+      },
+    };
+
+    await dispatchAppDeploymentRun(
+      bindings as ApiBindings,
+      { appDeploymentRunId: run.id },
+      { cloudflareClient, runner },
+    );
+
+    const deployment = await database
+      .app()
+      .select({ deletedAt: appDeploymentsTable.deletedAt })
+      .from(appDeploymentsTable)
+      .where(eq(appDeploymentsTable.id, run.deploymentId))
+      .get();
+    const runRow = await database
+      .app()
+      .select({
+        errorCode: appDeploymentRunsTable.errorCode,
+        status: appDeploymentRunsTable.status,
+      })
+      .from(appDeploymentRunsTable)
+      .where(eq(appDeploymentRunsTable.id, run.id))
+      .get();
+
+    expect(externallyCreated).toEqual([`pages:${APP_ID}`]);
+    expect(deployment?.deletedAt).toBeNumber();
+    expect(runRow).toEqual({ errorCode: "deployment_deleted", status: "failed" });
+    expect(deleted).toHaveLength(10);
+    expect(deleted.filter((entry) => entry.startsWith("pages:"))).toHaveLength(2);
+    expect(deleted.filter((entry) => entry.startsWith("worker:"))).toHaveLength(2);
+  });
+
+  test("does not compensate a deleted deployment after a replacement is active", async () => {
+    const database = createDatabase();
+    const { bindings } = createBindings(database);
+    const deleted: string[] = [];
+    const cloudflareClient = createCloudflareDeleteRecorder(deleted);
+    const run = await deployApp(
+      bindings,
+      VIEWER,
+      { appId: APP_ID, repoUrl: "https://github.com/samzong/awire" },
+      { fetch: githubFetch, nowMs: () => NOW_MS },
+    );
+    const runner: AppDeploymentBuildRunner = {
+      async build() {},
+      async deploy() {
+        await deleteAppDeployment(bindings, VIEWER, { appId: APP_ID }, { cloudflareClient });
+        await deployApp(
+          bindings,
+          VIEWER,
+          { appId: APP_ID, repoUrl: "https://github.com/samzong/awire" },
+          { fetch: githubFetch, nowMs: () => NOW_MS + 1 },
+        );
+
+        return {
+          externalDeploymentId: "pages-deployment-after-replacement",
+          externalProjectId: "pages-project-after-replacement",
+          externalVersionId: null,
+          url: `https://app-${APP_ID.toLowerCase()}.apps.localhost`,
+        };
+      },
+      async prepare() {
+        return {
+          repoDir: "/repo",
+          snapshot: { files: { "index.html": "<main>Hello</main>" } },
+        };
+      },
+    };
+
+    await dispatchAppDeploymentRun(
+      bindings as ApiBindings,
+      { appDeploymentRunId: run.id },
+      { cloudflareClient, runner },
+    );
+
+    const activeDeployment = await getAppDeployment(bindings, VIEWER, APP_ID);
+
+    expect(activeDeployment).not.toBeNull();
+    expect(deleted).toHaveLength(5);
+  });
+
   test("deletes the active deployment and fails the active run", async () => {
     const database = createDatabase();
     const { bindings } = createBindings(database);


### PR DESCRIPTION
Closes #306.

## Summary

- Detect when a deployment is tombstoned while its external deployment attempt is still in flight.
- Compensate by deleting the resulting Cloudflare resources after that attempt returns.
- Avoid compensation when an active replacement deployment exists for the same app.

## Why

Deleting a deployment during an in-flight external creation could leave Pages, Worker, route, hostname, or domain resources orphaned. Those resources can remain reachable or incur ongoing platform charges.

## Verification

- Commands: `just test-file apps/api/tests/app-deployment-service.test.ts` (22 pass); `just tc-package @mosoo/api`.
- Manual steps: used the real deployment executor, deletion service, and in-memory D1 state. At the Cloudflare client boundary, injected a deployment attempt which completed after `deleteAppDeployment`; verified the executor issued compensation deletes. Also created an active replacement deployment and verified compensation did not delete its resources.
- Not run: `just check` was not run; no real Cloudflare production account or remote Pages/Workers resources were used.

## Impact

- User/API/contract changes: None.
- Generated files / GraphQL / DB / lockfile: None.
- Env or config changes: None.
- Risk and rollback: Compensation is restricted to a tombstoned deployment without an active replacement. Revert this PR to restore prior behavior; it does not alter existing deployment records or migrations.

## Review

- Closest review areas: deployment executor lifecycle, deployment deletion, Cloudflare resource cleanup.
- Known trade-offs: The real local D1/service execution path was tested, but Cloudflare API calls were injected at the client boundary because no production Cloudflare account was available. Remote API latency, permissions, and vendor failure semantics still require isolated-account verification.
