### PR TITLE
fix(auth): ignore enter while ime is composing

### DIFF
--- a/apps/web/src/routes/login/auth-card.tsx
+++ b/apps/web/src/routes/login/auth-card.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { Separator } from "@/shared/ui/separator";
 
+import { shouldSubmitLoginInput } from "./login-keyboard";
 import type { AuthStep } from "./use-login";
 
 const AUTH_CARD_STYLE = { boxShadow: "var(--shadow-md)" } satisfies CSSProperties;
@@ -71,7 +72,13 @@ export function LoginAuthCard({
                   onChangeOtp(event.target.value);
                 }}
                 onKeyDown={(event) => {
-                  if (event.key === "Enter") {
+                  if (
+                    shouldSubmitLoginInput({
+                      isComposing: event.nativeEvent.isComposing,
+                      key: event.key,
+                      keyCode: event.nativeEvent.keyCode,
+                    })
+                  ) {
                     onVerifyOtp();
                   }
                 }}
@@ -145,7 +152,13 @@ export function LoginAuthCard({
                   onChangeEmail(event.target.value);
                 }}
                 onKeyDown={(event) => {
-                  if (event.key === "Enter") {
+                  if (
+                    shouldSubmitLoginInput({
+                      isComposing: event.nativeEvent.isComposing,
+                      key: event.key,
+                      keyCode: event.nativeEvent.keyCode,
+                    })
+                  ) {
                     onSendOtp();
                   }
                 }}

--- a/apps/web/src/routes/login/login-keyboard.ts
+++ b/apps/web/src/routes/login/login-keyboard.ts
@@ -1,0 +1,9 @@
+interface LoginInputKey {
+  readonly isComposing: boolean;
+  readonly key: string;
+  readonly keyCode: number;
+}
+
+export function shouldSubmitLoginInput(input: LoginInputKey): boolean {
+  return input.key === "Enter" && !input.isComposing && input.keyCode !== 229;
+}

--- a/apps/web/tests/login-keyboard.test.ts
+++ b/apps/web/tests/login-keyboard.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldSubmitLoginInput } from "../src/routes/login/login-keyboard";
+
+describe("login input keyboard handling", () => {
+  test("submits only a regular Enter keydown", () => {
+    expect(
+      shouldSubmitLoginInput({
+        isComposing: false,
+        key: "Enter",
+        keyCode: 13,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSubmitLoginInput({
+        isComposing: false,
+        key: "a",
+        keyCode: 65,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not submit when Enter confirms IME composition", () => {
+    expect(
+      shouldSubmitLoginInput({
+        isComposing: true,
+        key: "Enter",
+        keyCode: 13,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSubmitLoginInput({
+        isComposing: false,
+        key: "Enter",
+        keyCode: 229,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- ignore Enter keydown while email or OTP input is in an IME composition session
- preserve normal Enter submission behavior
- cover both `isComposing` and the Safari/legacy `keyCode === 229` fallback

## Root cause

The login inputs treated every Enter keydown as a submit action. Chinese and other IMEs emit Enter while confirming composition, so the login action ran before text composition finished.

## Verification

- `just test-file apps/web/tests/login-keyboard.test.ts`
- `just tc-package @mosoo/web`
- `just fmt-check-path apps/web/src/routes/login`
- `just fmt-check-path apps/web/tests/login-keyboard.test.ts`
- Playwright coverage for email and OTP composition Enter, keyCode 229, and regular Enter
- `just commit-check`

Generated files: no. GraphQL codegen: no. DB migrations: no. Lockfile changes: no.
