### PR TITLE
fix(files): retain failed scope cleanup for retry

### DIFF
--- a/apps/api/src/modules/files/infrastructure/file-delete.ts
+++ b/apps/api/src/modules/files/infrastructure/file-delete.ts
@@ -166,7 +166,7 @@ export async function deleteFileScope(
   await deleteFileRows(bindings, {
     actorAccountId: input.actorAccountId,
     rows,
-    storageFailureMode: "ignore",
+    storageFailureMode: "throw",
   });
   await deleteFileControlRowsForScope(bindings.DB, input);
 }

--- a/apps/api/tests/session-lifecycle-mutation.test.ts
+++ b/apps/api/tests/session-lifecycle-mutation.test.ts
@@ -30,6 +30,20 @@ const OWNER_VIEWER: AuthenticatedViewer = {
 };
 
 const FAILED_DRIVER_ID = "01J0000000000000000000000G";
+const SESSION_FILE_ID = "01J0000000000000000000000H";
+
+class RetriableSessionFileBucket {
+  readonly deletedKeys: string[] = [];
+  failDelete = true;
+
+  async delete(key: string): Promise<void> {
+    this.deletedKeys.push(key);
+
+    if (this.failDelete) {
+      throw new Error("R2 delete interrupted.");
+    }
+  }
+}
 
 function createDriverConnectionBinding(paths: string[]) {
   return {
@@ -286,6 +300,62 @@ async function insertDriverInstance(
   }
 }
 
+async function insertSessionFileForCleanup(database: D1Database): Promise<void> {
+  await database
+    .prepare(
+      `
+        INSERT INTO file_record (
+          id,
+          scope_kind,
+          scope_id,
+          session_kind,
+          status,
+          name,
+          path,
+          parent_path,
+          object_key,
+          owner_id,
+          owner_kind,
+          purpose,
+          expires_at,
+          mime_type,
+          size,
+          etag,
+          committed,
+          version,
+          created_by_account_id,
+          created_at,
+          updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    )
+    .bind(
+      SESSION_FILE_ID,
+      "session",
+      PUBLIC_API_TEST_IDS.nonOwnerSession,
+      "attachment",
+      "ready",
+      "notes.txt",
+      `attachment/${SESSION_FILE_ID}/notes.txt`,
+      `attachment/${SESSION_FILE_ID}`,
+      `session-files/${SESSION_FILE_ID}/notes.txt`,
+      PUBLIC_API_TEST_IDS.nonOwnerSession,
+      "session",
+      "session_attachment",
+      null,
+      "text/plain",
+      12,
+      null,
+      1,
+      1,
+      PUBLIC_API_TEST_IDS.nonOwnerAccount,
+      1,
+      1,
+    )
+    .run();
+}
+
 describe("session lifecycle mutations", () => {
   test("delete cascade removes live and terminal driver instances associated with the session", async () => {
     const database = await createPublicHttpContractDatabase();
@@ -414,6 +484,59 @@ describe("session lifecycle mutations", () => {
 
     expect(repairedCount).toBe(1);
     expect(session).toBeNull();
+  });
+
+  test("retains failed session R2 cleanup for repair instead of dropping its file record", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertNonOwnerSession(database);
+    await insertSessionFileForCleanup(database);
+    const bucket = new RetriableSessionFileBucket();
+    const bindings = withSessionLifecycleBinding(
+      createPublicHttpTestBindings(database, {
+        fileBucket: bucket as unknown as R2Bucket,
+      }) as ApiBindings,
+    );
+
+    await expect(
+      deleteSessionCascade(bindings, PUBLIC_API_TEST_IDS.nonOwnerSession, {
+        operationId: PUBLIC_API_TEST_IDS.operation as RuntimeOperationId,
+      }),
+    ).rejects.toThrow("R2 delete interrupted.");
+
+    const anchoredSession = await database
+      .prepare("SELECT status FROM session WHERE id = ?")
+      .bind(PUBLIC_API_TEST_IDS.nonOwnerSession)
+      .first<{ status: string }>();
+    const retainedFile = await database
+      .prepare("SELECT status FROM file_record WHERE id = ?")
+      .bind(SESSION_FILE_ID)
+      .first<{ status: string }>();
+
+    expect(bucket.deletedKeys).toEqual([`session-files/${SESSION_FILE_ID}/notes.txt`]);
+    expect(anchoredSession).toEqual({ status: "TERMINATED" });
+    expect(retainedFile).toEqual({ status: "deleting" });
+
+    bucket.failDelete = false;
+    const repairedCount = await repairStaleSessionDeleteCleanups(bindings, {
+      limit: 10,
+      staleUpdatedAtLte: Date.now(),
+    });
+    const session = await database
+      .prepare("SELECT id FROM session WHERE id = ?")
+      .bind(PUBLIC_API_TEST_IDS.nonOwnerSession)
+      .first();
+    const file = await database
+      .prepare("SELECT id FROM file_record WHERE id = ?")
+      .bind(SESSION_FILE_ID)
+      .first();
+
+    expect(repairedCount).toBe(1);
+    expect(bucket.deletedKeys).toEqual([
+      `session-files/${SESSION_FILE_ID}/notes.txt`,
+      `session-files/${SESSION_FILE_ID}/notes.txt`,
+    ]);
+    expect(session).toBeNull();
+    expect(file).toBeNull();
   });
 
   test("archive cancels active runs and exposes an idle archived session", async () => {


### PR DESCRIPTION
Closes #307.

## Summary

- Propagate R2 deletion failures from file-scope cleanup instead of ignoring them.
- Keep the file record in the durable `deleting` state until object deletion succeeds.
- Reuse the existing stale session cleanup repair path to retry the deletion safely.

## Why

Ignoring an R2 delete failure while deleting D1 metadata produces an untracked object. It can remain accessible through storage and continue consuming storage capacity with no retry path.

## Verification

- Commands: `just test-file apps/api/tests/session-lifecycle-mutation.test.ts` (7 pass); `just test-file apps/api/tests/session-resource-files.test.ts` (13 pass); `just tc-package @mosoo/api`.
- Manual steps: ran the real session deletion cascade and in-memory D1 state machine while injecting an R2 failure at the binding boundary. Verified that the session remains a durable cleanup anchor and the file row remains `deleting`; then allowed R2 deletion and ran the real stale-cleanup repair path to completion.
- Not run: `just check` was not run; no real Cloudflare production account or remote R2 bucket was used.

## Impact

- User/API/contract changes: None.
- Generated files / GraphQL / DB / lockfile: None.
- Env or config changes: None.
- Risk and rollback: Failed cleanup remains visible and retryable rather than silently dropping metadata. Revert this PR to restore the prior best-effort behavior; no migration is involved.

## Review

- Closest review areas: file deletion ordering, session lifecycle cleanup, stale cleanup repair.
- Known trade-offs: The real local D1/Worker/service path was exercised, with R2 behavior injected only at the Cloudflare binding boundary. Remote R2 service behavior and credentials were not validated against a production account.
