### PR TITLE
docs(readme): center standalone logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# <img src="https://github.com/user-attachments/assets/1f8e0e63-223c-4f04-b332-e34f8b087e5b" alt="Mosoo" width="220" />
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/4986c4b8-28fa-45ea-9be9-78c1c7133128" alt="Mosoo" width="96" height="96" />
+</p>
 
 Mosoo is building the production path from runnable agentic-app prototypes to hosted web products that real users can sign in to and use.
 


### PR DESCRIPTION
## Summary

- replace the README wordmark with the standalone Mosoo mark
- center it in a square 96 × 96 presentation
- keep the change scoped to `README.md`

## Why

A standalone green mark stays visually balanced across GitHub light and dark themes.

## Validation

- `just fmt-check-path README.md`
- `just docs-check`
- GitHub Markdown API render check