### PR TITLE
fix(web): reduce agent detail initial bundle

### DIFF
--- a/apps/web/src/routes/agent/agent-detail.route.tsx
+++ b/apps/web/src/routes/agent/agent-detail.route.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, Settings } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import type { ReactElement } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 import { useAppSession } from "@/app/session-provider";
@@ -7,19 +8,13 @@ import { useAgentDetailQuery, useAgentEditorStateQuery } from "@/domains/agent/q
 import { useAuth } from "@/domains/auth/use-auth";
 import { cn } from "@/shared/lib/class-names";
 import { Button } from "@/shared/ui/button";
-import { Sheet, SheetContent, SheetTitle } from "@/shared/ui/sheet";
 
 import { isTruthy } from "../../shared/lib/truthiness";
 import { canShowAgentDebugMenuItem } from "./agent-debug-menu-policy";
 import { mapAgentDetailToView } from "./agent-view.mapper";
 import type { Agent, AgentMode } from "./agent.types";
-import { ConsumeMode } from "./components/consume-mode";
-import { AgentCostTab } from "./components/cost-tab";
-import { LogsTab } from "./components/logs-tab";
 import { PreviewMode } from "./components/preview-mode";
 import { RuntimeIcon } from "./components/runtime-icon";
-import { SettingsSheet } from "./components/settings-dialog";
-import { VersionsTab } from "./components/versions-tab";
 import { getRuntimeInfo } from "./runtime-catalog";
 
 // The terminal pulls in the full xterm engine (~250 kB) and its stylesheet, yet
@@ -31,7 +26,55 @@ const TerminalMode = lazy(async () => {
   return { default: mod.TerminalMode };
 });
 
+const LogsTab = lazy(async () => {
+  const mod = await import("./components/logs-tab");
+  return { default: mod.LogsTab };
+});
+
+const AgentCostTab = lazy(async () => {
+  const mod = await import("./components/cost-tab");
+  return { default: mod.AgentCostTab };
+});
+
+const SettingsSheet = lazy(async () => {
+  const mod = await import("./components/settings-dialog");
+  return { default: mod.SettingsSheet };
+});
+
+const ConsumeMode = lazy(async () => {
+  const mod = await import("./components/consume-mode");
+  return { default: mod.ConsumeMode };
+});
+
 type DetailMode = AgentMode | "cost" | "logs" | "terminal";
+
+interface VersionsSheetProps {
+  agent: Agent;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}
+
+const VersionsSheet = lazy(async () => {
+  const [sheetModule, versionsModule] = await Promise.all([
+    import("@/shared/ui/sheet"),
+    import("./components/versions-tab"),
+  ]);
+  const { Sheet, SheetContent, SheetTitle } = sheetModule;
+  const { VersionsTab } = versionsModule;
+
+  function VersionsSheetContent({ agent, onOpenChange, open }: VersionsSheetProps) {
+    return (
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent className="w-[560px] max-w-[calc(100vw-2rem)] p-0">
+          <SheetTitle className="sr-only">Versions</SheetTitle>
+          <VersionsTab agent={agent} />
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return { default: VersionsSheetContent };
+});
 
 const MODE_TABS: { id: DetailMode; label: string }[] = [
   { id: "preview", label: "Preview" },
@@ -151,6 +194,14 @@ function AgentDetailHeader({
         </Button>
       </div>
     </header>
+  );
+}
+
+function PanelLoading(): ReactElement {
+  return (
+    <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
+      Loading…
+    </div>
   );
 }
 
@@ -284,13 +335,15 @@ export function AgentDetailPage() {
   // Consume mode keeps a config entry point back into the editor.
   if (mode === "consume") {
     return (
-      <ConsumeMode
-        agent={agent}
-        onOpenConfig={() => {
-          handleSelectMode("preview");
-        }}
-        showConfigButton
-      />
+      <Suspense fallback={<PanelLoading />}>
+        <ConsumeMode
+          agent={agent}
+          onOpenConfig={() => {
+            handleSelectMode("preview");
+          }}
+          showConfigButton
+        />
+      </Suspense>
     );
   }
 
@@ -319,28 +372,39 @@ export function AgentDetailPage() {
         {mode === "preview" && (
           <PreviewMode agent={agent} headerActionTarget={headerActionTarget} />
         )}
-        {mode === "logs" && <LogsTab agentId={agent.id} appId={agent.appId} />}
-        {mode === "cost" && <AgentCostTab agentId={agent.id} appId={agent.appId} />}
+        {mode === "logs" && (
+          <Suspense fallback={<PanelLoading />}>
+            <LogsTab agentId={agent.id} appId={agent.appId} />
+          </Suspense>
+        )}
+        {mode === "cost" && (
+          <Suspense fallback={<PanelLoading />}>
+            <AgentCostTab agentId={agent.id} appId={agent.appId} />
+          </Suspense>
+        )}
         {mode === "terminal" && (
-          <Suspense fallback={null}>
+          <Suspense fallback={<PanelLoading />}>
             <TerminalMode key={agent.id} agent={agent} />
           </Suspense>
         )}
       </div>
 
-      <SettingsSheet
-        agent={agent}
-        open={showSettings}
-        onOpenChange={setShowSettings}
-        canManageAccess={canManageAgentAccess}
-      />
+      {showSettings ? (
+        <Suspense fallback={null}>
+          <SettingsSheet
+            agent={agent}
+            open={showSettings}
+            onOpenChange={setShowSettings}
+            canManageAccess={canManageAgentAccess}
+          />
+        </Suspense>
+      ) : null}
 
-      <Sheet open={showVersions} onOpenChange={setShowVersions}>
-        <SheetContent className="w-[560px] max-w-[calc(100vw-2rem)] p-0">
-          <SheetTitle className="sr-only">Versions</SheetTitle>
-          <VersionsTab agent={agent} />
-        </SheetContent>
-      </Sheet>
+      {showVersions ? (
+        <Suspense fallback={null}>
+          <VersionsSheet agent={agent} open={showVersions} onOpenChange={setShowVersions} />
+        </Suspense>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/routes/agent/components/preview-mode.tsx
+++ b/apps/web/src/routes/agent/components/preview-mode.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { ReactElement } from "react";
-import { useEffect, useReducer } from "react";
+import { lazy, Suspense, useEffect, useReducer } from "react";
 import { createPortal } from "react-dom";
 
 import { publishAgent } from "@/domains/agent/api/agent-client";
@@ -14,12 +14,16 @@ import { PendingChangesBanner } from "../lifecycle/pending-changes-banner";
 import { PublishMenu } from "../lifecycle/publish-menu";
 import { PublishSuccessModal } from "../lifecycle/publish-success-modal";
 import { AgentKindSection } from "./agent-kind-section";
-import { AgentSessionPanel } from "./agent-session-panel";
 import { ChannelsConfigDialog } from "./channels-config-dialog";
 import { AgentFormView } from "./editor/form-view";
 import { useAgentEditorAutoSave } from "./editor/use-auto-save";
 import { useAgentEditorModel } from "./editor/use-model";
 import type { ChannelId } from "./settings-dialog-model";
+
+const AgentSessionPanel = lazy(async () => {
+  const mod = await import("./agent-session-panel");
+  return { default: mod.AgentSessionPanel };
+});
 
 type AppliedToastKind = LifecycleActionKind | "direct-update";
 
@@ -58,6 +62,14 @@ const PREVIEW_MODE_INITIAL_STATE: PreviewModeState = {
 export interface PreviewModeProps {
   agent: Agent;
   headerActionTarget: HTMLDivElement | null;
+}
+
+function PreviewChatLoading(): ReactElement {
+  return (
+    <div className="text-muted-foreground flex h-full items-center justify-center text-[13px]">
+      Loading preview…
+    </div>
+  );
 }
 
 function publishStatusMessage({
@@ -189,16 +201,18 @@ export function PreviewMode({ agent, headerActionTarget }: PreviewModeProps): Re
         : null}
       <div className="border-border-subtle flex min-h-0 w-1/2 shrink-0 flex-col border-r">
         <div className="min-h-0 flex-1 overflow-hidden">
-          <AgentSessionPanel
-            agentId={agent.id}
-            agentName={agent.name}
-            configurationChangedAt={agent.updatedAt}
-            configurationRevisionKey={`${agent.updatedAt}:${agent.liveVersion?.id ?? "draft"}`}
-            key={agent.id}
-            appId={agent.appId}
-            readiness={agent.readiness}
-            tone="preview"
-          />
+          <Suspense fallback={<PreviewChatLoading />}>
+            <AgentSessionPanel
+              agentId={agent.id}
+              agentName={agent.name}
+              configurationChangedAt={agent.updatedAt}
+              configurationRevisionKey={`${agent.updatedAt}:${agent.liveVersion?.id ?? "draft"}`}
+              key={agent.id}
+              appId={agent.appId}
+              readiness={agent.readiness}
+              tone="preview"
+            />
+          </Suspense>
         </div>
 
         {showAppliedToast && appliedKind ? (


### PR DESCRIPTION
## Summary

- Split non-default Agent detail panels and dialogs into lazy chunks.
- Split the preview chat/session panel away from the Agent detail route's initial bundle.

## Why

- Closes YEF-845.
- Keeps the Agent detail shell/editor path lighter before secondary panels or chat runtime finish loading.

## Verification

- Commands:
  - `just check`
  - `bun run --filter @mosoo/web build`
  - Playwright Chromium route timing against `bun run --filter @mosoo/web preview --host 127.0.0.1 --port 4173`
- Manual steps:
  - Timed all 39 registered route paths with fresh browser contexts, `1280x800` viewport, production preview assets, and a deterministic unauthenticated `/api/graphql` viewer stub. Worst page load was `/login` at `26.9 ms`; all routes stayed under `50 ms`.
- Not run:
  - Chrome DevTools MCP trace, because the MCP server could not connect to a running Chrome `DevToolsActivePort` in this environment.

## Impact

- User/API/contract changes: no API or contract changes. The Agent detail route now shows existing loading fallbacks while non-default panels, dialogs, consume mode, or preview chat chunks load.
- Generated files / GraphQL / DB / lockfile: none.
- Env or config changes: none.
- Risk and rollback: low risk; rollback by reverting this commit if lazy chunk loading regresses a panel.

## Review

- Closest review areas: `apps/web/src/routes/agent/agent-detail.route.tsx`, `apps/web/src/routes/agent/components/preview-mode.tsx`.
- Known trade-offs: first opening Logs, Cost, Settings, Versions, Consume, or the preview chat panel may fetch an extra chunk instead of arriving in the initial route payload.
