### PR TITLE
fix(api): disable local Sandbox HTTPS interception

### DIFF
--- a/apps/api/src/adapters/durable-objects/sandbox-https-interception.ts
+++ b/apps/api/src/adapters/durable-objects/sandbox-https-interception.ts
@@ -1,0 +1,14 @@
+interface SandboxHttpsInterception {
+  interceptHttps: boolean;
+}
+
+export function disableLocalSandboxHttpsInterception(
+  sandbox: SandboxHttpsInterception,
+  localBinding: string | undefined,
+): void {
+  // Local workerd can omit the ephemeral CA while HTTPS interception is active,
+  // resetting TLS before the sandbox reaches providers. Production keeps the SDK default.
+  if (localBinding === "true") {
+    sandbox.interceptHttps = false;
+  }
+}

--- a/apps/api/src/adapters/durable-objects/sandbox.do.ts
+++ b/apps/api/src/adapters/durable-objects/sandbox.do.ts
@@ -1,6 +1,7 @@
 import { DurableObject } from "cloudflare:workers";
 
 import type { ApiBindings } from "../../platform/cloudflare/worker-types";
+import { disableLocalSandboxHttpsInterception } from "./sandbox-https-interception";
 import { SANDBOX_RPC_FORWARD_METHODS } from "./sandbox-rpc-methods";
 import type { SandboxRpcForwardMethod } from "./sandbox-rpc-methods";
 
@@ -18,7 +19,13 @@ export class Sandbox extends DurableObject {
     super(ctx, env);
 
     this.#delegatePromise = import("@cloudflare/sandbox").then(
-      ({ Sandbox: SandboxImplementation }) => new SandboxImplementation(ctx, env),
+      ({ Sandbox: SandboxImplementation }) => {
+        const delegate = new SandboxImplementation(ctx, env);
+
+        disableLocalSandboxHttpsInterception(delegate, env.SANDBOX_FILE_BUCKET_LOCAL);
+
+        return delegate;
+      },
     );
   }
 

--- a/apps/api/tests/sandbox-https-interception.test.ts
+++ b/apps/api/tests/sandbox-https-interception.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+
+import { disableLocalSandboxHttpsInterception } from "../src/adapters/durable-objects/sandbox-https-interception";
+
+describe("Sandbox HTTPS interception", () => {
+  test("disables interception only for the explicit local binding", () => {
+    const local = { interceptHttps: true };
+    disableLocalSandboxHttpsInterception(local, "true");
+    expect(local.interceptHttps).toBe(false);
+
+    const production = { interceptHttps: true };
+    disableLocalSandboxHttpsInterception(production, "false");
+    expect(production.interceptHttps).toBe(true);
+
+    const unset = { interceptHttps: true };
+    disableLocalSandboxHttpsInterception(unset, undefined);
+    expect(unset.interceptHttps).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- disable Sandbox HTTPS interception only when the explicit local binding `SANDBOX_FILE_BUCKET_LOCAL=true`
- leave production (`false`) and unset bindings on the `@cloudflare/sandbox` SDK default
- cover the local, production, and unset branches with a focused unit test

## Evidence

`@cloudflare/sandbox` 0.12.3 is still the latest release. Its HTTPS interception path enables `SANDBOX_INTERCEPT_HTTPS`, while the container trust setup expects `/etc/cloudflare/certs/cloudflare-containers-ca.crt`. In the Mosoo local runtime that CA is absent and intercepted HTTPS is reset before reaching providers.

No matching fix was found in the current upstream release or default branch, so this PR keeps the workaround at Mosoo's local adapter boundary and does not propose a speculative upstream code change.

- [Sandbox 0.12.3 interception source](https://github.com/cloudflare/sandbox-sdk/blob/696388b24c1c59a19b484a9e8066dc431addf617/packages/sandbox/src/sandbox.ts#L1371-L1373)
- [Sandbox container CA setup](https://github.com/cloudflare/sandbox-sdk/blob/696388b24c1c59a19b484a9e8066dc431addf617/packages/sandbox-container/src/cert.ts#L14-L79)
- [Cloudflare outbound traffic documentation](https://developers.cloudflare.com/containers/platform-details/outbound-traffic/)

## Verification

- `just test-file apps/api/tests/sandbox-https-interception.test.ts` — 1 test, 3 assertions passed
- `just tc-package @mosoo/api` — passed
- `just check` — format, docs, lint, all typechecks, 958 API tests, and GraphQL generated-output check passed
- `bash ./init.sh acceptance` — local migrations current; API and Web typechecks passed
- real Mosoo local Sandbox smoke — CA check returned `ca=missing`; unauthenticated `https://api.openai.com/v1/models` returned HTTP 401 instead of a connection reset
- `just commit-check` and pre-push hooks — passed

No GraphQL or database schema/migration changed, so standalone GraphQL codegen and DB generation/reset are not applicable.

## Upstream minimal reproduction

Ready to submit via the [Cloudflare Sandbox SDK bug template](https://github.com/cloudflare/sandbox-sdk/issues/new?template=bug_report.md):

1. Use `@cloudflare/sandbox@0.12.3`, `wrangler@4.107.0`, and the matching 0.12.3 Sandbox container image in local development.
2. Keep `interceptHttps = true` and allow passthrough for `api.openai.com` with `Sandbox.outboundByHost["api.openai.com"] = (request) => fetch(request)`.
3. In the Sandbox, run `test -r /etc/cloudflare/certs/cloudflare-containers-ca.crt` and `curl -sS -o /dev/null -w '%{http_code}' https://api.openai.com/v1/models`.
4. Observed locally: the CA file is absent and the HTTPS connection resets. Control: with `interceptHttps = false`, the same unauthenticated request reaches OpenAI and returns 401.

An upstream report should also attach OS/architecture, Docker version, and Worker/proxy logs so Cloudflare can distinguish CA generation from CA injection failures.
