### PR TITLE
docs(readme): inline Agent as API demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="apps/web/public/brand/logo-mark.svg" alt="" width="48" height="48" /> Mosoo
+# <img src="https://github.com/user-attachments/assets/1f8e0e63-223c-4f04-b332-e34f8b087e5b" alt="Mosoo" width="220" />
 
 Mosoo is building the production path from runnable agentic-app prototypes to hosted web products that real users can sign in to and use.
 
@@ -38,10 +38,9 @@ Product and engineering references:
 - Current implementation architecture: [docs/architecture.md](./docs/architecture.md)
 - Development and contribution guide: [CONTRIBUTING.md](./CONTRIBUTING.md)
 
-## Use Cases
+## Demo
 
-- [Codex Pet — Agent as API](./examples/use-cases/codex-pet.md): publish one Mosoo Agent, then let Codex integrate it into an existing product backend.
-- [Watch the 57-second Agent as API video →](https://github.com/Yevanchen/mosoo-codex-pet/blob/9662d6a93893816ddf8e01d6fbce7fb15cf08188/docs/assets/mosoo-agent-as-api.mp4)
+https://github.com/user-attachments/assets/4a4bbaab-c192-4462-99e0-020eab966fff
 
 ## Local Development
 


### PR DESCRIPTION
## Summary

- replace the small square mark in the README title with the official Mosoo wordmark
- render the Agent as API MP4 as a native inline GitHub video player

## Why

- let repository visitors understand the use case without leaving the main README

## Verification

- Commands: `just fmt-check-path README.md`; `just docs-check`; GitHub Markdown API render check
- Manual steps: confirmed the rendered output contains the 220px Mosoo wordmark and a native `<video controls>` element
- Not run: `just check` because this PR changes only the root README; focused documentation checks passed

## Impact

- User/API/contract changes: README presentation only
- Generated files / GraphQL / DB / lockfile: none; codegen and DB generation are not applicable
- Env or config changes: none
- Risk and rollback: low; revert the single README commit

## Review

- Closest review areas: logo scale and video placement
- Known trade-offs: GitHub user attachments are required because GitHub strips ordinary `<video>` HTML and does not inline repository raw MP4 URLs
