### PR TITLE
fix(cost): atomically persist usage ledger

### DIFF
--- a/apps/api/src/modules/cost/application/cost-usage-event.service.ts
+++ b/apps/api/src/modules/cost/application/cost-usage-event.service.ts
@@ -16,6 +16,7 @@ import type {
 import { sql } from "drizzle-orm";
 
 import { getAppDatabase } from "../../../platform/db/drizzle";
+import type { AppDatabase } from "../../../platform/db/drizzle";
 import { isTruthy } from "../../../shared/truthiness";
 import { calculateUsageCost } from "../domain/cost-pricing";
 import { normalizeUsageTokens } from "../domain/usage-contract";
@@ -123,10 +124,10 @@ function toUsdMicros(value: number): number {
   return Math.round(value * 1_000_000);
 }
 
-export async function recordRuntimeUsageEvent(
-  database: D1Database,
+export function createRuntimeUsageEventUpsert(
+  database: AppDatabase,
   input: RecordRuntimeUsageEventInput,
-): Promise<void> {
+) {
   const rawInputTokens = toTokenCount(input.usage.inputTokens);
   const rawOutputTokens = toTokenCount(input.usage.outputTokens);
   const rawCacheReadTokens = toTokenCount(input.usage.cachedReadTokens);
@@ -140,7 +141,7 @@ export async function recordRuntimeUsageEvent(
     rawCacheCreationTokens === 0 &&
     providedCostUsd === null
   ) {
-    return;
+    return null;
   }
 
   const provider = input.run.provider;
@@ -168,7 +169,7 @@ export async function recordRuntimeUsageEvent(
     ? `${input.driverInstanceId}:${input.nativeCallId}`
     : `${input.driverInstanceId}:${input.run.sessionRunId}:${input.callKey}`;
 
-  await getAppDatabase(database)
+  return database
     .insert(usageEventsTable)
     .values({
       actorUserId: input.run.actorUserId,
@@ -211,6 +212,18 @@ export async function recordRuntimeUsageEvent(
         usageContract: sql`excluded.usage_contract`,
       },
       target: [usageEventsTable.source, usageEventsTable.sourceEventId],
-    })
-    .run();
+    });
+}
+
+export async function recordRuntimeUsageEvent(
+  database: D1Database,
+  input: RecordRuntimeUsageEventInput,
+): Promise<void> {
+  const query = createRuntimeUsageEventUpsert(getAppDatabase(database), input);
+
+  if (query === null) {
+    return;
+  }
+
+  await query.run();
 }

--- a/apps/api/src/modules/sessions/infrastructure/session-model-call.repository.ts
+++ b/apps/api/src/modules/sessions/infrastructure/session-model-call.repository.ts
@@ -20,10 +20,10 @@ import type {
 } from "@mosoo/id";
 import { and, eq, sql } from "drizzle-orm";
 
-import { getAppDatabase } from "../../../platform/db/drizzle";
+import { getAppDatabase, runAppDatabaseBatch } from "../../../platform/db/drizzle";
 import { isTruthy } from "../../../shared/truthiness";
 import { currentTimestampMs } from "../../../time";
-import { recordRuntimeUsageEvent } from "../../cost/application/cost-usage-event.service";
+import { createRuntimeUsageEventUpsert } from "../../cost/application/cost-usage-event.service";
 import type { SessionUsageSummary } from "./session-live-state.types";
 interface SessionModelCallRunRow {
   agent_id: AgentId;
@@ -149,6 +149,7 @@ export async function upsertSessionModelCallUsage(
   if (!input.usage) {
     return;
   }
+  const usage = input.usage;
 
   const run = await getSessionModelCallRunRow(database, input.sessionRunId);
 
@@ -161,66 +162,12 @@ export async function upsertSessionModelCallUsage(
     input.status === "completed" || input.status === "failed"
       ? (run.completed_at ?? timestampMs)
       : null;
-  const nativeCallId = normalizeUsageCallId(input.usage.callId);
+  const nativeCallId = normalizeUsageCallId(usage.callId);
   const callKey = isTruthy(nativeCallId) ? `model_call:${nativeCallId}` : "run_usage";
   const provider = run.provider ?? run.session_provider;
   const model = run.model ?? run.session_model;
 
-  await getAppDatabase(database)
-    .insert(sessionModelCallsTable)
-    .values({
-      cacheCreationTokens: toTokenCount(input.usage.cachedWriteTokens),
-      cacheReadTokens: toTokenCount(input.usage.cachedReadTokens),
-      callKey,
-      completedAt,
-      costCurrency: input.usage.costCurrency ?? null,
-      createdAt: timestampMs,
-      driverInstanceId: input.driverInstanceId,
-      errorCode: null,
-      errorMessage: null,
-      id: createPlatformId<SessionModelCallId>(),
-      inputTokens: toTokenCount(input.usage.inputTokens),
-      metadataJson: buildUsageMetadata(input.usage),
-      model,
-      nativeCallId,
-      outputTokens: toTokenCount(input.usage.outputTokens),
-      provider,
-      sessionId: input.sessionId,
-      sessionRunId: input.sessionRunId,
-      startedAt: run.started_at ?? timestampMs,
-      status: input.status,
-      totalCostUsdMicros: toUsdMicros(input.usage.costAmount),
-      traceId: input.traceId,
-      updatedAt: timestampMs,
-    })
-    .onConflictDoUpdate({
-      set: {
-        cacheCreationTokens: sql`COALESCE(excluded.cache_creation_tokens, ${sessionModelCallsTable.cacheCreationTokens})`,
-        cacheReadTokens: sql`COALESCE(excluded.cache_read_tokens, ${sessionModelCallsTable.cacheReadTokens})`,
-        completedAt: sql`COALESCE(excluded.completed_at, ${sessionModelCallsTable.completedAt})`,
-        costCurrency: sql`COALESCE(excluded.cost_currency, ${sessionModelCallsTable.costCurrency})`,
-        driverInstanceId: sql`excluded.driver_instance_id`,
-        inputTokens: sql`COALESCE(excluded.input_tokens, ${sessionModelCallsTable.inputTokens})`,
-        metadataJson: sql`excluded.metadata_json`,
-        model: sql`excluded.model`,
-        outputTokens: sql`COALESCE(excluded.output_tokens, ${sessionModelCallsTable.outputTokens})`,
-        provider: sql`excluded.provider`,
-        startedAt: sql`COALESCE(${sessionModelCallsTable.startedAt}, excluded.started_at)`,
-        status: sql`CASE
-          WHEN ${sessionModelCallsTable.status} IN ('completed', 'failed')
-            AND excluded.status = 'started'
-            THEN ${sessionModelCallsTable.status}
-          ELSE excluded.status
-        END`,
-        totalCostUsdMicros: sql`COALESCE(excluded.total_cost_usd_micros, ${sessionModelCallsTable.totalCostUsdMicros})`,
-        traceId: sql`excluded.trace_id`,
-        updatedAt: sql`excluded.updated_at`,
-      },
-      target: [sessionModelCallsTable.sessionRunId, sessionModelCallsTable.callKey],
-    })
-    .run();
-
-  await recordRuntimeUsageEvent(database, {
+  const usageEventInput = {
     callKey,
     driverInstanceId: input.driverInstanceId,
     nativeCallId,
@@ -242,7 +189,65 @@ export async function upsertSessionModelCallUsage(
       trigger: run.trigger,
       triggerProvider: run.trigger_provider,
     },
-    usage: input.usage,
+    usage,
+  } satisfies Parameters<typeof createRuntimeUsageEventUpsert>[1];
+
+  await runAppDatabaseBatch(database, (appDatabase) => {
+    const modelCallUpsert = appDatabase
+      .insert(sessionModelCallsTable)
+      .values({
+        cacheCreationTokens: toTokenCount(usage.cachedWriteTokens),
+        cacheReadTokens: toTokenCount(usage.cachedReadTokens),
+        callKey,
+        completedAt,
+        costCurrency: usage.costCurrency ?? null,
+        createdAt: timestampMs,
+        driverInstanceId: input.driverInstanceId,
+        errorCode: null,
+        errorMessage: null,
+        id: createPlatformId<SessionModelCallId>(),
+        inputTokens: toTokenCount(usage.inputTokens),
+        metadataJson: buildUsageMetadata(usage),
+        model,
+        nativeCallId,
+        outputTokens: toTokenCount(usage.outputTokens),
+        provider,
+        sessionId: input.sessionId,
+        sessionRunId: input.sessionRunId,
+        startedAt: run.started_at ?? timestampMs,
+        status: input.status,
+        totalCostUsdMicros: toUsdMicros(usage.costAmount),
+        traceId: input.traceId,
+        updatedAt: timestampMs,
+      })
+      .onConflictDoUpdate({
+        set: {
+          cacheCreationTokens: sql`COALESCE(excluded.cache_creation_tokens, ${sessionModelCallsTable.cacheCreationTokens})`,
+          cacheReadTokens: sql`COALESCE(excluded.cache_read_tokens, ${sessionModelCallsTable.cacheReadTokens})`,
+          completedAt: sql`COALESCE(excluded.completed_at, ${sessionModelCallsTable.completedAt})`,
+          costCurrency: sql`COALESCE(excluded.cost_currency, ${sessionModelCallsTable.costCurrency})`,
+          driverInstanceId: sql`excluded.driver_instance_id`,
+          inputTokens: sql`COALESCE(excluded.input_tokens, ${sessionModelCallsTable.inputTokens})`,
+          metadataJson: sql`excluded.metadata_json`,
+          model: sql`excluded.model`,
+          outputTokens: sql`COALESCE(excluded.output_tokens, ${sessionModelCallsTable.outputTokens})`,
+          provider: sql`excluded.provider`,
+          startedAt: sql`COALESCE(${sessionModelCallsTable.startedAt}, excluded.started_at)`,
+          status: sql`CASE
+            WHEN ${sessionModelCallsTable.status} IN ('completed', 'failed')
+              AND excluded.status = 'started'
+              THEN ${sessionModelCallsTable.status}
+            ELSE excluded.status
+          END`,
+          totalCostUsdMicros: sql`COALESCE(excluded.total_cost_usd_micros, ${sessionModelCallsTable.totalCostUsdMicros})`,
+          traceId: sql`excluded.trace_id`,
+          updatedAt: sql`excluded.updated_at`,
+        },
+        target: [sessionModelCallsTable.sessionRunId, sessionModelCallsTable.callKey],
+      });
+    const usageEventUpsert = createRuntimeUsageEventUpsert(appDatabase, usageEventInput);
+
+    return usageEventUpsert === null ? [modelCallUpsert] : [modelCallUpsert, usageEventUpsert];
   });
 }
 

--- a/apps/api/tests/session-model-call-identity.test.ts
+++ b/apps/api/tests/session-model-call-identity.test.ts
@@ -157,6 +157,51 @@ function createSessionModelCallDatabase(): SqliteD1Database {
   return database;
 }
 
+function createUsageLedgerFailingDatabase(database: D1Database): D1Database {
+  let shouldFailUsageLedgerWrite = true;
+
+  function wrapStatement(
+    statement: D1PreparedStatement,
+    isUsageLedgerInsert: boolean,
+  ): D1PreparedStatement {
+    return new Proxy(statement, {
+      get(target, property) {
+        if (property === "bind") {
+          return (...values: unknown[]) =>
+            wrapStatement(target.bind(...values), isUsageLedgerInsert);
+        }
+
+        const value = Reflect.get(target, property);
+
+        if (property === "run" && typeof value === "function") {
+          return (...arguments_: unknown[]) => {
+            if (isUsageLedgerInsert && shouldFailUsageLedgerWrite) {
+              shouldFailUsageLedgerWrite = false;
+              throw new Error("injected usage ledger write failure");
+            }
+
+            return Reflect.apply(value, target, arguments_);
+          };
+        }
+
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+  }
+
+  return new Proxy(database, {
+    get(target, property) {
+      if (property === "prepare") {
+        return (query: string) =>
+          wrapStatement(target.prepare(query), /insert\s+into\s+["`]usage_event["`]/iu.test(query));
+      }
+
+      const value = Reflect.get(target, property);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
 async function seedRunIdentity(
   database: SqliteD1Database,
   input: {
@@ -394,5 +439,54 @@ describe("session model call identity", () => {
         usage,
       }),
     ).rejects.toThrow("Session run not found for model call usage.");
+  });
+
+  test("rolls back the model call when its usage ledger write fails, then recovers once", async () => {
+    const database = createSessionModelCallDatabase();
+    await seedRunIdentity(database);
+    const usage = {
+      callId: "atomic-ledger-call",
+      inputTokens: 10,
+      outputTokens: 5,
+      source: "prompt_response",
+      usageContract: "openai_total_with_cached_breakdown",
+    } satisfies SessionUsageSummary;
+    const input = {
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      sessionId: SESSION_ID,
+      sessionRunId: SESSION_RUN_ID,
+      status: "completed" as const,
+      traceId: "trace-atomic-ledger",
+      usage,
+    };
+
+    await expect(
+      upsertSessionModelCallUsage(createUsageLedgerFailingDatabase(database), input),
+    ).rejects.toThrow("injected usage ledger write failure");
+
+    expect(
+      await database
+        .prepare("SELECT COUNT(*) AS count FROM session_model_call")
+        .first<{ count: number }>(),
+    ).toEqual({ count: 0 });
+    expect(
+      await database
+        .prepare("SELECT COUNT(*) AS count FROM usage_event")
+        .first<{ count: number }>(),
+    ).toEqual({ count: 0 });
+
+    await upsertSessionModelCallUsage(database, input);
+    await upsertSessionModelCallUsage(database, input);
+
+    expect(
+      await database
+        .prepare("SELECT COUNT(*) AS count FROM session_model_call")
+        .first<{ count: number }>(),
+    ).toEqual({ count: 1 });
+    expect(
+      await database
+        .prepare("SELECT COUNT(*) AS count FROM usage_event")
+        .first<{ count: number }>(),
+    ).toEqual({ count: 1 });
   });
 });


### PR DESCRIPTION
## Summary

- Commit `session_model_call` and its corresponding `usage_event` in one D1 batch.
- Extract the usage-ledger upsert builder so the existing standalone service and the model-call transaction share identical pricing and source-identity semantics.
- Preserve both unique retry boundaries: `(session_run_id, call_key)` for model calls and `(source, source_event_id)` for usage events.
- Add a D1 boundary-injection regression proving failure rollback and exactly-once retry convergence.
- Fixes #322.

**Dependency: #324 must merge first.** This branch is intentionally stacked on `fix/cost-reported-usage`; until #324 lands, GitHub will show that prerequisite commit in this PR's comparison.

## Why

The previous runtime persistence sequence committed `session_model_call` before writing `usage_event`. A transient failure on the second write left contradictory durable state: the model call and its usage could exist in one table while App Usage, exports, and rollups omitted it.

A single D1 batch removes that partial-commit state. If either statement fails, both roll back; replaying the same runtime event then converges through the existing unique keys without duplicate cost.

This is a forward consistency fix. It does not guess at or mutate possible historical partial rows created before deployment. The separate, retention-aware audit and reconciliation boundary is tracked in #323.

## Verification

- Commands:
  - `just test-package @mosoo/api` — 965 passed, 0 failed across 165 files.
  - `just tc-package @mosoo/api` — passed.
  - `just lint` — passed, including formatting checks and generated Worker type validation.
  - `just commit-check` — passed for both stacked Conventional Commits.
  - `git diff --check fix/cost-reported-usage...HEAD` — passed.
- Manual steps:
  - Invoked the real `upsertSessionModelCallUsage()` repository/service path against the local SQLite D1 fixture.
  - Injected a failure only on the first `usage_event` insert inside the D1 batch.
  - Verified the rejected attempt left zero `session_model_call` rows and zero `usage_event` rows.
  - Retried the identical input twice and verified exactly one model-call row and one usage-ledger row.
  - Verified runtime event receipts remain downstream of this transaction, so a later receipt failure replays through the same idempotent upserts.
- Not run:
  - No remote Cloudflare Worker/D1 deployment, provider request, Queue, production database, or billable resource was used. The local adapter executes the real repository statements in a transaction and the injected test validates the CF D1 batch boundary contract locally; this is not a claim of observing a remote production incident.

## Impact

- User/API/contract changes:
  - No public GraphQL, HTTP, or shared payload shape changes.
  - Successful model-call persistence produces the same rows and pricing values as before.
  - On a ledger-write failure, the model-call row now rolls back instead of remaining as a contradictory diagnostic record. This failure-state change is necessary to preserve cost consistency.
- Generated files / GraphQL / DB / lockfile:
  - N/A. No schema, migration, generated file, submodule, or lockfile change.
- Env or config changes:
  - N/A.
- Risk and rollback:
  - The primary risk is coupling two writes into one transaction, increasing the scope of a statement failure; the intended result is fail-closed with neither fact committed.
  - Session/Run foreign-key failure also aborts the entire batch, so an orphan usage row cannot be created through this path.
  - Roll back the top commit after #324 to restore the former sequential writes; no migration is required.
  - Historical pre-fix gaps are not backfilled by this PR and are explicitly tracked in #323.

## Review

- Closest review areas:
  - Runtime event persistence ordering, D1 batch semantics, model-call identity, cost-ledger source identity, and retry behavior.
- Known trade-offs:
  - The Run context read still occurs before the write batch; Session/Run foreign keys make a concurrent deletion fail and roll back both writes.
  - Existing last-write-wins updates for repeated usage payloads remain unchanged.
  - This PR depends on #324 and should be reviewed as the single top commit once that prerequisite merges.
