### PR TITLE
fix(web): resolve ui-skills audit findings across a11y, viewport, and metadata

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,6 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Open-source agent runtime for coding agents. Run OpenAI Codex, Claude Agent SDK, and OpenCode behind API endpoints in isolated sandboxes."
+    />
+    <!-- Matches --bg (--paper-100) so browser chrome blends with the app surface. -->
+    <meta name="theme-color" content="#fbfbfc" />
+    <meta property="og:title" content="Mosoo" />
+    <meta
+      property="og:description"
+      content="Open-source agent runtime for coding agents. Run OpenAI Codex, Claude Agent SDK, and OpenCode behind API endpoints in isolated sandboxes."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Mosoo" />
+    <meta name="twitter:card" content="summary" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <!-- Preload the primary UI font so it streams in parallel with the CSS/JS
          instead of being discovered only after the stylesheet parses. Geist is

--- a/apps/web/src/app/route-guards.tsx
+++ b/apps/web/src/app/route-guards.tsx
@@ -28,7 +28,7 @@ interface RouteChildrenProps {
 
 export function AppLoading(): ReactElement {
   return (
-    <div className="text-muted-foreground flex h-screen items-center justify-center">Loading…</div>
+    <div className="text-muted-foreground flex h-dvh items-center justify-center">Loading…</div>
   );
 }
 

--- a/apps/web/src/domains/environment/components/environment-form.tsx
+++ b/apps/web/src/domains/environment/components/environment-form.tsx
@@ -35,6 +35,7 @@ function EnvironmentPackagesSection({
     <EnvironmentFormSection
       action={
         <Button
+          aria-label="Add package"
           className="size-8"
           disabled={disabled}
           onClick={onAdd}
@@ -65,6 +66,7 @@ function EnvironmentPackagesSection({
               value={row.manager}
             />
             <Input
+              aria-label="Package name and version"
               className={cn(
                 "font-mono text-[12px]",
                 row.packagesText.trim() && !row.manager ? "border-destructive" : null,
@@ -80,6 +82,7 @@ function EnvironmentPackagesSection({
               value={row.packagesText}
             />
             <Button
+              aria-label="Remove package"
               className="text-fg-3 hover:text-destructive size-9"
               disabled={disabled}
               onClick={() => {
@@ -124,6 +127,7 @@ function EnvironmentVariablesSection({
     <EnvironmentFormSection
       action={
         <Button
+          aria-label="Add environment variable"
           className="size-8"
           disabled={disabled}
           onClick={onAdd}
@@ -150,6 +154,7 @@ function EnvironmentVariablesSection({
             key={envVar.id}
           >
             <Input
+              aria-label="Variable name"
               className="font-mono text-[12px]"
               disabled={disabled}
               onChange={(event) => {
@@ -166,6 +171,7 @@ function EnvironmentVariablesSection({
               value={envVar.key}
             />
             <Input
+              aria-label="Variable value"
               className="font-mono text-[12px]"
               disabled={disabled}
               onChange={(event) => {
@@ -189,6 +195,7 @@ function EnvironmentVariablesSection({
               value={envVar.value}
             />
             <Button
+              aria-label="Remove environment variable"
               className="text-fg-3 hover:text-destructive size-9"
               disabled={disabled}
               onClick={() => {

--- a/apps/web/src/routes/environments/environment-list-table.tsx
+++ b/apps/web/src/routes/environments/environment-list-table.tsx
@@ -71,7 +71,12 @@ export function EnvironmentListTable({
           </div>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button className="size-8" size="icon" variant="ghost">
+              <Button
+                aria-label="Environment actions"
+                className="size-8"
+                size="icon"
+                variant="ghost"
+              >
                 <MoreHorizontal className="size-4" />
               </Button>
             </DropdownMenuTrigger>

--- a/apps/web/src/routes/integrations/mcp/mcp-list-item.tsx
+++ b/apps/web/src/routes/integrations/mcp/mcp-list-item.tsx
@@ -80,7 +80,12 @@ export function McpListItem({
         )}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" className="text-muted-foreground size-8">
+            <Button
+              aria-label="Server actions"
+              variant="ghost"
+              size="icon"
+              className="text-muted-foreground size-8"
+            >
               <MoreHorizontal />
             </Button>
           </DropdownMenuTrigger>

--- a/apps/web/src/routes/integrations/mcp/oauth-complete.route.tsx
+++ b/apps/web/src/routes/integrations/mcp/oauth-complete.route.tsx
@@ -26,7 +26,7 @@ export function McpOAuthCompletePage() {
   const flowId = searchParams.get("flowId");
 
   return (
-    <div className="bg-background flex min-h-screen items-center justify-center px-6">
+    <div className="bg-background flex min-h-dvh items-center justify-center px-6">
       <div className="border-border bg-card w-full max-w-md rounded-lg border p-8 shadow-sm">
         <h1 className="text-foreground text-[20px] font-semibold">MCP OAuth</h1>
         <p className="text-muted-foreground mt-3 text-sm">{getStatusLabel(status)}</p>

--- a/apps/web/src/routes/settings/access-tokens-tab.tsx
+++ b/apps/web/src/routes/settings/access-tokens-tab.tsx
@@ -269,6 +269,7 @@ function CreatedTokenPanel({
           {token}
         </code>
         <Button
+          aria-label={tooltip}
           onClick={() => {
             void onCopy();
           }}
@@ -312,6 +313,7 @@ function AccessTokensTable({
                 </div>
               </div>
               <Button
+                aria-label="Revoke token"
                 className="min-h-10 min-w-10 shrink-0"
                 disabled={pending || token.revokedAt !== null}
                 onClick={() => {
@@ -386,6 +388,7 @@ function AccessTokenRow({
       <div className="text-muted-foreground text-xs">{formatDateTime(token.lastUsedAt)}</div>
       <div className="flex justify-end">
         <Button
+          aria-label="Revoke token"
           disabled={pending || token.revokedAt !== null}
           onClick={onRevoke}
           size="icon-xs"

--- a/apps/web/src/shared/ui/empty-state.tsx
+++ b/apps/web/src/shared/ui/empty-state.tsx
@@ -30,9 +30,9 @@ export function EmptyState({
       <div className="bg-paper-200 text-fg-3 flex size-12 items-center justify-center rounded-full">
         <Icon className="size-5" strokeWidth={1.5} />
       </div>
-      <p className="text-fg-1 mt-4 text-[14px] font-semibold">{title}</p>
+      <p className="text-fg-1 mt-4 text-[14px] font-semibold text-balance">{title}</p>
       {description ? (
-        <p className="text-fg-3 mt-1.5 max-w-[360px] text-[13px]">{description}</p>
+        <p className="text-fg-3 mt-1.5 max-w-[360px] text-[13px] text-pretty">{description}</p>
       ) : null}
       {actionContent ? <div className="mt-5">{actionContent}</div> : null}
     </div>

--- a/apps/web/src/shared/ui/page-header.tsx
+++ b/apps/web/src/shared/ui/page-header.tsx
@@ -32,11 +32,13 @@ export function PageHeader({
             {eyebrow}
           </div>
         ) : null}
-        <h1 className="text-fg-1 text-[22px] font-semibold tracking-[-0.01em] sm:text-[24px]">
+        <h1 className="text-fg-1 text-[22px] font-semibold tracking-[-0.01em] text-balance sm:text-[24px]">
           {title}
         </h1>
         {description ? (
-          <p className="text-fg-2 mt-1 max-w-[560px] text-[13px] leading-5">{description}</p>
+          <p className="text-fg-2 mt-1 max-w-[560px] text-[13px] leading-5 text-pretty">
+            {description}
+          </p>
         ) : null}
       </div>
       {actionContent ? (


### PR DESCRIPTION
Fill what changed. Use N/A for irrelevant or maintainer-only items. See `CONTRIBUTING.md` for branch, CLA, generated file, and CI rules.

## Summary

- UI audit of `apps/web` guided by [ibelick/ui-skills](https://github.com/ibelick/ui-skills), routed per its `ui-skills-root` protocol to three skills: `baseline-ui`, `fixing-accessibility`, and `fixing-metadata`.
- Accessibility: add `aria-label` to icon-only buttons (add/remove rows in the environment form, environment and MCP server action menus, token copy/revoke buttons) and to placeholder-only inputs (package spec, variable name, variable value).
- Viewport: replace `h-screen` / `min-h-screen` with `h-dvh` / `min-h-dvh` in the app loading fallback and the MCP OAuth completion page so mobile browser chrome does not clip centered content.
- Typography: add `text-balance` to shared `PageHeader` and `EmptyState` titles and `text-pretty` to their descriptions, propagating better wrapping to every page that uses them.
- Metadata: give `index.html` a default meta description, `theme-color` matching the `--bg` token, Open Graph basics, and a `twitter:card` fallback (the SPA previously shipped only a title and favicon).

Audit findings that passed with no change needed: global `prefers-reduced-motion` handling in `app.css`, per-route titles via `DocumentTitle`, Base UI primitives for dialogs/menus, no gradients, no arbitrary z-index, no `will-change` misuse, no paste blocking, `tabular-nums` already used for data. Noted, not fixed (larger scope): destructive actions such as token revoke confirm via plain buttons rather than an `AlertDialog`; the package-manager select trigger exposes its value but not a field name.

## Why

- YEF-850 requested an audit of the web UI using the ibelick/ui-skills catalog with the resulting fixes submitted as a PR. All changes are minimal, targeted remediations of rule violations from the three selected skills.

## Verification

- Commands: `bun run lint`, `bun run tc` (tsc --noEmit), `bun run test` (169 pass, 0 fail) in `apps/web`; `bun run fmt:check:path` on all changed files; `bun run commit:check` (4 commits pass).
- Manual steps: none. Changes are attribute-level (aria, meta tags) or text-wrapping hints with no intended visual delta, so no before/after screenshots are attached.
- Not run: e2e suite.

## Impact

- User/API/contract changes: none. Accessible names are additive; assistive tech and social share previews improve.
- Generated files / GraphQL / DB / lockfile: none.
- Env or config changes: none.
- Risk and rollback: low; four atomic commits, each independently revertable.

## Review

- Closest review areas: label wording on the new `aria-label`s (`apps/web/src/domains/environment/components/environment-form.tsx`, `apps/web/src/routes/settings/access-tokens-tab.tsx`); metadata copy in `apps/web/index.html`.
- Known trade-offs: `text-balance`/`text-pretty` slightly change line breaks at narrow widths in shared components; `theme-color` is hardcoded to the light `--paper-100` value since the app does not currently expose a dark theme.
