### PR TITLE
fix(threads): show run failure details

### DIFF
--- a/apps/web/src/routes/threads/detail/run-failure-notice.tsx
+++ b/apps/web/src/routes/threads/detail/run-failure-notice.tsx
@@ -1,0 +1,92 @@
+import type { SessionRunStatus, SessionRunSummary } from "@mosoo/contracts/session-run";
+import { ChevronRight, CircleX } from "lucide-react";
+import type { ReactElement } from "react";
+
+import { Button } from "@/shared/ui/button";
+
+interface ThreadRunFailureDetails {
+  code: string | null;
+  message: string;
+  title: string;
+}
+
+const FAILURE_STATUSES = new Set<SessionRunStatus>(["cancelled", "expired", "failed"]);
+
+function getFailureFallback(
+  status: SessionRunStatus,
+): Pick<ThreadRunFailureDetails, "message" | "title"> {
+  switch (status) {
+    case "cancelled": {
+      return {
+        message: "The run was cancelled before it completed.",
+        title: "Run cancelled",
+      };
+    }
+    case "expired": {
+      return {
+        message: "The run expired before it completed.",
+        title: "Run expired",
+      };
+    }
+    default: {
+      return {
+        message: "The run failed before an error message was recorded.",
+        title: "Run failed",
+      };
+    }
+  }
+}
+
+export function getThreadRunFailure(run: SessionRunSummary | null): ThreadRunFailureDetails | null {
+  if (run === null || !FAILURE_STATUSES.has(run.status)) {
+    return null;
+  }
+
+  const fallback = getFailureFallback(run.status);
+  const errorMessage = run.error?.message.trim() ?? "";
+
+  return {
+    code: run.error?.code ?? null,
+    message: errorMessage.length > 0 ? errorMessage : fallback.message,
+    title: fallback.title,
+  };
+}
+
+export function ThreadRunFailureNotice({
+  onOpenProcess,
+  run,
+}: {
+  onOpenProcess: () => void;
+  run: SessionRunSummary | null;
+}): ReactElement | null {
+  const failure = getThreadRunFailure(run);
+
+  if (failure === null) {
+    return null;
+  }
+
+  return (
+    <div
+      className="border-destructive/20 bg-destructive/[0.04] mt-4 flex flex-col gap-3 rounded-lg border px-4 py-3 sm:flex-row sm:items-start"
+      data-testid="thread-run-failure"
+      role="alert"
+    >
+      <div className="flex min-w-0 flex-1 items-start gap-2.5">
+        <CircleX className="text-destructive mt-0.5 size-4 shrink-0" aria-hidden="true" />
+        <div className="min-w-0">
+          <div className="text-destructive text-[12.5px] font-semibold">{failure.title}</div>
+          <div className="text-fg-2 mt-0.5 text-[12.5px] leading-relaxed break-words">
+            {failure.message}
+          </div>
+          {failure.code === null ? null : (
+            <div className="text-fg-3 mt-1 font-mono text-[10.5px] break-all">{failure.code}</div>
+          )}
+        </div>
+      </div>
+      <Button size="xs" variant="outline" className="shrink-0 self-start" onClick={onOpenProcess}>
+        View process
+        <ChevronRight className="size-3" />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/routes/threads/detail/view.tsx
+++ b/apps/web/src/routes/threads/detail/view.tsx
@@ -47,6 +47,7 @@ import { ThreadStateIcon } from "../thread-state-icon";
 import { UserAvatar } from "../user-avatar";
 import { createThreadArtifactLinkResolver } from "./artifact-links";
 import { ArtifactPreviewSheet } from "./artifact-preview-sheet";
+import { ThreadRunFailureNotice } from "./run-failure-notice";
 
 interface ViewerInfo {
   image: string | null;
@@ -196,12 +197,22 @@ function ThreadDetailHeader({
               <span>Working</span>
             </button>
           </Badge>
+        ) : thread.failed ? (
+          <Badge asChild variant="danger" className="cursor-pointer focus-visible:ring-offset-1">
+            <button
+              type="button"
+              aria-label="Open failed run process"
+              title="Open failed run process"
+              onClick={onOpenProcess}
+            >
+              <ThreadStateIcon glyph={stateGlyph} />
+              <span>Failed</span>
+            </button>
+          </Badge>
         ) : (
-          <Badge variant={thread.failed ? "danger" : "outline"}>
+          <Badge variant="outline">
             <ThreadStateIcon glyph={stateGlyph} />
-            <span>
-              {thread.failed ? "Failed" : thread.bucket === "archived" ? "Archived" : "Completed"}
-            </span>
+            <span>{thread.bucket === "archived" ? "Archived" : "Completed"}</span>
           </Badge>
         )}
         {threadActionCapabilities.archive.available ? (
@@ -455,6 +466,13 @@ export function ThreadDetail({
               </div>
             </div>
           ) : null}
+
+          <ThreadRunFailureNotice
+            onOpenProcess={() => {
+              setProcessOpen(true);
+            }}
+            run={thread.session.lastRun}
+          />
 
           {messagesLoading ? (
             <div className="text-fg-3 py-12 text-center text-[13px]">Loading thread…</div>

--- a/apps/web/tests/thread-run-failure-notice.test.tsx
+++ b/apps/web/tests/thread-run-failure-notice.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+
+import type { SessionRunStatus, SessionRunSummary } from "@mosoo/contracts/session-run";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  getThreadRunFailure,
+  ThreadRunFailureNotice,
+} from "../src/routes/threads/detail/run-failure-notice";
+
+function createRun(
+  status: SessionRunStatus,
+  error: SessionRunSummary["error"] = null,
+): SessionRunSummary {
+  return {
+    completedAt: null,
+    createdAt: "2026-07-16T09:21:41.000Z",
+    deploymentVersionId: null,
+    deploymentVersionNumber: null,
+    error,
+    id: "01KXN3PND0KDGQQ0N74GWZFNWP",
+    model: "gpt-5.6-sol",
+    provider: "openai-compatible",
+    startedAt: null,
+    status,
+    traceId: "4ad5f3de8f815bedab2855ec0e582367",
+    trigger: "user_prompt",
+    updatedAt: "2026-07-16T09:22:12.000Z",
+  } as SessionRunSummary;
+}
+
+describe("thread run failure notice", () => {
+  test("renders the persisted run error and process action", () => {
+    const run = createRun("failed", {
+      code: "runtime.provision_failed",
+      details: {},
+      message: "Driver process exited before ready with exit code 1.",
+      retryable: true,
+    });
+    const html = renderToStaticMarkup(
+      <ThreadRunFailureNotice onOpenProcess={() => undefined} run={run} />,
+    );
+
+    expect(html).toContain('role="alert"');
+    expect(html).toContain("Driver process exited before ready with exit code 1.");
+    expect(html).toContain("runtime.provision_failed");
+    expect(html).toContain("View process");
+  });
+
+  test("provides status-specific copy when no run error was recorded", () => {
+    expect(getThreadRunFailure(createRun("cancelled"))).toMatchObject({
+      code: null,
+      message: "The run was cancelled before it completed.",
+      title: "Run cancelled",
+    });
+    expect(getThreadRunFailure(createRun("expired"))).toMatchObject({
+      code: null,
+      message: "The run expired before it completed.",
+      title: "Run expired",
+    });
+  });
+
+  test("does not render for a successful run", () => {
+    const run = createRun("completed");
+
+    expect(getThreadRunFailure(run)).toBeNull();
+    expect(
+      renderToStaticMarkup(<ThreadRunFailureNotice onOpenProcess={() => undefined} run={run} />),
+    ).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

- show persisted last-run failure details inline on Thread detail
- make the failed status and inline notice open the process dialog
- add status-specific fallbacks and regression tests

## Why

A run can fail before the Agent produces a reply. The backend already persists `lastRun.error` and the `run.failed` event, but Thread detail rendered only a `Failed` badge. The process dialog entry also existed only on Agent reply cards, so pre-ready failures had no visible explanation or way to inspect the process.

The reproduced run failed during Driver provisioning with `runtime.provision_failed` and `Driver process exited before ready with exit code 1.` This change surfaces that persisted user-safe error without exposing raw Driver logs.

## Verification

- `bun run --filter @mosoo/web lint`
- `bun run --filter @mosoo/web tc`
- `bun run --filter @mosoo/web test` (158 passed)
- `vp fmt --check` on the three changed files
- `git diff --check`
- `just commit-check`
- Playwright: verified the original failed Thread shows the error inline and opens the process dialog
- Playwright: verified desktop and 390px mobile layouts

## Impact

- User/API/contract changes: failed Threads now show persisted run details; no API contract changes
- Generated files / GraphQL / DB / lockfile: none
- Env or config changes: none
- Risk and rollback: Web-only presentation change; revert this commit to restore the previous badge-only behavior

## Review

- Closest review: failure-state mapping and Thread detail process interaction
- Known trade-off: only persisted user-safe `lastRun.error` is displayed; raw Driver stderr remains in operator logs
