### PR TITLE
feat(web): make agent preview send interactions optimistic

### DIFF
--- a/apps/web/src/features/session-chat/assistant-ui/session-thread-composer.tsx
+++ b/apps/web/src/features/session-chat/assistant-ui/session-thread-composer.tsx
@@ -22,6 +22,9 @@ interface SessionThreadComposerProps {
   fileInputRef: React.RefObject<HTMLInputElement | null>;
   onFilesSelected: (files: File[]) => void;
   onRetry: () => void;
+  // Send-intent signal (typing, opening the file picker) used to warm the
+  // session/runtime before the actual send. Callee is throttled/deduped.
+  onTypingActivity?: () => void;
   pendingSessionFiles: PendingSessionFileChip[];
   sendDisabledReason?: string | null;
   sessionResourceMentions: SessionResourceMention[];
@@ -83,6 +86,7 @@ export function SessionThreadComposer({
   fileInputRef,
   onFilesSelected,
   onRetry,
+  onTypingActivity,
   pendingSessionFiles,
   sendDisabledReason,
   sessionResourceMentions,
@@ -120,6 +124,7 @@ export function SessionThreadComposer({
         submitOnEnter
         minRows={1}
         maxRows={8}
+        onChange={onTypingActivity}
         placeholder="Describe a task for the agent…"
         className="text-fg-1 placeholder:text-fg-muted w-full resize-none bg-transparent px-3.5 pt-3 pb-1 text-[14.5px] leading-[1.5] outline-none"
         data-testid="agent-session-composer-input"
@@ -147,6 +152,7 @@ export function SessionThreadComposer({
           size="icon-sm"
           className="text-fg-3 rounded-full"
           onClick={() => {
+            onTypingActivity?.();
             fileInputRef.current?.click();
           }}
           aria-label="Attach file"

--- a/apps/web/src/routes/agent/components/agent-session-panel-model-types.ts
+++ b/apps/web/src/routes/agent/components/agent-session-panel-model-types.ts
@@ -13,6 +13,10 @@ export interface ComposerError {
 }
 
 export interface SendOptions {
+  // Invoked once the send passes the composer gate, before any network I/O.
+  // Lets the caller apply optimistic UI (e.g. clear mention chips) exactly when
+  // the send is committed rather than when it completes.
+  onAccepted?: () => void;
   sessionResourceMentions?: SessionResourceMention[];
   // Explicit text to send. When omitted, the model falls back to its own
   // composer input state (legacy path). assistant-ui owns the composer text and

--- a/apps/web/src/routes/agent/components/agent-session-panel-model-types.ts
+++ b/apps/web/src/routes/agent/components/agent-session-panel-model-types.ts
@@ -51,6 +51,7 @@ export interface AgentSessionPanelModel {
   lifecycle: SessionLiveState["lifecycle"];
   messages: SessionLiveState["messages"];
   messagesEndRef: RefObject<HTMLDivElement | null>;
+  notifyComposerTyping: () => void;
   permissionRequests: PermissionRequest[];
   readiness: AgentReadiness | null;
   readinessBlockMessage: string | null;

--- a/apps/web/src/routes/agent/components/agent-session-panel-rules.ts
+++ b/apps/web/src/routes/agent/components/agent-session-panel-rules.ts
@@ -108,6 +108,31 @@ export function shouldWaitForRuntimeReadyOnNewSession(input: RuntimeReadyWaitInp
   return input.waitForRuntimeReadyOnNewSession && input.sessionType === "preview";
 }
 
+export interface SpeculativeSessionCreateInput {
+  activeSessionId: string | null;
+  appId: string | null;
+  readinessBlockMessage: string | null;
+  sending: boolean;
+  sessionListLoaded: boolean;
+  sessionType: SessionType;
+}
+
+// Speculatively creating a session on typing is preview-only: preview sessions
+// are reset-scoped and cheap to abandon, while consume ("ui") sessions are
+// user-visible history and must not be created before a real send.
+export function shouldSpeculativelyCreateSessionOnTyping(
+  input: SpeculativeSessionCreateInput,
+): boolean {
+  return (
+    input.sessionType === "preview" &&
+    input.appId !== null &&
+    input.activeSessionId === null &&
+    input.sessionListLoaded &&
+    !input.sending &&
+    input.readinessBlockMessage === null
+  );
+}
+
 export function getSessionControlMode(tone: AgentSessionPanelTone): SessionControlMode {
   return tone === "preview" ? "reset" : "new_session";
 }

--- a/apps/web/src/routes/agent/components/agent-session-panel.tsx
+++ b/apps/web/src/routes/agent/components/agent-session-panel.tsx
@@ -146,10 +146,25 @@ export function AgentSessionPanel({
   const handleSendText = useCallback(
     async (text: string): Promise<void> => {
       lastSentTextRef.current = text;
-      const sent = await model.handleSend({ sessionResourceMentions, text });
+      const mentionsAtSend = sessionResourceMentions;
+      let accepted = false;
 
-      if (sent) {
-        resourceDraft.clearActiveMentions();
+      const sent = await model.handleSend({
+        onAccepted: () => {
+          accepted = true;
+          resourceDraft.clearActiveMentions();
+        },
+        sessionResourceMentions: mentionsAtSend,
+        text,
+      });
+
+      if (!sent && accepted && model.activeSessionId !== null) {
+        // Send failed after the optimistic clear — put the chips back so the
+        // existing "Retry send" path still carries the attachments.
+        // appendMention prepends, so reverse restores the original order.
+        for (const mention of mentionsAtSend.toReversed()) {
+          resourceDraft.appendMention(model.activeSessionId, mention);
+        }
       }
     },
     [model, resourceDraft, sessionResourceMentions],

--- a/apps/web/src/routes/agent/components/agent-session-panel.tsx
+++ b/apps/web/src/routes/agent/components/agent-session-panel.tsx
@@ -308,6 +308,7 @@ export function AgentSessionPanel({
                 fileInputRef={model.fileInputRef}
                 onFilesSelected={(files) => void handleUploadFiles(files)}
                 onRetry={handleRetrySend}
+                onTypingActivity={model.notifyComposerTyping}
                 pendingSessionFiles={pendingSessionFiles}
                 sendDisabledReason={sendDisabledReason}
                 sessionResourceMentions={sessionResourceMentions}

--- a/apps/web/src/routes/agent/components/agent-session-pending-sends.ts
+++ b/apps/web/src/routes/agent/components/agent-session-pending-sends.ts
@@ -1,0 +1,81 @@
+import type { SessionViewMessage } from "@mosoo/ag-ui-session";
+
+// Optimistic overlay for user messages that were submitted but not yet echoed
+// back over the session WebSocket. Lives outside SessionLiveState on purpose:
+// STATE_SNAPSHOT / MESSAGES_SNAPSHOT wholesale-replace reducer state, and the
+// echoed message id is a server ULID the client cannot predict, so entries are
+// reconciled by (user role + trimmed content + not a previously seen id).
+export interface PendingSend {
+  readonly baselineUserMessageIds: readonly string[];
+  readonly clientRequestId: string;
+  readonly createdAtMs: number;
+  readonly sessionId: string | null;
+  readonly text: string;
+}
+
+// Safety valve only: a persisted send always reconciles via echo or snapshot;
+// the TTL covers the black-swan case of server-side content transformation so
+// the composer can never stay blocked forever behind a stuck overlay entry.
+export const PENDING_SEND_TTL_MS = 30_000;
+
+export function createPendingSendMessage(pending: PendingSend): SessionViewMessage {
+  return {
+    content: pending.text,
+    createdAt: new Date(pending.createdAtMs).toISOString(),
+    id: `pending:${pending.clientRequestId}`,
+    plan: [],
+    role: "user",
+    segments: [],
+  };
+}
+
+export function mergePendingSendMessages(
+  messages: SessionViewMessage[],
+  pendingSends: readonly PendingSend[],
+): SessionViewMessage[] {
+  if (pendingSends.length === 0) {
+    return messages;
+  }
+
+  return [...messages, ...pendingSends.map(createPendingSendMessage)];
+}
+
+function isEchoOfPendingSend(message: SessionViewMessage, pending: PendingSend): boolean {
+  return (
+    message.role === "user" &&
+    !pending.baselineUserMessageIds.includes(message.id) &&
+    message.content.trim() === pending.text.trim()
+  );
+}
+
+export function prunePendingSends(
+  pendingSends: PendingSend[],
+  messages: readonly SessionViewMessage[],
+  nowMs: number,
+): PendingSend[] {
+  if (pendingSends.length === 0) {
+    return pendingSends;
+  }
+
+  const remaining = pendingSends.filter(
+    (pending) =>
+      nowMs - pending.createdAtMs < PENDING_SEND_TTL_MS &&
+      !messages.some((message) => isEchoOfPendingSend(message, pending)),
+  );
+
+  // Identity preservation is load-bearing: the model prunes inside a state
+  // updater on every message batch, and the unchanged reference is what stops
+  // React from re-rendering in a loop.
+  return remaining.length === pendingSends.length ? pendingSends : remaining;
+}
+
+export function prunePendingSendsForSession(
+  pendingSends: PendingSend[],
+  activeSessionId: string | null,
+): PendingSend[] {
+  const remaining = pendingSends.filter(
+    (pending) => pending.sessionId === null || pending.sessionId === activeSessionId,
+  );
+
+  return remaining.length === pendingSends.length ? pendingSends : remaining;
+}

--- a/apps/web/src/routes/agent/components/agent-session-pending-sends.ts
+++ b/apps/web/src/routes/agent/components/agent-session-pending-sends.ts
@@ -18,6 +18,11 @@ export interface PendingSend {
 // the composer can never stay blocked forever behind a stuck overlay entry.
 export const PENDING_SEND_TTL_MS = 30_000;
 
+// The TTL sweep runs on an interval, not a one-shot timer: a one-shot whose
+// prune no-ops (identity-preserved state, e.g. after a backwards wall-clock
+// step) would never re-arm and could leave the composer blocked forever.
+export const PENDING_SEND_SWEEP_INTERVAL_MS = 5_000;
+
 export function createPendingSendMessage(pending: PendingSend): SessionViewMessage {
   return {
     content: pending.text,

--- a/apps/web/src/routes/agent/components/agent-session-pending-sends.ts
+++ b/apps/web/src/routes/agent/components/agent-session-pending-sends.ts
@@ -1,3 +1,4 @@
+import { createSessionLiveStateMessage } from "@mosoo/ag-ui-session";
 import type { SessionViewMessage } from "@mosoo/ag-ui-session";
 
 // Optimistic overlay for user messages that were submitted but not yet echoed
@@ -13,10 +14,10 @@ export interface PendingSend {
   readonly text: string;
 }
 
-// Safety valve only: a persisted send always reconciles via echo or snapshot;
-// the TTL covers the black-swan case of server-side content transformation so
-// the composer can never stay blocked forever behind a stuck overlay entry.
-export const PENDING_SEND_TTL_MS = 30_000;
+// Safety valve only: a persisted send always reconciles via echo or snapshot
+// (normally well under a second); the TTL bounds how long the composer can
+// stay blocked in the black-swan case of server-side content transformation.
+export const PENDING_SEND_TTL_MS = 10_000;
 
 // The TTL sweep runs on an interval, not a one-shot timer: a one-shot whose
 // prune no-ops (identity-preserved state, e.g. after a backwards wall-clock
@@ -24,25 +25,23 @@ export const PENDING_SEND_TTL_MS = 30_000;
 export const PENDING_SEND_SWEEP_INTERVAL_MS = 5_000;
 
 export function createPendingSendMessage(pending: PendingSend): SessionViewMessage {
-  return {
+  return createSessionLiveStateMessage({
     content: pending.text,
     createdAt: new Date(pending.createdAtMs).toISOString(),
     id: `pending:${pending.clientRequestId}`,
-    plan: [],
     role: "user",
-    segments: [],
-  };
+  });
 }
 
 export function mergePendingSendMessages(
   messages: SessionViewMessage[],
-  pendingSends: readonly PendingSend[],
+  pendingMessages: readonly SessionViewMessage[],
 ): SessionViewMessage[] {
-  if (pendingSends.length === 0) {
+  if (pendingMessages.length === 0) {
     return messages;
   }
 
-  return [...messages, ...pendingSends.map(createPendingSendMessage)];
+  return [...messages, ...pendingMessages];
 }
 
 function isEchoOfPendingSend(message: SessionViewMessage, pending: PendingSend): boolean {
@@ -69,8 +68,8 @@ export function prunePendingSends(
   );
 
   // Identity preservation is load-bearing: the model prunes inside a state
-  // updater on every message batch, and the unchanged reference is what stops
-  // React from re-rendering in a loop.
+  // updater on every sweep, and the unchanged reference is what stops React
+  // from re-rendering in a loop.
   return remaining.length === pendingSends.length ? pendingSends : remaining;
 }
 

--- a/apps/web/src/routes/agent/components/use-agent-session-panel-model.ts
+++ b/apps/web/src/routes/agent/components/use-agent-session-panel-model.ts
@@ -33,6 +33,7 @@ import {
   deleteAgentSession,
 } from "./agent-session-panel-session-actions";
 import {
+  createPendingSendMessage,
   mergePendingSendMessages,
   PENDING_SEND_SWEEP_INTERVAL_MS,
   prunePendingSends,
@@ -147,40 +148,53 @@ export function useAgentSessionPanelModel(
   );
   const layout = useSessionChatLayoutState(stream.messages, permissionScrollSignal);
 
+  // Fresh messages for the sweep interval without keying the effect on
+  // stream.messages — that identity changes every animation frame during
+  // streaming and would tear the interval down per frame.
+  const streamMessagesRef = useRef(stream.messages);
+  streamMessagesRef.current = stream.messages;
+
   // Reconcile the optimistic overlay against server truth at render time, so
   // the frame that first contains the echoed message never also paints the
-  // pending bubble (a post-commit effect alone leaves a duplicate frame).
+  // pending bubble (a post-commit effect alone leaves a duplicate frame). The
+  // session filter runs here too so a pending entry bound to another session
+  // can never ghost into the newly selected session's thread mid-switch.
   const reconciledPendingSends = useMemo(
-    () => prunePendingSends(pendingSends, stream.messages, Date.now()),
-    [pendingSends, stream.messages],
+    () =>
+      prunePendingSends(
+        prunePendingSendsForSession(pendingSends, activeSessionId),
+        stream.messages,
+        Date.now(),
+      ),
+    [activeSessionId, pendingSends, stream.messages],
   );
-
-  // State GC for the same reconciliation: drop echoed/expired entries from
-  // state so gates and effects settle even when the derived value did the
-  // visual work first.
-  useEffect(() => {
-    setPendingSends((current) => prunePendingSends(current, stream.messages, Date.now()));
-  }, [stream.messages]);
 
   useEffect(() => {
     setPendingSends((current) => prunePendingSendsForSession(current, activeSessionId));
   }, [activeSessionId]);
 
-  // TTL sweep so a stuck entry expires even when no further events arrive;
-  // without it the composer could stay blocked behind a never-reconciled send.
+  // State GC + TTL sweep: gates and visuals read the render-time reconciled
+  // value, so state only needs to catch up eventually — eagerly when the
+  // overlay changes, then every sweep tick so a stuck entry expires even when
+  // no further events arrive and the composer can never stay blocked forever.
   useEffect(() => {
     if (pendingSends.length === 0) {
       return;
     }
 
-    const interval = globalThis.setInterval(() => {
-      setPendingSends((current) => prunePendingSends(current, stream.messages, Date.now()));
-    }, PENDING_SEND_SWEEP_INTERVAL_MS);
+    const sweep = (): void => {
+      setPendingSends((current) =>
+        prunePendingSends(current, streamMessagesRef.current, Date.now()),
+      );
+    };
+
+    sweep();
+    const interval = globalThis.setInterval(sweep, PENDING_SEND_SWEEP_INTERVAL_MS);
 
     return () => {
       globalThis.clearInterval(interval);
     };
-  }, [pendingSends, stream.messages]);
+  }, [pendingSends]);
 
   async function refreshSessions(): Promise<void> {
     if (input.appId === null) {
@@ -193,6 +207,15 @@ export function useAgentSessionPanelModel(
   function clearComposerError(): void {
     setComposerError(null);
   }
+
+  // "Supersede any in-flight create" is one invariant: the epoch bump and the
+  // promise-slot reset must always move together.
+  function supersedeInFlightSessionCreate(): void {
+    sessionEpochRef.current += 1;
+    sessionCreatePromiseRef.current = null;
+  }
+
+  const streamingWithPending = stream.streaming || reconciledPendingSends.length > 0;
 
   async function createSessionAndSelect(
     options: { waitForRuntimeReady?: boolean } = {},
@@ -237,8 +260,7 @@ export function useAgentSessionPanelModel(
     }
 
     setSending(true);
-    sessionEpochRef.current += 1;
-    sessionCreatePromiseRef.current = null;
+    supersedeInFlightSessionCreate();
     setSelectedSessionId(null);
     setInputValue("");
     setPendingSends([]);
@@ -265,8 +287,7 @@ export function useAgentSessionPanelModel(
     }
 
     setSending(true);
-    sessionEpochRef.current += 1;
-    sessionCreatePromiseRef.current = null;
+    supersedeInFlightSessionCreate();
     setInputValue("");
     setPendingSends([]);
     clearComposerError();
@@ -364,7 +385,9 @@ export function useAgentSessionPanelModel(
         appId: input.appId,
         readinessBlockMessage,
         sending,
-        sessionListLoaded: sessionsQuery.isFetched,
+        // isSuccess, not isFetched: a failed list query must not spawn
+        // invisible sessions the broken list cannot show.
+        sessionListLoaded: sessionsQuery.isSuccess,
         sessionType: input.sessionType,
       })
     ) {
@@ -383,8 +406,7 @@ export function useAgentSessionPanelModel(
     }
 
     setSending(true);
-    sessionEpochRef.current += 1;
-    sessionCreatePromiseRef.current = null;
+    supersedeInFlightSessionCreate();
     clearComposerError();
     setSelectedSessionId(null);
 
@@ -418,7 +440,7 @@ export function useAgentSessionPanelModel(
         // In-flight optimistic sends block re-submit like a running turn: the
         // server allows one active run, so a second Enter before the echo
         // would only surface an active-run error.
-        streaming: stream.streaming || reconciledPendingSends.length > 0,
+        streaming: streamingWithPending,
         typedText,
       })
     ) {
@@ -540,20 +562,31 @@ export function useAgentSessionPanelModel(
       return;
     }
 
-    // During the optimistic pending window there is no run to interrupt yet;
-    // skip only when the server itself does not report a running turn (a
-    // null runId with server-side RUNNING is a legitimate interrupt, e.g.
-    // right after a reconnect resume).
-    if (stream.run.id === null && !stream.streaming) {
-      return;
-    }
+    const runId = stream.run.id;
 
-    await stream.sendUserInterrupt({ runId: stream.run.id, sessionId: activeSessionId });
+    try {
+      // A null runId is resolved to the session's active run server-side, so
+      // Stop works during the optimistic window too: once the send HTTP has
+      // resolved, the queued run exists and gets interrupted.
+      await stream.sendUserInterrupt({ runId, sessionId: activeSessionId });
+    } catch (error) {
+      if (runId !== null) {
+        throw error;
+      }
+      // Best-effort in the optimistic window: with no known run a failed
+      // interrupt just means there was nothing to stop yet.
+    }
   }
 
+  // Two-step memo keeps the pending bubbles' object identity stable across
+  // streaming frames, so assistant-ui's per-message memoization holds.
+  const pendingSendMessages = useMemo(
+    () => reconciledPendingSends.map((pending) => createPendingSendMessage(pending)),
+    [reconciledPendingSends],
+  );
   const displayMessages = useMemo(
-    () => mergePendingSendMessages(stream.messages, reconciledPendingSends),
-    [stream.messages, reconciledPendingSends],
+    () => mergePendingSendMessages(stream.messages, pendingSendMessages),
+    [stream.messages, pendingSendMessages],
   );
 
   return {
@@ -587,6 +620,6 @@ export function useAgentSessionPanelModel(
     sessionCount: agentSessions.length,
     sessionLoadError: sessionsQuery.error instanceof Error ? sessionsQuery.error.message : null,
     setInput: setInputValue,
-    streaming: stream.streaming || reconciledPendingSends.length > 0,
+    streaming: streamingWithPending,
   };
 }

--- a/apps/web/src/routes/agent/components/use-agent-session-panel-model.ts
+++ b/apps/web/src/routes/agent/components/use-agent-session-panel-model.ts
@@ -389,6 +389,7 @@ export function useAgentSessionPanelModel(
 
     setSending(true);
     clearComposerError();
+    options.onAccepted?.();
 
     const clientRequestId = crypto.randomUUID();
     const pendingSend: PendingSend = {

--- a/apps/web/src/routes/agent/components/use-agent-session-panel-model.ts
+++ b/apps/web/src/routes/agent/components/use-agent-session-panel-model.ts
@@ -1,7 +1,7 @@
 import type { SessionType } from "@mosoo/contracts/session";
 import { ignorePromiseRejection } from "@mosoo/effects";
 import { useQuery } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { KeyboardEvent } from "react";
 
 import { useSessionStream } from "@/domains/runtime/use-session-stream";
@@ -31,6 +31,13 @@ import {
   createAgentSession,
   deleteAgentSession,
 } from "./agent-session-panel-session-actions";
+import {
+  mergePendingSendMessages,
+  PENDING_SEND_TTL_MS,
+  prunePendingSends,
+  prunePendingSendsForSession,
+} from "./agent-session-pending-sends";
+import type { PendingSend } from "./agent-session-pending-sends";
 
 async function autoTitleSessionAndRefresh(input: {
   appId: string | null;
@@ -89,6 +96,7 @@ export function useAgentSessionPanelModel(
   const [inputValue, setInputValue] = useState("");
   const [composerError, setComposerError] = useState<ComposerError | null>(null);
   const [sending, setSending] = useState(false);
+  const [pendingSends, setPendingSends] = useState<PendingSend[]>([]);
 
   const sessionsQuery = useQuery({
     enabled: input.appId !== null,
@@ -130,6 +138,38 @@ export function useAgentSessionPanelModel(
     [stream.permissionRequests],
   );
   const layout = useSessionChatLayoutState(stream.messages, permissionScrollSignal);
+
+  // Reconcile the optimistic overlay against server truth: drop an entry as
+  // soon as its echo (or any snapshot containing the persisted message) lands.
+  useEffect(() => {
+    setPendingSends((current) => prunePendingSends(current, stream.messages, Date.now()));
+  }, [stream.messages]);
+
+  useEffect(() => {
+    setPendingSends((current) => prunePendingSendsForSession(current, activeSessionId));
+  }, [activeSessionId]);
+
+  // TTL sweep so a stuck entry expires even when no further events arrive;
+  // without it the composer could stay blocked behind a never-reconciled send.
+  useEffect(() => {
+    if (pendingSends.length === 0) {
+      return;
+    }
+
+    const nextExpiryMs = Math.min(
+      ...pendingSends.map((pending) => pending.createdAtMs + PENDING_SEND_TTL_MS),
+    );
+    const timer = globalThis.setTimeout(
+      () => {
+        setPendingSends((current) => prunePendingSends(current, stream.messages, Date.now()));
+      },
+      Math.max(0, nextExpiryMs - Date.now()),
+    );
+
+    return () => {
+      globalThis.clearTimeout(timer);
+    };
+  }, [pendingSends, stream.messages]);
 
   async function refreshSessions(): Promise<void> {
     if (input.appId === null) {
@@ -180,6 +220,7 @@ export function useAgentSessionPanelModel(
     setSending(true);
     setSelectedSessionId(null);
     setInputValue("");
+    setPendingSends([]);
     clearComposerError();
 
     try {
@@ -204,6 +245,7 @@ export function useAgentSessionPanelModel(
 
     setSending(true);
     setInputValue("");
+    setPendingSends([]);
     clearComposerError();
 
     try {
@@ -284,7 +326,10 @@ export function useAgentSessionPanelModel(
         readinessBlockMessage,
         reconnecting: stream.reconnecting,
         sending,
-        streaming: stream.streaming,
+        // In-flight optimistic sends block re-submit like a running turn: the
+        // server allows one active run, so a second Enter before the echo
+        // would only surface an active-run error.
+        streaming: stream.streaming || pendingSends.length > 0,
         typedText,
       })
     ) {
@@ -294,6 +339,18 @@ export function useAgentSessionPanelModel(
     setSending(true);
     clearComposerError();
 
+    const clientRequestId = crypto.randomUUID();
+    const pendingSend: PendingSend = {
+      baselineUserMessageIds: stream.messages
+        .filter((message) => message.role === "user")
+        .map((message) => message.id),
+      clientRequestId,
+      createdAtMs: Date.now(),
+      sessionId: activeSessionId,
+      text: payload.text,
+    };
+    setPendingSends((current) => [...current, pendingSend]);
+
     const shouldAutoTitle =
       activeSessionId === null ||
       activeSession?.lastMessageAt === null ||
@@ -302,9 +359,17 @@ export function useAgentSessionPanelModel(
     try {
       const sessionId = await ensureActiveSession();
 
+      if (pendingSend.sessionId !== sessionId) {
+        setPendingSends((current) =>
+          current.map((pending) =>
+            pending.clientRequestId === clientRequestId ? { ...pending, sessionId } : pending,
+          ),
+        );
+      }
+
       await stream.sendUserMessage({
         attachmentIds: payload.attachmentIds,
-        clientRequestId: crypto.randomUUID(),
+        clientRequestId,
         sessionId,
         text: payload.text,
       });
@@ -331,6 +396,9 @@ export function useAgentSessionPanelModel(
       void refreshSessions();
       return true;
     } catch (error) {
+      setPendingSends((current) =>
+        current.filter((pending) => pending.clientRequestId !== clientRequestId),
+      );
       setComposerError({
         actionLabel: "Retry send",
         message: error instanceof Error ? error.message : "Message send failed.",
@@ -378,6 +446,11 @@ export function useAgentSessionPanelModel(
     await stream.sendUserInterrupt({ runId: stream.run.id, sessionId: activeSessionId });
   }
 
+  const displayMessages = useMemo(
+    () => mergePendingSendMessages(stream.messages, pendingSends),
+    [stream.messages, pendingSends],
+  );
+
   return {
     activeSession,
     activeSessionId,
@@ -392,9 +465,10 @@ export function useAgentSessionPanelModel(
     handleStartNewSession,
     input: inputValue,
     inputRef: layout.inputRef,
-    isConversationLoading: activeSessionId !== null && !stream.hydrated,
+    isConversationLoading:
+      activeSessionId !== null && !stream.hydrated && pendingSends.length === 0,
     lifecycle: stream.lifecycle,
-    messages: stream.messages,
+    messages: displayMessages,
     messagesEndRef: layout.messagesEndRef,
     permissionRequests: stream.permissionRequests,
     readiness,
@@ -407,6 +481,6 @@ export function useAgentSessionPanelModel(
     sessionCount: agentSessions.length,
     sessionLoadError: sessionsQuery.error instanceof Error ? sessionsQuery.error.message : null,
     setInput: setInputValue,
-    streaming: stream.streaming,
+    streaming: stream.streaming || pendingSends.length > 0,
   };
 }

--- a/apps/web/src/routes/agent/components/use-agent-session-panel-model.ts
+++ b/apps/web/src/routes/agent/components/use-agent-session-panel-model.ts
@@ -1,12 +1,12 @@
 import type { SessionType } from "@mosoo/contracts/session";
 import { ignorePromiseRejection } from "@mosoo/effects";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
 
 import { useSessionStream } from "@/domains/runtime/use-session-stream";
 import type { PermissionRequest } from "@/domains/runtime/use-session-stream";
-import { listAgentSessions } from "@/domains/session/api/agent-session";
+import { listAgentSessions, triggerAgentSessionPrewarm } from "@/domains/session/api/agent-session";
 import { createSessionResourceMentionMessagePayload } from "@/features/session-chat/session-resource-mentions";
 import { useSessionChatLayoutState } from "@/features/session-chat/use-session-chat-layout-state";
 import { toAgentId, toAppId, toSessionId } from "@/routes/typed-id";
@@ -24,6 +24,7 @@ import {
   hasStaleSessionConfiguration,
   isComposerSendBlocked,
   selectSessionPanelReadiness,
+  shouldSpeculativelyCreateSessionOnTyping,
   shouldWaitForRuntimeReadyOnNewSession,
 } from "./agent-session-panel-rules";
 import {
@@ -97,6 +98,7 @@ export function useAgentSessionPanelModel(
   const [composerError, setComposerError] = useState<ComposerError | null>(null);
   const [sending, setSending] = useState(false);
   const [pendingSends, setPendingSends] = useState<PendingSend[]>([]);
+  const sessionCreatePromiseRef = useRef<Promise<string> | null>(null);
 
   const sessionsQuery = useQuery({
     enabled: input.appId !== null,
@@ -218,6 +220,7 @@ export function useAgentSessionPanelModel(
     }
 
     setSending(true);
+    sessionCreatePromiseRef.current = null;
     setSelectedSessionId(null);
     setInputValue("");
     setPendingSends([]);
@@ -244,6 +247,7 @@ export function useAgentSessionPanelModel(
     }
 
     setSending(true);
+    sessionCreatePromiseRef.current = null;
     setInputValue("");
     setPendingSends([]);
     clearComposerError();
@@ -287,7 +291,53 @@ export function useAgentSessionPanelModel(
       return activeSessionId;
     }
 
-    return createSessionAndSelect();
+    // Typing-triggered speculative creation and send-triggered creation share
+    // one in-flight promise so a send never races a second create. A resolved
+    // promise stays cached on purpose: activeSessionId state can lag a render
+    // and re-awaiting it returns the same id. Failures clear the slot so the
+    // next attempt retries and owns error surfacing.
+    if (sessionCreatePromiseRef.current === null) {
+      sessionCreatePromiseRef.current = createSessionAndSelect().catch((error: unknown) => {
+        sessionCreatePromiseRef.current = null;
+        throw error;
+      });
+    }
+
+    return sessionCreatePromiseRef.current;
+  }
+
+  function notifyComposerTyping(): void {
+    if (input.appId === null) {
+      return;
+    }
+
+    if (activeSessionId !== null) {
+      if (
+        stream.lifecycle === "TERMINATED" ||
+        configurationRefreshRequired ||
+        readinessBlockMessage !== null
+      ) {
+        return;
+      }
+
+      triggerAgentSessionPrewarm(toAppId(input.appId), toSessionId(activeSessionId));
+      return;
+    }
+
+    if (
+      shouldSpeculativelyCreateSessionOnTyping({
+        activeSessionId,
+        appId: input.appId,
+        readinessBlockMessage,
+        sending,
+        sessionListLoaded: sessionsQuery.isFetched,
+        sessionType: input.sessionType,
+      })
+    ) {
+      // Silent by design: the user has not acted yet, so the send path owns
+      // error surfacing when creation genuinely fails.
+      void ensureActiveSession().catch(ignorePromiseRejection);
+    }
   }
 
   async function retryProviderCheck(): Promise<void> {
@@ -296,6 +346,7 @@ export function useAgentSessionPanelModel(
     }
 
     setSending(true);
+    sessionCreatePromiseRef.current = null;
     clearComposerError();
     setSelectedSessionId(null);
 
@@ -470,6 +521,7 @@ export function useAgentSessionPanelModel(
     lifecycle: stream.lifecycle,
     messages: displayMessages,
     messagesEndRef: layout.messagesEndRef,
+    notifyComposerTyping,
     permissionRequests: stream.permissionRequests,
     readiness,
     readinessBlockMessage,

--- a/apps/web/src/routes/agent/components/use-agent-session-panel-model.ts
+++ b/apps/web/src/routes/agent/components/use-agent-session-panel-model.ts
@@ -34,11 +34,13 @@ import {
 } from "./agent-session-panel-session-actions";
 import {
   mergePendingSendMessages,
-  PENDING_SEND_TTL_MS,
+  PENDING_SEND_SWEEP_INTERVAL_MS,
   prunePendingSends,
   prunePendingSendsForSession,
 } from "./agent-session-pending-sends";
 import type { PendingSend } from "./agent-session-pending-sends";
+
+const SPECULATIVE_CREATE_FAILURE_COOLDOWN_MS = 30_000;
 
 async function autoTitleSessionAndRefresh(input: {
   appId: string | null;
@@ -99,6 +101,10 @@ export function useAgentSessionPanelModel(
   const [sending, setSending] = useState(false);
   const [pendingSends, setPendingSends] = useState<PendingSend[]>([]);
   const sessionCreatePromiseRef = useRef<Promise<string> | null>(null);
+  // Bumped by reset/new-session/retry so an in-flight create that they
+  // superseded cannot re-select its (now orphaned) session when it resolves.
+  const sessionEpochRef = useRef(0);
+  const speculativeCreateFailedAtMsRef = useRef(0);
 
   const sessionsQuery = useQuery({
     enabled: input.appId !== null,
@@ -141,8 +147,17 @@ export function useAgentSessionPanelModel(
   );
   const layout = useSessionChatLayoutState(stream.messages, permissionScrollSignal);
 
-  // Reconcile the optimistic overlay against server truth: drop an entry as
-  // soon as its echo (or any snapshot containing the persisted message) lands.
+  // Reconcile the optimistic overlay against server truth at render time, so
+  // the frame that first contains the echoed message never also paints the
+  // pending bubble (a post-commit effect alone leaves a duplicate frame).
+  const reconciledPendingSends = useMemo(
+    () => prunePendingSends(pendingSends, stream.messages, Date.now()),
+    [pendingSends, stream.messages],
+  );
+
+  // State GC for the same reconciliation: drop echoed/expired entries from
+  // state so gates and effects settle even when the derived value did the
+  // visual work first.
   useEffect(() => {
     setPendingSends((current) => prunePendingSends(current, stream.messages, Date.now()));
   }, [stream.messages]);
@@ -158,18 +173,12 @@ export function useAgentSessionPanelModel(
       return;
     }
 
-    const nextExpiryMs = Math.min(
-      ...pendingSends.map((pending) => pending.createdAtMs + PENDING_SEND_TTL_MS),
-    );
-    const timer = globalThis.setTimeout(
-      () => {
-        setPendingSends((current) => prunePendingSends(current, stream.messages, Date.now()));
-      },
-      Math.max(0, nextExpiryMs - Date.now()),
-    );
+    const interval = globalThis.setInterval(() => {
+      setPendingSends((current) => prunePendingSends(current, stream.messages, Date.now()));
+    }, PENDING_SEND_SWEEP_INTERVAL_MS);
 
     return () => {
-      globalThis.clearTimeout(timer);
+      globalThis.clearInterval(interval);
     };
   }, [pendingSends, stream.messages]);
 
@@ -192,6 +201,7 @@ export function useAgentSessionPanelModel(
       throw new Error("App id is required to create an agent session.");
     }
 
+    const epoch = sessionEpochRef.current;
     const createdSession = await createAgentSession(
       toAppId(input.appId),
       toAgentId(input.agentId),
@@ -200,6 +210,13 @@ export function useAgentSessionPanelModel(
         waitForRuntimeReady: options.waitForRuntimeReady === true,
       },
     );
+
+    if (sessionEpochRef.current !== epoch) {
+      // Reset/new-session superseded this create while it was in flight; the
+      // orphaned session is reaped by the next reset.
+      return createdSession.id;
+    }
+
     const revisionKey = input.configurationRevisionKey;
 
     if (revisionKey !== null && revisionKey.length > 0) {
@@ -220,6 +237,7 @@ export function useAgentSessionPanelModel(
     }
 
     setSending(true);
+    sessionEpochRef.current += 1;
     sessionCreatePromiseRef.current = null;
     setSelectedSessionId(null);
     setInputValue("");
@@ -247,6 +265,7 @@ export function useAgentSessionPanelModel(
     }
 
     setSending(true);
+    sessionEpochRef.current += 1;
     sessionCreatePromiseRef.current = null;
     setInputValue("");
     setPendingSends([]);
@@ -294,13 +313,19 @@ export function useAgentSessionPanelModel(
     // Typing-triggered speculative creation and send-triggered creation share
     // one in-flight promise so a send never races a second create. A resolved
     // promise stays cached on purpose: activeSessionId state can lag a render
-    // and re-awaiting it returns the same id. Failures clear the slot so the
-    // next attempt retries and owns error surfacing.
+    // and re-awaiting it returns the same id. Failures clear the slot (only if
+    // it still owns it — reset may have handed the slot to a newer create) so
+    // the next attempt retries and owns error surfacing.
     if (sessionCreatePromiseRef.current === null) {
-      sessionCreatePromiseRef.current = createSessionAndSelect().catch((error: unknown) => {
-        sessionCreatePromiseRef.current = null;
+      const createPromise = createSessionAndSelect().catch((error: unknown) => {
+        if (sessionCreatePromiseRef.current === createPromise) {
+          sessionCreatePromiseRef.current = null;
+        }
+
         throw error;
       });
+
+      sessionCreatePromiseRef.current = createPromise;
     }
 
     return sessionCreatePromiseRef.current;
@@ -324,6 +349,15 @@ export function useAgentSessionPanelModel(
       return;
     }
 
+    // Cooldown after a failed speculative create so a failing endpoint is not
+    // re-hit on every keystroke; a real send retries immediately regardless.
+    if (
+      Date.now() - speculativeCreateFailedAtMsRef.current <
+      SPECULATIVE_CREATE_FAILURE_COOLDOWN_MS
+    ) {
+      return;
+    }
+
     if (
       shouldSpeculativelyCreateSessionOnTyping({
         activeSessionId,
@@ -336,7 +370,10 @@ export function useAgentSessionPanelModel(
     ) {
       // Silent by design: the user has not acted yet, so the send path owns
       // error surfacing when creation genuinely fails.
-      void ensureActiveSession().catch(ignorePromiseRejection);
+      void ensureActiveSession().catch((error: unknown) => {
+        speculativeCreateFailedAtMsRef.current = Date.now();
+        ignorePromiseRejection(error);
+      });
     }
   }
 
@@ -346,6 +383,7 @@ export function useAgentSessionPanelModel(
     }
 
     setSending(true);
+    sessionEpochRef.current += 1;
     sessionCreatePromiseRef.current = null;
     clearComposerError();
     setSelectedSessionId(null);
@@ -380,7 +418,7 @@ export function useAgentSessionPanelModel(
         // In-flight optimistic sends block re-submit like a running turn: the
         // server allows one active run, so a second Enter before the echo
         // would only surface an active-run error.
-        streaming: stream.streaming || pendingSends.length > 0,
+        streaming: stream.streaming || reconciledPendingSends.length > 0,
         typedText,
       })
     ) {
@@ -392,6 +430,10 @@ export function useAgentSessionPanelModel(
     options.onAccepted?.();
 
     const clientRequestId = crypto.randomUUID();
+    // Sending into an existing but not-yet-hydrated session would capture an
+    // empty baseline, letting an identical message from history falsely prune
+    // the overlay — skip optimism there (sub-second race, pre-existing UX).
+    const canRenderOptimistically = activeSessionId === null || stream.hydrated;
     const pendingSend: PendingSend = {
       baselineUserMessageIds: stream.messages
         .filter((message) => message.role === "user")
@@ -401,7 +443,10 @@ export function useAgentSessionPanelModel(
       sessionId: activeSessionId,
       text: payload.text,
     };
-    setPendingSends((current) => [...current, pendingSend]);
+
+    if (canRenderOptimistically) {
+      setPendingSends((current) => [...current, pendingSend]);
+    }
 
     const shouldAutoTitle =
       activeSessionId === null ||
@@ -495,12 +540,20 @@ export function useAgentSessionPanelModel(
       return;
     }
 
+    // During the optimistic pending window there is no run to interrupt yet;
+    // skip only when the server itself does not report a running turn (a
+    // null runId with server-side RUNNING is a legitimate interrupt, e.g.
+    // right after a reconnect resume).
+    if (stream.run.id === null && !stream.streaming) {
+      return;
+    }
+
     await stream.sendUserInterrupt({ runId: stream.run.id, sessionId: activeSessionId });
   }
 
   const displayMessages = useMemo(
-    () => mergePendingSendMessages(stream.messages, pendingSends),
-    [stream.messages, pendingSends],
+    () => mergePendingSendMessages(stream.messages, reconciledPendingSends),
+    [stream.messages, reconciledPendingSends],
   );
 
   return {
@@ -518,7 +571,7 @@ export function useAgentSessionPanelModel(
     input: inputValue,
     inputRef: layout.inputRef,
     isConversationLoading:
-      activeSessionId !== null && !stream.hydrated && pendingSends.length === 0,
+      activeSessionId !== null && !stream.hydrated && reconciledPendingSends.length === 0,
     lifecycle: stream.lifecycle,
     messages: displayMessages,
     messagesEndRef: layout.messagesEndRef,
@@ -534,6 +587,6 @@ export function useAgentSessionPanelModel(
     sessionCount: agentSessions.length,
     sessionLoadError: sessionsQuery.error instanceof Error ? sessionsQuery.error.message : null,
     setInput: setInputValue,
-    streaming: stream.streaming || pendingSends.length > 0,
+    streaming: stream.streaming || reconciledPendingSends.length > 0,
   };
 }

--- a/apps/web/tests/agent-session-panel-boundary.test.ts
+++ b/apps/web/tests/agent-session-panel-boundary.test.ts
@@ -5,8 +5,10 @@ import type { AgentReadiness } from "@mosoo/contracts/agent";
 import {
   getSessionControlMode,
   selectSessionPanelReadiness,
+  shouldSpeculativelyCreateSessionOnTyping,
   shouldWaitForRuntimeReadyOnNewSession,
 } from "../src/routes/agent/components/agent-session-panel-rules";
+import type { SpeculativeSessionCreateInput } from "../src/routes/agent/components/agent-session-panel-rules";
 import {
   getResetSessionIds,
   removeSessionConfigurationRevisionKeys,
@@ -64,6 +66,36 @@ describe("agent session panel boundary", () => {
       shouldWaitForRuntimeReadyOnNewSession({
         sessionType: "preview",
         waitForRuntimeReadyOnNewSession: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("speculatively creates a session on typing only for a ready, empty Preview panel", () => {
+    const readyInput: SpeculativeSessionCreateInput = {
+      activeSessionId: null,
+      appId: "app_1",
+      readinessBlockMessage: null,
+      sending: false,
+      sessionListLoaded: true,
+      sessionType: "preview",
+    };
+
+    expect(shouldSpeculativelyCreateSessionOnTyping(readyInput)).toBe(true);
+    expect(shouldSpeculativelyCreateSessionOnTyping({ ...readyInput, sessionType: "ui" })).toBe(
+      false,
+    );
+    expect(shouldSpeculativelyCreateSessionOnTyping({ ...readyInput, appId: null })).toBe(false);
+    expect(
+      shouldSpeculativelyCreateSessionOnTyping({ ...readyInput, activeSessionId: "session_1" }),
+    ).toBe(false);
+    expect(
+      shouldSpeculativelyCreateSessionOnTyping({ ...readyInput, sessionListLoaded: false }),
+    ).toBe(false);
+    expect(shouldSpeculativelyCreateSessionOnTyping({ ...readyInput, sending: true })).toBe(false);
+    expect(
+      shouldSpeculativelyCreateSessionOnTyping({
+        ...readyInput,
+        readinessBlockMessage: "Provider key required.",
       }),
     ).toBe(false);
   });

--- a/apps/web/tests/agent-session-pending-sends.test.ts
+++ b/apps/web/tests/agent-session-pending-sends.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { SessionViewMessage } from "@mosoo/ag-ui-session";
 
 import {
+  createPendingSendMessage,
   mergePendingSendMessages,
   PENDING_SEND_TTL_MS,
   prunePendingSends,
@@ -37,7 +38,7 @@ describe("agent session pending sends", () => {
   test("merges the pending user bubble after server messages", () => {
     const serverMessages = [message({ id: "msg_1", role: "assistant" })];
     const merged = mergePendingSendMessages(serverMessages, [
-      pendingSend({ clientRequestId: "req_a", text: "run the tests" }),
+      createPendingSendMessage(pendingSend({ clientRequestId: "req_a", text: "run the tests" })),
     ]);
 
     expect(merged).toHaveLength(2);

--- a/apps/web/tests/agent-session-pending-sends.test.ts
+++ b/apps/web/tests/agent-session-pending-sends.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+
+import type { SessionViewMessage } from "@mosoo/ag-ui-session";
+
+import {
+  mergePendingSendMessages,
+  PENDING_SEND_TTL_MS,
+  prunePendingSends,
+  prunePendingSendsForSession,
+} from "../src/routes/agent/components/agent-session-pending-sends";
+import type { PendingSend } from "../src/routes/agent/components/agent-session-pending-sends";
+
+function message(overrides: Partial<SessionViewMessage>): SessionViewMessage {
+  return {
+    content: "hello",
+    createdAt: "2026-07-17T00:00:00.000Z",
+    id: "msg_1",
+    plan: [],
+    role: "user",
+    segments: [],
+    ...overrides,
+  };
+}
+
+function pendingSend(overrides: Partial<PendingSend>): PendingSend {
+  return {
+    baselineUserMessageIds: [],
+    clientRequestId: "req_1",
+    createdAtMs: 1_000,
+    sessionId: null,
+    text: "hello",
+    ...overrides,
+  };
+}
+
+describe("agent session pending sends", () => {
+  test("merges the pending user bubble after server messages", () => {
+    const serverMessages = [message({ id: "msg_1", role: "assistant" })];
+    const merged = mergePendingSendMessages(serverMessages, [
+      pendingSend({ clientRequestId: "req_a", text: "run the tests" }),
+    ]);
+
+    expect(merged).toHaveLength(2);
+    expect(merged[1]).toMatchObject({
+      content: "run the tests",
+      id: "pending:req_a",
+      role: "user",
+    });
+  });
+
+  test("returns the same array reference when there are no pending sends", () => {
+    const serverMessages = [message({})];
+
+    expect(mergePendingSendMessages(serverMessages, [])).toBe(serverMessages);
+  });
+
+  test("prunes an entry when its echo arrives as a new user message", () => {
+    const pending = [pendingSend({ baselineUserMessageIds: ["msg_old"], text: "hello " })];
+    const messages = [message({ content: "hello", id: "msg_new", role: "user" })];
+
+    expect(prunePendingSends(pending, messages, 2_000)).toHaveLength(0);
+  });
+
+  test("keeps the entry when only a baseline message matches the same text", () => {
+    const pending = [pendingSend({ baselineUserMessageIds: ["msg_old"], text: "hello" })];
+    const messages = [message({ content: "hello", id: "msg_old", role: "user" })];
+
+    expect(prunePendingSends(pending, messages, 2_000)).toBe(pending);
+  });
+
+  test("ignores assistant messages with matching content", () => {
+    const pending = [pendingSend({ text: "hello" })];
+    const messages = [message({ content: "hello", id: "msg_new", role: "assistant" })];
+
+    expect(prunePendingSends(pending, messages, 2_000)).toBe(pending);
+  });
+
+  test("prunes entries past the TTL even without a matching echo", () => {
+    const pending = [pendingSend({ createdAtMs: 1_000 })];
+
+    expect(prunePendingSends(pending, [], 1_000 + PENDING_SEND_TTL_MS)).toHaveLength(0);
+    expect(prunePendingSends(pending, [], 1_000 + PENDING_SEND_TTL_MS - 1)).toBe(pending);
+  });
+
+  test("session prune keeps unbound entries and drops foreign-session entries", () => {
+    const pending = [
+      pendingSend({ clientRequestId: "req_unbound", sessionId: null }),
+      pendingSend({ clientRequestId: "req_mine", sessionId: "session_a" }),
+      pendingSend({ clientRequestId: "req_foreign", sessionId: "session_b" }),
+    ];
+
+    const remaining = prunePendingSendsForSession(pending, "session_a");
+
+    expect(remaining.map((entry) => entry.clientRequestId)).toEqual(["req_unbound", "req_mine"]);
+    expect(prunePendingSendsForSession(pending, "session_b")).not.toBe(pending);
+    expect(
+      prunePendingSendsForSession([pendingSend({ sessionId: "session_a" })], "session_a"),
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What

Makes every user-perceptible interaction in the Agent Preview send-message flow optimistic, so the UI never waits on a round-trip it doesn't have to:

- **Instant user bubble** (`1d4bb6b0`): a pending-send overlay in the panel model renders the user's message the moment Enter is pressed, instead of waiting for the HTTP mutation + WebSocket echo. The overlay lives outside the AG-UI live state (snapshots wholesale-replace it) and reconciles against the echo by user role + trimmed content + a baseline id set (the echoed id is a server ULID, not the `clientRequestId`), with a 10s TTL + 5s interval sweep as the stuck-entry safety valve. The Working pill and Stop button flip immediately (`streaming || pending`), and the first send no longer blanks the thread with "Loading conversation…" during socket hydration.
- **Warm-up on typing intent** (`10a3e64b`): typing (or opening the file picker) in the preview composer now prewarms the runtime via the existing throttled `triggerAgentSessionPrewarm` (previously only wired in the threads route), and — preview tone only — speculatively creates the session through a deduped in-flight promise, moving the create RTT, socket connect, snapshot hydration, and sandbox boot into the seconds the user spends typing. Consume tone never speculatively creates.
- **Optimistic mention chips** (`d46bd41a`): `@file` chips clear at gate-pass instead of after the round-trip, and restore on failure so "Retry send" still carries the attachments.
- **Hardening** (`63b6359d`, `25aefc3f`): fixes from three review passes (multi-lens adversarially-verified fan-out, independent Codex review, /code-review) — render-time reconciliation (no duplicate-bubble frame), interval sweep keyed off per-frame message identity, session-epoch guard so a reset can't resurrect a superseded create, ownership-checked create-promise slot, hydration guard for the baseline, best-effort Stop during the pending window (null runId resolves to the active run server-side), speculative-create failure cooldown + `isSuccess` list gate, stable pending-bubble object identity, and reuse of `createSessionLiveStateMessage`.

## Why

The composer input already cleared optimistically (assistant-ui), but the message itself round-tripped GraphQL → persist → WS echo before rendering — several hundred ms of "did it swallow my message?", and worse on first send where the thread was replaced by a blank loader mid-create. Server contract facts this relies on (verified in `apps/api`): sends are accepted on a cold runtime (persist + queue; dispatch boots the sandbox), the echo is a `TEXT_MESSAGE_CHUNK` + `run.updated{lifecycle: RUNNING}`, and `clientRequestId` is the wire-level dedup key.

## Test plan

- `apps/web`: `bun run tc` / `bun run lint` clean, `bun run test` 177 pass (8 new: pending-send reconciliation identity/baseline/TTL/session-scope, speculative-create guard).
- Manual smoke: first-send instant bubble w/o loader blank; echo reconciliation (no dup, same-text-twice safe); failed send removes bubble + Retry card; reset mid-create yields a fresh session; typing fires throttled prewarm; consume tone never speculatively creates.

## Follow-up (out of scope)

Threading `clientRequestId` into the AG-UI user message would let the client reconcile by id and collapse the content-match + baseline + TTL machinery; today the correlation id is dropped before `SessionViewMessage`. Recorded as the root-cause altitude for a future protocol change.
