### PR TITLE
docs(product): align positioning with agent runtime

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Before changing code, read the relevant product and architecture documents:
 
 These documents define system boundaries, module relationships, and design intent. If the PRD, architecture, and implementation disagree, fix the source of truth instead of hiding the mismatch in generated files, local adapters, or temporary branches.
 
-When a change pivots a core noun or ownership boundary, update the documentation anchors first: README, architecture, PRD index, and the active boundary PRD. The canonical product contract is [docs/SPEC.md](./docs/SPEC.md); [App Boundary](./docs/prd/app-boundary.md) is the historical App-pivot baseline that decodes older Organization-owned, member-governance, Workspace, and Agent-first wording, and yields to the Spec where they conflict.
+When a change pivots a core noun or ownership boundary, update the documentation anchors first: README, architecture, PRD index, and the active boundary PRD. The canonical product contract is [docs/SPEC.md](./docs/SPEC.md); [App Boundary](./docs/prd/app-boundary.md) records the current resource and ownership shell around the managed Agent runtime.
 
 ## Repository Structure
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,22 @@
   <img src="https://github.com/user-attachments/assets/4986c4b8-28fa-45ea-9be9-78c1c7133128" alt="Mosoo" width="96" height="96" />
 </p>
 
-Mosoo is building the production path from runnable agentic-app prototypes to hosted web products that real users can sign in to and use.
+# Mosoo
 
-Builders keep authoring with a local coding agent. The Mosoo Production Alpha target handles a strict repository contract, deterministic validation, isolated builds, App authentication, durable data and files, managed agent execution, observable Runs, enforceable confirmation gates, immutable Releases, and recovery.
+**An open-source agent runtime for coding agents.**
+
+Run OpenAI Codex, Claude Agent SDK, and OpenCode behind API endpoints in isolated AI agent sandboxes.
+
+Mosoo provides a Cloudflare-native control plane to stream tool activity, inspect Run history, and keep Threads and files across executions. It is self-hostable in your own account.
+
+Your application remains yours. Its backend owns product behavior and end-user access. Mosoo focuses on Agent execution and lifecycle; App Deployment is a separate Alpha surface, not the core product contract.
 
 ```text
-describe the business to Codex / Claude Code / OpenCode
-  + use the Mosoo Build Skill and CLI
-  -> produce a Deployable Repo that passes the Mosoo Contract
-  -> deploy through Mosoo
-  -> App Users sign in to the hosted App
+configure Agent + Skills + MCP + provider
+  -> preview and publish an Agent version
+  -> call it from a backend or the Mosoo console
+  -> stream events, handle permission requests, inspect files and usage
+  -> continue a durable Thread across Runs
 ```
 
 <p align="center">
@@ -21,17 +27,21 @@ describe the business to Codex / Claude Code / OpenCode
   <a href="https://github.com/langgenius/mosoo-connector">Mosoo Connector</a>
 </p>
 
+## Agent Runtime and API: What Works Today
+
+- **Agent runtime and control plane.** Configure and run OpenAI Codex, Claude Agent SDK, and OpenCode behind one normalized runtime protocol.
+- **Agent API.** Start, follow, continue, stop, archive, and delete Agent work from a trusted backend.
+- **AI agent sandboxes.** Stream responses and tool activity, handle permission requests, cancel work, and inspect diagnostics in isolated execution environments.
+- **Durable work.** Keep Threads, Runs, events, and managed files across individual executions.
+- **Agent observability.** Inspect Run status, replayable activity, diagnostics, and usage estimates; this is operational visibility, not a compliance audit trail or provider bill.
+
 ## Who It Is For
 
-Mosoo is for independent builders and small teams that already use local coding agents to make working software but do not want to become the DevOps, backend, and security team for every App.
-
-The narrow first use case is an existing runnable App that combines ordinary web behavior with one agentic business workflow. The Builder keeps using their preferred local coding agent; Mosoo starts where local authoring ends.
+Mosoo is for developers extending Codex, Claude Agent SDK, OpenCode, or another coding agent into products and automations who do not want to operate a separate agent runtime, Sandbox service, session store, file pipeline, and Agent API for every integration.
 
 ## Product Status
 
-Mosoo is being reset around this production path. The canonical target contract is [docs/SPEC.md](./docs/SPEC.md). Existing Agent-first, Thread-first, and public-GitHub-Web-artifact behavior in the repository is migration input, not the desired product model when it conflicts with that Spec.
-
-The launch standard is **Production Alpha**: isolation, durable state, recoverability, and portability are hard requirements; SLA, compliance certification, custom infrastructure, and reversal of already-completed business side effects are not promised yet. This repository does not claim stable APIs or backward compatibility while the migration is in progress.
+Mosoo is in Alpha. The managed runtime and Agent API surfaces above are shipped and covered by repository tests, but production reliability and external adoption have not been proven. Public APIs and product behavior may still change.
 
 Product and engineering references:
 
@@ -40,7 +50,9 @@ Product and engineering references:
 - Current implementation architecture: [docs/architecture.md](./docs/architecture.md)
 - Development and contribution guide: [CONTRIBUTING.md](./CONTRIBUTING.md)
 
-## Demo
+## Example: Build a Codex Agent API
+
+[Codex Pet](./examples/use-cases/codex-pet.md) shows a published Mosoo Agent integrated into an existing product backend through the Thread API. The same API can expose Agents backed by Claude Agent SDK or OpenCode.
 
 https://github.com/user-attachments/assets/4a4bbaab-c192-4462-99e0-020eab966fff
 
@@ -50,7 +62,7 @@ Prerequisites:
 
 - `bun >= 1.4.0-canary.1`
 - `just >= 1.51`
-- Docker Desktop for Agent runtime and Sandbox flows
+- A Docker-compatible daemon for Agent runtime and Sandbox flows
 
 From a clean clone:
 
@@ -75,7 +87,7 @@ curl http://localhost:5173/api/health
 curl http://localhost:8787/api/health
 ```
 
-API health is `/api/health`, not `/health`. The current Mosoo control-plane development login uses OTP; under local loopback origins, addresses ending with `@mosoo.ai` skip that OTP and log in directly. This is separate from the target per-App Auth Realm.
+API health is `/api/health`, not `/health`. The Mosoo control-plane development login uses OTP; under local loopback origins, addresses ending with `@mosoo.ai` skip that OTP and log in directly.
 
 If setup fails, start with the focused recipe: submodule issues use `git submodule update --init`, missing local secrets use `just env-init`, and D1 schema errors use `just db-migrate`. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full workflow and verification expectations.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,67 +1,66 @@
 # Mosoo Spec
 
-Status: canonical target product contract for the next Mosoo launch. Implementation migration is in progress.
+Status: canonical product contract for the current Mosoo Alpha direction.
 
-This document defines what Mosoo is building, the boundaries it guarantees, and the launch acceptance contract. It supersedes older Agent-first, Thread-first, external-Web-artifact, Workspace, and Organization-governance language whenever they disagree. Existing code and older PRDs are evidence about the migration baseline, not authority over this product model.
+This document defines what Mosoo is building and the boundaries it guarantees. It supersedes older App-hosting, Deployable Repo, Release, Workspace, and Organization-governance language whenever they disagree. Current product notes and code remain the authority for what is shipped today.
 
-This Spec is deliberately narrower than a general-purpose application platform. Exact API schemas, manifest fields, quotas, and internal topology belong in implementation contracts once the engineering proof obligations in this document have passed.
+This Spec is deliberately narrower than a general-purpose application platform. Exact API schemas, manifest fields, quotas, and internal topology belong in implementation contracts.
 
 ## 1. Product Thesis
 
-People can use local coding agents to create a runnable frontend quickly. The difficulty rises sharply when the App needs a backend, durable state, file storage, authentication, scheduled work, long-running agent execution, secrets, safe side effects, deployment, and recovery.
+Coding agents are useful on a developer's machine. Turning one into a dependable product capability requires a runtime, isolated execution, durable work history, files, streaming events, provider credentials, permission handling, usage visibility, and an API that survives beyond one local session.
 
-Mosoo serves Builders who have a runnable agentic-app prototype but do not want to become its DevOps, backend, and security team. The Builder continues authoring locally with Codex, Claude Code, OpenCode, or another compatible coding agent. Mosoo converts a repository that satisfies a strict contract into a hosted App that App Users can sign in to and use.
+Mosoo is an open-source runtime and control plane for configuring, running, and integrating coding agents. It normalizes OpenAI, Claude Agent SDK, and OpenCode execution behind one managed lifecycle while the Builder keeps ownership of the application, its business logic, and its end users.
 
 The product loop is:
 
 ```text
-local coding agent + Mosoo Build Skill
-  -> Deployable Repo
-  -> local contract validation
-  -> Mosoo-managed build and Release
-  -> authenticated App Users
-  -> durable business state and Agent Workload Runs
+Agent Manifest + Skills + MCP + provider credential
+  -> Preview and publish an Agent version
+  -> call the Agent from a trusted backend or the Mosoo console
+  -> isolated Run with streamed events and explicit permission requests
+  -> durable Thread, files, outcomes, and usage records
 ```
 
-Mosoo's wedge is not “Agent Cloud,” generic AI integration, cloud code generation, or arbitrary application hosting. It is the production path for a supported class of agentic Apps.
+Mosoo's wedge is the managed coding-agent runtime and Agent API. It is not an AI app builder, a general workflow builder, an end-user identity service, or a promise to host an application's ordinary frontend and backend.
 
 ### Evidence status
 
-- Founder-built prototypes demonstrate that agentic business workflows and full-stack deployment create repeated operational work.
-- Existing hosting and coding-agent products solve parts of that path but leave the Builder responsible for integration, security, and lifecycle correctness.
-- Mosoo has not yet proved external adoption or willingness to pay. Production Alpha validates the product hypothesis; it is not evidence of product-market fit.
+- The current repository implements normalized runtime adapters, isolated Sandbox execution, durable Threads, Runs, events, files, Agent versions, and an App-owner API.
+- Existing coding-agent tools solve local execution but leave product developers responsible for runtime integration and lifecycle infrastructure.
+- Mosoo has not yet proved production reliability, external adoption, or willingness to pay. Alpha validates the product hypothesis; it is not evidence of product-market fit.
 
 ## 2. Target User And Job
 
 ### Builder
 
-A Builder uses a local coding agent and Mosoo to create, own, and operate an App. The Builder may be an independent developer, operator, or small internal-tools team, but is not expected to be an infrastructure specialist.
+A Builder configures a coding Agent in Mosoo and integrates it into a product or automation. The Builder may be an independent developer, operator, or small internal-tools team, but is not expected to be an agent-runtime infrastructure specialist.
 
 The Builder's job is:
 
-> Turn business-specific code that runs locally into a hosted agentic App without owning a custom deployment platform, agent runtime, auth service, durable job system, or security control plane.
+> Make a coding Agent callable and operable from a product backend without owning its Sandbox, runtime adapters, durable work history, file pipeline, event stream, or usage instrumentation.
 
 ### App Owner
 
-The App Owner is the Builder responsible for the product offered to App Users. In the launch phase, one Mosoo Account owns an App. Team ownership, roles, invitations, and transfer are later extensions.
+The App Owner is the Builder responsible for the Mosoo App and its Agents. In Alpha, one Mosoo Account owns an App. Team ownership, roles, invitations, and transfer are later extensions.
 
-### App User
+### End User
 
-An App User uses the deployed App. App Users authenticate to that App, not to Mosoo, and should not need to know which agent runtime, model provider, or cloud service powers it.
+An End User may trigger Agent work through the Builder's product, but Mosoo does not represent or authenticate that person today. The Builder's trusted backend enforces end-user access and maps its users to Mosoo Threads.
 
 ### Mosoo Account
 
-A Mosoo Account authenticates the Builder to the Mosoo control plane. It is never reused as an App User identity. An Organization may remain an internal billing or tenancy shell, but it is not the business-user model of deployed Apps.
+A Mosoo Account authenticates the Builder to the Mosoo control plane. It is never reused as an End User identity. An Organization may remain an internal billing or tenancy shell, but it is not the business-user model of integrations.
 
 ## 3. Design Principles
 
-1. **Local agents own authoring.** Mosoo does not compete for the programming conversation.
-2. **The repository owns the product.** Business logic, schema, Skills, and domain semantics live in the App repository.
-3. **The contract is strict.** Mosoo guarantees a narrow production profile, not best-effort deployment of arbitrary repositories or containers.
-4. **The App is the product boundary.** Web, backend, auth integration, state, the Agent Workload, and Releases belong to one App.
-5. **Agent execution is a capability, not an identity hierarchy.** An Agent Workload is part of an App; users do not first construct a separate cloud Agent resource.
-6. **One action has one path.** Buttons and schedules use the same Dispatch operation and produce the same Run record.
-7. **Durable state is explicit.** Database records and files outlive Sandboxes, processes, Runs, and Releases.
-8. **High-impact side effects are mediated.** Prompts and UI warnings are defense in depth, not the authorization boundary.
-9. **Production claims require recovery.** A runnable demo without isolation, backup, export, and rollback is not Production Alpha.
-10. **Delete before generalizing.** Launch excludes broad SaaS templates, provider matrices, infrastructure choices, and governance that do not prove the wedge.
+1. **Mosoo owns Agent execution, not the Builder's application.** Product code, business state, and end-user access remain with the Builder.
+2. **One runtime contract spans supported agents.** Runtime-specific protocols are normalized before they reach product integrations.
+3. **The Agent Manifest is the reproducible configuration.** Runtime, model, instructions, Skills, MCP connections, and Environment resolve from saved configuration rather than a developer's laptop.
+4. **A Thread is the durable work boundary.** Messages, Runs, public events, and managed files remain addressable across individual executions.
+5. **A Run is one observable execution.** Console and API entry points produce the same lifecycle records.
+6. **Sandbox state is explicit.** Temporary execution state is not confused with durable Threads, files, Agent configuration, or bounded Assistant continuity.
+7. **The public API is backend-to-backend.** App-owner tokens stay on trusted servers; Mosoo does not claim App User authentication.
+8. **High-impact side effects are mediated.** Permission requests and confirmation gates are enforceable runtime boundaries, not prompt conventions.
+9. **Usage is observable, not billing truth.** Recorded model usage supports operational decisions without pretending to replace provider invoices.
+10. **Do not broaden the product to hide missing proof.** App hosting, broad provider matrices, channels, governance, and recovery become promises only after their user-visible paths are proven.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,10 @@
-# Cloudflare-native Agent Cloud Architecture
+# Managed Agent Runtime Architecture
 
 ## 1. Vision And Principles
 
-Mosoo provides a deliberately simple web experience for orchestrating App-local Agents and concrete resources backed by CLI tools and SDK-based runtimes.
+Mosoo provides an App-scoped control plane for configuring, publishing, running, and observing coding Agents through the console and Public Thread API.
 
-The current priority is OPCs, personal developers, and small self-hosted deployments. A user should be able to bring `PRD.md`, invoke `@mosoo`, and get a running Agent App with low operational overhead. In the hosted product, App Deployment publishes an App-owned external Web artifact into Mosoo's Cloudflare account; users do not provide their own Cloudflare credentials for that flow. The deployed artifact remains separate from Agent runtime. In the current construction phase, assume one human owns one Organization: Organization is the account / billing / tenant shell, and App is the code, data, product, and console boundary. App owns concrete resources directly; it does not introduce a generic Service entity, `services` table, or polymorphic `service.kind`. Additional operational controls are extension paths for the same architecture, not default complexity for the current community edition.
+The product boundary is managed Agent execution. Builders keep ownership of their application and end-user identity; Mosoo owns runtime adaptation, Sandbox lifecycle, durable Thread and Run records, managed files, credentials, events, and usage visibility. App Deployment is a separate Alpha surface and does not define the runtime or API contract. In the current construction phase, assume one human owns one Organization: Organization is the account / billing / tenant shell, and App is the code, data, product, and console boundary. App owns concrete resources directly; it does not introduce a generic Service entity, `services` table, or polymorphic `service.kind`. Additional operational controls are extension paths for the same architecture, not default complexity for the current community edition.
 
 To support lightweight deployment, fast iteration, and future governance expansion, the architecture embraces Serverless and edge computing and follows these baseline principles:
 
@@ -29,7 +29,7 @@ The architecture is built on the Cloudflare platform and uses a Serverless shape
   as session artifacts. Sandbox private state backups use a separate backup
   bucket and must not be mixed with user-visible file prefixes.
 - **Execution sandbox: Cloudflare Sandbox / Containers**. Heterogeneous Agents run in container-image-backed isolated environments, with Sandbox APIs and Durable Object boundaries controlling runtime lifecycle.
-- **App deployment: Mosoo-managed Cloudflare Pages / Workers**. App Deployment clones and builds a public GitHub repository in an isolated Sandbox, then publishes the resulting Web artifact with Mosoo platform credentials. D1 stores the App-owned Deployment and DeploymentRun records, while the successful artifact receives a Mosoo-owned URL. This is not App runtime and does not change Agent runtime ownership.
+- **Secondary App deployment: Mosoo-managed Cloudflare Pages / Workers**. App Deployment clones and builds a public GitHub repository in an isolated Sandbox, then publishes the resulting Web artifact with Mosoo platform credentials. D1 stores the App-owned Deployment and DeploymentRun records, while the successful artifact receives a Mosoo-owned URL. This is an independent Alpha capability, not App runtime or part of the core Agent API promise.
 - **Configuration editing**. Owner-side Agent configuration is currently edited through Preview, which combines the writable configuration form with in-context test chat. There is no dedicated `AgentBuilderSystemAgent` topology in the current codebase. Future configuration assistance must remain a control-plane feature and must not enter the full Sandbox / Driver runtime path.
 
 ---

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -9,43 +9,43 @@ note, the Spec, and current code disagree, do not guess: verify the behavior and
 update the stale note. Exact APIs, data shapes, and runtime topology belong in
 their machine-readable contracts, code, or [Architecture](../architecture.md).
 
-## Apps and Agents
+## Runtime and API
+
+- [Agent API Endpoint](./agent-endpoint-mvp.md)
+- [Public Thread API](./public-thread-api-surface.md)
+- [Runtime Sessions](./runtime-session-kernel.md)
+- [Runtime Choice](./runtime-catalog.md)
+- [Runs and Threads](./default-consumption-surface.md)
+- [Agent Work History](./agent-session-api.md)
+- [Thread Lifecycle](./session-lifecycle.md)
+- [Runtime State Operations](./runtime-state-operations.md)
+- [Agent Terminal](./agent-terminal.md)
+- [Session Log](./session-log.md)
+
+## Agent configuration
 
 - [App Boundary](./app-boundary.md)
-- [App Deployment](./app-deployment.md)
 - [Agent Type](./agent-type.md)
 - [Agent Manifest](./agent-manifest.md)
 - [Agent Publishing and Versions](./agent-service-identity.md)
 - [Agent Version History](./agent-versions.md)
 - [Agent Import, Export, and Fork](./agent-package-import-export-fork.md)
-- [Agent API Endpoint](./agent-endpoint-mvp.md)
 
-## Work and runtime
+## Resources and operations
 
-- [Runs and Threads](./default-consumption-surface.md)
-- [Agent Work History](./agent-session-api.md)
-- [Thread Lifecycle](./session-lifecycle.md)
-- [Runtime Sessions](./runtime-session-kernel.md)
-- [Runtime Choice](./runtime-catalog.md)
-- [Runtime State Operations](./runtime-state-operations.md)
-- [Agent Terminal](./agent-terminal.md)
-- [Session Log](./session-log.md)
-
-## Delivery and resources
-
-- [Public Thread API](./public-thread-api-surface.md)
-- [Channels](./channels.md)
 - [Thread Files](./session-files.md)
-- [Files API legacy link](./files-api-contract.md)
 - [Skills](./skill-interaction.md)
 - [MCP Connections](./mcp-interaction.md)
 - [Credentials](./credentials.md)
 - [Environment](./environment.md)
-
-## Operations
-
 - [App Usage](./cost-dashboard.md)
 
-## Removed names
+## Secondary Alpha surfaces
 
+- [App Deployment](./app-deployment.md)
+- [Channels](./channels.md)
+
+## Legacy aliases
+
+- [Files API](./files-api-contract.md)
 - [Public Task API](./public-task-api.md)

--- a/docs/prd/agent-manifest.md
+++ b/docs/prd/agent-manifest.md
@@ -1,6 +1,6 @@
 # Agent Manifest
 
-Status: available in the current alpha console. Mosoo's launch product direction is defined by the [Mosoo Spec](../SPEC.md); this page explains the Agent configuration people can use today.
+Status: available in the current Alpha console. The [Mosoo Spec](../SPEC.md) defines how this configuration fits the managed Agent runtime.
 
 ## What problem it solves
 

--- a/docs/prd/agent-service-identity.md
+++ b/docs/prd/agent-service-identity.md
@@ -4,7 +4,7 @@ Status: core behavior is shipped, with known console gaps.
 
 ## Why this exists
 
-A Builder can improve an Agent after people have started using it. Without a stable identity and saved releases, every edit could send users to a new Agent or silently change an existing conversation. Mosoo keeps the published Agent recognizable while separating its past and current behavior.
+A Builder can improve an Agent after people have started using it. Without a stable identity and saved versions, every edit could send users to a new Agent or silently change an existing conversation. Mosoo keeps the published Agent recognizable while separating its past and current behavior.
 
 ## Who uses it
 
@@ -13,11 +13,11 @@ The App Owner publishes and updates the Agent. App Users and authorized integrat
 ## How it works
 
 1. The owner tests the Agent in Preview and publishes it when ready.
-2. Publishing creates the first live version. People keep using the same Agent as later versions are released.
+2. Publishing creates the first live version. People keep using the same Agent as later versions are activated.
 3. A new conversation uses the live version available when that conversation starts. An existing conversation stays tied to the version it began with, so later edits do not silently rewrite its behavior.
-4. The owner can open Versions to see which version is live and review earlier releases.
+4. The owner can open Versions to see which version is live and review earlier versions.
 5. Changes that would redefine the Agent itself, such as its type or runtime, cannot overwrite the published Agent. The owner forks a new draft and leaves the original Agent and its history intact.
 
 ## Current limits
 
-The stable identity, version history, and per-conversation version choice are implemented for published Agents. Version history is view-only: there is no compare or restore action. Type switching has an assisted fork flow, but changing runtime still requires manually forking first and then editing the copy. Some console text says an owner must republish after a live edit even though the current save path already activates a new version; until that messaging is corrected, the release moment is not communicated consistently.
+The stable identity, version history, and per-conversation version choice are implemented for published Agents. Version history is view-only: there is no compare or restore action. Type switching has an assisted fork flow, but changing runtime still requires manually forking first and then editing the copy. Some console text says an owner must republish after a live edit even though the current save path already activates a new version; until that messaging is corrected, the activation moment is not communicated consistently.

--- a/docs/prd/agent-session-api.md
+++ b/docs/prd/agent-session-api.md
@@ -1,6 +1,6 @@
 # Agent Work History
 
-Status: implemented foundation in Alpha. [Mosoo Spec](../SPEC.md) defines the launch direction.
+Status: implemented foundation in Alpha and part of the managed runtime contract in the [Mosoo Spec](../SPEC.md).
 
 ## Why It Exists
 

--- a/docs/prd/app-boundary.md
+++ b/docs/prd/app-boundary.md
@@ -1,6 +1,6 @@
 # App Boundary
 
-Status: historical shipped baseline. [Mosoo Spec](../SPEC.md) is the source of truth wherever the two documents differ.
+Status: shipped resource and ownership boundary. [Mosoo Spec](../SPEC.md) defines the managed Agent runtime contract.
 
 ## Problem
 
@@ -24,12 +24,12 @@ Agent conversations and channel delivery remain managed through individual Agent
 
 ## Current Availability
 
-The App-centered console and public-repository deployment flow are implemented in the current Alpha. They are useful for organizing and operating today's Mosoo resources, but the repository does not prove a successful production deployment or recovery exercise.
+The App-centered console and managed Agent resources are implemented in the current Alpha. App Deployment is also implemented as a separate public-repository publishing surface, but the repository does not prove a successful production deployment or recovery exercise.
 
-They do not yet deliver the complete hosted App described by the Spec. The current deployment publishes a website while Agent operations remain a separate part of the App experience.
+The current deployment publishes a website while Agent operations remain a separate part of the App experience. It is not part of the core runtime and Agent API contract.
 
 ## User-Visible Boundary
 
 An App is the Builder's product container in Mosoo. Its resources, activity, settings, usage, and deployed site are kept separate from other Apps.
 
-The baseline is single-owner and does not offer organization-wide catalogs or collaboration. Use the Spec—not this historical document—for new launch promises and product decisions.
+The baseline is single-owner and does not offer organization-wide catalogs or collaboration. Use the Spec for new runtime and integration promises.

--- a/docs/prd/app-deployment.md
+++ b/docs/prd/app-deployment.md
@@ -1,10 +1,10 @@
 # App Deployment
 
-Status: implemented migration baseline. This is not yet the complete Production Alpha Release experience defined by the [Mosoo Spec](../SPEC.md).
+Status: implemented secondary Alpha surface. It is not part of the core managed Agent runtime contract in the [Mosoo Spec](../SPEC.md).
 
 ## Why It Matters
 
-A Builder with a working agentic App should not need to become a deployment specialist just to share it. App Deployment covers a narrower first step: publish a supported public repository to a Mosoo-managed URL and operate that site from the App Overview.
+A Builder may want a simple way to share a supported website alongside a Mosoo Agent. App Deployment covers that secondary use case: publish a supported public repository to a Mosoo-managed URL and operate that site from the App Overview.
 
 ## Who Uses It
 
@@ -25,4 +25,4 @@ When a bound capability is accepted, the Run records the App, Agent, Deployment,
 
 The console flow, deployment processing, history, retry, and deletion are implemented. Repository evidence does not prove a successful real production deployment or recovery exercise, so the honest claim is **implemented**, not **production-proven**.
 
-The canonical Spec supersedes the older idea that App Deployment is merely an external Web artifact. Its target is a strict Deployable Repo becoming a managed Release for authenticated App Users, with durable state, Agent Workload Runs, and recovery. Today's baseline publishes one supported public repository to a Mosoo-owned URL. It does not itself provide App User authentication, durable backend state, schedules, recovery, private repositories, custom domains, branch previews, automatic deployment, or rollback.
+App Deployment is not the canonical Mosoo product wedge. Today's baseline publishes one supported public repository to a Mosoo-owned URL. It does not itself provide App User authentication, durable backend state, schedules, recovery, private repositories, custom domains, branch previews, automatic deployment, or rollback.

--- a/docs/prd/default-consumption-surface.md
+++ b/docs/prd/default-consumption-surface.md
@@ -1,6 +1,6 @@
 # Runs and Threads
 
-Status: available in the current Mosoo web console. This document describes the product users can see today; it does not treat the target launch model in `docs/SPEC.md` as already delivered.
+Status: available in the current Mosoo web console as the human-facing view of managed Agent work.
 
 ## Product value
 

--- a/docs/prd/runtime-catalog.md
+++ b/docs/prd/runtime-catalog.md
@@ -1,6 +1,6 @@
 # Runtime Choice
 
-Status: current console behavior during migration to the canonical [Mosoo Spec](../SPEC.md).
+Status: current core runtime surface under the canonical [Mosoo Spec](../SPEC.md).
 
 ## Value
 
@@ -27,6 +27,6 @@ Custom OpenAI-compatible models remain on OpenCode by default because some endpo
 
 The Providers page currently offers those nine named providers plus the custom-model action. A saved key unlocks only models that the selected runtime can run.
 
-## Launch boundary
+## Product boundary
 
-This chooser is a migration baseline, not a launch promise. The canonical Spec commits to turning a supported repository into a hosted App with a reliable Agent Workload; it explicitly avoids a broad provider matrix, and App Users remain unaware of runtime choices. Launch acceptance therefore requires the supported workload to run, not preservation or expansion of this entire chooser.
+The runtime catalog exists to launch supported Agents reliably, not to become a provider marketplace. The exact provider list may change during Alpha; the stable product promise is a normalized managed runtime and API for supported Agent configurations.

--- a/examples/use-cases/codex-pet.md
+++ b/examples/use-cases/codex-pet.md
@@ -1,6 +1,6 @@
 # Codex Pet — Agent as API
 
-Codex Pet shows how a workflow built in a coding IDE can become a reusable Mosoo Agent in the cloud.
+Codex Pet shows how a workflow built in a coding IDE can become a reusable Mosoo-managed Agent exposed through an API.
 
 A builder publishes a Pet Agent with an avatar-generation skill, then copies its generated **Instruction for LLM** into Codex. Codex uses that instruction to integrate the Mosoo Thread API into an existing product backend. The finished app accepts one avatar and returns a validated ZIP containing all nine Codex Pet animation states.
 


### PR DESCRIPTION
## Summary

- align the README, canonical Spec, architecture, and PRD index with Mosoo's shipped agent runtime and Agent API
- make `agent runtime` the primary search intent, supported by AI agent sandbox, API, scoped observability, and control-plane language
- move App Deployment and Channels to secondary Alpha surfaces and remove App User auth and Release from the core promise
- clarify the supported Codex, Claude Agent SDK, and OpenCode runtime integrations

## Discoverability evidence

- directional monthly volume: `agent runtime` 720, `AI agent observability` 480, `AI agent sandbox` 390, `AI agent API` 320, `agent control plane` 260
- GitHub exact-phrase supply: 2,701, 152, 163, 303, and 299 repositories respectively
- head terms such as `Claude Agent SDK` and `Claude Code API`, and zero-volume `coding agent runtime`, were intentionally not chosen as the primary intent
- volume data is an estimate from Google Ads/clickstream aggregation and is used for relative ranking; GitHub competition counts were queried live on 2026-07-17

Repository description and topics were updated separately through GitHub settings because they are not stored in this repository.

## Verification

- `just fmt-check-path README.md`
- `just fmt-check-path docs`
- `just docs-check`
- `git diff --check`
- `just check` — formatting, documentation links, lint, typecheck, 1,012 tests, and GraphQL freshness passed
- `just commit-check`

## Change inventory

- generated files: none
- GraphQL codegen source changes: none; freshness check passed
- database migrations: none
- lockfile changes: none
