### PR TITLE
fix(threads): ignore stale rescheduling after terminal run

### DIFF
--- a/apps/web/src/routes/threads/model/thread.ts
+++ b/apps/web/src/routes/threads/model/thread.ts
@@ -58,6 +58,12 @@ const WORKING_RUN_STATUSES = new Set<SessionRunStatus>([
 ]);
 
 const FAILED_RUN_STATUSES = new Set<SessionRunStatus>(["cancelled", "expired", "failed"]);
+const TERMINAL_RUN_STATUSES = new Set<SessionRunStatus>([
+  "completed",
+  "cancelled",
+  "expired",
+  "failed",
+]);
 
 function getThreadLastActivityAt(session: SessionSummary): string {
   return session.lastMessageAt ?? session.lastRun?.updatedAt ?? session.updatedAt;
@@ -67,10 +73,18 @@ function isThreadFailed(session: SessionSummary): boolean {
   return session.lastRun !== null && FAILED_RUN_STATUSES.has(session.lastRun.status);
 }
 
+function hasTerminalLastRun(session: SessionSummary): boolean {
+  return session.lastRun !== null && TERMINAL_RUN_STATUSES.has(session.lastRun.status);
+}
+
 export function isThreadWorking(session: SessionSummary): boolean {
   const lifecycle = getAgentSessionUserLifecycleProjection(session);
 
   if (lifecycle.readOnly) {
+    return false;
+  }
+
+  if (hasTerminalLastRun(session)) {
     return false;
   }
 
@@ -117,7 +131,7 @@ function getThreadStatusLine(session: SessionSummary): string {
     return "archived";
   }
 
-  if (session.status === "RESCHEDULING") {
+  if (session.status === "RESCHEDULING" && !hasTerminalLastRun(session)) {
     const previous = getThreadStatusLine({
       ...session,
       archivedAt: null,

--- a/apps/web/tests/thread-summary-counts.test.ts
+++ b/apps/web/tests/thread-summary-counts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { SessionSummary } from "@mosoo/contracts/session";
+import type { SessionRunSummary } from "@mosoo/contracts/session-run";
 
 import { summarizeThreads, toThreadListItem } from "../src/routes/threads/model/thread";
 import type {
@@ -44,6 +45,24 @@ function session(id: string): SessionSummary {
     title: "Thread",
     type: "ui",
     updatedAt: "2026-05-27T00:00:00.000Z",
+  };
+}
+
+function run(input: Pick<SessionRunSummary, "status">): SessionRunSummary {
+  return {
+    completedAt: input.status === "completed" ? "2026-05-27T00:01:00.000Z" : null,
+    createdAt: "2026-05-27T00:00:00.000Z",
+    deploymentVersionId: null,
+    deploymentVersionNumber: null,
+    error: null,
+    id: "run-1",
+    model: "gpt-5.4",
+    provider: "openai",
+    startedAt: "2026-05-27T00:00:01.000Z",
+    status: input.status,
+    traceId: "trace-1",
+    trigger: "user_prompt",
+    updatedAt: "2026-05-27T00:01:00.000Z",
   };
 }
 
@@ -113,5 +132,25 @@ describe("thread summary counts", () => {
 
     expect(archived.bucket).toBe("archived");
     expect(terminal.bucket).toBe("completed");
+  });
+
+  test("does not treat stale rescheduling sessions with terminal runs as working", () => {
+    const ui = {
+      pinnedThreadIds: new Set<string>(),
+      readAtByThreadId: {},
+    } satisfies ThreadUiSnapshot;
+    const threadItem = toThreadListItem({
+      actionCapabilities: [],
+      agentsById: new Map(),
+      session: {
+        ...session("thread-stale-rescheduling"),
+        lastRun: run({ status: "completed" }),
+        status: "RESCHEDULING",
+      },
+      ui,
+    });
+
+    expect(threadItem.bucket).toBe("completed");
+    expect(threadItem.statusLine).not.toContain("reconnecting");
   });
 });


### PR DESCRIPTION
Closes YEF-842

## Summary

- Stop treating stale `RESCHEDULING` thread summaries as working when the last run is already terminal.
- Add a regression test for a completed last run paired with stale reconnecting session status.

## Why

- The thread list used session lifecycle status before checking terminal run state, so old sessions could remain in `WORKING` as `done ✓ · reconnecting` even though the last run had finished.

## Verification

- Commands:
  - `bun test apps/web/tests/thread-summary-counts.test.ts`
  - `bun run --filter @mosoo/web test`
  - `bun run --filter @mosoo/web tc`
  - `bun run fmt:check:path apps/web/src/routes/threads/model/thread.ts apps/web/tests/thread-summary-counts.test.ts`
  - `bun run --filter @mosoo/web lint`
  - `bun run check`
  - `bun run commit:check`
- Manual steps: N/A
- Not run: N/A

## Impact

- User/API/contract changes: Thread list now shows terminal-run stale reconnecting sessions under Completed instead of Working.
- Generated files / GraphQL / DB / lockfile: N/A
- Env or config changes: N/A
- Risk and rollback: Low; localized thread-list projection change. Revert the commit to restore previous grouping behavior.

## Review

- Closest review areas: `apps/web/src/routes/threads/model/thread.ts`, `apps/web/tests/thread-summary-counts.test.ts`
- Known trade-offs: This corrects frontend projection for stale summaries; it does not mutate existing stale backend session records.
