### PR TITLE
fix(runtime): allow container-reachable control origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,8 @@ no_proxy=localhost,127.0.0.1,::1
 WEB_DEV_PORT=5173
 WRANGLER_DEV_PORT=
 API_PROXY_TARGET=
+# Container-to-API callbacks when requests enter through a public tunnel.
+MOSOO_RUNTIME_CONTROL_ORIGIN=
 
 # Preview latency output.
 MOSOO_E2E_LATENCY_LABEL=current

--- a/apps/api/bin/dev-local.ts
+++ b/apps/api/bin/dev-local.ts
@@ -15,6 +15,7 @@ const wranglerBin = `${apiDir}/node_modules/.bin/wrangler`;
 const DOCKER_HOST_ENV_KEY = "DOCKER_HOST";
 const DEV_DOCKER_HOST_ENV_KEY = "MOSOO_API_DEV_DOCKER_HOST";
 const DEV_RUNTIME_PROXY_HOST_ENV_KEY = "MOSOO_API_DEV_RUNTIME_PROXY_HOST";
+const RUNTIME_CONTROL_ORIGIN_ENV_KEY = "MOSOO_RUNTIME_CONTROL_ORIGIN";
 const LARK_SIDECAR_DISABLED_ENV_KEY = "MOSOO_LARK_SIDECAR_DISABLED";
 const LARK_SIDECAR_SECRET_ENV_KEY = "MOSOO_LARK_SIDECAR_SECRET";
 const SCRUB_HOST_PROXY_ENV_KEY = "MOSOO_API_DEV_SCRUB_HOST_PROXY";
@@ -240,6 +241,13 @@ function createRuntimeProxyVarArgs(env: NodeJS.ProcessEnv): string[] {
   );
 
   return args;
+}
+
+function createRuntimeControlOriginVarArgs(env: NodeJS.ProcessEnv): string[] {
+  const value = env[RUNTIME_CONTROL_ORIGIN_ENV_KEY]?.trim();
+  return value === undefined || value.length === 0
+    ? []
+    : ["--var", `${RUNTIME_CONTROL_ORIGIN_ENV_KEY}:${value}`];
 }
 
 function unquoteDevVarValue(value: string): string {
@@ -486,6 +494,7 @@ const wranglerResult = await run(
     "--var",
     `WEB_ORIGIN:${webOrigin}`,
     ...createProviderFetchProxyVarArgs(providerFetchProxy),
+    ...createRuntimeControlOriginVarArgs(wranglerEnv),
     ...createRuntimeProxyVarArgs(wranglerEnv),
     ...(await createWeChatIlinkBaseUrlVarArgs(wranglerEnv)),
     ...(larkSidecarSecret ? createLarkSidecarVarArgs(larkSidecarSecret) : []),

--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-provisioning.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-provisioning.service.ts
@@ -202,7 +202,8 @@ async function provisionDriver(
         );
   void nativeResumeRefPromise.catch(() => undefined);
 
-  const containerRequestUrl = toContainerReachableOrigin(input.requestUrl);
+  const explicitControlOrigin = env.MOSOO_RUNTIME_CONTROL_ORIGIN?.trim() || undefined;
+  const containerRequestUrl = toContainerReachableOrigin(input.requestUrl, explicitControlOrigin);
   const environmentInstall = createRuntimeEnvironmentInstallState();
   let driverGeneration: number | null = null;
   let process: RuntimeProcessHandle | null = null;

--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-sandbox-provisioning.paths.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-sandbox-provisioning.paths.ts
@@ -2,8 +2,15 @@ import { SANDBOX_CACHE_PATH, SANDBOX_MEMORY_PATH } from "agent-driver/paths";
 
 import type { DriverProfileConfig } from "../../domain/driver-snapshot";
 
-export function toContainerReachableOrigin(requestUrl: string): string {
+export function toContainerReachableOrigin(requestUrl: string, explicitOrigin?: string): string {
   const url = new URL(requestUrl);
+
+  if (explicitOrigin !== undefined) {
+    const origin = new URL(explicitOrigin);
+    url.protocol = origin.protocol;
+    url.host = origin.host;
+    return url.toString();
+  }
 
   // Keep the original port: local requests reach the API through whichever
   // dev server received them (vite on WEB_DEV_PORT or wrangler on

--- a/apps/api/src/platform/cloudflare/worker-types.ts
+++ b/apps/api/src/platform/cloudflare/worker-types.ts
@@ -34,7 +34,8 @@ interface OptionalLocalProviderFetchProxyBindings {
   MOSOO_PROVIDER_FETCH_PROXY_URL?: string;
 }
 
-interface OptionalRuntimeProxyBindings {
+interface OptionalRuntimeBindings {
+  MOSOO_RUNTIME_CONTROL_ORIGIN?: string;
   MOSOO_RUNTIME_ALL_PROXY?: string;
   MOSOO_RUNTIME_HTTP_PROXY?: string;
   MOSOO_RUNTIME_HTTPS_PROXY?: string;
@@ -77,7 +78,7 @@ export type ApiBindings = Env &
   OptionalDriverConnectionBinding &
   OptionalSessionBinding &
   OptionalLocalProviderFetchProxyBindings &
-  OptionalRuntimeProxyBindings &
+  OptionalRuntimeBindings &
   OptionalSlackAdapterBindings &
   OptionalWeChatIlinkBindings &
   OptionalLarkSidecarBindings &

--- a/apps/api/tests/runtime-sandbox-provisioning-paths.test.ts
+++ b/apps/api/tests/runtime-sandbox-provisioning-paths.test.ts
@@ -29,4 +29,13 @@ describe("toContainerReachableOrigin", () => {
       "https://try.mosoo.ai/api/graphql",
     );
   });
+
+  test("uses an explicit container origin for tunneled requests", () => {
+    expect(
+      toContainerReachableOrigin(
+        "https://random.trycloudflare.com/api/v1/threads",
+        "http://host.docker.internal:8787",
+      ),
+    ).toBe("http://host.docker.internal:8787/api/v1/threads");
+  });
 });


### PR DESCRIPTION
## Summary

- add an optional `MOSOO_RUNTIME_CONTROL_ORIGIN` local runtime binding
- replace tunneled request origins at the shared container callback boundary
- cover a trycloudflare request with an explicit `host.docker.internal` origin

## Why

Public Thread API requests entering through Cloudflare Tunnel currently derive Driver callback URLs from the public request Host. The tunnel security gateway does not expose `/api/driver/*`, so local container provisioning waits for Driver readiness until timeout.

## Verification

- Commands: `just test-file apps/api/tests/runtime-sandbox-provisioning-paths.test.ts`; `just tc-package @mosoo/api`; `just fmt`; `just lint`; `bash ./init.sh acceptance`; `just check`; `just commit-check`
- Manual steps: verified the active OrbStack Docker daemon and independently reviewed the complete diff against Mosoo guardrails
- Not run: live trycloudflare Public API runtime smoke; this checkout has no provider credential, so a Run cannot pass provider readiness into provisioning

## Impact

- User/API/contract changes: local developers can set `MOSOO_RUNTIME_CONTROL_ORIGIN=http://host.docker.internal:8787` when ingress uses a public tunnel; unset behavior is unchanged
- Generated files / GraphQL / DB / lockfile: none; GraphQL freshness passed in `just check`
- Env or config changes: optional local-only env forwarded by `dev-local`; production `wrangler.toml` is unchanged
- Risk and rollback: low; remove the optional binding/forwarding to roll back

## Review

- Closest review areas: runtime provisioning URL derivation and dev-local Wrangler var forwarding
- Known trade-offs: intentionally no Demo, PAT, TLS, or tunnel lifecycle changes
