### PR TITLE
fix(auth): allow bearer tokens to create access tokens

### DIFF
--- a/apps/api/src/adapters/http/routes/access-token-route.ts
+++ b/apps/api/src/adapters/http/routes/access-token-route.ts
@@ -8,10 +8,7 @@ import {
   listPersonalAccessTokens,
   revokePersonalAccessToken,
 } from "../../../modules/auth/application/personal-access-token.service";
-import {
-  getAuthenticatedViewerFromRequest,
-  getViewerFromRequest,
-} from "../../../modules/auth/application/viewer-auth.service";
+import { getAuthenticatedViewerFromRequest } from "../../../modules/auth/application/viewer-auth.service";
 import { createErrorLogContext, logError } from "../../../platform/cloudflare/logger";
 import type { ApiGatewayEnvironment } from "../../../platform/cloudflare/worker-types";
 import {
@@ -85,7 +82,7 @@ export function registerAccessTokenRoute(app: Hono<ApiGatewayEnvironment>) {
 
   app.post("/access-tokens", async (c) => {
     try {
-      const viewer = await getViewerFromRequest(c.env, c.req.raw);
+      const viewer = await getAuthenticatedViewerFromRequest(c.env, c.req.raw);
       if (!viewer) {
         return unauthorized();
       }

--- a/apps/api/tests/personal-access-token.test.ts
+++ b/apps/api/tests/personal-access-token.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
+import { PUBLIC_API_PREFIX } from "@mosoo/contracts/public-api";
+
+import { createHttpApp } from "../src/adapters/http/create-http-app";
 import {
   authenticatePersonalAccessToken,
   createPersonalAccessToken,
@@ -8,6 +11,12 @@ import {
   revokePersonalAccessToken,
 } from "../src/modules/auth/application/personal-access-token.service";
 import type { AuthenticatedViewer } from "../src/modules/auth/application/viewer-auth.service";
+import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
+import {
+  createPublicHttpContractDatabase,
+  createPublicHttpTestBindings,
+  TOKENS,
+} from "./helpers/public-api-http-test-fixture";
 import { SqliteD1Database } from "./helpers/sqlite-d1";
 
 const MISSING_TOKEN_ID = "01J000000000000000000000K6";
@@ -105,6 +114,24 @@ function createPersonalTokenDatabase(): SqliteD1Database {
 }
 
 describe("personal access tokens", () => {
+  test("creates a token over HTTP with Bearer authentication", async () => {
+    const database = await createPublicHttpContractDatabase();
+    const response = await createHttpApp().request(
+      `${PUBLIC_API_PREFIX}/access-tokens`,
+      {
+        body: JSON.stringify({ label: "CLI token" }),
+        headers: {
+          authorization: `Bearer ${TOKENS.owner}`,
+          "content-type": "application/json",
+        },
+        method: "POST",
+      },
+      createPublicHttpTestBindings(database) as ApiBindings,
+    );
+
+    expect(response.status).toBe(201);
+  });
+
   test("generates Mosoo access tokens with the MST prefix", async () => {
     const database = createPersonalTokenDatabase();
 


### PR DESCRIPTION
## Summary

- authenticate `POST /api/access-tokens` through the same session-or-PAT viewer helper already used by GET and DELETE
- add an HTTP regression test for creating an access token with a Bearer/PAT

## Root cause

`GET /access-tokens` and `DELETE /access-tokens/:tokenId` used `getAuthenticatedViewerFromRequest`, which accepts a Better Auth session or a valid Personal Access Token. `POST /access-tokens` instead used the session-cookie-only `getViewerFromRequest`, so `mosoo console-rest access create` returned 401 after a successful OAuth CLI login issued a PAT.

## User impact

OAuth-authenticated CLI clients can now create access tokens without a browser session cookie. The existing PAT validation and account boundary remain unchanged: the Bearer token must be valid and unrevoked, and the new token is created for that authenticated account.

## Verification

- pre-fix HTTP regression reproduced 401 (`5 pass, 1 fail`)
- `just test-file apps/api/tests/personal-access-token.test.ts` (`6 pass, 0 fail`)
- `just tc-package @mosoo/api`
- `just fmt`
- `just lint`
- `just check` (including `958 pass, 0 fail` API tests)
- `bash ./init.sh acceptance` (local D1 migration plus API/Web typechecks)
- `just commit-check`

## Change inventory

- Generated files: none
- GraphQL codegen: N/A (no GraphQL changes)
- DB migrations: none
- Lockfile changes: none
