### PR TITLE
fix(cost): retain reported usage without tokens

### DIFF
--- a/apps/api/src/modules/cost/application/cost-usage-event.service.ts
+++ b/apps/api/src/modules/cost/application/cost-usage-event.service.ts
@@ -131,12 +131,14 @@ export async function recordRuntimeUsageEvent(
   const rawOutputTokens = toTokenCount(input.usage.outputTokens);
   const rawCacheReadTokens = toTokenCount(input.usage.cachedReadTokens);
   const rawCacheCreationTokens = toTokenCount(input.usage.cachedWriteTokens);
+  const providedCostUsd = toProvidedUsdCost(input.usage);
 
   if (
     rawInputTokens === 0 &&
     rawOutputTokens === 0 &&
     rawCacheReadTokens === 0 &&
-    rawCacheCreationTokens === 0
+    rawCacheCreationTokens === 0 &&
+    providedCostUsd === null
   ) {
     return;
   }
@@ -158,7 +160,7 @@ export async function recordRuntimeUsageEvent(
     model,
     outputTokens: tokens.outputTokens,
     pricedAtMs: input.run.createdAtMs,
-    providedCostUsd: toProvidedUsdCost(input.usage),
+    providedCostUsd,
     provider,
   });
   const source = "runtime_driver";

--- a/apps/api/src/modules/cost/domain/cost-pricing.ts
+++ b/apps/api/src/modules/cost/domain/cost-pricing.ts
@@ -488,6 +488,29 @@ export function calculateUsageCost(input: {
     modelId: input.model,
     providerId: input.provider,
   });
+  const tokensUnavailable =
+    input.cacheCreationTokens === 0 &&
+    input.cacheReadTokens === 0 &&
+    input.inputTokens === 0 &&
+    input.outputTokens === 0;
+
+  if (tokensUnavailable && input.providedCostUsd !== null && input.providedCostUsd !== undefined) {
+    return {
+      priceSnapshotJson:
+        pricing === null
+          ? null
+          : JSON.stringify({
+              model: pricing.model,
+              provider: pricing.provider,
+              reportedCostUsd: input.providedCostUsd,
+              source: "runtime_reported_usd",
+              tokenCountersUnavailable: true,
+            }),
+      pricing,
+      pricingStatus: pricing === null ? "unknown" : "priced",
+      totalCostUsd: input.providedCostUsd,
+    };
+  }
 
   if (!pricing) {
     return {

--- a/apps/api/tests/cost-usage-event.test.ts
+++ b/apps/api/tests/cost-usage-event.test.ts
@@ -367,4 +367,114 @@ describe("cost usage event", () => {
       run_purpose: "channel",
     });
   });
+
+  test("persists and idempotently updates reported USD cost without token counters", async () => {
+    const database = createUsageEventDatabase();
+    const usage = {
+      costAmount: 0.42,
+      costCurrency: "USD",
+      source: "session_update",
+      usageContract: "openai_total_with_cached_breakdown",
+    } satisfies SessionUsageSummary;
+    const input = {
+      callKey: "cost-only-call",
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      nativeCallId: "cost-only-native-call",
+      run: RUN_CONTEXT,
+      usage,
+    };
+
+    await recordRuntimeUsageEvent(database, input);
+    await recordRuntimeUsageEvent(database, {
+      ...input,
+      usage: {
+        ...usage,
+        costAmount: 0.84,
+      },
+    });
+
+    const row = await database
+      .prepare(
+        `
+          SELECT
+            COUNT(*) AS count,
+            cache_creation_tokens,
+            cache_read_tokens,
+            input_tokens,
+            output_tokens,
+            pricing_status,
+            total_cost_usd_micros,
+            usage_contract
+          FROM usage_event
+        `,
+      )
+      .first<{
+        count: number;
+        cache_creation_tokens: number;
+        cache_read_tokens: number;
+        input_tokens: number;
+        output_tokens: number;
+        pricing_status: string;
+        total_cost_usd_micros: number;
+        usage_contract: string;
+      }>();
+
+    expect(row).toEqual({
+      cache_creation_tokens: 0,
+      cache_read_tokens: 0,
+      count: 1,
+      input_tokens: 0,
+      output_tokens: 0,
+      pricing_status: "unknown",
+      total_cost_usd_micros: 840_000,
+      usage_contract: "openai_total_with_cached_breakdown",
+    });
+  });
+
+  test("uses reported USD cost for a known model when token counters are unavailable", async () => {
+    const database = createUsageEventDatabase();
+    const usage = {
+      costAmount: 0.42,
+      costCurrency: "USD",
+      source: "session_update",
+      usageContract: "openai_total_with_cached_breakdown",
+    } satisfies SessionUsageSummary;
+
+    await recordRuntimeUsageEvent(database, {
+      callKey: "known-cost-only-call",
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      nativeCallId: "known-cost-only-native-call",
+      run: {
+        ...RUN_CONTEXT,
+        model: "gpt-5.4",
+        provider: "openai",
+      },
+      usage,
+    });
+
+    const row = await database
+      .prepare(
+        `
+          SELECT price_snapshot_json, pricing_status, total_cost_usd_micros
+          FROM usage_event
+        `,
+      )
+      .first<{
+        price_snapshot_json: string | null;
+        pricing_status: string;
+        total_cost_usd_micros: number;
+      }>();
+
+    expect(row).toMatchObject({
+      pricing_status: "priced",
+      total_cost_usd_micros: 420_000,
+    });
+    expect(JSON.parse(row?.price_snapshot_json ?? "{}")).toEqual({
+      model: "gpt-5.4",
+      provider: "openai",
+      reportedCostUsd: 0.42,
+      source: "runtime_reported_usd",
+      tokenCountersUnavailable: true,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Persist a valid non-negative reported USD cost when all runtime token counters are absent.
- Preserve zero token buckets while retaining the reported amount for both known and unknown models.
- Record an explicit `runtime_reported_usd` pricing snapshot for known-model cost-only events.
- Keep the existing `(source, source_event_id)` upsert boundary so retries update one logical usage fact.
- Fixes #321.

## Why

`SessionUsageSummary` permits an upstream runtime or aggregator to report billed USD cost without a token breakdown. The previous zero-token early return discarded that valid cost before pricing and ledger persistence, while `session_model_call` could retain the same amount. This made App Usage, exports, detail queries, and later rollups undercount consumption.

This PR closes that ingestion gap without changing token-present pricing behavior. A separate follow-up PR on `fix/cost-ledger-recovery` is stacked on this branch and makes model-call plus ledger persistence atomic.

## Verification

- Commands:
  - `just test-package @mosoo/api` — 964 passed, 0 failed across 165 files.
  - `just tc-package @mosoo/api` — passed.
  - `just lint` — passed, including formatting checks and generated Worker type validation.
  - `git diff --check upstream/main...HEAD` — passed.
- Manual steps:
  - Invoked the real cost usage service against the local SQLite D1 fixture with `costAmount: 0.42`, `costCurrency: "USD"`, a declared usage contract, and no token counters.
  - Verified one `usage_event` row with zero token buckets and `420000` USD micros.
  - Replayed the same native call identity with an updated amount and verified the unique source boundary retained exactly one row.
  - Covered both unknown-model fallback and known-model reported-USD snapshot behavior.
- Not run:
  - No remote Cloudflare Worker/D1 deployment, provider request, Queue, production database, or billable resource was used. Verification covers the real local service/repository/D1 boundary, not a remote production incident.

## Impact

- User/API/contract changes:
  - App Usage and exports now include valid USD-only runtime consumption that was previously omitted.
  - No GraphQL, HTTP, or shared payload shape changes.
  - Cost-only usage now follows the same declared-`usageContract` requirement as token-bearing usage; current official Driver mappings already provide it.
- Generated files / GraphQL / DB / lockfile:
  - N/A. No schema, migration, generated file, submodule, or lockfile change.
- Env or config changes:
  - N/A.
- Risk and rollback:
  - Risk is limited to cost-ledger semantics for valid USD-only events. Token-present pricing remains unchanged.
  - Existing last-write-wins upsert behavior is intentionally preserved because a runtime may update one logical usage fact.
  - Roll back this single commit to restore the former behavior; no data migration is required.

## Review

- Closest review areas:
  - Cost usage ingestion, usage-contract normalization, pricing fallback, and ledger idempotency.
- Known trade-offs:
  - Only finite, non-negative `USD` reports qualify as a reported-cost fallback.
  - This PR fixes cost-only ingestion but not the separate two-write atomicity boundary; the stacked follow-up PR depends on this one and addresses #322.
