### PR TITLE
fix(db): reconcile historical model call ledger gaps in consistency

### DIFF
--- a/apps/api/src/modules/api-command/application/api-command-enqueue.ts
+++ b/apps/api/src/modules/api-command/application/api-command-enqueue.ts
@@ -5,6 +5,7 @@ import { enqueueApiCommand } from "./api-command-ledger";
 import type {
   AppDeploymentRunDispatchCommandPayload,
   ChannelWorkTriggerCommandPayload,
+  CostLedgerReconciliationCommandPayload,
   ScheduledMaintenanceCommandPayload,
   SessionRunDispatchCommandPayload,
 } from "./api-command-payload";
@@ -37,6 +38,22 @@ export async function enqueueChannelWorkTriggerCommand(
   await enqueueApiCommand(bindings, {
     dedupeKey: createChannelWorkTriggerDedupeKey(payload),
     kind: "channel_work_trigger",
+    payload,
+  });
+}
+
+export async function enqueueCostLedgerReconciliationCommand(
+  bindings: Pick<ApiBindings, "API_COMMAND_QUEUE" | "DB">,
+  payload: CostLedgerReconciliationCommandPayload,
+): Promise<void> {
+  await enqueueApiCommand(bindings, {
+    dedupeKey: [
+      "cost_ledger_reconciliation",
+      payload.scheduledTime,
+      payload.mode,
+      payload.cursor ?? "start",
+    ].join(":"),
+    kind: "cost_ledger_reconciliation",
     payload,
   });
 }

--- a/apps/api/src/modules/api-command/application/api-command-payload.ts
+++ b/apps/api/src/modules/api-command/application/api-command-payload.ts
@@ -15,10 +15,15 @@ import type { DiscordWorkTrigger } from "../../channels/discord/discord-events";
 import type { LarkWorkTrigger } from "../../channels/lark/lark-events";
 import type { SlackWorkTrigger } from "../../channels/slack/slack-events";
 import type { TelegramWorkTrigger } from "../../channels/telegram/telegram-events";
+import type {
+  CostLedgerReconciliationCursor,
+  CostLedgerReconciliationMode,
+} from "../../cost/application/cost-ledger-reconciliation.service";
 
 type ApiCommandPayload =
   | AppDeploymentRunDispatchCommandPayload
   | ChannelWorkTriggerCommandPayload
+  | CostLedgerReconciliationCommandPayload
   | ScheduledMaintenanceCommandPayload
   | SessionRunDispatchCommandPayload;
 
@@ -53,6 +58,12 @@ export type ChannelWorkTriggerCommandPayload =
     };
 
 export interface ScheduledMaintenanceCommandPayload {
+  scheduledTime: number;
+}
+
+export interface CostLedgerReconciliationCommandPayload {
+  cursor: CostLedgerReconciliationCursor | null;
+  mode: CostLedgerReconciliationMode;
   scheduledTime: number;
 }
 
@@ -436,6 +447,35 @@ function parseScheduledMaintenancePayload(value: unknown): ScheduledMaintenanceC
   };
 }
 
+function parseCostLedgerReconciliationPayload(
+  value: unknown,
+): CostLedgerReconciliationCommandPayload {
+  const label = "cost_ledger_reconciliation payload";
+  const record = requireRecord(value, label);
+  const cursor = readOptionalString(record, "cursor", label);
+  const mode = readNonEmptyString(record, "mode", label);
+
+  if (mode !== "audit" && mode !== "repair") {
+    throw new ApiCommandPayloadError(`${label}.mode must be 'audit' or 'repair'.`);
+  }
+
+  if (cursor !== null && cursor.length === 0) {
+    throw new ApiCommandPayloadError(`${label}.cursor must not be empty.`);
+  }
+
+  const scheduledTime = readInteger(record, "scheduledTime", label);
+
+  if (scheduledTime < 0 || !Number.isFinite(new Date(scheduledTime).getTime())) {
+    throw new ApiCommandPayloadError(`${label}.scheduledTime must be a valid timestamp.`);
+  }
+
+  return {
+    cursor,
+    mode,
+    scheduledTime,
+  };
+}
+
 function parseAppDeploymentRunDispatchPayload(
   value: unknown,
 ): AppDeploymentRunDispatchCommandPayload {
@@ -469,6 +509,9 @@ export function parseApiCommandPayload(
     }
     case "channel_work_trigger": {
       return parseChannelWorkTriggerPayload(parsed);
+    }
+    case "cost_ledger_reconciliation": {
+      return parseCostLedgerReconciliationPayload(parsed);
     }
     case "scheduled_maintenance": {
       return parseScheduledMaintenancePayload(parsed);

--- a/apps/api/src/modules/api-command/application/api-command-processor.ts
+++ b/apps/api/src/modules/api-command/application/api-command-processor.ts
@@ -29,10 +29,17 @@ import { processLarkWorkTrigger } from "../../channels/lark/lark-first-party-ada
 import { processSlackWorkTrigger } from "../../channels/slack/slack-first-party-adapter";
 import { parseTelegramCredentials } from "../../channels/telegram/telegram-credentials";
 import { processTelegramWorkTrigger } from "../../channels/telegram/telegram-first-party-adapter";
+import {
+  parseCostLedgerReconciliationActivationMode,
+  reconcileCostLedgerPage,
+} from "../../cost/application/cost-ledger-reconciliation.service";
 import { runUsageDailyRollup } from "../../cost/application/cost-rollup.service";
 import { dispatchQueuedSessionRun } from "../../runtime/application/session-runs/dispatch-queued-run.service";
 import { runSandboxMaintenance } from "../../runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service";
-import { APP_DEPLOYMENT_RUN_DISPATCH_DEDUPE_PREFIX } from "./api-command-enqueue";
+import {
+  APP_DEPLOYMENT_RUN_DISPATCH_DEDUPE_PREFIX,
+  enqueueCostLedgerReconciliationCommand,
+} from "./api-command-enqueue";
 import {
   API_COMMAND_LEASE_RENEWAL_INTERVAL_MS,
   claimApiCommand,
@@ -49,6 +56,7 @@ import { ApiCommandPayloadError, parseApiCommandPayload } from "./api-command-pa
 import type {
   AppDeploymentRunDispatchCommandPayload,
   ChannelWorkTriggerCommandPayload,
+  CostLedgerReconciliationCommandPayload,
   ScheduledMaintenanceCommandPayload,
   SessionRunDispatchCommandPayload,
 } from "./api-command-payload";
@@ -85,6 +93,10 @@ function shouldRunUsageDailyRollup(now: Date): boolean {
   return now.getUTCHours() === 2 && now.getUTCMinutes() === 0;
 }
 
+function shouldStartCostLedgerReconciliation(now: Date): boolean {
+  return now.getUTCHours() === 1 && now.getUTCMinutes() === 0;
+}
+
 async function processScheduledMaintenanceCommand(
   bindings: ApiBindings,
   payload: ScheduledMaintenanceCommandPayload,
@@ -102,7 +114,55 @@ async function processScheduledMaintenanceCommand(
     tasks.push(runUsageDailyRollup(bindings, scheduledAt));
   }
 
+  if (shouldStartCostLedgerReconciliation(scheduledAt)) {
+    const mode = parseCostLedgerReconciliationActivationMode(
+      bindings.MOSOO_COST_LEDGER_RECONCILIATION_MODE,
+    );
+
+    if (mode !== null) {
+      tasks.push(
+        enqueueCostLedgerReconciliationCommand(bindings, {
+          cursor: null,
+          mode,
+          scheduledTime: payload.scheduledTime,
+        }),
+      );
+    }
+  }
+
   await Promise.all(tasks);
+}
+
+async function processCostLedgerReconciliationCommand(
+  bindings: ApiBindings,
+  payload: CostLedgerReconciliationCommandPayload,
+  processedAtMs: number,
+): Promise<void> {
+  const result = await reconcileCostLedgerPage(bindings.DB, {
+    cursor: payload.cursor,
+    mode: payload.mode,
+    now: new Date(processedAtMs),
+  });
+
+  logInfo("cost.ledger_reconciliation.page_completed", {
+    ...result,
+    processedAtMs,
+    scheduledTime: payload.scheduledTime,
+  });
+
+  if (!result.hasMore) {
+    return;
+  }
+
+  if (result.nextCursor === null) {
+    throw new Error("Cost ledger reconciliation returned no cursor for an incomplete page.");
+  }
+
+  await enqueueCostLedgerReconciliationCommand(bindings, {
+    cursor: result.nextCursor,
+    mode: payload.mode,
+    scheduledTime: payload.scheduledTime,
+  });
 }
 
 async function processSlackChannelWorkTrigger(
@@ -436,6 +496,7 @@ function readAppDeploymentRunIdFromPayload(input: {
 async function processClaimedApiCommand(
   bindings: ApiBindings,
   claim: ApiCommandClaim,
+  processedAtMs: number,
 ): Promise<void> {
   const payload = parseApiCommandPayload(claim.kind, claim.payloadJson);
 
@@ -446,6 +507,14 @@ async function processClaimedApiCommand(
     }
     case "channel_work_trigger": {
       await processChannelWorkTriggerCommand(bindings, payload as ChannelWorkTriggerCommandPayload);
+      return;
+    }
+    case "cost_ledger_reconciliation": {
+      await processCostLedgerReconciliationCommand(
+        bindings,
+        payload as CostLedgerReconciliationCommandPayload,
+        processedAtMs,
+      );
       return;
     }
     case "scheduled_maintenance": {
@@ -466,6 +535,7 @@ async function processClaimedApiCommandWithLeaseRenewal(
   bindings: ApiBindings,
   claim: ApiCommandClaim,
   ownerId: string,
+  processedAtMs: number,
 ): Promise<void> {
   let stopped = false;
   let renewal = Promise.resolve();
@@ -503,7 +573,7 @@ async function processClaimedApiCommandWithLeaseRenewal(
   }, API_COMMAND_LEASE_RENEWAL_INTERVAL_MS);
 
   try {
-    await processClaimedApiCommand(bindings, claim);
+    await processClaimedApiCommand(bindings, claim, processedAtMs);
     stopped = true;
     await renewal;
   } finally {
@@ -545,7 +615,7 @@ export async function processApiCommandMessage(
   }
 
   try {
-    await processClaimedApiCommandWithLeaseRenewal(bindings, claim, ownerId);
+    await processClaimedApiCommandWithLeaseRenewal(bindings, claim, ownerId, nowMs());
     await completeApiCommand({
       commandId,
       database: bindings.DB,

--- a/apps/api/src/modules/cost/application/cost-ledger-reconciliation.service.ts
+++ b/apps/api/src/modules/cost/application/cost-ledger-reconciliation.service.ts
@@ -1,0 +1,629 @@
+import type { SessionUsageSummary } from "@mosoo/ag-ui-session";
+import { SESSION_TYPES } from "@mosoo/contracts/session";
+import type { SessionType } from "@mosoo/contracts/session";
+import { SESSION_RUN_TRIGGERS } from "@mosoo/contracts/session-run";
+import type { SessionRunTrigger } from "@mosoo/contracts/session-run";
+import { parsePlatformId } from "@mosoo/id";
+import type {
+  AccountId,
+  AgentDeploymentVersionId,
+  AgentId,
+  DriverInstanceId,
+  OrganizationId,
+  AppId,
+  SessionId,
+  SessionModelCallId,
+  SessionRunId,
+} from "@mosoo/id";
+
+import { createErrorLogContext, logError } from "../../../platform/cloudflare/logger";
+import { getD1ChangeCount, runAppDatabaseBatch } from "../../../platform/db/drizzle";
+import type { AppDatabase } from "../../../platform/db/drizzle";
+import type { UsageContract } from "../domain/usage-contract";
+import { getUsageDetailRetentionCutoffMs } from "./cost-rollup.service";
+import {
+  createRuntimeUsageEventInsertIfMissing,
+  hasRecordableRuntimeUsage,
+} from "./cost-usage-event.service";
+import type { RecordRuntimeUsageEventInput } from "./cost-usage-event.service";
+
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = 100;
+
+export type CostLedgerReconciliationMode = "audit" | "repair";
+export type CostLedgerReconciliationCursor = string;
+
+export type CostLedgerIndeterminateReason =
+  | "ambiguous_existing_ledger_event"
+  | "invalid_platform_identity"
+  | "invalid_run_trigger"
+  | "invalid_session_metadata"
+  | "invalid_session_type"
+  | "invalid_usage_timestamp"
+  | "invalid_usage_metadata"
+  | "invalid_usage_values"
+  | "missing_driver_identity"
+  | "missing_published_revision"
+  | "missing_run_context"
+  | "predates_safe_repair_window";
+
+export interface CostLedgerReconciliationInput {
+  cursor?: CostLedgerReconciliationCursor | null;
+  limit?: number;
+  mode?: CostLedgerReconciliationMode;
+  now?: Date;
+}
+
+export interface CostLedgerReconciliationResult {
+  failed: number;
+  hasMore: boolean;
+  historyBeforeRetentionIndeterminate: boolean;
+  indeterminate: number;
+  indeterminateByReason: Partial<Record<CostLedgerIndeterminateReason, number>>;
+  mode: CostLedgerReconciliationMode;
+  nextCursor: CostLedgerReconciliationCursor | null;
+  present: number;
+  repairable: number;
+  repaired: number;
+  scanned: number;
+  skipped: number;
+}
+
+interface CostLedgerCandidateRow {
+  actor_user_id: string | null;
+  agent_id: string | null;
+  agent_owner_user_id: string | null;
+  agent_revision_id: string | null;
+  app_id: string | null;
+  cache_creation_tokens: number | null;
+  cache_read_tokens: number | null;
+  call_key: string;
+  completed_at: number | null;
+  cost_currency: string | null;
+  created_at: number;
+  driver_instance_id: string | null;
+  input_tokens: number | null;
+  metadata_json: string | null;
+  model: string;
+  model_call_id: string;
+  native_call_id: string | null;
+  organization_id: string | null;
+  output_tokens: number | null;
+  potential_usage_event_id: string | null;
+  provider: string;
+  run_runtime_id: string | null;
+  run_trigger: string | null;
+  resolved_revision_id: string | null;
+  session_id: string;
+  resolved_run_id: string | null;
+  session_run_id: string;
+  session_runtime_id: string | null;
+  session_metadata_valid: number | null;
+  session_type: string | null;
+  total_cost_usd_micros: number | null;
+  trigger_provider: string | null;
+  usage_event_id: string | null;
+}
+
+interface RepairableCostLedgerCandidate {
+  input: RecordRuntimeUsageEventInput;
+}
+
+type ClassifiedCostLedgerCandidate =
+  | { kind: "indeterminate"; reason: CostLedgerIndeterminateReason }
+  | { kind: "present" }
+  | { kind: "repairable"; value: RepairableCostLedgerCandidate }
+  | { kind: "skipped" };
+
+const LIST_USAGE_CANDIDATES_SQL = `
+  WITH model_call_candidates AS (
+    SELECT
+      session_model_call.id AS model_call_id,
+      session_model_call.cache_creation_tokens,
+      session_model_call.cache_read_tokens,
+      session_model_call.call_key,
+      session_model_call.completed_at,
+      session_model_call.cost_currency,
+      session_model_call.created_at,
+      session_model_call.driver_instance_id,
+      session_model_call.input_tokens,
+      session_model_call.metadata_json,
+      session_model_call.model,
+      session_model_call.native_call_id,
+      session_model_call.output_tokens,
+      session_model_call.provider,
+      session_model_call.session_id,
+      session_model_call.session_run_id,
+      session_model_call.total_cost_usd_micros,
+      session_run.id AS resolved_run_id,
+      session_run.agent_id,
+      session_run.created_by_account_id AS actor_user_id,
+      session_run.deployment_version_id AS agent_revision_id,
+      session_run.runtime_id AS run_runtime_id,
+      session_run.trigger AS run_trigger,
+      agent_deployment_version.id AS resolved_revision_id,
+      json_valid(session.metadata_json) AS session_metadata_valid,
+      session.type AS session_type,
+      session.runtime_id AS session_runtime_id,
+      CASE
+        WHEN json_valid(session.metadata_json)
+          THEN json_extract(session.metadata_json, '$.triggered_by.provider')
+        ELSE NULL
+      END AS trigger_provider,
+      agent.owner_account_id AS agent_owner_user_id,
+      app.id AS app_id,
+      app.organization_id,
+      CASE
+        WHEN session_model_call.driver_instance_id IS NULL THEN NULL
+        WHEN session_model_call.native_call_id IS NOT NULL
+          AND trim(session_model_call.native_call_id) <> ''
+          THEN session_model_call.driver_instance_id || ':' || trim(session_model_call.native_call_id)
+        ELSE session_model_call.driver_instance_id || ':' || session_model_call.session_run_id || ':' || session_model_call.call_key
+      END AS expected_source_event_id,
+      CASE
+        WHEN session_model_call.native_call_id IS NOT NULL
+          AND trim(session_model_call.native_call_id) <> ''
+          THEN trim(session_model_call.native_call_id)
+        ELSE session_model_call.session_run_id || ':' || session_model_call.call_key
+      END AS expected_source_event_suffix
+    FROM session_model_call
+    LEFT JOIN session_run
+      ON session_run.id = session_model_call.session_run_id
+    LEFT JOIN session
+      ON session.id = session_model_call.session_id
+      AND session.id = session_run.session_id
+    LEFT JOIN agent
+      ON agent.id = session_run.agent_id
+      AND agent.app_id = session.app_id
+    LEFT JOIN agent_deployment_version
+      ON agent_deployment_version.id = session_run.deployment_version_id
+      AND agent_deployment_version.agent_id = session_run.agent_id
+    LEFT JOIN app
+      ON app.id = session.app_id
+    WHERE session_model_call.id < ?
+      AND COALESCE(session_model_call.completed_at, session_model_call.created_at) >= ?
+  )
+  SELECT
+    model_call_candidates.*,
+    usage_event.id AS usage_event_id,
+    (
+      SELECT historical_usage_event.id
+      FROM usage_event AS historical_usage_event
+      WHERE historical_usage_event.source = 'runtime_driver'
+        AND historical_usage_event.session_run_id = model_call_candidates.session_run_id
+        AND instr(historical_usage_event.source_event_id, ':') > 0
+        AND substr(
+          historical_usage_event.source_event_id,
+          instr(historical_usage_event.source_event_id, ':') + 1
+        ) = model_call_candidates.expected_source_event_suffix
+        AND (
+          model_call_candidates.expected_source_event_id IS NULL
+          OR historical_usage_event.source_event_id <> model_call_candidates.expected_source_event_id
+        )
+      LIMIT 1
+    ) AS potential_usage_event_id
+  FROM model_call_candidates
+  LEFT JOIN usage_event
+    ON usage_event.source = 'runtime_driver'
+    AND usage_event.source_event_id = model_call_candidates.expected_source_event_id
+  ORDER BY model_call_candidates.model_call_id DESC
+  LIMIT ?
+`;
+
+const HAS_HISTORY_BEFORE_RETENTION_SQL = `
+  SELECT 1 AS found
+  FROM session_model_call
+  WHERE COALESCE(completed_at, created_at) < ?
+    AND (
+      COALESCE(input_tokens, 0) > 0
+      OR COALESCE(output_tokens, 0) > 0
+      OR COALESCE(cache_read_tokens, 0) > 0
+      OR COALESCE(cache_creation_tokens, 0) > 0
+      OR (
+        cost_currency = 'USD'
+        AND total_cost_usd_micros IS NOT NULL
+        AND total_cost_usd_micros >= 0
+      )
+    )
+  LIMIT 1
+`;
+
+function requirePageSize(value: number | undefined): number {
+  const pageSize = value ?? DEFAULT_PAGE_SIZE;
+
+  if (!Number.isSafeInteger(pageSize) || pageSize < 1 || pageSize > MAX_PAGE_SIZE) {
+    throw new Error(`Cost ledger reconciliation limit must be between 1 and ${MAX_PAGE_SIZE}.`);
+  }
+
+  return pageSize;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readUsageSource(value: unknown): SessionUsageSummary["source"] | null {
+  return value === "prompt_response" || value === "session_update" ? value : null;
+}
+
+function readUsageContract(value: unknown): UsageContract | null {
+  if (
+    value === "anthropic_bucketed" ||
+    value === "openai_runtime_total_with_cached_breakdown" ||
+    value === "openai_total_with_cached_breakdown"
+  ) {
+    return value;
+  }
+
+  return null;
+}
+
+function restoreStoredUsage(row: CostLedgerCandidateRow): SessionUsageSummary | null {
+  if (row.metadata_json === null) {
+    return null;
+  }
+
+  let metadata: unknown;
+  try {
+    metadata = JSON.parse(row.metadata_json) as unknown;
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(metadata)) {
+    return null;
+  }
+
+  const source = readUsageSource(metadata["source"]);
+  const usageContract = readUsageContract(metadata["usageContract"]);
+
+  if (source === null || usageContract === null) {
+    return null;
+  }
+
+  return {
+    cachedReadTokens: row.cache_read_tokens,
+    cachedWriteTokens: row.cache_creation_tokens,
+    callId: row.native_call_id,
+    costAmount: row.total_cost_usd_micros === null ? null : row.total_cost_usd_micros / 1_000_000,
+    costCurrency: row.cost_currency,
+    inputTokens: row.input_tokens,
+    outputTokens: row.output_tokens,
+    source,
+    usageContract,
+  };
+}
+
+function isSessionType(value: string | null): value is SessionType {
+  return value !== null && SESSION_TYPES.some((candidate) => candidate === value);
+}
+
+function isSessionRunTrigger(value: string | null): value is SessionRunTrigger {
+  return value !== null && SESSION_RUN_TRIGGERS.some((candidate) => candidate === value);
+}
+
+function normalizeNativeCallId(value: string | null): string | null {
+  const normalized = value?.trim() ?? "";
+  return normalized.length > 0 ? normalized : null;
+}
+
+function hasStoredRecordableUsage(row: CostLedgerCandidateRow): boolean {
+  return (
+    (row.input_tokens ?? 0) > 0 ||
+    (row.output_tokens ?? 0) > 0 ||
+    (row.cache_read_tokens ?? 0) > 0 ||
+    (row.cache_creation_tokens ?? 0) > 0 ||
+    (row.cost_currency === "USD" &&
+      row.total_cost_usd_micros !== null &&
+      row.total_cost_usd_micros >= 0)
+  );
+}
+
+function hasValidStoredUsageValues(row: CostLedgerCandidateRow): boolean {
+  return [
+    row.input_tokens,
+    row.output_tokens,
+    row.cache_read_tokens,
+    row.cache_creation_tokens,
+    row.total_cost_usd_micros,
+  ].every((value) => value === null || (Number.isSafeInteger(value) && value >= 0));
+}
+
+function classifyCandidate(
+  row: CostLedgerCandidateRow,
+  cutoffMs: number,
+  nowMs: number,
+): ClassifiedCostLedgerCandidate {
+  if (row.usage_event_id !== null) {
+    return { kind: "present" };
+  }
+
+  if (row.potential_usage_event_id !== null) {
+    return { kind: "indeterminate", reason: "ambiguous_existing_ledger_event" };
+  }
+
+  if (!hasValidStoredUsageValues(row)) {
+    return { kind: "indeterminate", reason: "invalid_usage_values" };
+  }
+
+  if (!hasStoredRecordableUsage(row)) {
+    return { kind: "skipped" };
+  }
+
+  if (row.driver_instance_id === null) {
+    return { kind: "indeterminate", reason: "missing_driver_identity" };
+  }
+
+  const usageTimestamp = row.completed_at ?? row.created_at;
+
+  if (
+    !Number.isSafeInteger(row.created_at) ||
+    row.created_at < 0 ||
+    row.created_at > nowMs ||
+    !Number.isSafeInteger(usageTimestamp) ||
+    usageTimestamp < 0 ||
+    usageTimestamp > nowMs
+  ) {
+    return { kind: "indeterminate", reason: "invalid_usage_timestamp" };
+  }
+
+  if (row.created_at < cutoffMs) {
+    return { kind: "indeterminate", reason: "predates_safe_repair_window" };
+  }
+
+  const usage = restoreStoredUsage(row);
+
+  if (usage === null) {
+    return { kind: "indeterminate", reason: "invalid_usage_metadata" };
+  }
+
+  if (!hasRecordableRuntimeUsage(usage)) {
+    return { kind: "skipped" };
+  }
+
+  if (
+    row.resolved_run_id === null ||
+    row.actor_user_id === null ||
+    row.agent_id === null ||
+    row.agent_owner_user_id === null ||
+    row.app_id === null ||
+    row.organization_id === null ||
+    (row.run_runtime_id === null && row.session_runtime_id === null)
+  ) {
+    return { kind: "indeterminate", reason: "missing_run_context" };
+  }
+
+  if (row.agent_revision_id === null || row.resolved_revision_id === null) {
+    return { kind: "indeterminate", reason: "missing_published_revision" };
+  }
+
+  if (!isSessionType(row.session_type)) {
+    return { kind: "indeterminate", reason: "invalid_session_type" };
+  }
+
+  if (row.session_type === "api_channel" && row.session_metadata_valid !== 1) {
+    return { kind: "indeterminate", reason: "invalid_session_metadata" };
+  }
+
+  if (!isSessionRunTrigger(row.run_trigger)) {
+    return { kind: "indeterminate", reason: "invalid_run_trigger" };
+  }
+
+  try {
+    parsePlatformId<SessionModelCallId>(row.model_call_id, "model call ID");
+    const sessionRunId = parsePlatformId<SessionRunId>(row.session_run_id, "session run ID");
+    const input: RecordRuntimeUsageEventInput = {
+      callKey: row.call_key,
+      driverInstanceId: parsePlatformId<DriverInstanceId>(
+        row.driver_instance_id,
+        "driver instance ID",
+      ),
+      nativeCallId: normalizeNativeCallId(row.native_call_id),
+      run: {
+        actorUserId: parsePlatformId<AccountId>(row.actor_user_id, "actor user ID"),
+        agentId: parsePlatformId<AgentId>(row.agent_id, "agent ID"),
+        agentOwnerUserId: parsePlatformId<AccountId>(
+          row.agent_owner_user_id,
+          "agent owner user ID",
+        ),
+        agentRevisionId: parsePlatformId<AgentDeploymentVersionId>(
+          row.agent_revision_id,
+          "agent revision ID",
+        ),
+        agentStatus: "published",
+        createdAtMs: row.completed_at ?? row.created_at,
+        model: row.model,
+        organizationId: parsePlatformId<OrganizationId>(row.organization_id, "organization ID"),
+        appId: parsePlatformId<AppId>(row.app_id, "app ID"),
+        provider: row.provider,
+        runtimeId: row.run_runtime_id ?? row.session_runtime_id,
+        sessionId: parsePlatformId<SessionId>(row.session_id, "session ID"),
+        sessionType: row.session_type,
+        sessionRunId,
+        trigger: row.run_trigger,
+        triggerProvider: row.trigger_provider,
+      },
+      usage,
+    };
+
+    return { kind: "repairable", value: { input } };
+  } catch {
+    return { kind: "indeterminate", reason: "invalid_platform_identity" };
+  }
+}
+
+async function listUsageCandidates(
+  database: D1Database,
+  input: {
+    cursor: CostLedgerReconciliationCursor | null;
+    cutoffMs: number;
+    limit: number;
+  },
+): Promise<CostLedgerCandidateRow[]> {
+  const result = await database
+    .prepare(LIST_USAGE_CANDIDATES_SQL)
+    .bind(input.cursor ?? "~", input.cutoffMs, input.limit)
+    .all<CostLedgerCandidateRow>();
+
+  return result.results;
+}
+
+async function hasHistoryBeforeRetention(database: D1Database, cutoffMs: number): Promise<boolean> {
+  const row = await database
+    .prepare(HAS_HISTORY_BEFORE_RETENTION_SQL)
+    .bind(cutoffMs)
+    .first<{ found: number }>();
+
+  return row !== null;
+}
+
+function incrementIndeterminateReason(
+  reasons: Partial<Record<CostLedgerIndeterminateReason, number>>,
+  reason: CostLedgerIndeterminateReason,
+): void {
+  reasons[reason] = (reasons[reason] ?? 0) + 1;
+}
+
+async function repairCandidates(
+  database: D1Database,
+  candidates: readonly RepairableCostLedgerCandidate[],
+  cursor: CostLedgerReconciliationCursor | null,
+): Promise<{ present: number; repaired: number }> {
+  if (candidates.length === 0) {
+    return { present: 0, repaired: 0 };
+  }
+
+  const firstCandidate = candidates[0];
+
+  if (firstCandidate === undefined) {
+    return { present: 0, repaired: 0 };
+  }
+
+  const remainingCandidates = candidates.slice(1);
+
+  function createRepairQuery(appDatabase: AppDatabase, candidate: RepairableCostLedgerCandidate) {
+    const query = createRuntimeUsageEventInsertIfMissing(appDatabase, candidate.input);
+
+    if (query === null) {
+      throw new Error("Repairable cost ledger candidate produced no usage event write.");
+    }
+
+    return query;
+  }
+
+  try {
+    const results = await runAppDatabaseBatch(database, (db) => [
+      createRepairQuery(db, firstCandidate),
+      ...remainingCandidates.map((candidate) => createRepairQuery(db, candidate)),
+    ]);
+    let repaired = 0;
+
+    for (const result of results as readonly unknown[]) {
+      repaired += getD1ChangeCount(result);
+    }
+
+    return {
+      present: candidates.length - repaired,
+      repaired,
+    };
+  } catch (error) {
+    logError("cost.ledger_reconciliation.repair_failed", {
+      ...createErrorLogContext(error),
+      cursor,
+      failed: candidates.length,
+    });
+    throw error;
+  }
+}
+
+export function parseCostLedgerReconciliationActivationMode(
+  value: string | undefined,
+): CostLedgerReconciliationMode | null {
+  const normalized = value?.trim() ?? "";
+
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  if (normalized === "audit" || normalized === "repair") {
+    return normalized;
+  }
+
+  throw new Error("MOSOO_COST_LEDGER_RECONCILIATION_MODE must be unset, 'audit', or 'repair'.");
+}
+
+export async function reconcileCostLedgerPage(
+  database: D1Database,
+  input: CostLedgerReconciliationInput = {},
+): Promise<CostLedgerReconciliationResult> {
+  const cursor = input.cursor ?? null;
+  const limit = requirePageSize(input.limit);
+  const mode = input.mode ?? "audit";
+  const now = input.now ?? new Date();
+  const nowMs = now.getTime();
+
+  if (!Number.isSafeInteger(nowMs) || nowMs < 0) {
+    throw new Error("Cost ledger reconciliation time must be a valid non-negative timestamp.");
+  }
+
+  const cutoffMs = getUsageDetailRetentionCutoffMs(now);
+  const rows = await listUsageCandidates(database, {
+    cursor,
+    cutoffMs,
+    limit: limit + 1,
+  });
+  const pageRows = rows.slice(0, limit);
+  const hasMore = rows.length > limit;
+  const lastRow = pageRows.at(-1);
+  const nextCursor = hasMore && lastRow !== undefined ? lastRow.model_call_id : null;
+  const repairableCandidates: RepairableCostLedgerCandidate[] = [];
+  const indeterminateByReason: Partial<Record<CostLedgerIndeterminateReason, number>> = {};
+  let present = 0;
+  let skipped = 0;
+
+  for (const row of pageRows) {
+    const classified = classifyCandidate(row, cutoffMs, nowMs);
+
+    if (classified.kind === "repairable") {
+      repairableCandidates.push(classified.value);
+      continue;
+    }
+
+    if (classified.kind === "present") {
+      present += 1;
+      continue;
+    }
+
+    if (classified.kind === "skipped") {
+      skipped += 1;
+      continue;
+    }
+
+    incrementIndeterminateReason(indeterminateByReason, classified.reason);
+  }
+
+  const writeResult =
+    mode === "repair"
+      ? await repairCandidates(database, repairableCandidates, cursor)
+      : { present: 0, repaired: 0 };
+  const indeterminate = Object.values(indeterminateByReason).reduce(
+    (total, count) => total + count,
+    0,
+  );
+
+  return {
+    failed: 0,
+    hasMore,
+    historyBeforeRetentionIndeterminate:
+      cursor === null ? await hasHistoryBeforeRetention(database, cutoffMs) : false,
+    indeterminate,
+    indeterminateByReason,
+    mode,
+    nextCursor,
+    present: present + writeResult.present,
+    repairable: repairableCandidates.length,
+    repaired: writeResult.repaired,
+    scanned: pageRows.length,
+    skipped,
+  };
+}

--- a/apps/api/src/modules/cost/application/cost-rollup.service.ts
+++ b/apps/api/src/modules/cost/application/cost-rollup.service.ts
@@ -22,14 +22,25 @@ export function getDailyRollupRetentionCutoffDate(now: Date): string {
   return toUtcDate(cutoff);
 }
 
+export function getUsageDetailRetentionCutoffMs(now: Date): number {
+  const cutoff = startOfUtcDay(now);
+  cutoff.setUTCDate(cutoff.getUTCDate() - DETAIL_RETENTION_DAYS);
+  return cutoff.getTime();
+}
+
 export function createDailyRollupRetentionPredicate(now: Date) {
   return lt(usageDailyRollupsTable.date, getDailyRollupRetentionCutoffDate(now));
 }
 
 export async function runUsageDailyRollup(env: ApiBindings, now = new Date()): Promise<void> {
-  const cutoff = startOfUtcDay(now);
-  cutoff.setUTCDate(cutoff.getUTCDate() - DETAIL_RETENTION_DAYS);
-  const cutoffMs = cutoff.getTime();
+  const cutoffMs = getUsageDetailRetentionCutoffMs(now);
+
+  if (!Number.isSafeInteger(cutoffMs)) {
+    throw new Error("Usage detail retention cutoff must be a valid timestamp.");
+  }
+
+  // Drizzle's D1 batch cannot prepare parameterized db.run(sql) queries.
+  const cutoffSql = sql.raw(String(cutoffMs));
 
   await runAppDatabaseBatch(env.DB, (db) => [
     db.run(sql`
@@ -73,7 +84,7 @@ export async function runUsageDailyRollup(env: ApiBindings, now = new Date()): P
           SUM(CASE WHEN ${usageEventsTable.pricingStatus} = 'unknown' THEN 1 ELSE 0 END)
             AS unpriced_request_count
         FROM ${usageEventsTable}
-        WHERE ${usageEventsTable.createdAt} < ${cutoffMs}
+        WHERE ${usageEventsTable.createdAt} < ${cutoffSql}
         GROUP BY
           ${usageEventsTable.organizationId},
           ${usageEventsTable.appId},

--- a/apps/api/src/modules/cost/application/cost-usage-event.service.ts
+++ b/apps/api/src/modules/cost/application/cost-usage-event.service.ts
@@ -124,23 +124,24 @@ function toUsdMicros(value: number): number {
   return Math.round(value * 1_000_000);
 }
 
-export function createRuntimeUsageEventUpsert(
-  database: AppDatabase,
-  input: RecordRuntimeUsageEventInput,
-) {
+export function hasRecordableRuntimeUsage(usage: SessionUsageSummary): boolean {
+  return (
+    toTokenCount(usage.inputTokens) > 0 ||
+    toTokenCount(usage.outputTokens) > 0 ||
+    toTokenCount(usage.cachedReadTokens) > 0 ||
+    toTokenCount(usage.cachedWriteTokens) > 0 ||
+    toProvidedUsdCost(usage) !== null
+  );
+}
+
+function createRuntimeUsageEventInsert(database: AppDatabase, input: RecordRuntimeUsageEventInput) {
   const rawInputTokens = toTokenCount(input.usage.inputTokens);
   const rawOutputTokens = toTokenCount(input.usage.outputTokens);
   const rawCacheReadTokens = toTokenCount(input.usage.cachedReadTokens);
   const rawCacheCreationTokens = toTokenCount(input.usage.cachedWriteTokens);
   const providedCostUsd = toProvidedUsdCost(input.usage);
 
-  if (
-    rawInputTokens === 0 &&
-    rawOutputTokens === 0 &&
-    rawCacheReadTokens === 0 &&
-    rawCacheCreationTokens === 0 &&
-    providedCostUsd === null
-  ) {
+  if (!hasRecordableRuntimeUsage(input.usage)) {
     return null;
   }
 
@@ -169,50 +170,75 @@ export function createRuntimeUsageEventUpsert(
     ? `${input.driverInstanceId}:${input.nativeCallId}`
     : `${input.driverInstanceId}:${input.run.sessionRunId}:${input.callKey}`;
 
-  return database
-    .insert(usageEventsTable)
-    .values({
-      actorUserId: input.run.actorUserId,
-      agentId: input.run.agentId,
-      agentOwnerUserId: input.run.agentOwnerUserId,
-      agentPublicationStateAtRun: resolvePublicationState(input.run),
-      agentRevisionId: input.run.agentRevisionId,
-      cacheCreationTokens: tokens.cacheCreationTokens,
-      cacheReadTokens: tokens.cacheReadTokens,
-      createdAt: input.run.createdAtMs,
-      id: createPlatformId(),
-      inputTokens: tokens.inputTokens,
-      model,
-      organizationId: input.run.organizationId,
-      appId: input.run.appId,
-      outputTokens: tokens.outputTokens,
-      priceSnapshotJson: cost.priceSnapshotJson,
-      pricingStatus: cost.pricingStatus,
-      provider,
-      runPurpose: resolveRunPurpose(input.run),
-      runtimeId: input.run.runtimeId,
-      sessionId: input.run.sessionId,
-      sessionRunId: input.run.sessionRunId,
-      source,
-      sourceEventId,
-      totalCostUsdMicros: toUsdMicros(cost.totalCostUsd),
-      usageContract,
-    })
-    .onConflictDoUpdate({
-      set: {
-        cacheCreationTokens: sql`excluded.cache_creation_tokens`,
-        cacheReadTokens: sql`excluded.cache_read_tokens`,
-        inputTokens: sql`excluded.input_tokens`,
-        model: sql`excluded.model`,
-        outputTokens: sql`excluded.output_tokens`,
-        priceSnapshotJson: sql`excluded.price_snapshot_json`,
-        pricingStatus: sql`excluded.pricing_status`,
-        provider: sql`excluded.provider`,
-        totalCostUsdMicros: sql`excluded.total_cost_usd_micros`,
-        usageContract: sql`excluded.usage_contract`,
-      },
-      target: [usageEventsTable.source, usageEventsTable.sourceEventId],
-    });
+  return database.insert(usageEventsTable).values({
+    actorUserId: input.run.actorUserId,
+    agentId: input.run.agentId,
+    agentOwnerUserId: input.run.agentOwnerUserId,
+    agentPublicationStateAtRun: resolvePublicationState(input.run),
+    agentRevisionId: input.run.agentRevisionId,
+    cacheCreationTokens: tokens.cacheCreationTokens,
+    cacheReadTokens: tokens.cacheReadTokens,
+    createdAt: input.run.createdAtMs,
+    id: createPlatformId(),
+    inputTokens: tokens.inputTokens,
+    model,
+    organizationId: input.run.organizationId,
+    appId: input.run.appId,
+    outputTokens: tokens.outputTokens,
+    priceSnapshotJson: cost.priceSnapshotJson,
+    pricingStatus: cost.pricingStatus,
+    provider,
+    runPurpose: resolveRunPurpose(input.run),
+    runtimeId: input.run.runtimeId,
+    sessionId: input.run.sessionId,
+    sessionRunId: input.run.sessionRunId,
+    source,
+    sourceEventId,
+    totalCostUsdMicros: toUsdMicros(cost.totalCostUsd),
+    usageContract,
+  });
+}
+
+export function createRuntimeUsageEventUpsert(
+  database: AppDatabase,
+  input: RecordRuntimeUsageEventInput,
+) {
+  const query = createRuntimeUsageEventInsert(database, input);
+
+  if (query === null) {
+    return null;
+  }
+
+  return query.onConflictDoUpdate({
+    set: {
+      cacheCreationTokens: sql`excluded.cache_creation_tokens`,
+      cacheReadTokens: sql`excluded.cache_read_tokens`,
+      inputTokens: sql`excluded.input_tokens`,
+      model: sql`excluded.model`,
+      outputTokens: sql`excluded.output_tokens`,
+      priceSnapshotJson: sql`excluded.price_snapshot_json`,
+      pricingStatus: sql`excluded.pricing_status`,
+      provider: sql`excluded.provider`,
+      totalCostUsdMicros: sql`excluded.total_cost_usd_micros`,
+      usageContract: sql`excluded.usage_contract`,
+    },
+    target: [usageEventsTable.source, usageEventsTable.sourceEventId],
+  });
+}
+
+export function createRuntimeUsageEventInsertIfMissing(
+  database: AppDatabase,
+  input: RecordRuntimeUsageEventInput,
+) {
+  const query = createRuntimeUsageEventInsert(database, input);
+
+  if (query === null) {
+    return null;
+  }
+
+  return query.onConflictDoNothing({
+    target: [usageEventsTable.source, usageEventsTable.sourceEventId],
+  });
 }
 
 export async function recordRuntimeUsageEvent(

--- a/apps/api/src/platform/cloudflare/worker-types.ts
+++ b/apps/api/src/platform/cloudflare/worker-types.ts
@@ -42,6 +42,10 @@ interface OptionalRuntimeBindings {
   MOSOO_RUNTIME_NO_PROXY?: string;
 }
 
+interface OptionalCostLedgerReconciliationBindings {
+  MOSOO_COST_LEDGER_RECONCILIATION_MODE?: string;
+}
+
 export interface OptionalSlackAdapterBindings {
   MOSOO_AGENT_ID?: string;
   MOSOO_API_BASE_URL?: string;
@@ -77,6 +81,7 @@ export type ApiBindings = Env &
   OptionalSandboxBinding &
   OptionalDriverConnectionBinding &
   OptionalSessionBinding &
+  OptionalCostLedgerReconciliationBindings &
   OptionalLocalProviderFetchProxyBindings &
   OptionalRuntimeBindings &
   OptionalSlackAdapterBindings &

--- a/apps/api/tests/cost-ledger-reconciliation.test.ts
+++ b/apps/api/tests/cost-ledger-reconciliation.test.ts
@@ -1,0 +1,993 @@
+import { describe, expect, test } from "bun:test";
+
+import { apiCommandsTable } from "@mosoo/db";
+import { eq } from "drizzle-orm";
+
+import { enqueueCostLedgerReconciliationCommand } from "../src/modules/api-command/application/api-command-enqueue";
+import type { ApiCommandMessage } from "../src/modules/api-command/application/api-command-message";
+import { parseApiCommandPayload } from "../src/modules/api-command/application/api-command-payload";
+import { processApiCommandMessage } from "../src/modules/api-command/application/api-command-processor";
+import {
+  parseCostLedgerReconciliationActivationMode,
+  reconcileCostLedgerPage,
+} from "../src/modules/cost/application/cost-ledger-reconciliation.service";
+import { runUsageDailyRollup } from "../src/modules/cost/application/cost-rollup.service";
+import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
+import {
+  createApiCommandQueueStub,
+  createPublicHttpTestBindings,
+  createRecordedQueueMessage,
+} from "./helpers/public-api-http-test-fixture";
+import { SqliteD1Database } from "./helpers/sqlite-d1";
+
+const NOW_MS = Date.parse("2026-06-10T12:00:00.000Z");
+const RECENT_MS = Date.parse("2026-06-09T12:00:00.000Z");
+const BEFORE_RETENTION_MS = Date.parse("2026-06-02T23:59:59.999Z");
+
+const ACTOR_ID = "01J00000000000000000000001";
+const OWNER_ID = "01J00000000000000000000002";
+const ORGANIZATION_ID = "01J00000000000000000000003";
+const APP_ID = "01J00000000000000000000004";
+const AGENT_ID = "01J00000000000000000000005";
+const SESSION_ID = "01J00000000000000000000006";
+const RUN_ID = "01J00000000000000000000007";
+const DEPLOYMENT_ID = "01J00000000000000000000008";
+const DRIVER_INSTANCE_ID = "01J00000000000000000000009";
+const RUN_WITHOUT_REVISION_ID = "01J0000000000000000000000A";
+const HISTORICAL_DRIVER_INSTANCE_ID = "01J0000000000000000000000B";
+
+const MODEL_CALL_IDS = {
+  auditRepairable: "01J00000000000000000000101",
+  auditPresent: "01J00000000000000000000102",
+  auditSkipped: "01J00000000000000000000103",
+  auditInvalidMetadata: "01J00000000000000000000104",
+  auditNoRevision: "01J00000000000000000000105",
+  old: "01J00000000000000000000106",
+  nativeRepair: "01J00000000000000000000107",
+  fallbackRepair: "01J00000000000000000000108",
+  race: "01J00000000000000000000109",
+  batchFirst: "01J0000000000000000000010A",
+  batchSecond: "01J0000000000000000000010B",
+  pageFirst: "01J0000000000000000000010C",
+  pageSecond: "01J0000000000000000000010D",
+  pageThird: "01J0000000000000000000010E",
+  command: "01J0000000000000000000010F",
+  future: "01J0000000000000000000010G",
+  oldCreatedRecentCompletion: "01J0000000000000000000010H",
+  historicalDriver: "01J0000000000000000000010J",
+  invalidValues: "01J0000000000000000000010K",
+  validAfterInvalidId: "01J0000000000000000000010M",
+} as const;
+
+const VALID_USAGE_METADATA = JSON.stringify({
+  source: "prompt_response",
+  usageContract: "openai_total_with_cached_breakdown",
+});
+
+interface ModelCallInput {
+  callKey?: string;
+  completedAt?: number | null;
+  costCurrency?: string | null;
+  createdAt?: number;
+  driverInstanceId?: string | null;
+  id: string;
+  inputTokens?: number | null;
+  metadataJson?: string | null;
+  nativeCallId: string | null;
+  outputTokens?: number | null;
+  runId?: string;
+  totalCostUsdMicros?: number | null;
+}
+
+interface UsageEventProjection {
+  created_at: number;
+  source_event_id: string;
+  total_cost_usd_micros: number;
+}
+
+async function createReconciliationDatabase(): Promise<SqliteD1Database> {
+  const database = new SqliteD1Database({ foreignKeys: false });
+
+  database.execute(`
+    CREATE TABLE app (
+      id text PRIMARY KEY NOT NULL,
+      organization_id text NOT NULL
+    );
+
+    CREATE TABLE agent (
+      id text PRIMARY KEY NOT NULL,
+      owner_account_id text NOT NULL,
+      app_id text NOT NULL,
+      status text NOT NULL
+    );
+
+    CREATE TABLE agent_deployment_version (
+      id text PRIMARY KEY NOT NULL,
+      agent_id text NOT NULL
+    );
+
+    CREATE TABLE session (
+      id text PRIMARY KEY NOT NULL,
+      metadata_json text DEFAULT '{}' NOT NULL,
+      model text NOT NULL,
+      app_id text NOT NULL,
+      provider text NOT NULL,
+      runtime_id text NOT NULL,
+      type text NOT NULL
+    );
+
+    CREATE TABLE session_run (
+      agent_id text NOT NULL,
+      completed_at integer,
+      created_by_account_id text NOT NULL,
+      deployment_version_id text,
+      id text PRIMARY KEY NOT NULL,
+      model text,
+      provider text,
+      runtime_id text,
+      session_id text NOT NULL,
+      started_at integer,
+      trigger text NOT NULL
+    );
+
+    CREATE TABLE session_model_call (
+      cache_creation_tokens integer,
+      cache_read_tokens integer,
+      call_key text NOT NULL,
+      completed_at integer,
+      cost_currency text,
+      created_at integer NOT NULL,
+      driver_instance_id text,
+      error_code text,
+      error_message text,
+      id text PRIMARY KEY NOT NULL,
+      input_tokens integer,
+      metadata_json text,
+      model text NOT NULL,
+      native_call_id text,
+      output_tokens integer,
+      provider text NOT NULL,
+      session_id text NOT NULL,
+      session_run_id text NOT NULL,
+      started_at integer,
+      status text NOT NULL,
+      total_cost_usd_micros integer,
+      trace_id text NOT NULL,
+      updated_at integer NOT NULL,
+      UNIQUE (session_run_id, call_key)
+    );
+
+    CREATE TABLE usage_event (
+      actor_user_id text NOT NULL,
+      agent_id text NOT NULL,
+      agent_owner_user_id text NOT NULL,
+      agent_publication_state_at_run text NOT NULL,
+      agent_revision_id text,
+      cache_creation_tokens integer NOT NULL,
+      cache_read_tokens integer NOT NULL,
+      created_at integer NOT NULL,
+      id text PRIMARY KEY NOT NULL,
+      input_tokens integer NOT NULL,
+      model text NOT NULL,
+      organization_id text NOT NULL,
+      app_id text NOT NULL,
+      output_tokens integer NOT NULL,
+      price_snapshot_json text,
+      pricing_status text NOT NULL,
+      provider text NOT NULL,
+      run_purpose text NOT NULL,
+      runtime_id text,
+      session_id text,
+      session_run_id text,
+      source text NOT NULL,
+      source_event_id text NOT NULL,
+      total_cost_usd_micros integer NOT NULL,
+      usage_contract text NOT NULL,
+      UNIQUE (source, source_event_id)
+    );
+
+    CREATE TABLE usage_daily_rollup (
+      organization_id text NOT NULL,
+      app_id text NOT NULL,
+      agent_id text NOT NULL,
+      actor_user_id text NOT NULL,
+      agent_owner_user_id text NOT NULL,
+      date text NOT NULL,
+      agent_publication_state_at_run text NOT NULL,
+      run_purpose text NOT NULL,
+      provider text NOT NULL,
+      model text NOT NULL,
+      request_count integer NOT NULL,
+      input_tokens integer NOT NULL,
+      output_tokens integer NOT NULL,
+      cache_read_tokens integer NOT NULL,
+      cache_creation_tokens integer NOT NULL,
+      total_cost_usd_micros integer NOT NULL,
+      unpriced_request_count integer NOT NULL,
+      PRIMARY KEY (
+        organization_id,
+        app_id,
+        agent_id,
+        actor_user_id,
+        agent_owner_user_id,
+        date,
+        agent_publication_state_at_run,
+        run_purpose,
+        provider,
+        model
+      )
+    );
+
+    CREATE TABLE api_command (
+      id text PRIMARY KEY NOT NULL,
+      kind text NOT NULL,
+      dedupe_key text NOT NULL,
+      payload_json text NOT NULL,
+      status text NOT NULL,
+      attempt_count integer DEFAULT 0 NOT NULL,
+      claim_owner text,
+      claim_expires_at integer,
+      last_error_code text,
+      last_error_message text,
+      completed_at integer,
+      created_at integer NOT NULL,
+      updated_at integer NOT NULL
+    );
+
+    CREATE UNIQUE INDEX api_command_dedupe_idx ON api_command (dedupe_key);
+  `);
+
+  database.execute(`
+    INSERT INTO app (id, organization_id)
+    VALUES ('${APP_ID}', '${ORGANIZATION_ID}');
+
+    INSERT INTO agent (id, owner_account_id, app_id, status)
+    VALUES ('${AGENT_ID}', '${OWNER_ID}', '${APP_ID}', 'published');
+
+    INSERT INTO agent_deployment_version (id, agent_id)
+    VALUES ('${DEPLOYMENT_ID}', '${AGENT_ID}');
+
+    INSERT INTO session (id, metadata_json, model, app_id, provider, runtime_id, type)
+    VALUES (
+      '${SESSION_ID}',
+      '{}',
+      'custom-model',
+      '${APP_ID}',
+      'custom-provider',
+      'session-runtime',
+      'ui'
+    );
+  `);
+
+  await insertRun(database, RUN_ID, DEPLOYMENT_ID);
+  return database;
+}
+
+async function insertRun(
+  database: SqliteD1Database,
+  runId: string,
+  deploymentVersionId: string | null,
+): Promise<void> {
+  await database
+    .prepare(
+      `
+        INSERT INTO session_run (
+          agent_id,
+          completed_at,
+          created_by_account_id,
+          deployment_version_id,
+          id,
+          model,
+          provider,
+          runtime_id,
+          session_id,
+          started_at,
+          trigger
+        )
+        VALUES (?, ?, ?, ?, ?, 'custom-model', 'custom-provider', 'run-runtime', ?, ?, 'user_prompt')
+      `,
+    )
+    .bind(AGENT_ID, RECENT_MS, ACTOR_ID, deploymentVersionId, runId, SESSION_ID, RECENT_MS - 1_000)
+    .run();
+}
+
+async function insertModelCall(database: D1Database, input: ModelCallInput): Promise<void> {
+  const createdAt = input.createdAt ?? RECENT_MS;
+  const completedAt = input.completedAt === undefined ? createdAt : input.completedAt;
+  const inputTokens = input.inputTokens === undefined ? 10 : input.inputTokens;
+  const outputTokens = input.outputTokens === undefined ? 5 : input.outputTokens;
+  const costCurrency = input.costCurrency === undefined ? "USD" : input.costCurrency;
+  const totalCostUsdMicros =
+    input.totalCostUsdMicros === undefined ? 123_456 : input.totalCostUsdMicros;
+  const metadataJson = input.metadataJson === undefined ? VALID_USAGE_METADATA : input.metadataJson;
+  const callKey =
+    input.callKey ??
+    (input.nativeCallId === null ? `run_usage_${input.id}` : `model_call:${input.nativeCallId}`);
+
+  await database
+    .prepare(
+      `
+        INSERT INTO session_model_call (
+          cache_creation_tokens,
+          cache_read_tokens,
+          call_key,
+          completed_at,
+          cost_currency,
+          created_at,
+          driver_instance_id,
+          id,
+          input_tokens,
+          metadata_json,
+          model,
+          native_call_id,
+          output_tokens,
+          provider,
+          session_id,
+          session_run_id,
+          started_at,
+          status,
+          total_cost_usd_micros,
+          trace_id,
+          updated_at
+        )
+        VALUES (0, 0, ?, ?, ?, ?, ?, ?, ?, ?, 'custom-model', ?, ?, 'custom-provider', ?, ?, ?, 'completed', ?, ?, ?)
+      `,
+    )
+    .bind(
+      callKey,
+      completedAt,
+      costCurrency,
+      createdAt,
+      input.driverInstanceId === undefined ? DRIVER_INSTANCE_ID : input.driverInstanceId,
+      input.id,
+      inputTokens,
+      metadataJson,
+      input.nativeCallId,
+      outputTokens,
+      SESSION_ID,
+      input.runId ?? RUN_ID,
+      createdAt - 1_000,
+      totalCostUsdMicros,
+      `trace-${input.id}`,
+      createdAt,
+    )
+    .run();
+}
+
+async function insertUsageEvent(
+  database: D1Database,
+  input: {
+    createdAt?: number;
+    id: string;
+    sourceEventId: string;
+    totalCostUsdMicros?: number;
+  },
+): Promise<void> {
+  await database
+    .prepare(
+      `
+        INSERT INTO usage_event (
+          actor_user_id,
+          agent_id,
+          agent_owner_user_id,
+          agent_publication_state_at_run,
+          agent_revision_id,
+          cache_creation_tokens,
+          cache_read_tokens,
+          created_at,
+          id,
+          input_tokens,
+          model,
+          organization_id,
+          app_id,
+          output_tokens,
+          price_snapshot_json,
+          pricing_status,
+          provider,
+          run_purpose,
+          runtime_id,
+          session_id,
+          session_run_id,
+          source,
+          source_event_id,
+          total_cost_usd_micros,
+          usage_contract
+        )
+        VALUES (?, ?, ?, 'published', ?, 0, 0, ?, ?, 10, 'custom-model', ?, ?, 5, NULL, 'unknown', 'custom-provider', 'production', 'run-runtime', ?, ?, 'runtime_driver', ?, ?, 'openai_total_with_cached_breakdown')
+      `,
+    )
+    .bind(
+      ACTOR_ID,
+      AGENT_ID,
+      OWNER_ID,
+      DEPLOYMENT_ID,
+      input.createdAt ?? RECENT_MS,
+      input.id,
+      ORGANIZATION_ID,
+      APP_ID,
+      SESSION_ID,
+      RUN_ID,
+      input.sourceEventId,
+      input.totalCostUsdMicros ?? 123_456,
+    )
+    .run();
+}
+
+function createConcurrentRuntimeWriteDatabase(
+  database: SqliteD1Database,
+  input: { sourceEventId: string },
+): D1Database {
+  let inserted = false;
+
+  return new Proxy(database, {
+    get(target, property) {
+      if (property === "batch") {
+        return async <T = unknown>(statements: D1PreparedStatement[]) => {
+          if (!inserted) {
+            inserted = true;
+            await insertUsageEvent(target, {
+              id: "01J00000000000000000000201",
+              sourceEventId: input.sourceEventId,
+              totalCostUsdMicros: 999_999,
+            });
+          }
+
+          return target.batch<T>(statements);
+        };
+      }
+
+      const value = Reflect.get(target, property);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+function createInterruptedBatchDatabase(database: SqliteD1Database): D1Database {
+  return new Proxy(database, {
+    get(target, property) {
+      if (property === "batch") {
+        return async <T = unknown>(statements: D1PreparedStatement[]) => {
+          let runCount = 0;
+          const interruptedStatements = statements.map(
+            (statement) =>
+              new Proxy(statement, {
+                get(statementTarget, statementProperty) {
+                  if (statementProperty === "run") {
+                    return async <R = unknown>() => {
+                      runCount += 1;
+
+                      if (runCount === 2) {
+                        throw new Error("injected reconciliation batch interruption");
+                      }
+
+                      return statementTarget.run<R>();
+                    };
+                  }
+
+                  const value = Reflect.get(statementTarget, statementProperty);
+                  return typeof value === "function" ? value.bind(statementTarget) : value;
+                },
+              }),
+          );
+
+          return target.batch<T>(interruptedStatements);
+        };
+      }
+
+      const value = Reflect.get(target, property);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+async function countUsageEvents(database: D1Database): Promise<number> {
+  const row = await database
+    .prepare("SELECT COUNT(*) AS count FROM usage_event")
+    .first<{ count: number }>();
+  return row?.count ?? 0;
+}
+
+describe("cost ledger reconciliation", () => {
+  test("audits present, repairable, skipped, and indeterminate history without writing", async () => {
+    const database = await createReconciliationDatabase();
+    await insertRun(database, RUN_WITHOUT_REVISION_ID, null);
+
+    await insertModelCall(database, {
+      id: MODEL_CALL_IDS.auditRepairable,
+      nativeCallId: "audit-repairable",
+    });
+    await insertModelCall(database, {
+      id: MODEL_CALL_IDS.auditPresent,
+      nativeCallId: "audit-present",
+    });
+    await insertUsageEvent(database, {
+      id: "01J00000000000000000000202",
+      sourceEventId: `${DRIVER_INSTANCE_ID}:audit-present`,
+    });
+    await insertModelCall(database, {
+      costCurrency: null,
+      id: MODEL_CALL_IDS.auditSkipped,
+      inputTokens: 0,
+      nativeCallId: "audit-skipped",
+      outputTokens: 0,
+      totalCostUsdMicros: null,
+    });
+    await insertModelCall(database, {
+      id: MODEL_CALL_IDS.auditInvalidMetadata,
+      metadataJson: "{invalid",
+      nativeCallId: "audit-invalid-metadata",
+    });
+    await insertModelCall(database, {
+      id: MODEL_CALL_IDS.auditNoRevision,
+      nativeCallId: "audit-no-revision",
+      runId: RUN_WITHOUT_REVISION_ID,
+    });
+    await insertModelCall(database, {
+      completedAt: NOW_MS + 1,
+      createdAt: NOW_MS + 1,
+      id: MODEL_CALL_IDS.future,
+      nativeCallId: "future-call",
+    });
+    await insertModelCall(database, {
+      completedAt: BEFORE_RETENTION_MS,
+      createdAt: BEFORE_RETENTION_MS,
+      id: MODEL_CALL_IDS.old,
+      nativeCallId: "old-history",
+    });
+
+    const result = await reconcileCostLedgerPage(database, {
+      limit: 10,
+      now: new Date(NOW_MS),
+    });
+
+    expect(result).toEqual({
+      failed: 0,
+      hasMore: false,
+      historyBeforeRetentionIndeterminate: true,
+      indeterminate: 3,
+      indeterminateByReason: {
+        invalid_usage_metadata: 1,
+        invalid_usage_timestamp: 1,
+        missing_published_revision: 1,
+      },
+      mode: "audit",
+      nextCursor: null,
+      present: 1,
+      repairable: 1,
+      repaired: 0,
+      scanned: 6,
+      skipped: 1,
+    });
+    expect(await countUsageEvents(database)).toBe(1);
+  });
+
+  test("repairs native and fallback source identities exactly once", async () => {
+    const database = await createReconciliationDatabase();
+    await insertModelCall(database, {
+      id: MODEL_CALL_IDS.nativeRepair,
+      nativeCallId: "native-repair",
+    });
+    await insertModelCall(database, {
+      callKey: "run_usage",
+      id: MODEL_CALL_IDS.fallbackRepair,
+      nativeCallId: null,
+    });
+
+    const first = await reconcileCostLedgerPage(database, {
+      limit: 10,
+      mode: "repair",
+      now: new Date(NOW_MS),
+    });
+    const rows = await database
+      .prepare(
+        `
+          SELECT created_at, source_event_id, total_cost_usd_micros
+          FROM usage_event
+          ORDER BY source_event_id
+        `,
+      )
+      .all<UsageEventProjection>();
+    const second = await reconcileCostLedgerPage(database, {
+      limit: 10,
+      mode: "repair",
+      now: new Date(NOW_MS),
+    });
+
+    expect(first).toMatchObject({
+      present: 0,
+      repairable: 2,
+      repaired: 2,
+      scanned: 2,
+    });
+    expect(rows.results).toEqual([
+      {
+        created_at: RECENT_MS,
+        source_event_id: `${DRIVER_INSTANCE_ID}:${RUN_ID}:run_usage`,
+        total_cost_usd_micros: 123_456,
+      },
+      {
+        created_at: RECENT_MS,
+        source_event_id: `${DRIVER_INSTANCE_ID}:native-repair`,
+        total_cost_usd_micros: 123_456,
+      },
+    ]);
+    expect(second).toMatchObject({
+      present: 2,
+      repairable: 0,
+      repaired: 0,
+      scanned: 2,
+    });
+    expect(await countUsageEvents(database)).toBe(2);
+  });
+
+  test("never repairs history outside the raw-detail retention window", async () => {
+    const database = await createReconciliationDatabase();
+    await insertModelCall(database, {
+      completedAt: BEFORE_RETENTION_MS,
+      createdAt: BEFORE_RETENTION_MS,
+      id: MODEL_CALL_IDS.old,
+      nativeCallId: "old-history",
+    });
+
+    const result = await reconcileCostLedgerPage(database, {
+      mode: "repair",
+      now: new Date(NOW_MS),
+    });
+
+    expect(result).toMatchObject({
+      historyBeforeRetentionIndeterminate: true,
+      repaired: 0,
+      scanned: 0,
+    });
+    expect(await countUsageEvents(database)).toBe(0);
+  });
+
+  test("does not resurrect detail that the daily rollup already consumed", async () => {
+    const database = await createReconciliationDatabase();
+    const sourceEventId = `${DRIVER_INSTANCE_ID}:rolled-history`;
+    await insertModelCall(database, {
+      completedAt: BEFORE_RETENTION_MS,
+      createdAt: BEFORE_RETENTION_MS,
+      id: MODEL_CALL_IDS.old,
+      nativeCallId: "rolled-history",
+    });
+    await insertUsageEvent(database, {
+      createdAt: BEFORE_RETENTION_MS,
+      id: "01J00000000000000000000203",
+      sourceEventId,
+    });
+    const bindings = createPublicHttpTestBindings(database) as ApiBindings;
+
+    await runUsageDailyRollup(bindings, new Date(NOW_MS));
+    const beforeReconciliation = await database
+      .prepare("SELECT request_count, total_cost_usd_micros FROM usage_daily_rollup ORDER BY date")
+      .all<{ request_count: number; total_cost_usd_micros: number }>();
+    const result = await reconcileCostLedgerPage(database, {
+      mode: "repair",
+      now: new Date(NOW_MS),
+    });
+    const afterReconciliation = await database
+      .prepare("SELECT request_count, total_cost_usd_micros FROM usage_daily_rollup ORDER BY date")
+      .all<{ request_count: number; total_cost_usd_micros: number }>();
+
+    expect(beforeReconciliation.results).toEqual([
+      { request_count: 1, total_cost_usd_micros: 123_456 },
+    ]);
+    expect(result).toMatchObject({
+      historyBeforeRetentionIndeterminate: true,
+      repaired: 0,
+      scanned: 0,
+    });
+    expect(await countUsageEvents(database)).toBe(0);
+    expect(afterReconciliation.results).toEqual(beforeReconciliation.results);
+  });
+
+  test("does not repair a recent completion whose model call predates retention", async () => {
+    const database = await createReconciliationDatabase();
+    await insertModelCall(database, {
+      completedAt: RECENT_MS,
+      createdAt: BEFORE_RETENTION_MS,
+      id: MODEL_CALL_IDS.oldCreatedRecentCompletion,
+      nativeCallId: "old-created-recent-completion",
+    });
+
+    const result = await reconcileCostLedgerPage(database, {
+      mode: "repair",
+      now: new Date(NOW_MS),
+    });
+
+    expect(result).toMatchObject({
+      indeterminate: 1,
+      indeterminateByReason: { predates_safe_repair_window: 1 },
+      repaired: 0,
+      scanned: 1,
+    });
+    expect(await countUsageEvents(database)).toBe(0);
+  });
+
+  test("does not duplicate a ledger event written under a historical driver identity", async () => {
+    const database = await createReconciliationDatabase();
+    await insertModelCall(database, {
+      id: MODEL_CALL_IDS.historicalDriver,
+      nativeCallId: "driver-drift",
+    });
+    await insertUsageEvent(database, {
+      id: "01J00000000000000000000204",
+      sourceEventId: `${HISTORICAL_DRIVER_INSTANCE_ID}:driver-drift`,
+    });
+
+    const result = await reconcileCostLedgerPage(database, {
+      mode: "repair",
+      now: new Date(NOW_MS),
+    });
+
+    expect(result).toMatchObject({
+      indeterminate: 1,
+      indeterminateByReason: { ambiguous_existing_ledger_event: 1 },
+      repaired: 0,
+      scanned: 1,
+    });
+    expect(await countUsageEvents(database)).toBe(1);
+  });
+
+  test("does not normalize invalid historical usage values into a new ledger event", async () => {
+    const database = await createReconciliationDatabase();
+    await insertModelCall(database, {
+      id: MODEL_CALL_IDS.invalidValues,
+      inputTokens: -1,
+      nativeCallId: "invalid-values",
+    });
+
+    const result = await reconcileCostLedgerPage(database, {
+      mode: "repair",
+      now: new Date(NOW_MS),
+    });
+
+    expect(result).toMatchObject({
+      indeterminate: 1,
+      indeterminateByReason: { invalid_usage_values: 1 },
+      repaired: 0,
+      scanned: 1,
+    });
+    expect(await countUsageEvents(database)).toBe(0);
+  });
+
+  test("reports malformed channel session metadata instead of failing or inferring purpose", async () => {
+    const database = await createReconciliationDatabase();
+    await database
+      .prepare("UPDATE session SET metadata_json = '{invalid', type = 'api_channel'")
+      .run();
+    await insertModelCall(database, {
+      id: MODEL_CALL_IDS.auditInvalidMetadata,
+      nativeCallId: "invalid-channel-metadata",
+    });
+
+    const result = await reconcileCostLedgerPage(database, {
+      mode: "repair",
+      now: new Date(NOW_MS),
+    });
+
+    expect(result).toMatchObject({
+      indeterminate: 1,
+      indeterminateByReason: { invalid_session_metadata: 1 },
+      repaired: 0,
+    });
+    expect(await countUsageEvents(database)).toBe(0);
+  });
+
+  test("preserves a concurrent runtime ledger write instead of replacing it", async () => {
+    const database = await createReconciliationDatabase();
+    const sourceEventId = `${DRIVER_INSTANCE_ID}:race-call`;
+    await insertModelCall(database, {
+      id: MODEL_CALL_IDS.race,
+      nativeCallId: "race-call",
+    });
+
+    const result = await reconcileCostLedgerPage(
+      createConcurrentRuntimeWriteDatabase(database, { sourceEventId }),
+      {
+        mode: "repair",
+        now: new Date(NOW_MS),
+      },
+    );
+    const row = await database
+      .prepare("SELECT created_at, source_event_id, total_cost_usd_micros FROM usage_event")
+      .first<UsageEventProjection>();
+
+    expect(result).toMatchObject({ present: 1, repairable: 1, repaired: 0 });
+    expect(row).toEqual({
+      created_at: RECENT_MS,
+      source_event_id: sourceEventId,
+      total_cost_usd_micros: 999_999,
+    });
+  });
+
+  test("rolls back an interrupted repair batch and converges on retry", async () => {
+    const database = await createReconciliationDatabase();
+    await insertModelCall(database, {
+      id: MODEL_CALL_IDS.batchFirst,
+      nativeCallId: "batch-first",
+    });
+    await insertModelCall(database, {
+      id: MODEL_CALL_IDS.batchSecond,
+      nativeCallId: "batch-second",
+    });
+
+    await expect(
+      reconcileCostLedgerPage(createInterruptedBatchDatabase(database), {
+        mode: "repair",
+        now: new Date(NOW_MS),
+      }),
+    ).rejects.toThrow("injected reconciliation batch interruption");
+    expect(await countUsageEvents(database)).toBe(0);
+
+    const retry = await reconcileCostLedgerPage(database, {
+      mode: "repair",
+      now: new Date(NOW_MS),
+    });
+
+    expect(retry).toMatchObject({ repairable: 2, repaired: 2 });
+    expect(await countUsageEvents(database)).toBe(2);
+  });
+
+  test("resumes bounded repair pages with a stable cursor", async () => {
+    const database = await createReconciliationDatabase();
+    for (const [id, nativeCallId] of [
+      [MODEL_CALL_IDS.pageFirst, "page-first"],
+      [MODEL_CALL_IDS.pageSecond, "page-second"],
+      [MODEL_CALL_IDS.pageThird, "page-third"],
+    ] as const) {
+      await insertModelCall(database, { id, nativeCallId });
+    }
+
+    const first = await reconcileCostLedgerPage(database, {
+      limit: 1,
+      mode: "repair",
+      now: new Date(NOW_MS),
+    });
+    const second = await reconcileCostLedgerPage(database, {
+      cursor: first.nextCursor,
+      limit: 1,
+      mode: "repair",
+      now: new Date(NOW_MS),
+    });
+    const third = await reconcileCostLedgerPage(database, {
+      cursor: second.nextCursor,
+      limit: 1,
+      mode: "repair",
+      now: new Date(NOW_MS),
+    });
+
+    expect(first).toMatchObject({ hasMore: true, repaired: 1, scanned: 1 });
+    expect(first.nextCursor).toBe(MODEL_CALL_IDS.pageThird);
+    expect(second).toMatchObject({ hasMore: true, repaired: 1, scanned: 1 });
+    expect(second.nextCursor).toBe(MODEL_CALL_IDS.pageSecond);
+    expect(third).toMatchObject({ hasMore: false, nextCursor: null, repaired: 1, scanned: 1 });
+    expect(await countUsageEvents(database)).toBe(3);
+  });
+
+  test("continues past a corrupt model-call ID without losing the next page", async () => {
+    const database = await createReconciliationDatabase();
+    await insertModelCall(database, {
+      id: "not-a-platform-id",
+      nativeCallId: "invalid-model-call-id",
+    });
+    await insertModelCall(database, {
+      id: MODEL_CALL_IDS.validAfterInvalidId,
+      nativeCallId: "valid-after-invalid-id",
+    });
+
+    const first = await reconcileCostLedgerPage(database, {
+      limit: 1,
+      mode: "repair",
+      now: new Date(NOW_MS),
+    });
+    const second = await reconcileCostLedgerPage(database, {
+      cursor: first.nextCursor,
+      limit: 1,
+      mode: "repair",
+      now: new Date(NOW_MS),
+    });
+
+    expect(first).toMatchObject({
+      hasMore: true,
+      indeterminateByReason: { invalid_platform_identity: 1 },
+      nextCursor: "not-a-platform-id",
+      repaired: 0,
+    });
+    expect(second).toMatchObject({ hasMore: false, repaired: 1, scanned: 1 });
+    expect(await countUsageEvents(database)).toBe(1);
+  });
+
+  test("runs repair through the durable API command ledger and local Queue boundary", async () => {
+    const database = await createReconciliationDatabase();
+    const queue = createApiCommandQueueStub();
+    const bindings = createPublicHttpTestBindings(database, {
+      apiCommandQueue: queue,
+    }) as ApiBindings;
+    await insertModelCall(database, {
+      id: MODEL_CALL_IDS.command,
+      nativeCallId: "command-repair",
+    });
+
+    await enqueueCostLedgerReconciliationCommand(bindings, {
+      cursor: null,
+      mode: "repair",
+      scheduledTime: NOW_MS,
+    });
+    const queued = queue.sent[0]?.body;
+
+    if (queued === undefined) {
+      throw new Error("Expected reconciliation API command to be queued.");
+    }
+
+    const recorded = createRecordedQueueMessage<ApiCommandMessage>({ body: queued });
+    await processApiCommandMessage(bindings, recorded.message, () => NOW_MS);
+
+    const command = await database
+      .app()
+      .select({ kind: apiCommandsTable.kind, status: apiCommandsTable.status })
+      .from(apiCommandsTable)
+      .where(eq(apiCommandsTable.id, queued.commandId))
+      .get();
+
+    expect(command).toEqual({ kind: "cost_ledger_reconciliation", status: "succeeded" });
+    expect(recorded.recorded).toEqual([{ type: "ack" }]);
+    expect(await countUsageEvents(database)).toBe(1);
+  });
+
+  test("does not resurrect rolled detail when a durable command is delayed", async () => {
+    const database = await createReconciliationDatabase();
+    const queue = createApiCommandQueueStub();
+    const bindings = createPublicHttpTestBindings(database, {
+      apiCommandQueue: queue,
+    }) as ApiBindings;
+    await insertModelCall(database, {
+      id: MODEL_CALL_IDS.command,
+      nativeCallId: "delayed-command",
+    });
+    await enqueueCostLedgerReconciliationCommand(bindings, {
+      cursor: null,
+      mode: "repair",
+      scheduledTime: NOW_MS,
+    });
+    const queued = queue.sent[0]?.body;
+
+    if (queued === undefined) {
+      throw new Error("Expected delayed reconciliation API command to be queued.");
+    }
+
+    const recorded = createRecordedQueueMessage<ApiCommandMessage>({ body: queued });
+    const processedAfterRetentionMs = Date.parse("2026-06-18T12:00:00.000Z");
+    await processApiCommandMessage(bindings, recorded.message, () => processedAfterRetentionMs);
+
+    expect(recorded.recorded).toEqual([{ type: "ack" }]);
+    expect(await countUsageEvents(database)).toBe(0);
+  });
+
+  test("fails closed on invalid operator and command modes", () => {
+    expect(parseCostLedgerReconciliationActivationMode(undefined)).toBeNull();
+    expect(parseCostLedgerReconciliationActivationMode(" audit ")).toBe("audit");
+    expect(() => parseCostLedgerReconciliationActivationMode("write")).toThrow(
+      "MOSOO_COST_LEDGER_RECONCILIATION_MODE",
+    );
+    expect(() =>
+      parseApiCommandPayload(
+        "cost_ledger_reconciliation",
+        JSON.stringify({ cursor: null, mode: "write", scheduledTime: NOW_MS }),
+      ),
+    ).toThrow("mode must be 'audit' or 'repair'");
+    expect(
+      parseApiCommandPayload(
+        "cost_ledger_reconciliation",
+        JSON.stringify({ cursor: "opaque-database-key", mode: "audit", scheduledTime: NOW_MS }),
+      ),
+    ).toMatchObject({ cursor: "opaque-database-key" });
+    expect(() =>
+      parseApiCommandPayload(
+        "cost_ledger_reconciliation",
+        JSON.stringify({ cursor: "", mode: "audit", scheduledTime: NOW_MS }),
+      ),
+    ).toThrow("cursor must not be empty");
+  });
+});

--- a/docs/prd/cost-dashboard.md
+++ b/docs/prd/cost-dashboard.md
@@ -24,3 +24,16 @@ The current user is the single owner of the selected App. App Users cannot see t
 The shipped view uses model-call usage recorded by Mosoo. For recognized models, dollar amounts are estimates calculated from observed tokens and Mosoo's reference prices. For an unknown model, Mosoo may retain a reported USD amount; without one, usage remains visible and the model is marked for pricing attention, but the event contributes $0, so totals can be understated.
 
 This view is not a Provider invoice or a Mosoo charge. It does not reconcile taxes, credits, discounts, subscriptions, or infrastructure costs. **All** can include usage types that have no separate filter. On an Agent's Cost tab, the latest seven usage events are shown and currently are not limited by the selected time range. Budgets, alerts, invoices, and payment controls are not available here.
+
+## Historical ledger reconciliation
+
+The API can audit model calls created before atomic model-call and usage-ledger persistence was introduced. The workflow is disabled unless `MOSOO_COST_LEDGER_RECONCILIATION_MODE` is set to `audit` or `repair`:
+
+- `audit` is read-only and reports bounded page counts for present, repairable, skipped, and indeterminate records.
+- `repair` inserts only recent records whose source identity and immutable published-run context can be reconstructed. The existing `(source, source_event_id)` uniqueness boundary makes retries idempotent and prevents reconciliation from replacing a concurrent runtime write.
+- Both modes use durable API commands with cursors. A new run starts at 01:00 UTC, and every page re-evaluates the current retention cutoff so a delayed retry cannot recreate detail that a later daily rollup has already consumed.
+- Only the seven-day raw-detail window is eligible for repair. Older model-call history may already be represented by a daily rollup, so it is reported as indeterminate and is never inserted or used to rewrite an aggregate.
+- Missing driver identity, usage metadata, published revision, or run context is reported as indeterminate instead of being inferred from mutable current state.
+- Calls created before the current raw-detail window, invalid stored usage values, and events that may already exist under a historical driver identity are also indeterminate; repair never normalizes or guesses through these states.
+
+Operators should begin with `audit`, inspect the structured `cost.ledger_reconciliation.page_completed` logs, enable `repair` only after reviewing those classifications, and unset the variable after the intended reconciliation run. This workflow repairs locally provable ledger gaps; it does not compare Mosoo estimates with a Provider invoice.

--- a/pkgs/db/src/schema/api-command.schema.ts
+++ b/pkgs/db/src/schema/api-command.schema.ts
@@ -8,6 +8,7 @@ export type ApiCommandId = SemanticPlatformId<"ApiCommandId">;
 export type ApiCommandKind =
   | "app_deployment_run_dispatch"
   | "channel_work_trigger"
+  | "cost_ledger_reconciliation"
   | "scheduled_maintenance"
   | "session_run_dispatch";
 export type ApiCommandStatus = "dead_lettered" | "failed" | "queued" | "running" | "succeeded";


### PR DESCRIPTION
## Summary

- Add an opt-in, bounded audit and reconciliation workflow for historical `session_model_call` rows that lack their canonical `usage_event` ledger fact.
- Default the service to read-only `audit`; allow explicit `repair` only for recent rows whose source identity, usage values, published revision, and Run/Session/App context can be proven.
- Preserve the existing `(source, source_event_id)` uniqueness boundary and use `ON CONFLICT DO NOTHING` so reconciliation retries converge without replacing a concurrent runtime write.
- Run pages through the durable API command ledger and Queue cursor chain, with structured counts and a retention cutoff recalculated at actual processing time.
- Keep records outside the seven-day raw-detail window, ambiguous historical-driver identities, invalid values, and incomplete context as `indeterminate` instead of guessing or rewriting daily aggregates.
- Make the existing daily rollup raw statement executable inside the current Drizzle D1 batch implementation without changing its cutoff or aggregate-then-delete semantics.
- Fixes #323.

**Dependencies: #324 and #325 must merge first, in that order.** This branch is intentionally stacked on `fix/cost-ledger-recovery` (#325), which is itself stacked on `fix/cost-reported-usage` (#324). Until both prerequisites land, GitHub will show their commits in this PR comparison. The intended merge order is **#324 -> #325 -> this PR**.

## Why

Before #325, model-call persistence and usage-ledger persistence were separate D1 writes. If the first write committed and the second failed, the durable state could contain a valid `session_model_call` without the corresponding cost-ledger row. #325 prevents that partial state for future writes, but it deliberately does not inspect or repair historical rows.

A blind anti-join backfill is unsafe. Raw `usage_event` detail is rolled into `usage_daily_rollup` and deleted after seven days, so an old model call without raw detail may already be represented by an aggregate. A model call can also have an event under a historical driver identity, or lack immutable context needed to reproduce the original dimensions. Reconstructing these cases could double count consumption.

This PR therefore limits mutation to recently created calls that are still inside the same raw-detail retention boundary and can be reconstructed through the canonical runtime ingestion rules. Everything else remains observable but fail-closed. The workflow is disabled by default and operators are expected to run `audit` before enabling `repair`.

## Verification

- Commands:
  - `just check` - passed: formatting, documentation links, lint, all workspace typechecks and tests, and GraphQL codegen freshness. The API suite reported 980 passed, 0 failed, and 3380 assertions across 166 files.
  - `just commit-check` - passed for all 7 stacked commits from `origin/main` through this branch.
  - `git diff --check fix/cost-ledger-recovery...HEAD` - passed.
  - Focused reconciliation suite - 15 passed, 0 failed, and 46 assertions.
- Manual steps:
  - Seeded the real local SQLite D1 repository shape with the historical `session_model_call = 1` / `usage_event = 0` state from the issue reproduction.
  - Verified default audit classifies the gap without mutation, explicit repair creates exactly one canonical event, and a second repair observes the existing event without duplication.
  - Verified native-call and Run/call-key fallback source identities.
  - Injected a failure on the second statement of a real D1 repair batch; verified the first insert rolled back and retry repaired both rows exactly once.
  - Injected a concurrent runtime ledger write between the audit query and repair batch; verified reconciliation did not overwrite its amount or dimensions.
  - Ran the real `runUsageDailyRollup()` path, verified old raw detail moved into `usage_daily_rollup` and was deleted, then verified reconciliation neither resurrected the raw event nor changed the aggregate.
  - Exercised the durable API command ledger and local Queue boundary, including a command delayed beyond retention and cursor continuation past a corrupt model-call ID.
  - Verified historical driver ambiguity, pre-retention call creation, invalid stored usage values, malformed channel metadata, missing revision, and missing context remain non-mutating `indeterminate` states.
- Not run:
  - No remote Cloudflare Worker/D1 deployment, production database read, provider request, production Queue, or billable Cloudflare resource was used.
  - Verification uses the real local service/repository/SQLite D1 path plus injected D1 batch, Queue, concurrency, and Cloudflare boundary failures. It proves local behavior and retry semantics, not that a particular remote production database contains affected rows.

## Impact

- User/API/contract changes:
  - No public GraphQL, HTTP, or shared client payload changes.
  - App Usage, exports, and later rollups can recover only locally provable recent historical omissions.
  - Audit and repair results are emitted as structured logs with scanned, present, repairable, repaired, skipped, indeterminate, and failed information.
- Generated files / GraphQL / DB / lockfile:
  - No generated GraphQL files, D1 migration files, frozen baseline changes, dependency changes, lockfile changes, or submodule changes.
  - `ApiCommandKind` gains a TypeScript command value only; the underlying D1 column is already text and requires no DDL migration.
- Env or config changes:
  - Adds optional `MOSOO_COST_LEDGER_RECONCILIATION_MODE` with exact values `audit` or `repair`.
  - Unset or blank keeps the workflow disabled. When enabled, a new run starts at 01:00 UTC and pages continue through durable Queue commands.
  - Operators should enable `audit`, inspect page logs, switch to `repair` only after review, and unset the variable after the intended run.
- Risk and rollback:
  - Cost consistency is treated fail-closed: uncertain rows are never written, records older than raw retention are never backfilled, and reconciliation never updates an existing daily aggregate.
  - Repair inserts use one D1 atomic batch per bounded page and do not overwrite a concurrent live event.
  - The daily rollup compatibility adjustment preserves its existing seven-day cutoff and atomic aggregate-then-delete behavior; it only avoids the current Drizzle D1 limitation for parameterized `db.run(sql)` batch entries.
  - Code rollback is straightforward by reverting these five top commits. Any ledger rows already inserted by an explicitly enabled repair are durable business records and are intentionally not deleted by code rollback; reversing those would require a targeted, reviewed data correction.

## Review

- Closest review areas:
  - Historical source-identity reconstruction and ambiguity handling.
  - Seven-day detail retention versus daily-rollup boundaries.
  - D1 batch atomicity, uniqueness conflicts, Queue retry/continuation, and actual-processing-time cutoffs.
  - Classification of published revision, Session/Run/App context, and malformed historical data.
- Known trade-offs:
  - History before raw retention is reported as an indeterminate-presence boolean rather than counted or repaired, avoiding an unsafe full-history financial rewrite.
  - The first opt-in page performs a read-only old-history existence probe whose read cost is data-volume dependent; repair writes and cursor pages remain bounded to at most 100 candidates.
  - This workflow reconciles Mosoo's internal operational usage ledger, not provider invoices, taxes, credits, discounts, or infrastructure charges.
  - This PR must not merge before #324 and #325.
