### PR TITLE
fix(web): improve mobile console responsiveness

### DIFF
--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -6,6 +6,7 @@ import PanelLeftCloseIcon from "@hugeicons/core-free-icons/PanelLeftCloseIcon";
 import PanelLeftOpenIcon from "@hugeicons/core-free-icons/PanelLeftOpenIcon";
 import PlusSignIcon from "@hugeicons/core-free-icons/PlusSignIcon";
 import type { AppSummary } from "@mosoo/contracts/app";
+import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
@@ -20,6 +21,7 @@ import {
   DropdownMenuTrigger,
 } from "@/shared/ui/dropdown-menu";
 import { Separator } from "@/shared/ui/separator";
+import { Sheet, SheetContent, SheetTitle } from "@/shared/ui/sheet";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 import { AccountMenu } from "./account-menu";
@@ -171,17 +173,107 @@ function NewAgentCta({ collapsed, disabled }: { collapsed: boolean; disabled: bo
   );
 }
 
-function ConsoleSidebarFooter({ collapsed }: { collapsed: boolean }) {
+function ConsoleSidebarFooter({
+  collapsed,
+  helpShortcutEnabled = true,
+}: {
+  collapsed: boolean;
+  helpShortcutEnabled?: boolean;
+}) {
   const { user } = useAppSession();
 
   return (
     <>
       <div className={cn("pb-2", collapsed ? "flex justify-center" : "px-0.5")}>
-        <HelpMenu collapsed={collapsed} />
+        <HelpMenu collapsed={collapsed} shortcutEnabled={helpShortcutEnabled} />
       </div>
       <Separator className="bg-border-soft" />
       <AccountMenu collapsed={collapsed} user={user} />
     </>
+  );
+}
+
+function MobileNavigation({
+  renderNavigation,
+  title,
+}: {
+  renderNavigation: (closeNavigation: () => void) => ReactNode;
+  title?: string | null;
+}) {
+  const location = useLocation();
+  const navigationLocation = `${location.pathname}${location.search}`;
+  const [openedAtLocation, setOpenedAtLocation] = useState<string | null>(null);
+  const open = openedAtLocation === navigationLocation;
+
+  function closeNavigation(): void {
+    setOpenedAtLocation(null);
+  }
+
+  useEffect(() => {
+    if (typeof globalThis.matchMedia !== "function") {
+      return;
+    }
+
+    const desktopBreakpoint = globalThis.matchMedia("(min-width: 768px)");
+
+    function handleBreakpointChange(event: MediaQueryListEvent): void {
+      if (event.matches) {
+        setOpenedAtLocation(null);
+      }
+    }
+
+    desktopBreakpoint.addEventListener("change", handleBreakpointChange);
+    return () => {
+      desktopBreakpoint.removeEventListener("change", handleBreakpointChange);
+    };
+  }, []);
+
+  return (
+    <div className="md:hidden">
+      <header className="border-border-soft bg-background flex h-14 shrink-0 items-center gap-3 border-b px-4">
+        <button
+          aria-label="Open navigation"
+          className="text-fg-2 hover:bg-ink-900/[0.04] hover:text-fg-1 flex h-10 shrink-0 items-center justify-center gap-1.5 rounded-md px-2 transition-colors"
+          onClick={() => {
+            setOpenedAtLocation(navigationLocation);
+          }}
+          type="button"
+        >
+          <ExpandSidebarIcon className="size-5" />
+          <span className="text-xs font-semibold">Menu</span>
+        </button>
+        <img src="/brand/logo-wordmark-onlight.svg" alt="Mosoo" className="block h-5" />
+        {title ? (
+          <h1 className="text-fg-1 ml-auto truncate text-sm font-semibold">{title}</h1>
+        ) : null}
+      </header>
+
+      <Sheet
+        onOpenChange={(nextOpen) => {
+          setOpenedAtLocation(nextOpen ? navigationLocation : null);
+        }}
+        open={open}
+      >
+        <SheetContent className="bg-sidebar data-[closed]:slide-out-to-left data-[open]:slide-in-from-left right-auto left-0 flex w-[min(20rem,calc(100vw-2rem))] max-w-none flex-col p-3">
+          <SheetTitle className="sr-only">Navigation</SheetTitle>
+          <div className="flex h-11 shrink-0 items-center px-1.5">
+            <img src="/brand/logo-wordmark-onlight.svg" alt="Mosoo" className="block h-[22px]" />
+          </div>
+          <nav
+            className="flex min-h-0 flex-1 flex-col overflow-y-auto pt-2 [&_a]:min-h-11 [&_button]:min-h-11"
+            onClickCapture={(event) => {
+              if (event.target instanceof Element && event.target.closest("a") !== null) {
+                closeNavigation();
+              }
+            }}
+          >
+            {renderNavigation(closeNavigation)}
+            <div className="min-h-4 flex-1" />
+            <ConsoleSidebarFooter collapsed={false} helpShortcutEnabled={false} />
+          </nav>
+        </SheetContent>
+      </Sheet>
+    </div>
   );
 }
 
@@ -202,11 +294,13 @@ function getOrgHeaderTitle(pathname: string): string | null {
 function ConsoleShell({
   children,
   collapsed,
+  mobileSidebar,
   onToggleCollapsed,
   sidebar,
 }: {
   children: ReactNode;
   collapsed: boolean;
+  mobileSidebar: (closeNavigation: () => void) => ReactNode;
   onToggleCollapsed: () => void;
   sidebar: ReactNode;
 }) {
@@ -214,7 +308,7 @@ function ConsoleShell({
   const toggleLabel = collapsed ? "Expand sidebar" : "Collapse sidebar";
 
   return (
-    <div className="bg-sidebar flex h-screen">
+    <div className="bg-sidebar flex h-dvh">
       <nav
         className={cn(
           "hidden shrink-0 flex-col bg-sidebar pt-3.5 transition-[width] duration-200 ease-out md:flex",
@@ -254,7 +348,8 @@ function ConsoleShell({
 
       <div className="flex min-w-0 flex-1">
         <main className="bg-background md:border-border-soft flex min-w-0 flex-1 flex-col overflow-hidden md:rounded-md md:border-l">
-          {children}
+          <MobileNavigation renderNavigation={mobileSidebar} />
+          <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
         </main>
       </div>
     </div>
@@ -273,24 +368,32 @@ export function Layout({ children }: { children: ReactNode }) {
     void navigate("/");
   }
 
+  function appSidebar(isCollapsed: boolean, onNavigate?: () => void): ReactNode {
+    return (
+      <>
+        <BackToOrgLink collapsed={isCollapsed} orgName={activeOrganization?.name ?? null} />
+        <AppSwitcher
+          activeApp={activeApp}
+          apps={apps}
+          collapsed={isCollapsed}
+          loading={appsLoading}
+          onSwitch={(appId) => {
+            switchApp(appId);
+            onNavigate?.();
+          }}
+        />
+        <NewAgentCta collapsed={isCollapsed} disabled={activeApp === null} />
+        <AppNavigation collapsed={isCollapsed} pathname={location.pathname} />
+      </>
+    );
+  }
+
   return (
     <ConsoleShell
       collapsed={collapsed}
+      mobileSidebar={(closeNavigation) => appSidebar(false, closeNavigation)}
       onToggleCollapsed={toggleCollapsed}
-      sidebar={
-        <>
-          <BackToOrgLink collapsed={collapsed} orgName={activeOrganization?.name ?? null} />
-          <AppSwitcher
-            activeApp={activeApp}
-            apps={apps}
-            collapsed={collapsed}
-            loading={appsLoading}
-            onSwitch={switchApp}
-          />
-          <NewAgentCta collapsed={collapsed} disabled={activeApp === null} />
-          <AppNavigation collapsed={collapsed} pathname={location.pathname} />
-        </>
-      }
+      sidebar={appSidebar(collapsed)}
     >
       {children}
     </ConsoleShell>
@@ -306,8 +409,8 @@ export function OrgLayout({ children }: { children: ReactNode }) {
   const headerTitle = getOrgHeaderTitle(location.pathname);
 
   return (
-    <div className="bg-background flex h-screen flex-col">
-      <header className="border-border-soft flex shrink-0 border-b">
+    <div className="bg-background flex h-dvh flex-col">
+      <header className="border-border-soft hidden shrink-0 border-b md:flex">
         <div className="flex min-h-[76px] w-[224px] shrink-0 items-center gap-2 px-4">
           <Link to="/apps" aria-label="Apps" className="flex items-center">
             <img src="/brand/logo-mark.svg" alt="Mosoo" className="block size-6" />
@@ -329,8 +432,12 @@ export function OrgLayout({ children }: { children: ReactNode }) {
           </div>
         )}
       </header>
+      <MobileNavigation
+        renderNavigation={() => <OrgNavigation collapsed={false} pathname={location.pathname} />}
+        title={headerTitle}
+      />
       <div className="flex min-h-0 flex-1">
-        <aside className="border-border-soft flex w-[224px] shrink-0 flex-col border-r px-3 py-4">
+        <aside className="border-border-soft hidden w-[224px] shrink-0 flex-col border-r px-3 py-4 md:flex">
           <OrgNavigation collapsed={false} pathname={location.pathname} />
           <div className="flex-1" />
           <ConsoleSidebarFooter collapsed={false} />

--- a/apps/web/src/features/help/help-menu.tsx
+++ b/apps/web/src/features/help/help-menu.tsx
@@ -22,7 +22,13 @@ function isTypingTarget(target: EventTarget | null): boolean {
   return tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable;
 }
 
-export function HelpMenu({ collapsed }: { collapsed: boolean }) {
+export function HelpMenu({
+  collapsed,
+  shortcutEnabled = true,
+}: {
+  collapsed: boolean;
+  shortcutEnabled?: boolean;
+}) {
   const [open, setOpen] = useState(false);
   // Keep the dialog mounted once it has been opened so its close animation can
   // still play, but never mount it before the first open so the chunk is not
@@ -44,6 +50,10 @@ export function HelpMenu({ collapsed }: { collapsed: boolean }) {
   // Press "?" anywhere outside a text field to open help, matching the common
   // shortcut used by other apps.
   useEffect(() => {
+    if (!shortcutEnabled) {
+      return;
+    }
+
     function handleKeyDown(event: KeyboardEvent): void {
       if (event.key !== "?" || event.metaKey || event.ctrlKey || event.altKey) {
         return;
@@ -60,7 +70,7 @@ export function HelpMenu({ collapsed }: { collapsed: boolean }) {
     return () => {
       globalThis.removeEventListener("keydown", handleKeyDown);
     };
-  }, []);
+  }, [shortcutEnabled]);
 
   const button = (
     <button

--- a/apps/web/src/routes/agent/agent-detail.route.tsx
+++ b/apps/web/src/routes/agent/agent-detail.route.tsx
@@ -75,14 +75,26 @@ function AgentDetailHeader({
   runtime: ReturnType<typeof getRuntimeInfo> | null;
 }) {
   return (
-    <header className="border-border-subtle relative flex h-13 shrink-0 items-center justify-between border-b bg-white px-5">
-      <div className="flex items-center gap-3">
-        <Button variant="ghost" size="icon-sm" onClick={onBack} className="text-muted-foreground">
+    <header className="border-border-subtle relative flex min-h-13 shrink-0 flex-wrap items-center gap-y-2 border-b bg-white px-3 py-2 sm:px-5 md:h-13 md:flex-nowrap md:py-0">
+      <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
+        <Button
+          aria-label="Back to agents"
+          variant="ghost"
+          size="icon-sm"
+          onClick={onBack}
+          className="text-muted-foreground shrink-0"
+        >
           <ArrowLeft className="size-4" />
         </Button>
 
-        {runtime ? <RuntimeIcon runtime={runtime} size={28} /> : null}
-        <span className="text-foreground text-[14px] font-medium">{agent.name}</span>
+        {runtime ? (
+          <span className="hidden shrink-0 sm:block">
+            <RuntimeIcon runtime={runtime} size={28} />
+          </span>
+        ) : null}
+        <span className="text-foreground min-w-0 truncate text-[14px] font-medium">
+          {agent.name}
+        </span>
         {agent.status === "draft" ? (
           <button
             type="button"
@@ -104,7 +116,7 @@ function AgentDetailHeader({
         ) : null}
       </div>
 
-      <div className="absolute left-1/2 flex -translate-x-1/2 items-center gap-1">
+      <div className="border-border-subtle order-3 flex w-full items-center gap-1 overflow-x-auto border-t pt-2 md:absolute md:left-1/2 md:order-none md:w-auto md:-translate-x-1/2 md:border-0 md:pt-0">
         {MODE_TABS.map((tab) => (
           <button
             key={tab.id}
@@ -139,7 +151,7 @@ function AgentDetailHeader({
         )}
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="flex shrink-0 items-center gap-1 sm:gap-2">
         <div ref={headerActionTargetRef} className="flex items-center gap-2" />
         <Button
           variant="ghost"

--- a/apps/web/src/routes/agent/components/agent-table.tsx
+++ b/apps/web/src/routes/agent/components/agent-table.tsx
@@ -35,8 +35,8 @@ export function AgentTable({
   className?: string;
 }): ReactElement {
   const gridCols = showOwner
-    ? "grid-cols-[1fr_160px_120px_180px_140px_48px]"
-    : "grid-cols-[1fr_160px_120px_140px_48px]";
+    ? "grid-cols-[minmax(0,1fr)_auto_32px] lg:grid-cols-[minmax(0,1fr)_160px_120px_180px_140px_48px]"
+    : "grid-cols-[minmax(0,1fr)_auto_32px] lg:grid-cols-[minmax(0,1fr)_160px_120px_140px_48px]";
 
   return (
     <div className={className}>
@@ -45,18 +45,18 @@ export function AgentTable({
           <span className="text-fg-3 text-[11px] font-extrabold tracking-[0.1em] uppercase">
             Agent
           </span>
-          <span className="text-fg-3 text-[11px] font-extrabold tracking-[0.1em] uppercase">
+          <span className="text-fg-3 hidden text-[11px] font-extrabold tracking-[0.1em] uppercase lg:block">
             Tools
           </span>
           <span className="text-fg-3 text-[11px] font-extrabold tracking-[0.1em] uppercase">
             Status
           </span>
           {showOwner && (
-            <span className="text-fg-3 text-[11px] font-extrabold tracking-[0.1em] uppercase">
+            <span className="text-fg-3 hidden text-[11px] font-extrabold tracking-[0.1em] uppercase lg:block">
               Owner
             </span>
           )}
-          <span className="text-fg-3 text-[11px] font-extrabold tracking-[0.1em] uppercase">
+          <span className="text-fg-3 hidden text-[11px] font-extrabold tracking-[0.1em] uppercase lg:block">
             Created
           </span>
           <span />
@@ -96,12 +96,14 @@ export function AgentTable({
                   </div>
                 </div>
 
-                <ToolIcons tools={agent.tools} />
+                <div className="hidden lg:block">
+                  <ToolIcons tools={agent.tools} />
+                </div>
 
                 <StatusBadge status={agent.status} />
 
                 {showOwner && (
-                  <div className="flex min-w-0 items-center gap-2">
+                  <div className="hidden min-w-0 items-center gap-2 lg:flex">
                     <Avatar size="sm">
                       {agent.owner.avatar !== undefined && agent.owner.avatar.length > 0 ? (
                         <AvatarImage
@@ -118,7 +120,7 @@ export function AgentTable({
                   </div>
                 )}
 
-                <span className="text-fg-3 font-mono text-[12px]">
+                <span className="text-fg-3 hidden font-mono text-[12px] lg:inline">
                   {formatDate(agent.createdAt)}
                 </span>
               </button>

--- a/apps/web/src/routes/agent/components/preview-mode.tsx
+++ b/apps/web/src/routes/agent/components/preview-mode.tsx
@@ -166,7 +166,7 @@ export function PreviewMode({ agent, headerActionTarget }: PreviewModeProps): Re
   };
 
   return (
-    <div className="flex h-full" data-testid="agent-preview-panel">
+    <div className="flex h-full flex-col md:flex-row" data-testid="agent-preview-panel">
       {headerActionTarget !== null
         ? createPortal(
             <PublishMenu
@@ -187,7 +187,7 @@ export function PreviewMode({ agent, headerActionTarget }: PreviewModeProps): Re
             headerActionTarget,
           )
         : null}
-      <div className="border-border-subtle flex min-h-0 w-1/2 shrink-0 flex-col border-r">
+      <div className="border-border-subtle flex h-[42%] w-full shrink-0 flex-col border-b md:h-auto md:w-1/2 md:border-r md:border-b-0">
         <div className="min-h-0 flex-1 overflow-hidden">
           <AgentSessionPanel
             agentId={agent.id}
@@ -208,7 +208,7 @@ export function PreviewMode({ agent, headerActionTarget }: PreviewModeProps): Re
         ) : null}
       </div>
 
-      <div className="flex min-h-0 w-1/2 min-w-0 flex-col">
+      <div className="flex h-[58%] w-full min-w-0 flex-col md:h-auto md:w-1/2">
         <PendingChangesBanner
           agent={agent}
           key={`${agent.id}:${discardCounter}`}
@@ -222,7 +222,10 @@ export function PreviewMode({ agent, headerActionTarget }: PreviewModeProps): Re
           }}
         />
 
-        <div className="min-h-0 flex-1 overflow-y-auto bg-white p-5" data-agent-editor-scroll>
+        <div
+          className="min-h-0 flex-1 overflow-y-auto bg-white p-4 sm:p-5"
+          data-agent-editor-scroll
+        >
           <div className="space-y-5">
             <AgentKindSection agent={draftAgent} onKindChange={model.setKind} />
             <AgentFormView agent={draftAgent} model={model} />

--- a/apps/web/src/routes/app-overview/deploy/components/deployments-history.tsx
+++ b/apps/web/src/routes/app-overview/deploy/components/deployments-history.tsx
@@ -79,100 +79,175 @@ export function DeploymentsHistory({ runs }: { runs: DeploymentRunVM[] }) {
   }
 
   return (
-    <div className="border-border overflow-hidden rounded-xl border">
-      <Table>
-        <TableHeader>
-          <TableRow className="border-border hover:bg-transparent">
-            <TableHead className="text-fg-3 h-11 pl-5 text-[13px] font-medium">Deploy</TableHead>
-            <TableHead className="text-fg-3 h-11 text-[13px] font-medium">Status</TableHead>
-            <TableHead className="text-fg-3 h-11 pr-5 text-[13px] font-medium">Changes</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {runs.map((run) => {
-            const failedError =
-              run.outcome === "failed" ? (run.errorMessage ?? run.errorCode) : null;
-            const expanded = expandedRunIds.has(run.id);
-            return (
-              <Fragment key={run.id}>
-                <TableRow>
-                  <TableCell className="py-4 pl-5">
-                    <div className="flex items-center gap-3">
-                      <span className="bg-bg-sunken text-fg-3 flex size-8 shrink-0 items-center justify-center rounded-full">
-                        <Rocket className="size-3.5" />
-                      </span>
-                      <div className="min-w-0">
-                        <div className="text-fg-1 text-[13.5px] font-semibold">
-                          {run.number === null ? "Deploy" : `Deploy #${String(run.number)}`}
-                        </div>
-                        <div className="text-fg-3 text-[12.5px]">
-                          {relativeLabel(run.createdAt, now)}
-                        </div>
-                      </div>
+    <>
+      <div className="space-y-2 md:hidden">
+        {runs.map((run) => {
+          const failedError = run.outcome === "failed" ? (run.errorMessage ?? run.errorCode) : null;
+          const expanded = expandedRunIds.has(run.id);
+
+          return (
+            <article className="border-border rounded-xl border p-4" key={run.id}>
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-3">
+                  <span className="bg-bg-sunken text-fg-3 flex size-8 shrink-0 items-center justify-center rounded-full">
+                    <Rocket className="size-3.5" />
+                  </span>
+                  <div className="min-w-0">
+                    <div className="text-fg-1 text-[13.5px] font-semibold">
+                      {run.number === null ? "Deploy" : `Deploy #${String(run.number)}`}
                     </div>
-                  </TableCell>
-                  <TableCell className="py-4 align-middle">
-                    <StatusBadge outcome={run.outcome} />
-                  </TableCell>
-                  <TableCell className="py-4 pr-5 align-middle">
-                    <div className="flex min-w-0 items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="text-fg-2 flex min-w-0 items-center gap-1.5 text-[13px]">
-                          <Code2 className="text-fg-3 size-3.5 shrink-0" />
-                          <span>commit</span>
-                          <span className="text-fg-1 truncate font-mono">{run.commitSha}</span>
-                          <span className="text-fg-3">· default branch HEAD</span>
-                        </div>
-                        <div className="text-fg-3 mt-0.5 flex items-center gap-1.5 text-[12px]">
-                          <GitBranch className="size-3.5" />
-                          <span className="font-mono">
-                            {run.targetKind === null
-                              ? "detecting target"
-                              : DEPLOY_TARGET_LABELS[run.targetKind]}
-                          </span>
-                        </div>
+                    <div className="text-fg-3 text-[12.5px]">
+                      {relativeLabel(run.createdAt, now)}
+                    </div>
+                  </div>
+                </div>
+                <StatusBadge outcome={run.outcome} />
+              </div>
+
+              <div className="text-fg-2 mt-3 flex min-w-0 items-start gap-1.5 text-[13px]">
+                <Code2 className="text-fg-3 mt-0.5 size-3.5 shrink-0" />
+                <span className="min-w-0 break-words">
+                  commit <span className="text-fg-1 font-mono">{run.commitSha}</span>
+                  <span className="text-fg-3"> · default branch HEAD</span>
+                </span>
+              </div>
+              <div className="text-fg-3 mt-1 flex items-center gap-1.5 text-[12px]">
+                <GitBranch className="size-3.5 shrink-0" />
+                <span className="font-mono">
+                  {run.targetKind === null
+                    ? "detecting target"
+                    : DEPLOY_TARGET_LABELS[run.targetKind]}
+                </span>
+              </div>
+
+              {failedError === null ? null : (
+                <>
+                  <button
+                    aria-expanded={expanded}
+                    className="text-fg-3 hover:text-fg-1 focus-visible:ring-ring mt-2 inline-flex min-h-10 items-center gap-1 rounded-md px-2 text-[12px] font-medium transition-colors focus:outline-none focus-visible:ring-2"
+                    onClick={() => toggleRun(run.id)}
+                    type="button"
+                  >
+                    Details
+                    <ChevronDown
+                      className={cn("size-3.5 transition-transform", expanded && "rotate-180")}
+                    />
+                  </button>
+                  {expanded ? (
+                    <div className="border-border bg-bg-sunken/40 mt-1 rounded-md border px-3.5 py-2.5 text-[13px]">
+                      <div className="text-fg-3 mb-1 text-[11.5px] font-medium">
+                        Failure details
                       </div>
-                      {failedError === null ? null : (
-                        <button
-                          type="button"
-                          aria-expanded={expanded}
-                          onClick={() => toggleRun(run.id)}
-                          className="text-fg-3 hover:text-fg-1 focus-visible:ring-ring inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-[12px] font-medium transition-colors focus:outline-none focus-visible:ring-2"
-                        >
-                          Details
-                          <ChevronDown
-                            className={cn(
-                              "size-3.5 transition-transform",
-                              expanded && "rotate-180",
-                            )}
-                          />
-                        </button>
+                      {run.errorCode === null ? null : (
+                        <span className="text-destructive mr-2 font-mono text-[12px] font-semibold">
+                          {run.errorCode}
+                        </span>
                       )}
+                      <span className="text-fg-2 break-words">{run.errorMessage ?? ""}</span>
                     </div>
-                  </TableCell>
-                </TableRow>
-                {failedError === null || !expanded ? null : (
-                  <TableRow className="hover:bg-transparent">
-                    <TableCell colSpan={3} className="px-5 pt-0 pb-4">
-                      <div className="border-border bg-bg-sunken/40 rounded-md border px-3.5 py-2.5 text-[13px]">
-                        <div className="text-fg-3 mb-1 text-[11.5px] font-medium">
-                          Failure details
+                  ) : null}
+                </>
+              )}
+            </article>
+          );
+        })}
+      </div>
+
+      <div className="border-border hidden overflow-hidden rounded-xl border md:block">
+        <Table>
+          <TableHeader>
+            <TableRow className="border-border hover:bg-transparent">
+              <TableHead className="text-fg-3 h-11 pl-5 text-[13px] font-medium">Deploy</TableHead>
+              <TableHead className="text-fg-3 h-11 text-[13px] font-medium">Status</TableHead>
+              <TableHead className="text-fg-3 h-11 pr-5 text-[13px] font-medium">Changes</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {runs.map((run) => {
+              const failedError =
+                run.outcome === "failed" ? (run.errorMessage ?? run.errorCode) : null;
+              const expanded = expandedRunIds.has(run.id);
+              return (
+                <Fragment key={run.id}>
+                  <TableRow>
+                    <TableCell className="py-4 pl-5">
+                      <div className="flex items-center gap-3">
+                        <span className="bg-bg-sunken text-fg-3 flex size-8 shrink-0 items-center justify-center rounded-full">
+                          <Rocket className="size-3.5" />
+                        </span>
+                        <div className="min-w-0">
+                          <div className="text-fg-1 text-[13.5px] font-semibold">
+                            {run.number === null ? "Deploy" : `Deploy #${String(run.number)}`}
+                          </div>
+                          <div className="text-fg-3 text-[12.5px]">
+                            {relativeLabel(run.createdAt, now)}
+                          </div>
                         </div>
-                        {run.errorCode === null ? null : (
-                          <span className="text-destructive mr-2 font-mono text-[12px] font-semibold">
-                            {run.errorCode}
-                          </span>
+                      </div>
+                    </TableCell>
+                    <TableCell className="py-4 align-middle">
+                      <StatusBadge outcome={run.outcome} />
+                    </TableCell>
+                    <TableCell className="py-4 pr-5 align-middle">
+                      <div className="flex min-w-0 items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="text-fg-2 flex min-w-0 items-center gap-1.5 text-[13px]">
+                            <Code2 className="text-fg-3 size-3.5 shrink-0" />
+                            <span>commit</span>
+                            <span className="text-fg-1 truncate font-mono">{run.commitSha}</span>
+                            <span className="text-fg-3">· default branch HEAD</span>
+                          </div>
+                          <div className="text-fg-3 mt-0.5 flex items-center gap-1.5 text-[12px]">
+                            <GitBranch className="size-3.5" />
+                            <span className="font-mono">
+                              {run.targetKind === null
+                                ? "detecting target"
+                                : DEPLOY_TARGET_LABELS[run.targetKind]}
+                            </span>
+                          </div>
+                        </div>
+                        {failedError === null ? null : (
+                          <button
+                            type="button"
+                            aria-expanded={expanded}
+                            onClick={() => toggleRun(run.id)}
+                            className="text-fg-3 hover:text-fg-1 focus-visible:ring-ring inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-[12px] font-medium transition-colors focus:outline-none focus-visible:ring-2"
+                          >
+                            Details
+                            <ChevronDown
+                              className={cn(
+                                "size-3.5 transition-transform",
+                                expanded && "rotate-180",
+                              )}
+                            />
+                          </button>
                         )}
-                        <span className="text-fg-2">{run.errorMessage ?? ""}</span>
                       </div>
                     </TableCell>
                   </TableRow>
-                )}
-              </Fragment>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
+                  {failedError === null || !expanded ? null : (
+                    <TableRow className="hover:bg-transparent">
+                      <TableCell colSpan={3} className="px-5 pt-0 pb-4">
+                        <div className="border-border bg-bg-sunken/40 rounded-md border px-3.5 py-2.5 text-[13px]">
+                          <div className="text-fg-3 mb-1 text-[11.5px] font-medium">
+                            Failure details
+                          </div>
+                          {run.errorCode === null ? null : (
+                            <span className="text-destructive mr-2 font-mono text-[12px] font-semibold">
+                              {run.errorCode}
+                            </span>
+                          )}
+                          <span className="text-fg-2">{run.errorMessage ?? ""}</span>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </Fragment>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </>
   );
 }

--- a/apps/web/src/routes/app-settings/app-settings-nav.tsx
+++ b/apps/web/src/routes/app-settings/app-settings-nav.tsx
@@ -17,18 +17,18 @@ const APP_SETTINGS_NAV_ITEMS: AppSettingsNavItem[] = [
 
 export function AppSettingsNav() {
   return (
-    <aside className="border-border-soft flex w-[220px] shrink-0 flex-col gap-3 border-r px-3 py-5">
-      <div className="text-fg-3 px-2.5 pb-1 text-[10px] font-semibold tracking-[0.14em] uppercase">
+    <aside className="border-border-soft flex w-full shrink-0 flex-col gap-3 overflow-x-auto border-b px-4 py-2 md:w-[220px] md:overflow-visible md:border-r md:border-b-0 md:px-3 md:py-5">
+      <div className="text-fg-3 hidden px-2.5 pb-1 text-[10px] font-semibold tracking-[0.14em] uppercase md:block">
         App
       </div>
-      <div className="flex flex-col gap-0.5">
+      <div className="flex gap-1 md:flex-col md:gap-0.5">
         {APP_SETTINGS_NAV_ITEMS.map((item) => (
           <NavLink
             key={item.path}
             to={item.path}
             className={({ isActive }) =>
               cn(
-                "flex items-center gap-2.5 rounded-md px-2.5 py-2 text-[13px] font-medium transition-colors",
+                "flex min-h-11 shrink-0 items-center gap-2.5 whitespace-nowrap rounded-md px-2.5 py-2 text-[13px] font-medium transition-colors md:min-h-0",
                 isActive
                   ? "bg-ink-100 text-fg-1"
                   : "text-fg-2 hover:bg-ink-900/[0.04] hover:text-fg-1",

--- a/apps/web/src/routes/app-settings/app-settings.route.tsx
+++ b/apps/web/src/routes/app-settings/app-settings.route.tsx
@@ -4,7 +4,7 @@ import { AppSettingsNav } from "./app-settings-nav";
 
 export function AppSettingsLayout() {
   return (
-    <div className="flex h-full overflow-hidden">
+    <div className="flex h-full flex-col overflow-hidden md:flex-row">
       <AppSettingsNav />
       <div className="flex h-full min-w-0 flex-1 flex-col overflow-hidden">
         <Outlet />

--- a/apps/web/src/routes/apps/apps-list.route.tsx
+++ b/apps/web/src/routes/apps/apps-list.route.tsx
@@ -107,7 +107,7 @@ export function AppsListPage() {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <main className="min-h-0 flex-1 overflow-y-auto px-8 pt-6 pb-8">
+      <main className="min-h-0 flex-1 overflow-y-auto px-4 pt-6 pb-8 sm:px-8">
         <div className="flex flex-wrap items-center gap-3">
           <div className="relative w-full max-w-[320px]">
             <Search className="text-fg-3 absolute top-1/2 left-3 size-3.5 -translate-y-1/2" />

--- a/apps/web/src/routes/cost/cost-page-header.tsx
+++ b/apps/web/src/routes/cost/cost-page-header.tsx
@@ -29,14 +29,14 @@ export function CostPageHeader({
   setRunPurpose: (value: CostRunPurpose | "all") => void;
 }) {
   return (
-    <header className="border-border-subtle flex h-12 shrink-0 items-center justify-between gap-3 border-b px-6">
+    <header className="border-border-subtle flex min-h-12 shrink-0 flex-col items-stretch gap-2 border-b px-4 py-3 sm:px-6 lg:h-12 lg:flex-row lg:items-center lg:justify-between lg:py-0">
       <div className="flex min-w-0 items-baseline gap-2">
         <span className="text-sm font-medium">App Usage</span>
         <span className="text-fg-3 hidden truncate text-xs sm:inline">
           {`${card?.appName ?? "App"} · ${rangeLabel(range)} · ${formatCurrency(card?.totals.totalCostUsd ?? 0)}`}
         </span>
       </div>
-      <div className="flex shrink-0 items-center gap-2">
+      <div className="flex w-full flex-wrap items-center gap-2 lg:w-auto lg:flex-nowrap">
         <div className="border-border bg-card flex rounded-md border p-0.5">
           {RUN_PURPOSE_FILTERS.map((item) => (
             <button
@@ -46,7 +46,7 @@ export function CostPageHeader({
                 setRunPurpose(item.value);
               }}
               className={cn(
-                "rounded px-2.5 py-1 text-xs font-semibold",
+                "min-h-10 rounded px-2.5 py-1 text-xs font-semibold lg:min-h-0",
                 runPurpose === item.value ? "bg-ink-100 text-fg-1" : "text-muted-foreground",
               )}
             >
@@ -63,7 +63,7 @@ export function CostPageHeader({
                 setRange(value);
               }}
               className={cn(
-                "rounded px-3 py-1 text-xs font-semibold uppercase",
+                "min-h-10 rounded px-3 py-1 text-xs font-semibold uppercase lg:min-h-0",
                 range === value ? "bg-ink-100 text-fg-1" : "text-muted-foreground",
               )}
             >

--- a/apps/web/src/routes/cost/cost-tab-bar.tsx
+++ b/apps/web/src/routes/cost/cost-tab-bar.tsx
@@ -11,7 +11,7 @@ export function CostTabBar({
   setActiveTab: (tab: CostTab) => void;
 }) {
   return (
-    <div className="border-border-subtle flex shrink-0 gap-1 border-b px-6 py-3">
+    <div className="border-border-subtle flex shrink-0 gap-1 overflow-x-auto border-b px-4 py-3 sm:px-6">
       {COST_TABS.map((tab) => (
         <button
           key={tab.id}
@@ -20,7 +20,7 @@ export function CostTabBar({
             setActiveTab(tab.id);
           }}
           className={cn(
-            "rounded-md px-3 py-1.5 text-sm font-semibold transition-colors",
+            "min-h-10 shrink-0 rounded-md px-3 py-1.5 text-sm font-semibold transition-colors sm:min-h-0",
             effectiveTab === tab.id
               ? "bg-ink-100 text-fg-1"
               : "text-muted-foreground hover:bg-muted/60",

--- a/apps/web/src/routes/cost/cost.route.tsx
+++ b/apps/web/src/routes/cost/cost.route.tsx
@@ -48,7 +48,7 @@ export function CostPage() {
       />
       <CostTabBar effectiveTab={activeTab} setActiveTab={setActiveTab} />
 
-      <main className="min-h-0 flex-1 overflow-y-auto p-6">
+      <main className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
         <div className="max-w-6xl space-y-5">
           {isLoading ? (
             <div className="border-border bg-card text-muted-foreground rounded-lg border px-4 py-10 text-center text-sm">

--- a/apps/web/src/routes/integrations/mcp/mcp-tab.tsx
+++ b/apps/web/src/routes/integrations/mcp/mcp-tab.tsx
@@ -101,8 +101,8 @@ export function McpTab() {
         </Button>
       </PageHeader>
 
-      <div className="flex shrink-0 items-center gap-2.5 px-8 pb-4">
-        <div className="relative w-[260px]">
+      <div className="flex shrink-0 items-center gap-2.5 px-4 pb-4 sm:px-8">
+        <div className="relative w-full sm:w-[260px]">
           <Search className="text-fg-3 absolute top-1/2 left-3 size-3.5 -translate-y-1/2" />
           <Input
             placeholder="Search MCP servers..."
@@ -115,7 +115,7 @@ export function McpTab() {
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-8 pb-8">
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-8 sm:px-8">
         {registry.error && (
           <div className="border-destructive/20 bg-destructive/[0.06] text-destructive mb-4 rounded-md border px-3 py-2 text-[12px]">
             {registry.error}

--- a/apps/web/src/routes/integrations/skills/skills-tab.tsx
+++ b/apps/web/src/routes/integrations/skills/skills-tab.tsx
@@ -61,10 +61,10 @@ export function SkillsTab() {
         </Button>
       </PageHeader>
 
-      <div className="flex shrink-0 items-center gap-2.5 px-8 pb-4">
-        <div className="flex-1" />
+      <div className="flex shrink-0 flex-wrap items-center gap-2.5 px-4 pb-4 sm:px-8">
+        <div className="hidden flex-1 sm:block" />
 
-        <div className="relative w-[260px]">
+        <div className="relative w-full sm:w-[260px]">
           <Search className="text-fg-3 absolute top-1/2 left-3 size-3.5 -translate-y-1/2" />
           <Input
             placeholder="Search skills…"
@@ -77,7 +77,7 @@ export function SkillsTab() {
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-8 pb-8">
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-8 sm:px-8">
         {registry.loading ? (
           <div className="text-fg-3 py-12 text-center text-[13px]">Loading skills…</div>
         ) : filtered.length === 0 ? (

--- a/apps/web/src/routes/onboarding/onboarding.route.tsx
+++ b/apps/web/src/routes/onboarding/onboarding.route.tsx
@@ -145,7 +145,7 @@ function OnboardingProvisioningScreen() {
 function OnboardingErrorScreen({ error, onRetry }: { error: string | null; onRetry: () => void }) {
   return (
     <div className="bg-background fixed inset-0 flex flex-col">
-      <div className="flex items-center px-8 py-5">
+      <div className="flex items-center px-4 py-5 sm:px-8">
         <span className="text-xl font-light tracking-tight">Mosoo</span>
       </div>
 

--- a/apps/web/src/routes/org/org-settings.route.tsx
+++ b/apps/web/src/routes/org/org-settings.route.tsx
@@ -48,7 +48,7 @@ export function OrgSettingsPage() {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <main className="min-h-0 flex-1 overflow-y-auto px-8 py-6">
+      <main className="min-h-0 flex-1 overflow-y-auto px-4 py-6 sm:px-8">
         <div className="max-w-[560px]">
           {activeOrganization === null ? (
             <div className="text-muted-foreground text-sm">

--- a/apps/web/src/routes/providers/providers-tab.tsx
+++ b/apps/web/src/routes/providers/providers-tab.tsx
@@ -306,7 +306,7 @@ export function ProvidersTab({ appId }: { appId: string }): ReactElement {
         </Button>
       </PageHeader>
 
-      <main className="min-h-0 flex-1 overflow-y-auto px-8 py-6">
+      <main className="min-h-0 flex-1 overflow-y-auto px-4 py-6 sm:px-8">
         <div className="mx-auto max-w-4xl space-y-6">
           {credentialsLoading ? (
             <div className="border-border bg-card text-muted-foreground rounded-lg border px-4 py-6 text-sm">

--- a/apps/web/src/routes/settings/access-tokens-tab.tsx
+++ b/apps/web/src/routes/settings/access-tokens-tab.tsx
@@ -294,9 +294,51 @@ function AccessTokensTable({
   pending: boolean;
   tokens: PersonalAccessTokenSummary[] | null;
 }) {
+  const emptyState = loading ? "Loading tokens..." : tokens?.length === 0 ? "No tokens yet." : null;
+
   return (
-    <section className="border-border bg-card overflow-x-auto rounded-lg border">
-      <div className="min-w-[560px]">
+    <section className="border-border bg-card overflow-hidden rounded-lg border xl:overflow-x-auto">
+      <div className="xl:hidden">
+        {emptyState === null ? null : (
+          <div className="text-muted-foreground px-4 py-8 text-sm">{emptyState}</div>
+        )}
+        {tokens?.map((token) => (
+          <div className="border-border border-b p-4 last:border-b-0" key={token.id}>
+            <div className="flex min-w-0 items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="text-foreground truncate text-sm font-medium">{token.label}</div>
+                <div className="text-muted-foreground mt-1 text-xs">
+                  Created {formatDateTime(token.createdAt)}
+                </div>
+              </div>
+              <Button
+                className="min-h-10 min-w-10 shrink-0"
+                disabled={pending || token.revokedAt !== null}
+                onClick={() => {
+                  onRevoke(token.id);
+                }}
+                size="icon-xs"
+                title="Revoke token"
+                variant="ghost"
+              >
+                <Trash2 className="size-3.5" />
+              </Button>
+            </div>
+            <dl className="mt-3 grid gap-2 text-xs">
+              <div>
+                <dt className="text-muted-foreground">Token ID</dt>
+                <dd className="text-foreground mt-0.5 font-mono break-all">{token.id}</dd>
+              </div>
+              <div>
+                <dt className="text-muted-foreground">Last used</dt>
+                <dd className="text-foreground mt-0.5">{formatDateTime(token.lastUsedAt)}</dd>
+              </div>
+            </dl>
+          </div>
+        ))}
+      </div>
+
+      <div className="hidden min-w-[560px] xl:block">
         <div className="border-border text-muted-foreground grid grid-cols-[minmax(180px,1fr)_140px_160px_64px] border-b px-4 py-2.5 text-[11px] font-semibold tracking-[0.12em] uppercase">
           <div>Label</div>
           <div>Token ID</div>
@@ -304,13 +346,9 @@ function AccessTokensTable({
           <div className="text-right">Action</div>
         </div>
 
-        {loading ? (
-          <div className="text-muted-foreground px-4 py-6 text-sm">Loading tokens...</div>
-        ) : null}
-
-        {tokens?.length === 0 ? (
-          <div className="text-muted-foreground px-4 py-8 text-sm">No tokens yet.</div>
-        ) : null}
+        {emptyState === null ? null : (
+          <div className="text-muted-foreground px-4 py-8 text-sm">{emptyState}</div>
+        )}
 
         {tokens?.map((token) => (
           <AccessTokenRow

--- a/apps/web/src/routes/settings/settings-nav.tsx
+++ b/apps/web/src/routes/settings/settings-nav.tsx
@@ -29,24 +29,24 @@ const SETTINGS_NAV_SECTIONS: SettingsNavSection[] = [
 
 export function SettingsNav() {
   return (
-    <aside className="border-border-soft flex w-[220px] shrink-0 flex-col gap-3 border-r px-3 py-5">
-      <div className="text-fg-3 px-2.5 pb-1 text-[10px] font-semibold tracking-[0.14em] uppercase">
+    <aside className="border-border-soft flex w-full shrink-0 flex-col gap-3 overflow-x-auto border-b px-4 py-2 md:w-[220px] md:overflow-visible md:border-r md:border-b-0 md:px-3 md:py-5">
+      <div className="text-fg-3 hidden px-2.5 pb-1 text-[10px] font-semibold tracking-[0.14em] uppercase md:block">
         Settings
       </div>
       {SETTINGS_NAV_SECTIONS.map((section) => {
         return (
           <div key={section.label} className="flex flex-col gap-1">
-            <div className="text-fg-3 px-2.5 pb-1 text-[10px] font-semibold tracking-[0.14em] uppercase">
+            <div className="text-fg-3 hidden px-2.5 pb-1 text-[10px] font-semibold tracking-[0.14em] uppercase md:block">
               {section.label}
             </div>
-            <div className="flex flex-col gap-0.5">
+            <div className="flex gap-1 md:flex-col md:gap-0.5">
               {section.items.map((item) => (
                 <NavLink
                   key={item.path}
                   to={item.path}
                   className={({ isActive }) =>
                     cn(
-                      "flex items-center gap-2.5 rounded-md px-2.5 py-2 text-[13px] font-medium transition-colors",
+                      "flex min-h-11 shrink-0 items-center gap-2.5 whitespace-nowrap rounded-md px-2.5 py-2 text-[13px] font-medium transition-colors md:min-h-0",
                       isActive
                         ? "bg-ink-100 text-fg-1"
                         : "text-fg-2 hover:bg-ink-900/[0.04] hover:text-fg-1",

--- a/apps/web/src/routes/settings/settings.route.tsx
+++ b/apps/web/src/routes/settings/settings.route.tsx
@@ -4,7 +4,7 @@ import { SettingsNav } from "./settings-nav";
 
 export function SettingsLayout() {
   return (
-    <div className="flex h-full overflow-hidden">
+    <div className="flex h-full flex-col overflow-hidden md:flex-row">
       <SettingsNav />
       <div className="flex h-full min-w-0 flex-1 flex-col overflow-hidden">
         <Outlet />

--- a/apps/web/src/shared/ui/list-page.tsx
+++ b/apps/web/src/shared/ui/list-page.tsx
@@ -11,7 +11,16 @@ export function ListPageToolbar({
   children: ReactNode;
   className?: string;
 }): ReactElement {
-  return <div className={cn("flex items-center gap-2.5 px-8 pb-4", className)}>{children}</div>;
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-2.5 px-4 pb-4 sm:px-8 [&_button]:min-h-10 sm:[&_button]:min-h-0",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
 }
 
 export function ListPageToolbarSpacer(): ReactElement {
@@ -30,7 +39,7 @@ export function ListPageSearch({
   className?: string;
 }): ReactElement {
   return (
-    <div className={cn("relative w-[260px]", className)}>
+    <div className={cn("relative w-full sm:w-[260px]", className)}>
       <Search className="text-fg-3 absolute top-1/2 left-3 size-3.5 -translate-y-1/2" />
       <Input
         className="h-8 pl-9"
@@ -51,5 +60,7 @@ export function ListPageContent({
   children: ReactNode;
   className?: string;
 }): ReactElement {
-  return <div className={cn("flex-1 overflow-y-auto px-8 pb-8", className)}>{children}</div>;
+  return (
+    <div className={cn("flex-1 overflow-y-auto px-4 pb-8 sm:px-8", className)}>{children}</div>
+  );
 }

--- a/apps/web/src/shared/ui/page-header.tsx
+++ b/apps/web/src/shared/ui/page-header.tsx
@@ -22,7 +22,7 @@ export function PageHeader({
   return (
     <div
       className={cn(
-        "flex flex-col gap-4 px-8 pt-7 pb-5 sm:flex-row sm:items-start sm:justify-between",
+        "flex flex-col gap-4 px-4 pt-5 pb-4 sm:flex-row sm:items-start sm:justify-between sm:px-8 sm:pt-7 sm:pb-5",
         className,
       )}
     >
@@ -32,13 +32,15 @@ export function PageHeader({
             {eyebrow}
           </div>
         ) : null}
-        <h1 className="text-fg-1 text-[24px] font-semibold tracking-[-0.01em]">{title}</h1>
+        <h1 className="text-fg-1 text-[22px] font-semibold tracking-[-0.01em] sm:text-[24px]">
+          {title}
+        </h1>
         {description ? (
           <p className="text-fg-2 mt-1 max-w-[560px] text-[13px] leading-5">{description}</p>
         ) : null}
       </div>
       {actionContent ? (
-        <div className="flex shrink-0 flex-wrap items-center gap-2 sm:justify-end">
+        <div className="flex w-full shrink-0 flex-wrap items-center gap-2 sm:w-auto sm:justify-end [&_button]:min-h-10 sm:[&_button]:min-h-0">
           {actionContent}
         </div>
       ) : null}

--- a/apps/web/tests/mobile-responsive-boundary.test.ts
+++ b/apps/web/tests/mobile-responsive-boundary.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const APP_SHELL_SOURCE = readFileSync(new URL("../src/app/app-shell.tsx", import.meta.url), "utf8");
+const APP_SETTINGS_LAYOUT_SOURCE = readFileSync(
+  new URL("../src/routes/app-settings/app-settings.route.tsx", import.meta.url),
+  "utf8",
+);
+const SETTINGS_LAYOUT_SOURCE = readFileSync(
+  new URL("../src/routes/settings/settings.route.tsx", import.meta.url),
+  "utf8",
+);
+const PREVIEW_MODE_SOURCE = readFileSync(
+  new URL("../src/routes/agent/components/preview-mode.tsx", import.meta.url),
+  "utf8",
+);
+const AGENT_DETAIL_SOURCE = readFileSync(
+  new URL("../src/routes/agent/agent-detail.route.tsx", import.meta.url),
+  "utf8",
+);
+const PAGE_HEADER_SOURCE = readFileSync(
+  new URL("../src/shared/ui/page-header.tsx", import.meta.url),
+  "utf8",
+);
+const LIST_PAGE_SOURCE = readFileSync(
+  new URL("../src/shared/ui/list-page.tsx", import.meta.url),
+  "utf8",
+);
+const ACCESS_TOKENS_SOURCE = readFileSync(
+  new URL("../src/routes/settings/access-tokens-tab.tsx", import.meta.url),
+  "utf8",
+);
+const DEPLOYMENT_HISTORY_SOURCE = readFileSync(
+  new URL("../src/routes/app-overview/deploy/components/deployments-history.tsx", import.meta.url),
+  "utf8",
+);
+const HELP_MENU_SOURCE = readFileSync(
+  new URL("../src/features/help/help-menu.tsx", import.meta.url),
+  "utf8",
+);
+
+describe("mobile console boundaries", () => {
+  test("App and Org shells expose a discoverable mobile navigation drawer", () => {
+    expect(APP_SHELL_SOURCE).toContain('aria-label="Open navigation"');
+    expect(APP_SHELL_SOURCE).toContain("mobileSidebar");
+    expect(APP_SHELL_SOURCE).toContain('className="md:hidden"');
+    expect(APP_SHELL_SOURCE).toContain("left-0");
+    expect(APP_SHELL_SOURCE).toContain("right-auto");
+    expect(APP_SHELL_SOURCE).toContain("hidden w-[224px] shrink-0 flex-col");
+    expect(APP_SHELL_SOURCE).toContain("md:flex");
+  });
+
+  test("mobile navigation closes for app switches, route changes, and desktop breakpoints", () => {
+    expect(APP_SHELL_SOURCE).toContain("renderNavigation(closeNavigation)");
+    expect(APP_SHELL_SOURCE).toContain('globalThis.matchMedia("(min-width: 768px)")');
+    expect(APP_SHELL_SOURCE).toContain("location.pathname");
+    expect(APP_SHELL_SOURCE).toContain("location.search");
+  });
+
+  test("mobile Org headers keep an accessible level-one heading", () => {
+    expect(APP_SHELL_SOURCE).toContain('<h1 className="text-fg-1 ml-auto');
+  });
+
+  test("only one responsive sidebar registers the global help shortcut", () => {
+    expect(APP_SHELL_SOURCE).toContain("helpShortcutEnabled={false}");
+    expect(HELP_MENU_SOURCE).toContain("shortcutEnabled = true");
+  });
+
+  test("nested settings navigation becomes a horizontal mobile tab strip", () => {
+    expect(APP_SETTINGS_LAYOUT_SOURCE).toContain(
+      "flex h-full flex-col overflow-hidden md:flex-row",
+    );
+    expect(SETTINGS_LAYOUT_SOURCE).toContain("flex h-full flex-col overflow-hidden md:flex-row");
+  });
+
+  test("agent preview stacks session and editor on mobile", () => {
+    expect(PREVIEW_MODE_SOURCE).toContain("flex-col md:flex-row");
+    expect(PREVIEW_MODE_SOURCE).toContain("h-[42%] w-full");
+    expect(PREVIEW_MODE_SOURCE).toContain("md:h-auto md:w-1/2");
+    expect(PREVIEW_MODE_SOURCE).toContain("h-[58%] w-full");
+  });
+
+  test("agent detail header wraps its tabs below primary controls on mobile", () => {
+    expect(AGENT_DETAIL_SOURCE).toContain("flex-wrap");
+    expect(AGENT_DETAIL_SOURCE).toContain("order-3");
+    expect(AGENT_DETAIL_SOURCE).toContain("w-full");
+  });
+
+  test("shared list chrome uses mobile-safe padding and wrapping", () => {
+    expect(PAGE_HEADER_SOURCE).toContain("px-4 pt-5 pb-4");
+    expect(PAGE_HEADER_SOURCE).toContain("sm:px-8");
+    expect(LIST_PAGE_SOURCE).toContain("flex-wrap");
+    expect(LIST_PAGE_SOURCE).toContain("w-full sm:w-[260px]");
+    expect(LIST_PAGE_SOURCE).toContain("px-4 pb-4 sm:px-8");
+  });
+
+  test("wide data tables switch to mobile cards instead of clipping", () => {
+    expect(ACCESS_TOKENS_SOURCE).toContain('className="xl:hidden"');
+    expect(ACCESS_TOKENS_SOURCE).toContain("hidden min-w-[560px] xl:block");
+    expect(DEPLOYMENT_HISTORY_SOURCE).toContain("space-y-2 md:hidden");
+    expect(DEPLOYMENT_HISTORY_SOURCE).toContain(
+      "hidden overflow-hidden rounded-xl border md:block",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a reusable mobile navigation sheet for both app and organization layouts
- make Agent list/detail, App Usage, Settings, App Settings, Apps, MCP, Skills, Providers, and organization pages responsive at narrow widths
- replace dense Access Token and Deployment Activity tables with mobile-first card layouts while preserving desktop tables
- improve mobile spacing, wrapping, horizontal tab navigation, and 40–44 px touch targets
- add responsive boundary regression coverage and locally captured real-browser evidence outside the repository

## What changed

### Global shell
- switch fixed viewport shells from `h-screen` to `h-dvh`
- hide desktop sidebars below `md` and expose the same navigation content through the existing `Sheet` primitive
- close the drawer after route changes, same-path App switches, and transitions to the desktop breakpoint
- preserve one accessible level-one page heading on mobile Org pages and avoid duplicate global Help shortcuts
- add a visible **Menu** label alongside the icon for discoverability

### Responsive content
- reduce fixed desktop padding at mobile breakpoints
- make Settings and App Settings navigation horizontally scrollable on mobile
- keep Agent name/status/actions visible while hiding secondary table columns below `lg`
- stack Agent chat/editor panes vertically and make detail tabs independently scrollable
- allow App Usage filters/actions to wrap and tabs to scroll
- render Access Tokens and Deployment Activity as cards on mobile, retaining existing desktop tables

## Verification

### Automated
- `vp fmt`: passed
- `vp lint`: **0 warnings, 0 errors**
- TypeScript (`@mosoo/web`): passed
- Web tests: **167 passed, 0 failed, 680 assertions**
- pre-commit and pre-push hooks: passed, including private-key detection

### Real-browser QA

Tested with Playwright using system Chromium (`/usr/bin/chromium`):

- viewports: **320×568**, **390×844**, **430×932**
- 18 routes per viewport / **54 route-viewport checks**
- final document-level horizontal overflow: **0 in all 54 checks**
- dedicated interaction pass at 320×568, 390×844, and 430×932 covered:
  - opening and closing mobile navigation
  - route changes, same-path App switches, and automatic drawer dismissal
  - closing an open mobile drawer when crossing the `md` desktop breakpoint
  - accessible mobile Org page headings
  - Agent list and detail loading
  - Create Agent dialog
  - App Usage controls
  - Access Tokens mobile layout
  - Provider credential dialog
  - Deployment Activity mobile cards
- a separate **1024×768** Access Tokens check confirmed the card layout remains active with no document overflow at the intermediate-width boundary

## Browser evidence — 320×568

The screenshots below are hosted as GitHub Release assets outside the source tree and are **not committed to this repository**.

<details open>
<summary>Navigation and Agent screens</summary>

### Mobile navigation
![Mobile navigation](https://images.weserv.nl/?url=github.com/RockChinQ/mosoo/releases/download/pr-evidence/pr-353-navigation-320x568.png&output=png)

### Agent list
![Agent list](https://images.weserv.nl/?url=github.com/RockChinQ/mosoo/releases/download/pr-evidence/pr-353-agents-320x568.png&output=png)

### Agent detail
![Agent detail](https://images.weserv.nl/?url=github.com/RockChinQ/mosoo/releases/download/pr-evidence/pr-353-agent-detail-320x568.png&output=png)

### Create Agent dialog
![Create Agent dialog](https://images.weserv.nl/?url=github.com/RockChinQ/mosoo/releases/download/pr-evidence/pr-353-create-agent-dialog-320x568.png&output=png)

</details>

<details>
<summary>Settings, Providers, Usage, and Deployment Activity</summary>

### App Usage
![App Usage](https://images.weserv.nl/?url=github.com/RockChinQ/mosoo/releases/download/pr-evidence/pr-353-usage-320x568.png&output=png)

### Access Tokens
![Access Tokens](https://images.weserv.nl/?url=github.com/RockChinQ/mosoo/releases/download/pr-evidence/pr-353-access-tokens-320x568.png&output=png)

### Provider credential dialog
![Provider credential dialog](https://images.weserv.nl/?url=github.com/RockChinQ/mosoo/releases/download/pr-evidence/pr-353-provider-dialog-320x568.png&output=png)

### Deployment Activity
![Deployment Activity](https://images.weserv.nl/?url=github.com/RockChinQ/mosoo/releases/download/pr-evidence/pr-353-deploy-activity-320x568.png&output=png)

</details>
