### PR TITLE
feat(runtime): support custom Responses providers

### DIFF
--- a/apps/api/tests/available-models.test.ts
+++ b/apps/api/tests/available-models.test.ts
@@ -127,7 +127,7 @@ function createAvailableModelsDatabase(): SqliteD1Database {
 }
 
 describe("available models", () => {
-  test("keeps custom models visible but unavailable for OpenAI runtime", async () => {
+  test("makes custom models available for OpenAI runtime", async () => {
     const entries = await resolveAvailableModels(createAvailableModelsDatabase(), {
       appId: APP_ID,
       runtimeId: "openai-runtime",
@@ -141,11 +141,10 @@ describe("available models", () => {
         (entry) => entry.vendorId === "openai-compatible" && entry.modelId === "qwen-coder",
       ),
     ).toMatchObject({
-      available: false,
-      reason: "wrong-runtime",
+      available: true,
       source: "custom",
-      statusDetail: "Custom · Custom default is not available for OpenAI Runtime.",
-      statusLabel: "Not available",
+      statusDetail: null,
+      statusLabel: "Available",
     });
     expect(entries.find((entry) => entry.vendorId === "anthropic")).toMatchObject({
       available: false,
@@ -288,7 +287,7 @@ describe("available models", () => {
     });
   });
 
-  test("apps missing current custom models through runtime availability", async () => {
+  test("marks a missing current custom model as needing a key for OpenAI runtime", async () => {
     const entries = await resolveAvailableModels(createAvailableModelsDatabase(), {
       currentModelId: "removed-custom-model",
       currentVendorId: "openai-compatible",
@@ -303,10 +302,10 @@ describe("available models", () => {
       ),
     ).toMatchObject({
       available: false,
-      reason: "wrong-runtime",
+      reason: "needs-key",
       source: "custom",
-      statusDetail: "Custom Provider is not available for OpenAI Runtime.",
-      statusLabel: "Not available",
+      statusDetail: "Configure a Provider key for Custom Provider.",
+      statusLabel: "Provider key required",
     });
   });
 });

--- a/apps/api/tests/runtime-openai-compatible-models.test.ts
+++ b/apps/api/tests/runtime-openai-compatible-models.test.ts
@@ -60,13 +60,38 @@ function createAvailableModelsDatabase(): D1Database {
       1,
       1
     );
+
+    INSERT INTO vendor_credential (
+      api_base,
+      api_key_secret_id,
+      created_at,
+      id,
+      is_default,
+      models,
+      name,
+      app_id,
+      updated_at,
+      vendor_id
+    )
+    VALUES (
+      'https://models.example.com/v1',
+      'secret-custom',
+      1,
+      'credential-custom',
+      true,
+      '["qwen-coder"]',
+      'Custom default',
+      '${APP_ID}',
+      1,
+      '${VENDOR_OPENAI_COMPATIBLE.vendorId}'
+    );
   `);
 
   return database;
 }
 
 describe("OpenAI-compatible runtime model support", () => {
-  test("marks current custom models as wrong-runtime for OpenAI app-server runtime", async () => {
+  test("makes current custom models available for OpenAI app-server runtime", async () => {
     const entries = await resolveAvailableModels(createAvailableModelsDatabase(), {
       currentModelId: "qwen-coder",
       currentVendorId: VENDOR_OPENAI_COMPATIBLE.vendorId,
@@ -79,8 +104,10 @@ describe("OpenAI-compatible runtime model support", () => {
     );
 
     expect(currentCustomEntry).toMatchObject({
-      available: false,
-      reason: "wrong-runtime",
+      available: true,
+      source: "custom",
+      statusDetail: null,
+      statusLabel: "Available",
     });
   });
 

--- a/apps/api/tests/runtime-vendor-env-vars.test.ts
+++ b/apps/api/tests/runtime-vendor-env-vars.test.ts
@@ -16,6 +16,25 @@ import type { RuntimeCatalogVendor } from "@mosoo/runtime-catalog";
 import { buildRuntimeVendorEnvVars } from "../src/modules/runtime/application/session-definition/hydrate-run-context.service";
 
 describe("runtime vendor env vars", () => {
+  test("injects a custom Responses provider for OpenAI runtime", () => {
+    const envVars = buildRuntimeVendorEnvVars({
+      credential: {
+        apiBase: "https://gateway.example.com/v1",
+        apiKey: "sk-custom-responses",
+        credentialId: "01J000000000000000000000C9",
+        models: ["gpt-custom"],
+      },
+      model: "gpt-custom",
+      runtimeId: "openai-runtime",
+      vendor: VENDOR_OPENAI_COMPATIBLE,
+    });
+
+    expect(envVars).toEqual({
+      OPENAI_COMPATIBLE_API_KEY: "sk-custom-responses",
+      OPENAI_COMPATIBLE_BASE_URL: "https://gateway.example.com/v1",
+    });
+  });
+
   test("fails closed before injecting credentials for unsafe stored API bases", () => {
     expect(() =>
       buildRuntimeVendorEnvVars({

--- a/apps/web/src/routes/agent/runtime-default.ts
+++ b/apps/web/src/routes/agent/runtime-default.ts
@@ -7,6 +7,8 @@ import {
 
 import type { VendorCredential } from "@/domains/vendor-credential/api/vendor-credential-client";
 
+const DEFAULT_CUSTOM_PROVIDER_RUNTIME_ID = "acp-fallback";
+
 export interface DefaultAgentRuntimeSelection {
   readonly model: string;
   readonly provider: string;
@@ -64,7 +66,10 @@ export function resolveDefaultAgentRuntime(
       credential.vendorId === VENDOR_OPENAI_COMPATIBLE.vendorId &&
       (credential.models?.length ?? 0) > 0,
   );
-  const customRuntime = PUBLIC_RUNTIME_CATALOG.find((entry) => entry.acceptsCustomProvider);
+  const customRuntime = PUBLIC_RUNTIME_CATALOG.find(
+    (entry) =>
+      entry.runtimeId === DEFAULT_CUSTOM_PROVIDER_RUNTIME_ID && entry.acceptsCustomProvider,
+  );
   const customModel = customCredential?.models?.[0];
 
   if (customCredential !== undefined && customRuntime !== undefined && customModel !== undefined) {

--- a/apps/web/tests/provider-runtime-availability.test.ts
+++ b/apps/web/tests/provider-runtime-availability.test.ts
@@ -62,8 +62,8 @@ describe("provider runtime availability", () => {
       tone: "ready",
     });
     expect(openAiRow).toMatchObject({
-      status: "Needs key · Add OpenAI",
-      tone: "muted",
+      status: "Ready · Custom model configured",
+      tone: "ready",
     });
     expect(claudeRow).toMatchObject({
       status: "Needs key · Add Anthropic",

--- a/docs/prd/credentials.md
+++ b/docs/prd/credentials.md
@@ -20,7 +20,7 @@ The App owner manages credentials. Agents in that same App may use them when the
 
 ## Current Availability and Boundaries
 
-Provider keys and remote MCP credentials are available now, including custom provider endpoints. A connection test is optional and does not make saving conditional on success.
+Provider keys and remote MCP credentials are available now, including custom provider endpoints. Custom OpenAI-compatible credentials can run through OpenCode, or through OpenAI Runtime when the endpoint implements the Responses API. A connection test is optional and does not make saving conditional on success.
 
 Credentials belong to one App and can be managed only by its owner. There is no organization-wide pool, personal key selection, caller-selected key, or cross-App inheritance.
 

--- a/docs/prd/runtime-catalog.md
+++ b/docs/prd/runtime-catalog.md
@@ -20,8 +20,10 @@ The App Owner configures runtime access while creating and editing an Agent. The
 ## Current availability
 
 - **Claude Agent SDK** runs Anthropic Claude models.
-- **OpenAI Runtime** runs OpenAI GPT models.
+- **OpenAI Runtime** runs OpenAI GPT models and custom OpenAI-compatible models that implement the Responses API.
 - **OpenCode** can use Anthropic, OpenAI, DeepSeek, Gemini, Qwen, Kimi, Zhipu, MiniMax, OpenCode Zen, and custom OpenAI-compatible models.
+
+Custom OpenAI-compatible models remain on OpenCode by default because some endpoints implement only Chat Completions. Builders can explicitly select OpenAI Runtime when the configured endpoint implements the Responses API.
 
 The Providers page currently offers those nine named providers plus the custom-model action. A saved key unlocks only models that the selected runtime can run.
 

--- a/pkgs/runtime-catalog/catalog/runtime-catalog.jsonc
+++ b/pkgs/runtime-catalog/catalog/runtime-catalog.jsonc
@@ -464,7 +464,7 @@
       "label": "OpenAI Runtime",
       "visibility": "public",
       "transport": "openai-app-server",
-      "acceptsCustomProvider": false,
+      "acceptsCustomProvider": true,
       "capabilityProfile": "standard",
       "defaultIdentity": {
         "providerId": "openai",

--- a/pkgs/runtime-catalog/src/catalog.generated.ts
+++ b/pkgs/runtime-catalog/src/catalog.generated.ts
@@ -554,7 +554,7 @@ export const GENERATED_RUNTIME_CATALOG = [
     ],
   },
   {
-    acceptsCustomProvider: false,
+    acceptsCustomProvider: true,
     defaultIdentity: {
       modelId: "gpt-5.5",
       providerId: "openai",

--- a/pkgs/runtime-catalog/tests/runtime-model-identity-admission.test.ts
+++ b/pkgs/runtime-catalog/tests/runtime-model-identity-admission.test.ts
@@ -201,7 +201,7 @@ describe("runtime catalog identity admission", () => {
     });
   });
 
-  test("rejects custom providers for OpenAI app-server runtime", () => {
+  test("admits custom providers for OpenAI runtime but not the disabled System Agent", () => {
     const systemAgentRuntime = RUNTIME_CATALOG.find(
       (runtime) => runtime.runtimeId === SYSTEM_AGENT_RUNTIME_ID,
     );
@@ -228,10 +228,13 @@ describe("runtime catalog identity admission", () => {
     );
 
     expect(systemAgentRuntime?.acceptsCustomProvider).toBe(false);
-    expect(openAiRuntime?.acceptsCustomProvider).toBe(false);
+    expect(openAiRuntime?.acceptsCustomProvider).toBe(true);
     expect(custom).toMatchObject({
-      code: "provider-unsupported",
-      ok: false,
+      model: null,
+      ok: true,
+      vendor: {
+        vendorId: VENDOR_OPENAI_COMPATIBLE.vendorId,
+      },
     });
     expect(systemAgentCustom).toMatchObject({
       code: "runtime-disabled",


### PR DESCRIPTION
## Summary

- allow OpenAI Runtime to admit custom OpenAI-compatible model credentials
- pass custom provider base URL and API key through the existing Codex Responses configuration path
- keep OpenCode as the default runtime for custom providers, since some compatible endpoints only implement Chat Completions
- update runtime and credential documentation plus focused API, web, and catalog regression coverage

## Why

The OpenAI app-server driver already materializes custom providers with a configurable `base_url`, `env_key`, and `wire_api = "responses"`. The runtime catalog rejected custom providers before that path could be selected, which caused affected Agents to remain on the built-in OpenAI provider and call `api.openai.com`.

## Impact

Builders can explicitly select OpenAI Runtime for a custom provider that implements the Responses API. Existing custom-provider Agents continue to default to OpenCode.

## Verification

- focused API, web, runtime catalog, and driver auth-state tests passed
- `just tc-package @mosoo/api`
- `just tc-package @mosoo/web`
- `just tc-package @mosoo/runtime-catalog`
- `just tc-package agent-driver`
- runtime catalog generation check passed
- formatting, documentation links, lint, and repository-wide type checking passed through `just check`
- the full parallel test gate remains blocked by the existing OpenCode ACP contract receiving non-JSON CLI output; three tasks terminated with exit 137 under parallel load and passed when rerun individually
