### PR TITLE
refactor(web): optimize MCP binding lookup

### DIFF
--- a/apps/web/src/routes/agent/components/editor/mcp-bindings-field.tsx
+++ b/apps/web/src/routes/agent/components/editor/mcp-bindings-field.tsx
@@ -18,6 +18,7 @@ import { Switch } from "@/shared/ui/switch";
 import { isTruthy } from "../../../../shared/lib/truthiness";
 import { IconAvatar } from "../../../integrations/mcp/icon-avatar";
 import type { McpServer } from "../../agent.types";
+import { createPoolServerById } from "./mcp-bindings-projections";
 
 function toDraftMcpServer(server: PoolServer): McpServer {
   const draftServer: McpServer = {
@@ -41,18 +42,6 @@ function toDraftMcpServer(server: PoolServer): McpServer {
   }
 
   return draftServer;
-}
-
-export function createPoolServerById(servers: readonly PoolServer[]): Map<string, PoolServer> {
-  const poolServerById = new Map<string, PoolServer>();
-
-  for (const server of servers) {
-    if (!poolServerById.has(server.id)) {
-      poolServerById.set(server.id, server);
-    }
-  }
-
-  return poolServerById;
 }
 
 function McpAddDropdown({

--- a/apps/web/src/routes/agent/components/editor/mcp-bindings-field.tsx
+++ b/apps/web/src/routes/agent/components/editor/mcp-bindings-field.tsx
@@ -43,6 +43,18 @@ function toDraftMcpServer(server: PoolServer): McpServer {
   return draftServer;
 }
 
+export function createPoolServerById(servers: readonly PoolServer[]): Map<string, PoolServer> {
+  const poolServerById = new Map<string, PoolServer>();
+
+  for (const server of servers) {
+    if (!poolServerById.has(server.id)) {
+      poolServerById.set(server.id, server);
+    }
+  }
+
+  return poolServerById;
+}
+
 function McpAddDropdown({
   addedIds,
   onPick,
@@ -137,6 +149,7 @@ export function AgentMcpBindingsField({
   const registryQuery = useMcpRegistryQuery(appId);
 
   const poolServers = registryQuery.data?.servers ?? [];
+  const poolServerById = useMemo(() => createPoolServerById(poolServers), [poolServers]);
   const addedIds = useMemo(
     () => new Set(selectedServers.map((server) => server.id)),
     [selectedServers],
@@ -180,7 +193,7 @@ export function AgentMcpBindingsField({
   return (
     <div className="border-border divide-border-subtle divide-y overflow-hidden rounded-lg border">
       {selectedServers.map((server) => {
-        const pool = poolServers.find((candidate) => candidate.id === server.id);
+        const pool = poolServerById.get(server.id);
         const sourceLabel = `App · ${pool?.ownerName ?? "Owner"}`;
 
         return (

--- a/apps/web/src/routes/agent/components/editor/mcp-bindings-projections.ts
+++ b/apps/web/src/routes/agent/components/editor/mcp-bindings-projections.ts
@@ -1,0 +1,13 @@
+import type { McpServerWithCredential as PoolServer } from "@mosoo/contracts/mcp";
+
+export function createPoolServerById(servers: readonly PoolServer[]): Map<string, PoolServer> {
+  const poolServerById = new Map<string, PoolServer>();
+
+  for (const server of servers) {
+    if (!poolServerById.has(server.id)) {
+      poolServerById.set(server.id, server);
+    }
+  }
+
+  return poolServerById;
+}

--- a/apps/web/tests/mcp-bindings-field.test.ts
+++ b/apps/web/tests/mcp-bindings-field.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { McpServerWithCredential } from "@mosoo/contracts/mcp";
 
-import { createPoolServerById } from "../src/routes/agent/components/editor/mcp-bindings-field";
+import { createPoolServerById } from "../src/routes/agent/components/editor/mcp-bindings-projections";
 
 function poolServer(id: string, ownerName: string): McpServerWithCredential {
   return {

--- a/apps/web/tests/mcp-bindings-field.test.ts
+++ b/apps/web/tests/mcp-bindings-field.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import type { McpServerWithCredential } from "@mosoo/contracts/mcp";
+
+import { createPoolServerById } from "../src/routes/agent/components/editor/mcp-bindings-field";
+
+function poolServer(id: string, ownerName: string): McpServerWithCredential {
+  return {
+    appId: "01J000000000000000000000A1" as McpServerWithCredential["appId"],
+    authType: "bearer",
+    authorizationState: "active",
+    createdAt: "2026-07-16T00:00:00.000Z",
+    credential: null,
+    credentialScope: "app",
+    credentialStatus: "none",
+    description: null,
+    enabled: true,
+    hasCredential: false,
+    iconUrl: null,
+    id: id as McpServerWithCredential["id"],
+    name: "Server",
+    ownerId: "01J000000000000000000000B1" as McpServerWithCredential["ownerId"],
+    ownerName,
+    source: "app",
+    updatedAt: "2026-07-16T00:00:00.000Z",
+    url: "https://mcp.example.com",
+  };
+}
+
+describe("MCP bindings field projections", () => {
+  test("indexes pool servers once while preserving first-match lookup behavior", () => {
+    const first = poolServer("server-a", "First owner");
+    const duplicate = poolServer("server-a", "Second owner");
+    const other = poolServer("server-b", "Other owner");
+
+    const lookup = createPoolServerById([first, duplicate, other]);
+
+    expect(lookup.size).toBe(2);
+    expect(lookup.get("server-a")).toBe(first);
+    expect(lookup.get("server-b")).toBe(other);
+  });
+});


### PR DESCRIPTION
Closes YEF-837

## Summary

- Adds a first-match MCP pool server lookup map for the Agent editor bindings field.
- Uses the lookup while rendering selected MCP servers instead of scanning the pool for each selected server.
- Adds a focused projection test for duplicate server ids so the new map preserves prior `Array.find` behavior.

## Why

- The complexity scan flagged `mcp-bindings-field.tsx` as a render-path nested lookup.
- Before: selected server rendering did `selectedServers.map(...)` plus `poolServers.find(...)`, which is O(selected * pool).
- After: pool servers are indexed once and selected rows use `Map.get`, which is O(selected + pool).

## Verification

- Commands:
  - `bun test apps/web/tests/mcp-bindings-field.test.ts`
  - `bun run --filter @mosoo/web tc`
  - `bun run --filter @mosoo/web lint`
  - `bun run fmt:check:path apps/web/src/routes/agent/components/editor/mcp-bindings-field.tsx apps/web/tests/mcp-bindings-field.test.ts`
  - `python3 /Users/evanmore/multica_workspaces_desktop-api.multica.ai/baf2a510-889b-4b05-b7c8-c079f5c28938/d3e09bab/codex-home/skills/complexity-optimizer/scripts/analyze_complexity.py /Users/evanmore/multica_workspaces_desktop-api.multica.ai/baf2a510-889b-4b05-b7c8-c079f5c28938/d3e09bab/workdir/mosoo/apps/web/src/routes/agent/components/editor/mcp-bindings-field.tsx --format markdown`
- Manual steps:
  - N/A
- Not run:
  - Full `bun run --filter @mosoo/web test` is currently blocked by order-sensitive failures in `apps/web/tests/providers-tab-dialog.test.tsx`; the same provider dialog file passes when run alone.

## Impact

- User/API/contract changes: none.
- Generated files / GraphQL / DB / lockfile: none.
- Env or config changes: none.
- Risk and rollback: low; the fallback owner label remains unchanged and duplicate ids keep first-match behavior.

## Review

- Closest review areas:
  - `apps/web/src/routes/agent/components/editor/mcp-bindings-field.tsx`
  - `apps/web/tests/mcp-bindings-field.test.ts`
- Known trade-offs:
  - This is a localized render-path complexity reduction, not a broad rewrite of every scanner lead.
