### PR TITLE
feat(web): add motion polish across console surfaces

### DIFF
--- a/apps/web/src/app/account-menu.tsx
+++ b/apps/web/src/app/account-menu.tsx
@@ -92,11 +92,11 @@ export function AccountMenu({
       className="hover:bg-ink-900/[0.04] flex h-auto w-full items-center justify-start gap-2.5 rounded-lg p-2 text-left"
     >
       <UserAvatar user={user} />
-      <div className="min-w-0 flex-1">
+      <div className="sidebar-label-enter min-w-0 flex-1">
         <div className="text-fg-1 truncate text-[13px] font-bold">{user?.name}</div>
         <div className="text-fg-3 truncate text-[11.5px]">{user?.email}</div>
       </div>
-      <AccountMenuChevronIcon className="text-fg-3 size-3.5 shrink-0" />
+      <AccountMenuChevronIcon className="sidebar-label-enter text-fg-3 size-3.5 shrink-0" />
     </Button>
   );
 

--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -54,7 +54,7 @@ function BackToOrgLink({ collapsed, orgName }: { collapsed: boolean; orgName: st
       )}
     >
       <BackIcon className="size-3.5 shrink-0" />
-      {collapsed ? null : <span className="truncate">{label}</span>}
+      {collapsed ? null : <span className="sidebar-label-enter truncate">{label}</span>}
     </Link>
   );
 
@@ -98,13 +98,13 @@ function AppSwitcher({
       <AppSwitcherIcon className="size-4 shrink-0" />
       {collapsed ? null : (
         <>
-          <div className="min-w-0 flex-1 text-left">
+          <div className="sidebar-label-enter min-w-0 flex-1 text-left">
             <div className="text-muted-foreground text-[10.5px] leading-3 font-semibold uppercase">
               App
             </div>
             <div className="truncate">{displayLabel}</div>
           </div>
-          <SwitcherChevronIcon className="text-fg-3 size-3.5 shrink-0" />
+          <SwitcherChevronIcon className="sidebar-label-enter text-fg-3 size-3.5 shrink-0" />
         </>
       )}
     </button>
@@ -147,7 +147,7 @@ function NewAgentCta({ collapsed, disabled }: { collapsed: boolean; disabled: bo
     return (
       <Button disabled aria-label={label} className={className}>
         <NewAgentIcon className="size-4" />
-        {collapsed ? null : label}
+        {collapsed ? null : <span className="sidebar-label-enter">{label}</span>}
       </Button>
     );
   }
@@ -156,7 +156,7 @@ function NewAgentCta({ collapsed, disabled }: { collapsed: boolean; disabled: bo
     <Button asChild aria-label={label} className={className}>
       <Link to="/agent?create=1">
         <NewAgentIcon className="size-4" />
-        {collapsed ? null : label}
+        {collapsed ? null : <span className="sidebar-label-enter">{label}</span>}
       </Link>
     </Button>
   );
@@ -322,7 +322,11 @@ function ConsoleShell({
           )}
         >
           {collapsed ? null : (
-            <img src="/brand/logo-wordmark-onlight.svg" alt="Mosoo" className="block h-[22px]" />
+            <img
+              src="/brand/logo-wordmark-onlight.svg"
+              alt="Mosoo"
+              className="sidebar-label-enter block h-[22px]"
+            />
           )}
           <Tooltip>
             <TooltipTrigger asChild>

--- a/apps/web/src/app/navigation.tsx
+++ b/apps/web/src/app/navigation.tsx
@@ -101,7 +101,7 @@ function NavLink({
       )}
     >
       <Icon className="size-4" />
-      {collapsed ? null : <span>{label}</span>}
+      {collapsed ? null : <span className="sidebar-label-enter">{label}</span>}
     </Link>
   );
 
@@ -192,7 +192,7 @@ function NavGroup({
           className="flex min-w-0 flex-1 items-center gap-2.5 rounded-md px-2.5 py-2 text-[13.5px] font-semibold"
         >
           <Icon className="size-4 shrink-0" />
-          <span className="flex-1 truncate text-left">{item.label}</span>
+          <span className="sidebar-label-enter flex-1 truncate text-left">{item.label}</span>
         </Link>
         {item.children && item.children.length > 0 ? (
           <button
@@ -220,7 +220,7 @@ function NavGroup({
           )}
         >
           <div className="overflow-hidden">
-            <div className="mt-0.5 flex flex-col gap-0.5 pl-[34px]">
+            <div className="sidebar-label-enter mt-0.5 flex flex-col gap-0.5 pl-[34px]">
               {item.children.map((child) => {
                 const childActive = isNavItemActive(pathname, child.path);
                 return (
@@ -265,7 +265,7 @@ function NavSection({
   return (
     <div className={cn("flex flex-col", collapsed ? "gap-1" : "gap-0.5")}>
       {!collapsed && section.label ? (
-        <div className="text-fg-3 mt-3 mb-1 px-2.5 text-[10.5px] font-semibold tracking-wider uppercase">
+        <div className="sidebar-label-enter text-fg-3 mt-3 mb-1 px-2.5 text-[10.5px] font-semibold tracking-wider uppercase">
           {section.label}
         </div>
       ) : null}

--- a/apps/web/src/features/help/help-menu.tsx
+++ b/apps/web/src/features/help/help-menu.tsx
@@ -85,7 +85,7 @@ export function HelpMenu({
       )}
     >
       <HelpCircle className="size-4" />
-      {collapsed ? null : <span>Help &amp; docs</span>}
+      {collapsed ? null : <span className="sidebar-label-enter">Help &amp; docs</span>}
     </button>
   );
 

--- a/apps/web/src/routes/agent/lifecycle/publish-success-modal.tsx
+++ b/apps/web/src/routes/agent/lifecycle/publish-success-modal.tsx
@@ -37,7 +37,7 @@ export function PublishSuccessModal({
       <DialogContent className="flex max-h-[88vh] flex-col overflow-hidden rounded-lg p-0 sm:max-w-[540px]">
         <DialogHeader className="px-6 pt-6 pb-3">
           <div className="flex items-center gap-3">
-            <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-green-100 text-green-800">
+            <div className="success-check-enter flex size-10 shrink-0 items-center justify-center rounded-full bg-green-100 text-green-800">
               <Check className="size-5" strokeWidth={2.5} />
             </div>
             <div className="min-w-0">

--- a/apps/web/src/routes/app-overview/app-overview-install.tsx
+++ b/apps/web/src/routes/app-overview/app-overview-install.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy, KeyRound } from "lucide-react";
+import { Check, KeyRound } from "lucide-react";
 import type { ReactElement } from "react";
 import { useState } from "react";
 import { Link } from "react-router-dom";
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom";
 import { writeClipboardText } from "@/shared/lib/clipboard";
 import { RuntimeIcon } from "@/shared/ui/brand-icons";
 import { Button } from "@/shared/ui/button";
+import { CopyCheckIcon } from "@/shared/ui/copy-check-icon";
 
 const INSTALL_COMMAND = "curl -fsSL https://install.mosoo.ai/install.sh | bash";
 const API_TOKENS_PATH = "/settings/access-tokens";
@@ -67,7 +68,7 @@ export function AppOverviewInstallGuide(): ReactElement {
             size="default"
             variant="accent"
           >
-            {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+            <CopyCheckIcon copied={copied} />
             {copied ? "Copied" : "Copy"}
           </Button>
         </div>

--- a/apps/web/src/routes/app-overview/deploy/components/deployments-history.tsx
+++ b/apps/web/src/routes/app-overview/deploy/components/deployments-history.tsx
@@ -134,16 +134,20 @@ export function DeploymentsHistory({ runs }: { runs: DeploymentRunVM[] }) {
                     />
                   </button>
                   {expanded ? (
-                    <div className="border-border bg-bg-sunken/40 mt-1 rounded-md border px-3.5 py-2.5 text-[13px]">
-                      <div className="text-fg-3 mb-1 text-[11.5px] font-medium">
-                        Failure details
+                    <div className="grid grid-rows-[1fr] transition-[grid-template-rows] duration-200 ease-out starting:grid-rows-[0fr]">
+                      <div className="overflow-hidden">
+                        <div className="border-border bg-bg-sunken/40 mt-1 rounded-md border px-3.5 py-2.5 text-[13px]">
+                          <div className="text-fg-3 mb-1 text-[11.5px] font-medium">
+                            Failure details
+                          </div>
+                          {run.errorCode === null ? null : (
+                            <span className="text-destructive mr-2 font-mono text-[12px] font-semibold">
+                              {run.errorCode}
+                            </span>
+                          )}
+                          <span className="text-fg-2 break-words">{run.errorMessage ?? ""}</span>
+                        </div>
                       </div>
-                      {run.errorCode === null ? null : (
-                        <span className="text-destructive mr-2 font-mono text-[12px] font-semibold">
-                          {run.errorCode}
-                        </span>
-                      )}
-                      <span className="text-fg-2 break-words">{run.errorMessage ?? ""}</span>
                     </div>
                   ) : null}
                 </>
@@ -228,16 +232,20 @@ export function DeploymentsHistory({ runs }: { runs: DeploymentRunVM[] }) {
                   {failedError === null || !expanded ? null : (
                     <TableRow className="hover:bg-transparent">
                       <TableCell colSpan={3} className="px-5 pt-0 pb-4">
-                        <div className="border-border bg-bg-sunken/40 rounded-md border px-3.5 py-2.5 text-[13px]">
-                          <div className="text-fg-3 mb-1 text-[11.5px] font-medium">
-                            Failure details
+                        <div className="grid grid-rows-[1fr] transition-[grid-template-rows] duration-200 ease-out starting:grid-rows-[0fr]">
+                          <div className="overflow-hidden">
+                            <div className="border-border bg-bg-sunken/40 rounded-md border px-3.5 py-2.5 text-[13px]">
+                              <div className="text-fg-3 mb-1 text-[11.5px] font-medium">
+                                Failure details
+                              </div>
+                              {run.errorCode === null ? null : (
+                                <span className="text-destructive mr-2 font-mono text-[12px] font-semibold">
+                                  {run.errorCode}
+                                </span>
+                              )}
+                              <span className="text-fg-2">{run.errorMessage ?? ""}</span>
+                            </div>
                           </div>
-                          {run.errorCode === null ? null : (
-                            <span className="text-destructive mr-2 font-mono text-[12px] font-semibold">
-                              {run.errorCode}
-                            </span>
-                          )}
-                          <span className="text-fg-2">{run.errorMessage ?? ""}</span>
                         </div>
                       </TableCell>
                     </TableRow>

--- a/apps/web/src/routes/cli-auth/cli-auth.route.tsx
+++ b/apps/web/src/routes/cli-auth/cli-auth.route.tsx
@@ -70,7 +70,7 @@ function StatusMessage({ error, status }: { error: Error | null; status: string 
   if (status === "authorized") {
     return (
       <p className="text-success inline-flex items-center gap-2 text-sm">
-        <CheckCircle2 className="size-4" />
+        <CheckCircle2 className="success-check-enter size-4" />
         CLI access authorized.
       </p>
     );

--- a/apps/web/src/routes/environments/environment-list-table.tsx
+++ b/apps/web/src/routes/environments/environment-list-table.tsx
@@ -1,10 +1,19 @@
 import type { EnvironmentSummary } from "@mosoo/contracts/environment";
-import { GitFork, MoreHorizontal } from "lucide-react";
+import { GitFork, MoreHorizontal, Trash2 } from "lucide-react";
+import { useState } from "react";
 import type { ReactElement } from "react";
 import { Link } from "react-router-dom";
 
 import { cn } from "@/shared/lib/class-names";
 import { Button } from "@/shared/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -34,6 +43,17 @@ export function EnvironmentListTable({
   onDelete,
   onSetDefault,
 }: EnvironmentListTableProps): ReactElement {
+  // Delete is destructive and irreversible, so it sits behind a confirm dialog
+  // (same convention as deleting a deployment in deploy-actions.tsx).
+  const [confirmingDelete, setConfirmingDelete] = useState<EnvironmentSummary | null>(null);
+
+  function confirmDelete(): void {
+    if (confirmingDelete !== null) {
+      onDelete(confirmingDelete.id);
+    }
+    setConfirmingDelete(null);
+  }
+
   return (
     <div className="border-border bg-card overflow-hidden rounded-lg border">
       {environments.map((environment, index) => (
@@ -97,8 +117,9 @@ export function EnvironmentListTable({
                 <>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
+                    variant="destructive"
                     onClick={() => {
-                      onDelete(environment.id);
+                      setConfirmingDelete(environment);
                     }}
                   >
                     Delete
@@ -109,6 +130,45 @@ export function EnvironmentListTable({
           </DropdownMenu>
         </div>
       ))}
+
+      <Dialog
+        open={confirmingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setConfirmingDelete(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete this environment?</DialogTitle>
+            <DialogDescription>
+              This permanently deletes{" "}
+              <span className="text-fg-1 font-semibold">{confirmingDelete?.name}</span> from this
+              App and cannot be undone.
+              {confirmingDelete !== null && confirmingDelete.usedByAgentCount > 0
+                ? ` It is currently used by ${String(confirmingDelete.usedByAgentCount)} ${
+                    confirmingDelete.usedByAgentCount === 1 ? "agent" : "agents"
+                  }.`
+                : null}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setConfirmingDelete(null);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={confirmDelete}>
+              <Trash2 className="size-4" />
+              Delete environment
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/web/src/routes/settings/access-tokens-tab.tsx
+++ b/apps/web/src/routes/settings/access-tokens-tab.tsx
@@ -1,6 +1,6 @@
 import type { PersonalAccessTokenSummary } from "@mosoo/contracts/auth";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, Copy, ExternalLink, KeyRound, Loader2, Plus, Trash2 } from "lucide-react";
+import { ExternalLink, KeyRound, Loader2, Plus, Trash2 } from "lucide-react";
 import { useReducer } from "react";
 
 import {
@@ -10,6 +10,7 @@ import {
 } from "@/domains/auth/api/personal-access-token-client";
 import { MOSOO_API_REFERENCE_URL } from "@/shared/config/external-links";
 import { Button } from "@/shared/ui/button";
+import { CopyCheckIcon } from "@/shared/ui/copy-check-icon";
 import { Input } from "@/shared/ui/input";
 
 import { isTruthy } from "../../shared/lib/truthiness";
@@ -277,7 +278,7 @@ function CreatedTokenPanel({
           title={tooltip}
           variant="outline"
         >
-          {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+          <CopyCheckIcon copied={copied} />
         </Button>
       </div>
     </div>

--- a/apps/web/src/routes/threads/detail/view.tsx
+++ b/apps/web/src/routes/threads/detail/view.tsx
@@ -7,7 +7,6 @@ import type {
 import {
   Archive,
   ArrowLeft,
-  ChevronDown,
   ChevronRight,
   CornerDownLeft,
   Inbox,
@@ -24,6 +23,7 @@ import type { ReactElement } from "react";
 import type { ListedFileEntry } from "@/domains/file/api/files";
 import { triggerAgentSessionPrewarm } from "@/domains/session/api/agent-session";
 import { toSessionId } from "@/routes/typed-id";
+import { cn } from "@/shared/lib/class-names";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 import {
@@ -88,11 +88,12 @@ function ThreadActivityCard({
         }}
         className="hover:bg-ink-900/[0.02] flex w-full items-center gap-2 rounded-t-lg px-3 py-2 text-left"
       >
-        {open ? (
-          <ChevronDown className="text-fg-3 size-3.5 shrink-0" />
-        ) : (
-          <ChevronRight className="text-fg-3 size-3.5 shrink-0" />
-        )}
+        <ChevronRight
+          className={cn(
+            "text-fg-3 size-3.5 shrink-0 transition-transform duration-150 ease-out",
+            open ? "rotate-90" : "rotate-0",
+          )}
+        />
         {isUser ? (
           <UserAvatar
             image={viewer.image}
@@ -112,35 +113,42 @@ function ThreadActivityCard({
           {formatRelativeTime(message.createdAt)}
         </span>
       </button>
-      {open ? (
-        <div className="border-border-subtle border-t px-4 py-3">
-          {isUser ? (
-            <div className="text-fg-1 text-[13.5px] leading-relaxed whitespace-pre-wrap">
-              {message.content}
-            </div>
-          ) : (
-            <div className="text-fg-1 text-[13.5px] leading-relaxed">
-              <Markdown linkResolver={artifactLinkResolver}>{message.content}</Markdown>
-            </div>
-          )}
-          {!isUser ? (
-            <div className="mt-3">
-              <Button
-                size="xs"
-                variant="outline"
-                className="font-mono text-[11px]"
-                onClick={onOpenProcess}
-              >
-                <ChevronRight className="size-3" />
-                {processButtonText}
-                {processEventCount > 0 ? (
-                  <span className="text-fg-3 ml-1">· {processEventCount} events</span>
-                ) : null}
-              </Button>
-            </div>
-          ) : null}
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows] duration-200 ease-out",
+          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+        )}
+      >
+        <div className="overflow-hidden">
+          <div className="border-border-subtle border-t px-4 py-3">
+            {isUser ? (
+              <div className="text-fg-1 text-[13.5px] leading-relaxed whitespace-pre-wrap">
+                {message.content}
+              </div>
+            ) : (
+              <div className="text-fg-1 text-[13.5px] leading-relaxed">
+                <Markdown linkResolver={artifactLinkResolver}>{message.content}</Markdown>
+              </div>
+            )}
+            {!isUser ? (
+              <div className="mt-3">
+                <Button
+                  size="xs"
+                  variant="outline"
+                  className="font-mono text-[11px]"
+                  onClick={onOpenProcess}
+                >
+                  <ChevronRight className="size-3" />
+                  {processButtonText}
+                  {processEventCount > 0 ? (
+                    <span className="text-fg-3 ml-1">· {processEventCount} events</span>
+                  ) : null}
+                </Button>
+              </div>
+            ) : null}
+          </div>
         </div>
-      ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/routes/threads/process-modal/process-event-row.tsx
+++ b/apps/web/src/routes/threads/process-modal/process-event-row.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import type { ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";
@@ -42,11 +42,12 @@ export function ProcessEventRow({
         }}
         className="grid w-full grid-cols-[12px_136px_minmax(0,1fr)_56px_56px_40px_56px] items-center gap-2 px-3 py-2 pl-4 text-left"
       >
-        {expanded ? (
-          <ChevronDown className="text-fg-3 size-3 shrink-0" />
-        ) : (
-          <ChevronRight className="text-fg-3 size-3 shrink-0" />
-        )}
+        <ChevronRight
+          className={cn(
+            "text-fg-3 size-3 shrink-0 transition-transform duration-150 ease-out",
+            expanded ? "rotate-90" : "rotate-0",
+          )}
+        />
 
         <span
           className={cn(
@@ -74,13 +75,17 @@ export function ProcessEventRow({
       </button>
 
       {expanded ? (
-        <div className="border-border-subtle bg-muted/20 border-t px-3 py-2">
-          <div className="text-fg-3 text-[10.5px] font-bold tracking-[0.14em] uppercase">
-            content
+        <div className="grid grid-rows-[1fr] transition-[grid-template-rows] duration-200 ease-out starting:grid-rows-[0fr]">
+          <div className="overflow-hidden">
+            <div className="border-border-subtle bg-muted/20 border-t px-3 py-2">
+              <div className="text-fg-3 text-[10.5px] font-bold tracking-[0.14em] uppercase">
+                content
+              </div>
+              <pre className="text-fg-2 mt-1 max-h-40 overflow-auto font-mono text-[11px] leading-relaxed whitespace-pre-wrap">
+                {event.content}
+              </pre>
+            </div>
           </div>
-          <pre className="text-fg-2 mt-1 max-h-40 overflow-auto font-mono text-[11px] leading-relaxed whitespace-pre-wrap">
-            {event.content}
-          </pre>
         </div>
       ) : null}
     </div>

--- a/apps/web/src/shared/styles/app.css
+++ b/apps/web/src/shared/styles/app.css
@@ -484,6 +484,35 @@
   }
 }
 
+@keyframes sidebar-label-enter {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes success-check-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes success-check-enter-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 @layer utilities {
   .environment-row-enter {
     animation: environment-row-enter 220ms cubic-bezier(0.22, 1, 0.36, 1);
@@ -492,6 +521,19 @@
 
   .login-doodle {
     animation: login-doodle-bob 3.6s ease-in-out infinite alternate;
+  }
+
+  /* Sidebar labels fade in slightly after the rail starts widening, so text
+     never overflows the mid-animation rail; collapse unmounts them instantly
+     which matches the rail clipping them away. */
+  .sidebar-label-enter {
+    animation: sidebar-label-enter var(--dur-1) var(--ease-out) 80ms backwards;
+  }
+
+  /* Milestone-tier success check: small spring-scale entrance, delayed until
+     the surrounding dialog/page entrance has landed. */
+  .success-check-enter {
+    animation: success-check-enter var(--dur-3) var(--ease-spring) 120ms backwards;
   }
 
   .environment-scroll-area {
@@ -525,6 +567,14 @@
 
   .login-doodle {
     animation: none;
+  }
+
+  .sidebar-label-enter {
+    animation: none;
+  }
+
+  .success-check-enter {
+    animation: success-check-enter-fade var(--dur-3) var(--ease-out) 120ms backwards;
   }
 }
 

--- a/apps/web/src/shared/ui/copy-check-icon.tsx
+++ b/apps/web/src/shared/ui/copy-check-icon.tsx
@@ -1,0 +1,33 @@
+import { Check, Copy } from "lucide-react";
+import type { ReactElement } from "react";
+
+import { cn } from "@/shared/lib/class-names";
+
+/**
+ * Copy-button glyph: the copy and check icons stacked in one grid cell,
+ * cross-fading on `copied` instead of teleporting between two renders.
+ */
+export function CopyCheckIcon({
+  className,
+  copied,
+}: {
+  className?: string;
+  copied: boolean;
+}): ReactElement {
+  return (
+    <span className={cn("grid size-3.5 shrink-0 *:col-start-1 *:row-start-1", className)}>
+      <Copy
+        className={cn(
+          "size-full transition-[opacity,scale] duration-(--dur-1) ease-(--ease-out)",
+          copied ? "scale-75 opacity-0" : "scale-100 opacity-100",
+        )}
+      />
+      <Check
+        className={cn(
+          "size-full transition-[opacity,scale] duration-(--dur-1) ease-(--ease-out)",
+          copied ? "scale-100 opacity-100" : "scale-75 opacity-0",
+        )}
+      />
+    </span>
+  );
+}

--- a/apps/web/src/shared/ui/dropdown-menu.tsx
+++ b/apps/web/src/shared/ui/dropdown-menu.tsx
@@ -50,7 +50,7 @@ function DropdownMenuContent({
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
           className={cn(
-            "min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+            "min-w-[8rem] origin-(--transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
             className,
           )}
           {...props}

--- a/apps/web/src/shared/ui/select.tsx
+++ b/apps/web/src/shared/ui/select.tsx
@@ -71,7 +71,7 @@ function SelectContent({
         <SelectPrimitive.Popup
           data-slot="select-content"
           className={cn(
-            "bg-popover text-popover-foreground data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2 max-h-[min(24rem,var(--available-height))] min-w-[var(--anchor-width)] border-border-strong overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md outline-none",
+            "bg-popover text-popover-foreground origin-(--transform-origin) data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2 max-h-[min(24rem,var(--available-height))] min-w-[var(--anchor-width)] border-border-strong overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md outline-none",
             className,
           )}
           {...props}

--- a/apps/web/src/shared/ui/session-events/feed-turn-card.tsx
+++ b/apps/web/src/shared/ui/session-events/feed-turn-card.tsx
@@ -1,5 +1,5 @@
 import type { SessionProcessEvent } from "@mosoo/contracts/session";
-import { ChevronDown, ChevronRight, Clock3 } from "lucide-react";
+import { ChevronRight, Clock3 } from "lucide-react";
 import type { ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";
@@ -116,11 +116,12 @@ export function TurnCard({
           className="flex min-w-0 flex-1 items-start gap-2 text-left"
         >
           <span className="text-fg-3 mt-0.5 flex size-5 shrink-0 items-center justify-center">
-            {collapsed ? (
-              <ChevronRight className="size-3.5" />
-            ) : (
-              <ChevronDown className="size-3.5" />
-            )}
+            <ChevronRight
+              className={cn(
+                "size-3.5 transition-transform duration-150 ease-out",
+                collapsed ? "rotate-0" : "rotate-90",
+              )}
+            />
           </span>
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-2">
@@ -155,17 +156,26 @@ export function TurnCard({
           <span className="text-fg-3">{visibleTurnEventCount}</span>
         </Button>
       </div>
-      {!collapsed && visible ? (
-        <div className="border-border-subtle bg-paper-100 flex flex-col gap-1.5 border-t p-2.5">
-          {filteredEvents.map((event) => (
-            <SessionEventRow
-              key={event.id}
-              event={event}
-              onOpen={() => {
-                onOpenDrawer(event.id);
-              }}
-            />
-          ))}
+      {visible ? (
+        <div
+          className={cn(
+            "grid transition-[grid-template-rows] duration-200 ease-out",
+            collapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]",
+          )}
+        >
+          <div className="overflow-hidden">
+            <div className="border-border-subtle bg-paper-100 flex flex-col gap-1.5 border-t p-2.5">
+              {filteredEvents.map((event) => (
+                <SessionEventRow
+                  key={event.id}
+                  event={event}
+                  onOpen={() => {
+                    onOpenDrawer(event.id);
+                  }}
+                />
+              ))}
+            </div>
+          </div>
         </div>
       ) : null}
     </section>

--- a/apps/web/src/shared/ui/session-events/feed-turn-drawer.tsx
+++ b/apps/web/src/shared/ui/session-events/feed-turn-drawer.tsx
@@ -1,10 +1,11 @@
 import type { SessionProcessEvent } from "@mosoo/contracts/session";
-import { Check, ChevronDown, ChevronRight, Copy } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import { useMemo, useState } from "react";
 import type { ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";
 import { Button } from "@/shared/ui/button";
+import { CopyCheckIcon } from "@/shared/ui/copy-check-icon";
 import {
   Dialog,
   DialogContent,
@@ -153,11 +154,12 @@ function DrawerEventRow({
         }}
         className="grid w-full grid-cols-[16px_136px_minmax(122px,0.45fr)_minmax(0,1fr)_64px_64px_44px_54px] items-center gap-2 px-3 py-2 pl-4 text-left"
       >
-        {expanded ? (
-          <ChevronDown className="text-fg-3 size-3 shrink-0" />
-        ) : (
-          <ChevronRight className="text-fg-3 size-3 shrink-0" />
-        )}
+        <ChevronRight
+          className={cn(
+            "text-fg-3 size-3 shrink-0 transition-transform duration-150 ease-out",
+            expanded ? "rotate-90" : "rotate-0",
+          )}
+        />
         <span
           className={cn(
             "inline-flex items-center justify-self-start whitespace-nowrap rounded-sm px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
@@ -185,13 +187,17 @@ function DrawerEventRow({
       </button>
 
       {expanded ? (
-        <div className="border-border-subtle bg-muted/20 border-t px-3 py-2">
-          <div className="text-fg-3 text-[10.5px] font-bold tracking-[0.14em] uppercase">
-            content
+        <div className="grid grid-rows-[1fr] transition-[grid-template-rows] duration-200 ease-out starting:grid-rows-[0fr]">
+          <div className="overflow-hidden">
+            <div className="border-border-subtle bg-muted/20 border-t px-3 py-2">
+              <div className="text-fg-3 text-[10.5px] font-bold tracking-[0.14em] uppercase">
+                content
+              </div>
+              <pre className="text-fg-2 mt-1 max-h-48 overflow-auto font-mono text-[11px] leading-relaxed whitespace-pre-wrap">
+                {event.content}
+              </pre>
+            </div>
           </div>
-          <pre className="text-fg-2 mt-1 max-h-48 overflow-auto font-mono text-[11px] leading-relaxed whitespace-pre-wrap">
-            {event.content}
-          </pre>
         </div>
       ) : null}
     </div>
@@ -260,7 +266,7 @@ export function SessionTurnDrawer({
               size="sm"
               variant="outline"
             >
-              {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+              <CopyCheckIcon copied={copied} />
               {copied ? "Copied" : "Copy"}
             </Button>
           </div>


### PR DESCRIPTION
Implements the six findings from the YEF-851 motion audit (based on [emilkowalski/skills → find-animation-opportunities](https://github.com/emilkowalski/skills/blob/main/skills/find-animation-opportunities/SKILL.md)) in `apps/web`. Everything uses the existing motion tokens and tw-animate-css; no new dependency.

## Summary

- Dropdown and select popups now scale from their trigger (`origin-(--transform-origin)`), matching the tooltip.
- Expand/collapse no longer snaps: turn cards and thread activity cards reuse the navigation's `grid-template-rows` pattern; drawer event details and deploy failure details animate open via `@starting-style`; disclosure chevrons rotate instead of swapping icons.
- Copy buttons cross-fade between the copy and check icons (new shared `CopyCheckIcon`, 120ms).
- Environment Delete now opens a confirm dialog (was: mutation ran immediately with no confirmation) — same convention as deployment delete in `deploy-actions.tsx`; menu item styled destructive.
- Sidebar labels and the wordmark fade in ~80ms after the rail starts expanding, so text no longer pops in at full opacity mid-transition.
- The success check on agent publish and CLI auth springs in using the previously unused `--ease-spring` token.

## Why

- The audit found the high-frequency paths correctly instant and the primitives already animated; the gaps were seams where one part animates and its neighbor teleports (full report + Chinese version on YEF-851).
- The environment delete item was a safety gap first, motion second: a destructive, irreversible action ran with zero confirmation.

## Verification

- Commands: `just check` (pass — fmt, doc links, lint, typecheck, 177 web tests, GraphQL freshness), `just commit-check` (pass, 6 commits).
- Manual steps: booted the local stack (wrangler dev with `--enable-containers=false` + `vp dev`), logged in via the `@mosoo.ai` loopback backdoor, exercised sidebar collapse/expand, install-guide copy button, environment create → row menu → delete confirm, dropdown menus. Screenshots attached to YEF-851.
- Not run: `just dev` container path (no Docker on this machine — containers are not exercised by these UI paths); e2e suites.

## Impact

- User/API/contract changes: environment Delete now requires a confirmation click; all other changes are visual-only. No API or contract changes.
- Generated files / GraphQL / DB / lockfile: none.
- Env or config changes: none.
- Risk and rollback: low; each finding is an isolated commit and can be reverted independently. `@starting-style` (Chrome 117+, Safari 17.5+, Firefox 129+) degrades to today's instant appearance on older browsers. New keyframe utilities respect `prefers-reduced-motion` (sidebar fade disabled; success check falls back to opacity-only).

## Review

- Closest review areas: the `grid-template-rows` wrappers in `feed-turn-card.tsx` / `threads/detail/view.tsx` (collapsed content now stays mounted, like the nav); the confirm flow in `environment-list-table.tsx`.
- Known trade-offs: drawer event rows and deploy failure details animate enter-only — their bodies stay conditionally mounted (large payloads / virtualized offsets), so closing is instant. Sidebar label fade-in also runs on initial mount (same behavior as the existing `environment-row-enter`). The org-layer sidebar is untouched: it is fixed-width, so no collapse transition exists to smooth. Follow-up candidate outside this scope: the `motion` package in `apps/web/package.json` is still unused — drop it or adopt it deliberately.
