### PR TITLE
fix(session): keep turn drawer state across process event polls

### DIFF
--- a/apps/api/src/modules/sessions/application/session-process-events.service.ts
+++ b/apps/api/src/modules/sessions/application/session-process-events.service.ts
@@ -1,6 +1,9 @@
+import {
+  createNoRuntimeEventsRecordedEventId,
+  createProcessEventsTruncatedEventId,
+} from "@mosoo/contracts/session";
 import type { SessionProcessEvent } from "@mosoo/contracts/session";
 import { sessionEventsTable } from "@mosoo/db";
-import { createPlatformId } from "@mosoo/id";
 import type { AccountId, AppId, RuntimeEventId, SessionId, SessionRunId } from "@mosoo/id";
 import { and, desc, eq } from "drizzle-orm";
 
@@ -117,7 +120,7 @@ function createNoRuntimeEventsRecordedEvent(
   return {
     content: "No runtime events have been recorded for this thread.",
     durationMs: null,
-    id: createPlatformId<RuntimeEventId>(),
+    id: createNoRuntimeEventsRecordedEventId(session.id),
     occurredAt: session.updatedAt,
     status: "unsupported",
     tokens: null,
@@ -133,7 +136,7 @@ function createProcessEventsTruncatedEvent(input: {
   return {
     content: `Earlier runtime events are hidden; showing the latest ${input.limit} events.`,
     durationMs: 0,
-    id: createPlatformId<RuntimeEventId>(),
+    id: createProcessEventsTruncatedEventId(input.sessionId),
     occurredAt: input.occurredAt,
     status: "unsupported",
     tokens: null,

--- a/apps/api/tests/session-process-events.test.ts
+++ b/apps/api/tests/session-process-events.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
+import {
+  createNoRuntimeEventsRecordedEventId,
+  createProcessEventsTruncatedEventId,
+} from "@mosoo/contracts/session";
 import type {
   SessionProcessEventStatus,
   SessionProcessEventType,
@@ -511,6 +515,56 @@ describe("session process event projection", () => {
       id: "event-1001",
       type: "run.completed",
     });
+  });
+
+  test("keeps synthetic process event ids valid and stable across repeated reads", async () => {
+    const innerDatabase = createProcessEventQueryDatabase();
+
+    for (let seq = 1; seq <= 3; seq += 1) {
+      await insertSessionProcessEvent(innerDatabase, {
+        id: `event-${seq}`,
+        seq,
+      });
+    }
+
+    const readTruncated = async () =>
+      getThreadSessionProcessEvents(
+        innerDatabase,
+        VIEWER,
+        {
+          appId: APP_ID,
+          sessionId: SESSION_ID,
+        },
+        {
+          limit: 2,
+        },
+      );
+    const readEmpty = async () =>
+      getThreadSessionProcessEvents(
+        innerDatabase,
+        VIEWER,
+        {
+          appId: APP_ID,
+          sessionId: ATTRIBUTED_SESSION_ID,
+        },
+        {
+          limit: 10,
+        },
+      );
+
+    const firstTruncated = await readTruncated();
+    const secondTruncated = await readTruncated();
+
+    expect(firstTruncated[0]?.id).toBe(createProcessEventsTruncatedEventId(SESSION_ID));
+    expect(secondTruncated[0]?.id).toBe(firstTruncated[0]?.id ?? "");
+    expect(() => parsePlatformId(firstTruncated[0]?.id, "truncated marker id")).not.toThrow();
+
+    const firstEmpty = await readEmpty();
+    const secondEmpty = await readEmpty();
+
+    expect(firstEmpty[0]?.id).toBe(createNoRuntimeEventsRecordedEventId(ATTRIBUTED_SESSION_ID));
+    expect(secondEmpty[0]?.id).toBe(firstEmpty[0]?.id ?? "");
+    expect(() => parsePlatformId(firstEmpty[0]?.id, "empty placeholder id")).not.toThrow();
   });
 
   test("admits attributed participants through the shared thread access path", async () => {

--- a/apps/web/src/shared/ui/session-events/domain.ts
+++ b/apps/web/src/shared/ui/session-events/domain.ts
@@ -1,3 +1,4 @@
+import { isNoRuntimeEventsRecordedEventId } from "@mosoo/contracts/session";
 import type {
   SessionProcessEvent,
   SessionProcessEventStatus,
@@ -258,5 +259,5 @@ export function summarizeSessionEvent(event: SessionProcessEvent): string {
 }
 
 export function isSyntheticNoRuntimeEventsEvent(event: SessionProcessEvent): boolean {
-  return event.id.endsWith(":process-events:not-recorded");
+  return isNoRuntimeEventsRecordedEventId(event.id);
 }

--- a/apps/web/src/shared/ui/session-events/session-event-feed.tsx
+++ b/apps/web/src/shared/ui/session-events/session-event-feed.tsx
@@ -15,7 +15,8 @@ import { EmptyFeedState } from "./empty-feed-state";
 import { TurnCard } from "./feed-turn-card";
 import { SessionTurnDrawer } from "./feed-turn-drawer";
 import { FilterEmptyState } from "./filter-empty-state";
-import { filterSessionTurnEvents, useSessionTurns } from "./turns";
+import { filterSessionTurnEvents, resolveSessionTurn, useSessionTurns } from "./turns";
+import type { SessionTurn } from "./turns";
 
 interface SessionEventFeedProps {
   events: SessionProcessEvent[];
@@ -23,7 +24,7 @@ interface SessionEventFeedProps {
 
 interface DrawerState {
   eventId: string | null;
-  turnId: string;
+  turn: SessionTurn;
 }
 
 export function SessionEventFeed({ events }: SessionEventFeedProps): ReactElement {
@@ -42,7 +43,7 @@ export function SessionEventFeed({ events }: SessionEventFeedProps): ReactElemen
   const [errorsOnly, setErrorsOnly] = useState(false);
   const [collapsedTurnIds, setCollapsedTurnIds] = useState<Set<string>>(() => new Set());
   const [drawerState, setDrawerState] = useState<DrawerState | null>(null);
-  const drawerTurn = turns.find((turn) => turn.id === drawerState?.turnId) ?? null;
+  const drawerTurn = resolveSessionTurn(turns, drawerState?.turn ?? null);
   const filteredTurns = useMemo(
     () =>
       turns.map((turn) => ({
@@ -126,7 +127,7 @@ export function SessionEventFeed({ events }: SessionEventFeedProps): ReactElemen
                 collapsed={collapsedTurnIds.has(turn.id) || filteredEvents.length === 0}
                 filteredEvents={filteredEvents}
                 onOpenDrawer={(eventId) => {
-                  setDrawerState({ eventId, turnId: turn.id });
+                  setDrawerState({ eventId, turn });
                 }}
                 onToggleCollapsed={() => {
                   toggleTurnCollapsed(turn.id);

--- a/apps/web/src/shared/ui/session-events/turns.ts
+++ b/apps/web/src/shared/ui/session-events/turns.ts
@@ -171,6 +171,22 @@ export function useSessionTurns(events: readonly SessionProcessEvent[]): Session
   return useMemo(() => projectSessionTurns(events), [events]);
 }
 
+// Turn ids derive from event ids, and the projected turn for an open drawer
+// can disappear between polls (the bounded event window slides, or a pending
+// turn is absorbed by an arriving run.started). Prefer the freshly projected
+// turn so an open drawer keeps live-updating, but fall back to the snapshot
+// instead of blanking the drawer into a false "no events" state.
+export function resolveSessionTurn(
+  turns: readonly SessionTurn[],
+  snapshot: SessionTurn | null,
+): SessionTurn | null {
+  if (snapshot === null) {
+    return null;
+  }
+
+  return turns.find((turn) => turn.id === snapshot.id) ?? snapshot;
+}
+
 export function countSessionTurnDomains(events: readonly SessionProcessEvent[]): SessionTurnCounts {
   const counts = createEmptyCounts();
 

--- a/apps/web/tests/session-event-domain.test.ts
+++ b/apps/web/tests/session-event-domain.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from "bun:test";
 
+import type { SessionId } from "@mosoo/contracts/id";
+import { createNoRuntimeEventsRecordedEventId } from "@mosoo/contracts/session";
 import type { SessionProcessEvent } from "@mosoo/contracts/session";
 
 import {
   SESSION_EVENT_FILTER_DOMAINS,
   getSessionEventDomain,
   isSessionEventVisibleInMainFeed,
+  isSyntheticNoRuntimeEventsEvent,
 } from "../src/shared/ui/session-events/domain";
 
 function eventOf(type: SessionProcessEvent["type"], content = type): SessionProcessEvent {
@@ -43,5 +46,20 @@ describe("session event v1.5 domain model", () => {
     expect(isSessionEventVisibleInMainFeed(assistantMessage)).toBe(true);
     expect(isSessionEventVisibleInMainFeed(toolUse)).toBe(true);
     expect(isSessionEventVisibleInMainFeed(runStarted)).toBe(true);
+  });
+
+  test("hides the synthetic no-runtime-events placeholder from the main feed", () => {
+    const sessionId = "01J0000000000000000000000B" as SessionId;
+    const placeholder: SessionProcessEvent = {
+      ...eventOf("session.status", "No runtime events have been recorded for this thread."),
+      id: createNoRuntimeEventsRecordedEventId(sessionId),
+      status: "unsupported",
+    };
+    const ordinaryStatus = eventOf("session.status");
+
+    expect(isSyntheticNoRuntimeEventsEvent(placeholder)).toBe(true);
+    expect(isSessionEventVisibleInMainFeed(placeholder)).toBe(false);
+    expect(isSyntheticNoRuntimeEventsEvent(ordinaryStatus)).toBe(false);
+    expect(isSessionEventVisibleInMainFeed(ordinaryStatus)).toBe(true);
   });
 });

--- a/apps/web/tests/session-event-turns.test.ts
+++ b/apps/web/tests/session-event-turns.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { SessionProcessEvent } from "@mosoo/contracts/session";
 
-import { projectSessionTurns } from "../src/shared/ui/session-events/turns";
+import { projectSessionTurns, resolveSessionTurn } from "../src/shared/ui/session-events/turns";
 
 function eventOf(
   id: string,
@@ -90,5 +90,42 @@ describe("session Turn projection", () => {
         status: "pending",
       }),
     ]);
+  });
+});
+
+describe("session Turn drawer resolution", () => {
+  test("prefers the freshly projected Turn when its id still exists", () => {
+    const snapshot = projectSessionTurns([
+      eventOf("event-1", "run.started", 1),
+      eventOf("event-2", "agent.message.delta", 2),
+    ])[0];
+    const refreshedTurns = projectSessionTurns([
+      eventOf("event-1", "run.started", 1),
+      eventOf("event-2", "agent.message.delta", 2),
+      eventOf("event-3", "run.completed", 3),
+    ]);
+
+    expect(snapshot).toBeDefined();
+    expect(resolveSessionTurn(refreshedTurns, snapshot ?? null)).toBe(refreshedTurns[0] ?? null);
+  });
+
+  test("falls back to the snapshot when the projected Turn id disappears", () => {
+    const snapshot = projectSessionTurns([
+      eventOf("marker-a", "session.status", 1),
+      eventOf("event-2", "tool.use.completed", 2),
+    ])[0];
+    const reprojectedTurns = projectSessionTurns([
+      eventOf("marker-b", "session.status", 1),
+      eventOf("event-2", "tool.use.completed", 2),
+    ]);
+
+    expect(snapshot).toBeDefined();
+    expect(snapshot?.id).toBe("pending:marker-a");
+    expect(reprojectedTurns[0]?.id).toBe("pending:marker-b");
+    expect(resolveSessionTurn(reprojectedTurns, snapshot ?? null)).toBe(snapshot ?? null);
+  });
+
+  test("resolves no Turn when the drawer has no snapshot", () => {
+    expect(resolveSessionTurn([], null)).toBeNull();
   });
 });

--- a/pkgs/contracts/src/session/session.contract.ts
+++ b/pkgs/contracts/src/session/session.contract.ts
@@ -190,6 +190,35 @@ export interface SessionProcessEvent {
   type: SessionProcessEventType;
 }
 
+// Synthetic process events (the empty-feed placeholder and the hidden-older-
+// events marker) are minted at read time instead of being persisted. Their ids
+// must be valid platform ULIDs (the GraphQL ULID scalar validates output) AND
+// deterministic per session: readers poll this projection and key turn
+// grouping and drawer selection off event ids, so a fresh random id per read
+// makes every poll drop UI state. The ids reuse the session ULID's 10-char
+// time prefix plus a fixed Crockford-base32 tail that a random event tail
+// cannot realistically collide with.
+
+const SYNTHETIC_PROCESS_EVENT_TIME_PREFIX_LENGTH = 10;
+const NO_RUNTIME_EVENTS_RECORDED_EVENT_ID_TAIL = "0EVENTSEMPTY0000";
+const PROCESS_EVENTS_TRUNCATED_EVENT_ID_TAIL = "0EVENTSCAPPED000";
+
+function createSyntheticProcessEventId(sessionId: SessionId, tail: string): RuntimeEventId {
+  return `${sessionId.slice(0, SYNTHETIC_PROCESS_EVENT_TIME_PREFIX_LENGTH)}${tail}` as RuntimeEventId;
+}
+
+export function createNoRuntimeEventsRecordedEventId(sessionId: SessionId): RuntimeEventId {
+  return createSyntheticProcessEventId(sessionId, NO_RUNTIME_EVENTS_RECORDED_EVENT_ID_TAIL);
+}
+
+export function createProcessEventsTruncatedEventId(sessionId: SessionId): RuntimeEventId {
+  return createSyntheticProcessEventId(sessionId, PROCESS_EVENTS_TRUNCATED_EVENT_ID_TAIL);
+}
+
+export function isNoRuntimeEventsRecordedEventId(id: string): boolean {
+  return id.endsWith(NO_RUNTIME_EVENTS_RECORDED_EVENT_ID_TAIL);
+}
+
 export const SESSION_RUNTIME_EVENT_FAMILIES = [
   "config",
   "diagnostics",


### PR DESCRIPTION
Fill what changed. Use N/A for irrelevant or maintainer-only items. See `CONTRIBUTING.md` for branch, CLA, generated file, and CI rules.

## Summary

- Fix the session log turn drawer losing its state after a poll: opening a turn detail first showed the events, then flipped to "No events recorded" (YEF-836).
- Derive the synthetic process event ids (empty-feed placeholder, hidden-older-events marker) deterministically from the session ULID in `@mosoo/contracts/session`, instead of minting a fresh random ULID per read in `session-process-events.service.ts`.
- Restore the web placeholder filter contract: `isSyntheticNoRuntimeEventsEvent` matched an id suffix (`:process-events:not-recorded`) the server stopped producing when the ULID output scalar forced canonical ids, so empty sessions leaked the placeholder row into the feed.
- Harden the drawer: `SessionEventFeed` now snapshots the opened turn and `resolveSessionTurn` falls back to that snapshot when a re-projection no longer contains the turn id (bounded window slid, pending turn absorbed by a `run.started`).

## Why

- The events query polls every 2.5s for non-terminated sessions. When the bounded read window is truncated mid-run (no in-window `run.started`), the whole window projects into a pending turn keyed off the first event — the synthetic truncation marker. With a fresh random marker id per read, the turn id changed on every poll, the drawer's `turns.find(...)` lookup failed, and the open dialog degraded to a false "No events recorded" state.
- Reproduced pixel-for-pixel against the reported screenshot with a deterministic fixture (per-read marker ids, no in-window `run.started`): drawer opens with 5 events, then flips to "Turn / 0 events / No events recorded" on the next poll. With this fix the drawer keeps its events through the same churn.

## Verification

- Commands: `just test-file apps/api/tests/session-process-events.test.ts` (9 pass), `just test-file apps/web/tests/session-event-turns.test.ts` (7 pass), `just test-file apps/web/tests/session-event-domain.test.ts` (3 pass), `just test-package @mosoo/api` (1000 pass), `just test-package @mosoo/web` (148 pass), `just test-package @mosoo/contracts` (14 pass), `just tc-package @mosoo/api|@mosoo/web|@mosoo/contracts`, `just lint`, `just fmt-check-path` on all touched files.
- Manual steps: replayed the logs tab against a Playwright GraphQL fixture that simulates the old server behavior (fresh synthetic marker id per poll, truncated window without `run.started`); before the fix the open drawer degrades to "No events recorded" after one 2.5s poll, after the fix it keeps its 5 events across polls (screenshots on YEF-836).
- Not run: `just check` full gate (covered by the per-package typecheck/test/lint commands above); live-provider e2e paths (no external credentials needed for this change).

## Impact

- User/API/contract changes: synthetic process event ids returned by `sessionProcessEvents` / `threadSessionProcessEvents` are now stable per session (still canonical ULIDs, so the ULID scalar contract is unchanged). New exported helpers in `@mosoo/contracts/session`.
- Generated files / GraphQL / DB / lockfile: none (no schema, codegen, migration, or dependency changes).
- Env or config changes: none.
- Risk and rollback: low; read-path-only id derivation plus a client-side fallback. Revert the single commit to roll back.

## Review

- Closest review areas: `pkgs/contracts/src/session/session.contract.ts` (synthetic id derivation), `apps/api/src/modules/sessions/application/session-process-events.service.ts`, `apps/web/src/shared/ui/session-events/{turns.ts,session-event-feed.tsx,domain.ts}`.
- Known trade-offs: when a turn id genuinely disappears mid-view (window slide on a live session), the drawer shows the open-time snapshot instead of live updates until the id resolves again — preferred over blanking an open dialog.
