### PR TITLE
feat(web): improve motion audit interactions

### DIFF
--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -39,6 +39,19 @@ const ExpandSidebarIcon = createHugeicon(PanelLeftOpenIcon, "ExpandSidebarIcon")
 const NewAgentIcon = createHugeicon(PlusSignIcon, "NewAgentIcon");
 const SwitcherChevronIcon = createHugeicon(ChevronsDownUpIcon, "SwitcherChevronIcon");
 
+function SidebarWordmark({ collapsed }: { collapsed: boolean }) {
+  return (
+    <span
+      className={cn(
+        "overflow-hidden transition-[max-width,opacity] duration-[var(--dur-1)] ease-[var(--ease-out)]",
+        collapsed ? "max-w-0 opacity-0" : "max-w-[104px] opacity-100 delay-[80ms]",
+      )}
+    >
+      <img src="/brand/logo-wordmark-onlight.svg" alt="Mosoo" className="block h-[22px]" />
+    </span>
+  );
+}
+
 // One-click return to the parent Org layer (the Apps list).
 function BackToOrgLink({ collapsed, orgName }: { collapsed: boolean; orgName: string | null }) {
   const label = orgName ?? "Apps";
@@ -321,9 +334,7 @@ function ConsoleShell({
             collapsed ? "justify-center" : "justify-between",
           )}
         >
-          {collapsed ? null : (
-            <img src="/brand/logo-wordmark-onlight.svg" alt="Mosoo" className="block h-[22px]" />
-          )}
+          <SidebarWordmark collapsed={collapsed} />
           <Tooltip>
             <TooltipTrigger asChild>
               <button

--- a/apps/web/src/app/navigation.tsx
+++ b/apps/web/src/app/navigation.tsx
@@ -73,6 +73,28 @@ const NAV_SECTIONS: AppNavSection[] = [
 
 const ExpandIcon = createHugeicon(ChevronRightIcon, "ExpandIcon");
 
+function SidebarLabel({
+  children,
+  className,
+  collapsed,
+}: {
+  children: string;
+  className?: string;
+  collapsed: boolean;
+}) {
+  return (
+    <span
+      className={cn(
+        "min-w-0 truncate transition-opacity duration-[var(--dur-1)] ease-[var(--ease-out)]",
+        collapsed ? "max-w-0 opacity-0" : "max-w-[160px] opacity-100 delay-[80ms]",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
 function isNavItemActive(pathname: string, path: string): boolean {
   return pathname === path || pathname.startsWith(`${path}/`);
 }
@@ -101,7 +123,7 @@ function NavLink({
       )}
     >
       <Icon className="size-4" />
-      {collapsed ? null : <span>{label}</span>}
+      <SidebarLabel collapsed={collapsed}>{label}</SidebarLabel>
     </Link>
   );
 

--- a/apps/web/src/app/org-navigation.tsx
+++ b/apps/web/src/app/org-navigation.tsx
@@ -39,6 +39,28 @@ function isOrgNavItemActive(pathname: string, path: string): boolean {
   return pathname === path || pathname.startsWith(`${path}/`);
 }
 
+function SidebarLabel({
+  children,
+  className,
+  collapsed,
+}: {
+  children: string;
+  className?: string;
+  collapsed: boolean;
+}) {
+  return (
+    <span
+      className={cn(
+        "min-w-0 truncate transition-opacity duration-[var(--dur-1)] ease-[var(--ease-out)]",
+        collapsed ? "max-w-0 opacity-0" : "max-w-[160px] opacity-100 delay-[80ms]",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
 function ComingSoonItem({
   collapsed,
   icon: Icon,
@@ -57,14 +79,17 @@ function ComingSoonItem({
       )}
     >
       <Icon className="size-4 shrink-0" />
-      {collapsed ? null : (
-        <>
-          <span className="flex-1 truncate text-left">{label}</span>
-          <span className="bg-bg-sunken text-fg-3 rounded-full px-1.5 py-0.5 text-[9.5px] font-semibold tracking-wide uppercase">
-            Soon
-          </span>
-        </>
-      )}
+      <SidebarLabel className="flex-1 text-left" collapsed={collapsed}>
+        {label}
+      </SidebarLabel>
+      <span
+        className={cn(
+          "bg-bg-sunken text-fg-3 rounded-full px-1.5 py-0.5 text-[9.5px] font-semibold tracking-wide uppercase transition-opacity duration-[var(--dur-1)] ease-[var(--ease-out)]",
+          collapsed ? "max-w-0 opacity-0" : "max-w-[44px] opacity-100 delay-[80ms]",
+        )}
+      >
+        Soon
+      </span>
     </div>
   );
 
@@ -104,7 +129,9 @@ function OrgNavLink({
       )}
     >
       <Icon className="size-4 shrink-0" />
-      {collapsed ? null : <span className="flex-1 truncate text-left">{label}</span>}
+      <SidebarLabel className="flex-1 text-left" collapsed={collapsed}>
+        {label}
+      </SidebarLabel>
     </Link>
   );
 

--- a/apps/web/src/routes/agent/lifecycle/publish-success-modal.tsx
+++ b/apps/web/src/routes/agent/lifecycle/publish-success-modal.tsx
@@ -37,7 +37,7 @@ export function PublishSuccessModal({
       <DialogContent className="flex max-h-[88vh] flex-col overflow-hidden rounded-lg p-0 sm:max-w-[540px]">
         <DialogHeader className="px-6 pt-6 pb-3">
           <div className="flex items-center gap-3">
-            <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-green-100 text-green-800">
+            <div className="mosoo-success-pop flex size-10 shrink-0 items-center justify-center rounded-full bg-green-100 text-green-800">
               <Check className="size-5" strokeWidth={2.5} />
             </div>
             <div className="min-w-0">

--- a/apps/web/src/routes/app-overview/app-overview-install.tsx
+++ b/apps/web/src/routes/app-overview/app-overview-install.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy, KeyRound } from "lucide-react";
+import { Check, KeyRound } from "lucide-react";
 import type { ReactElement } from "react";
 import { useState } from "react";
 import { Link } from "react-router-dom";
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom";
 import { writeClipboardText } from "@/shared/lib/clipboard";
 import { RuntimeIcon } from "@/shared/ui/brand-icons";
 import { Button } from "@/shared/ui/button";
+import { CopyIconFeedback } from "@/shared/ui/copy-icon-feedback";
 
 const INSTALL_COMMAND = "curl -fsSL https://install.mosoo.ai/install.sh | bash";
 const API_TOKENS_PATH = "/settings/access-tokens";
@@ -67,7 +68,7 @@ export function AppOverviewInstallGuide(): ReactElement {
             size="default"
             variant="accent"
           >
-            {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+            <CopyIconFeedback copied={copied} />
             {copied ? "Copied" : "Copy"}
           </Button>
         </div>

--- a/apps/web/src/routes/app-overview/deploy/components/deployments-history.tsx
+++ b/apps/web/src/routes/app-overview/deploy/components/deployments-history.tsx
@@ -133,19 +133,26 @@ export function DeploymentsHistory({ runs }: { runs: DeploymentRunVM[] }) {
                       className={cn("size-3.5 transition-transform", expanded && "rotate-180")}
                     />
                   </button>
-                  {expanded ? (
-                    <div className="border-border bg-bg-sunken/40 mt-1 rounded-md border px-3.5 py-2.5 text-[13px]">
-                      <div className="text-fg-3 mb-1 text-[11.5px] font-medium">
-                        Failure details
+                  <div
+                    className={cn(
+                      "grid transition-[grid-template-rows] duration-200 ease-out",
+                      expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+                    )}
+                  >
+                    <div className="overflow-hidden">
+                      <div className="border-border bg-bg-sunken/40 mt-1 rounded-md border px-3.5 py-2.5 text-[13px]">
+                        <div className="text-fg-3 mb-1 text-[11.5px] font-medium">
+                          Failure details
+                        </div>
+                        {run.errorCode === null ? null : (
+                          <span className="text-destructive mr-2 font-mono text-[12px] font-semibold">
+                            {run.errorCode}
+                          </span>
+                        )}
+                        <span className="text-fg-2 break-words">{run.errorMessage ?? ""}</span>
                       </div>
-                      {run.errorCode === null ? null : (
-                        <span className="text-destructive mr-2 font-mono text-[12px] font-semibold">
-                          {run.errorCode}
-                        </span>
-                      )}
-                      <span className="text-fg-2 break-words">{run.errorMessage ?? ""}</span>
                     </div>
-                  ) : null}
+                  </div>
                 </>
               )}
             </article>
@@ -225,19 +232,30 @@ export function DeploymentsHistory({ runs }: { runs: DeploymentRunVM[] }) {
                       </div>
                     </TableCell>
                   </TableRow>
-                  {failedError === null || !expanded ? null : (
+                  {failedError === null ? null : (
                     <TableRow className="hover:bg-transparent">
-                      <TableCell colSpan={3} className="px-5 pt-0 pb-4">
-                        <div className="border-border bg-bg-sunken/40 rounded-md border px-3.5 py-2.5 text-[13px]">
-                          <div className="text-fg-3 mb-1 text-[11.5px] font-medium">
-                            Failure details
-                          </div>
-                          {run.errorCode === null ? null : (
-                            <span className="text-destructive mr-2 font-mono text-[12px] font-semibold">
-                              {run.errorCode}
-                            </span>
+                      <TableCell colSpan={3} className="px-5 pt-0 pb-0">
+                        <div
+                          className={cn(
+                            "grid transition-[grid-template-rows] duration-200 ease-out",
+                            expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
                           )}
-                          <span className="text-fg-2">{run.errorMessage ?? ""}</span>
+                        >
+                          <div className="overflow-hidden">
+                            <div className="pb-4">
+                              <div className="border-border bg-bg-sunken/40 rounded-md border px-3.5 py-2.5 text-[13px]">
+                                <div className="text-fg-3 mb-1 text-[11.5px] font-medium">
+                                  Failure details
+                                </div>
+                                {run.errorCode === null ? null : (
+                                  <span className="text-destructive mr-2 font-mono text-[12px] font-semibold">
+                                    {run.errorCode}
+                                  </span>
+                                )}
+                                <span className="text-fg-2">{run.errorMessage ?? ""}</span>
+                              </div>
+                            </div>
+                          </div>
                         </div>
                       </TableCell>
                     </TableRow>

--- a/apps/web/src/routes/cli-auth/cli-auth.route.tsx
+++ b/apps/web/src/routes/cli-auth/cli-auth.route.tsx
@@ -70,7 +70,7 @@ function StatusMessage({ error, status }: { error: Error | null; status: string 
   if (status === "authorized") {
     return (
       <p className="text-success inline-flex items-center gap-2 text-sm">
-        <CheckCircle2 className="size-4" />
+        <CheckCircle2 className="mosoo-success-pop size-4" />
         CLI access authorized.
       </p>
     );

--- a/apps/web/src/routes/settings/access-tokens-tab.tsx
+++ b/apps/web/src/routes/settings/access-tokens-tab.tsx
@@ -1,6 +1,6 @@
 import type { PersonalAccessTokenSummary } from "@mosoo/contracts/auth";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, Copy, ExternalLink, KeyRound, Loader2, Plus, Trash2 } from "lucide-react";
+import { ExternalLink, KeyRound, Loader2, Plus, Trash2 } from "lucide-react";
 import { useReducer } from "react";
 
 import {
@@ -10,6 +10,7 @@ import {
 } from "@/domains/auth/api/personal-access-token-client";
 import { MOSOO_API_REFERENCE_URL } from "@/shared/config/external-links";
 import { Button } from "@/shared/ui/button";
+import { CopyIconFeedback } from "@/shared/ui/copy-icon-feedback";
 import { Input } from "@/shared/ui/input";
 
 import { isTruthy } from "../../shared/lib/truthiness";
@@ -277,7 +278,7 @@ function CreatedTokenPanel({
           title={tooltip}
           variant="outline"
         >
-          {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+          <CopyIconFeedback copied={copied} />
         </Button>
       </div>
     </div>

--- a/apps/web/src/routes/threads/detail/view.tsx
+++ b/apps/web/src/routes/threads/detail/view.tsx
@@ -7,7 +7,6 @@ import type {
 import {
   Archive,
   ArrowLeft,
-  ChevronDown,
   ChevronRight,
   CornerDownLeft,
   Inbox,
@@ -24,6 +23,7 @@ import type { ReactElement } from "react";
 import type { ListedFileEntry } from "@/domains/file/api/files";
 import { triggerAgentSessionPrewarm } from "@/domains/session/api/agent-session";
 import { toSessionId } from "@/routes/typed-id";
+import { cn } from "@/shared/lib/class-names";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 import {
@@ -88,11 +88,12 @@ function ThreadActivityCard({
         }}
         className="hover:bg-ink-900/[0.02] flex w-full items-center gap-2 rounded-t-lg px-3 py-2 text-left"
       >
-        {open ? (
-          <ChevronDown className="text-fg-3 size-3.5 shrink-0" />
-        ) : (
-          <ChevronRight className="text-fg-3 size-3.5 shrink-0" />
-        )}
+        <ChevronRight
+          className={cn(
+            "text-fg-3 size-3.5 shrink-0 transition-transform duration-150 ease-out",
+            open ? "rotate-90" : "rotate-0",
+          )}
+        />
         {isUser ? (
           <UserAvatar
             image={viewer.image}
@@ -112,35 +113,42 @@ function ThreadActivityCard({
           {formatRelativeTime(message.createdAt)}
         </span>
       </button>
-      {open ? (
-        <div className="border-border-subtle border-t px-4 py-3">
-          {isUser ? (
-            <div className="text-fg-1 text-[13.5px] leading-relaxed whitespace-pre-wrap">
-              {message.content}
-            </div>
-          ) : (
-            <div className="text-fg-1 text-[13.5px] leading-relaxed">
-              <Markdown linkResolver={artifactLinkResolver}>{message.content}</Markdown>
-            </div>
-          )}
-          {!isUser ? (
-            <div className="mt-3">
-              <Button
-                size="xs"
-                variant="outline"
-                className="font-mono text-[11px]"
-                onClick={onOpenProcess}
-              >
-                <ChevronRight className="size-3" />
-                {processButtonText}
-                {processEventCount > 0 ? (
-                  <span className="text-fg-3 ml-1">· {processEventCount} events</span>
-                ) : null}
-              </Button>
-            </div>
-          ) : null}
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows] duration-200 ease-out",
+          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+        )}
+      >
+        <div aria-hidden={!open} className="overflow-hidden" inert={!open ? true : undefined}>
+          <div className="border-border-subtle border-t px-4 py-3">
+            {isUser ? (
+              <div className="text-fg-1 text-[13.5px] leading-relaxed whitespace-pre-wrap">
+                {message.content}
+              </div>
+            ) : (
+              <div className="text-fg-1 text-[13.5px] leading-relaxed">
+                <Markdown linkResolver={artifactLinkResolver}>{message.content}</Markdown>
+              </div>
+            )}
+            {!isUser ? (
+              <div className="mt-3">
+                <Button
+                  size="xs"
+                  variant="outline"
+                  className="font-mono text-[11px]"
+                  onClick={onOpenProcess}
+                >
+                  <ChevronRight className="size-3" />
+                  {processButtonText}
+                  {processEventCount > 0 ? (
+                    <span className="text-fg-3 ml-1">· {processEventCount} events</span>
+                  ) : null}
+                </Button>
+              </div>
+            ) : null}
+          </div>
         </div>
-      ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/shared/styles/app.css
+++ b/apps/web/src/shared/styles/app.css
@@ -484,10 +484,34 @@
   }
 }
 
+@keyframes mosoo-success-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes mosoo-success-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 @layer utilities {
   .environment-row-enter {
     animation: environment-row-enter 220ms cubic-bezier(0.22, 1, 0.36, 1);
     transform-origin: top center;
+  }
+
+  .mosoo-success-pop {
+    animation: mosoo-success-pop var(--dur-3) var(--ease-spring) 120ms both;
   }
 
   .login-doodle {
@@ -521,6 +545,10 @@
 @media (prefers-reduced-motion: reduce) {
   .environment-row-enter {
     animation: none;
+  }
+
+  .mosoo-success-pop {
+    animation: mosoo-success-fade var(--dur-2) var(--ease-out) both;
   }
 
   .login-doodle {

--- a/apps/web/src/shared/ui/copy-icon-feedback.tsx
+++ b/apps/web/src/shared/ui/copy-icon-feedback.tsx
@@ -1,0 +1,34 @@
+import { Check, Copy } from "lucide-react";
+import type { ReactElement } from "react";
+
+import { cn } from "@/shared/lib/class-names";
+
+export function CopyIconFeedback({
+  className = "size-3.5",
+  copied,
+}: {
+  className?: string;
+  copied: boolean;
+}): ReactElement {
+  const iconClassName =
+    "col-start-1 row-start-1 transition-[opacity,transform] duration-[var(--dur-1)] ease-[var(--ease-out)]";
+
+  return (
+    <span aria-hidden="true" className={cn("grid shrink-0 place-items-center", className)}>
+      <Check
+        className={cn(
+          iconClassName,
+          className,
+          copied ? "scale-100 opacity-100" : "scale-75 opacity-0",
+        )}
+      />
+      <Copy
+        className={cn(
+          iconClassName,
+          className,
+          copied ? "scale-75 opacity-0" : "scale-100 opacity-100",
+        )}
+      />
+    </span>
+  );
+}

--- a/apps/web/src/shared/ui/dropdown-menu.tsx
+++ b/apps/web/src/shared/ui/dropdown-menu.tsx
@@ -50,7 +50,7 @@ function DropdownMenuContent({
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
           className={cn(
-            "min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+            "origin-(--transform-origin) min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
             className,
           )}
           {...props}

--- a/apps/web/src/shared/ui/select.tsx
+++ b/apps/web/src/shared/ui/select.tsx
@@ -71,7 +71,7 @@ function SelectContent({
         <SelectPrimitive.Popup
           data-slot="select-content"
           className={cn(
-            "bg-popover text-popover-foreground data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2 max-h-[min(24rem,var(--available-height))] min-w-[var(--anchor-width)] border-border-strong overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md outline-none",
+            "origin-(--transform-origin) bg-popover text-popover-foreground data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2 max-h-[min(24rem,var(--available-height))] min-w-[var(--anchor-width)] border-border-strong overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md outline-none",
             className,
           )}
           {...props}

--- a/apps/web/src/shared/ui/session-events/feed-turn-card.tsx
+++ b/apps/web/src/shared/ui/session-events/feed-turn-card.tsx
@@ -1,5 +1,5 @@
 import type { SessionProcessEvent } from "@mosoo/contracts/session";
-import { ChevronDown, ChevronRight, Clock3 } from "lucide-react";
+import { ChevronRight, Clock3 } from "lucide-react";
 import type { ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";
@@ -116,11 +116,12 @@ export function TurnCard({
           className="flex min-w-0 flex-1 items-start gap-2 text-left"
         >
           <span className="text-fg-3 mt-0.5 flex size-5 shrink-0 items-center justify-center">
-            {collapsed ? (
-              <ChevronRight className="size-3.5" />
-            ) : (
-              <ChevronDown className="size-3.5" />
-            )}
+            <ChevronRight
+              className={cn(
+                "size-3.5 transition-transform duration-150 ease-out",
+                collapsed ? "rotate-0" : "rotate-90",
+              )}
+            />
           </span>
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-2">
@@ -155,19 +156,30 @@ export function TurnCard({
           <span className="text-fg-3">{visibleTurnEventCount}</span>
         </Button>
       </div>
-      {!collapsed && visible ? (
-        <div className="border-border-subtle bg-paper-100 flex flex-col gap-1.5 border-t p-2.5">
-          {filteredEvents.map((event) => (
-            <SessionEventRow
-              key={event.id}
-              event={event}
-              onOpen={() => {
-                onOpenDrawer(event.id);
-              }}
-            />
-          ))}
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows] duration-200 ease-out",
+          !collapsed && visible ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+        )}
+      >
+        <div
+          aria-hidden={collapsed || !visible}
+          className="overflow-hidden"
+          inert={collapsed || !visible ? true : undefined}
+        >
+          <div className="border-border-subtle bg-paper-100 flex flex-col gap-1.5 border-t p-2.5">
+            {filteredEvents.map((event) => (
+              <SessionEventRow
+                key={event.id}
+                event={event}
+                onOpen={() => {
+                  onOpenDrawer(event.id);
+                }}
+              />
+            ))}
+          </div>
         </div>
-      ) : null}
+      </div>
     </section>
   );
 }

--- a/apps/web/src/shared/ui/session-events/feed-turn-drawer.tsx
+++ b/apps/web/src/shared/ui/session-events/feed-turn-drawer.tsx
@@ -1,10 +1,11 @@
 import type { SessionProcessEvent } from "@mosoo/contracts/session";
-import { Check, ChevronDown, ChevronRight, Copy } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import { useMemo, useState } from "react";
 import type { ReactElement } from "react";
 
 import { cn } from "@/shared/lib/class-names";
 import { Button } from "@/shared/ui/button";
+import { CopyIconFeedback } from "@/shared/ui/copy-icon-feedback";
 import {
   Dialog,
   DialogContent,
@@ -153,11 +154,12 @@ function DrawerEventRow({
         }}
         className="grid w-full grid-cols-[16px_136px_minmax(122px,0.45fr)_minmax(0,1fr)_64px_64px_44px_54px] items-center gap-2 px-3 py-2 pl-4 text-left"
       >
-        {expanded ? (
-          <ChevronDown className="text-fg-3 size-3 shrink-0" />
-        ) : (
-          <ChevronRight className="text-fg-3 size-3 shrink-0" />
-        )}
+        <ChevronRight
+          className={cn(
+            "text-fg-3 size-3 shrink-0 transition-transform duration-150 ease-out",
+            expanded ? "rotate-90" : "rotate-0",
+          )}
+        />
         <span
           className={cn(
             "inline-flex items-center justify-self-start whitespace-nowrap rounded-sm px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
@@ -184,16 +186,23 @@ function DrawerEventRow({
         </span>
       </button>
 
-      {expanded ? (
-        <div className="border-border-subtle bg-muted/20 border-t px-3 py-2">
-          <div className="text-fg-3 text-[10.5px] font-bold tracking-[0.14em] uppercase">
-            content
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows] duration-200 ease-out",
+          expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+        )}
+      >
+        <div className="overflow-hidden">
+          <div className="border-border-subtle bg-muted/20 border-t px-3 py-2">
+            <div className="text-fg-3 text-[10.5px] font-bold tracking-[0.14em] uppercase">
+              content
+            </div>
+            <pre className="text-fg-2 mt-1 max-h-48 overflow-auto font-mono text-[11px] leading-relaxed whitespace-pre-wrap">
+              {event.content}
+            </pre>
           </div>
-          <pre className="text-fg-2 mt-1 max-h-48 overflow-auto font-mono text-[11px] leading-relaxed whitespace-pre-wrap">
-            {event.content}
-          </pre>
         </div>
-      ) : null}
+      </div>
     </div>
   );
 }
@@ -260,7 +269,7 @@ export function SessionTurnDrawer({
               size="sm"
               variant="outline"
             >
-              {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+              <CopyIconFeedback copied={copied} />
               {copied ? "Copied" : "Copy"}
             </Button>
           </div>

--- a/apps/web/tests/motion-audit-boundary.test.ts
+++ b/apps/web/tests/motion-audit-boundary.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+function readSource(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+describe("motion audit boundary", () => {
+  test("anchors popup scale animations to the trigger origin", () => {
+    const dropdown = readSource("../src/shared/ui/dropdown-menu.tsx");
+    const select = readSource("../src/shared/ui/select.tsx");
+
+    expect(dropdown).toContain("origin-(--transform-origin)");
+    expect(select).toContain("origin-(--transform-origin)");
+  });
+
+  test("keeps expandable content mounted while animating height", () => {
+    const turnCard = readSource("../src/shared/ui/session-events/feed-turn-card.tsx");
+    const drawer = readSource("../src/shared/ui/session-events/feed-turn-drawer.tsx");
+    const deployments = readSource(
+      "../src/routes/app-overview/deploy/components/deployments-history.tsx",
+    );
+    const threadDetail = readSource("../src/routes/threads/detail/view.tsx");
+
+    for (const source of [turnCard, drawer, deployments, threadDetail]) {
+      expect(source).toContain("transition-[grid-template-rows]");
+      expect(source).toContain("grid-rows-[0fr]");
+      expect(source).toContain("grid-rows-[1fr]");
+    }
+
+    expect(turnCard).toContain("transition-transform duration-150 ease-out");
+    expect(drawer).toContain("transition-transform duration-150 ease-out");
+    expect(threadDetail).toContain("transition-transform duration-150 ease-out");
+  });
+
+  test("copy feedback uses a stable animated icon slot", () => {
+    const feedbackIcon = readSource("../src/shared/ui/copy-icon-feedback.tsx");
+    const tokens = readSource("../src/routes/settings/access-tokens-tab.tsx");
+    const installGuide = readSource("../src/routes/app-overview/app-overview-install.tsx");
+    const turnDrawer = readSource("../src/shared/ui/session-events/feed-turn-drawer.tsx");
+
+    expect(feedbackIcon).toContain("transition-[opacity,transform]");
+    expect(feedbackIcon).toContain("scale-75 opacity-0");
+    expect(feedbackIcon).toContain("scale-100 opacity-100");
+    expect(tokens).toContain("CopyIconFeedback");
+    expect(installGuide).toContain("CopyIconFeedback");
+    expect(turnDrawer).toContain("CopyIconFeedback");
+  });
+
+  test("sidebar labels fade instead of unmounting during collapse", () => {
+    const appShell = readSource("../src/app/app-shell.tsx");
+    const appNavigation = readSource("../src/app/navigation.tsx");
+    const orgNavigation = readSource("../src/app/org-navigation.tsx");
+
+    expect(appShell).toContain("SidebarWordmark");
+    expect(appNavigation).toContain("SidebarLabel");
+    expect(orgNavigation).toContain("SidebarLabel");
+    expect(appNavigation).toContain("delay-[80ms]");
+    expect(orgNavigation).toContain("delay-[80ms]");
+  });
+
+  test("success milestones use the shared spring motion with reduced-motion fallback", () => {
+    const css = readSource("../src/shared/styles/app.css");
+    const publishSuccess = readSource("../src/routes/agent/lifecycle/publish-success-modal.tsx");
+    const cliAuth = readSource("../src/routes/cli-auth/cli-auth.route.tsx");
+
+    expect(css).toContain("@keyframes mosoo-success-pop");
+    expect(css).toContain("var(--ease-spring)");
+    expect(css).toContain("@keyframes mosoo-success-fade");
+    expect(publishSuccess).toContain("mosoo-success-pop");
+    expect(cliAuth).toContain("mosoo-success-pop");
+  });
+});


### PR DESCRIPTION
## Summary

- Anchored dropdown and select zoom animations to the Base UI trigger origin.
- Replaced hard-cut expand/collapse areas with persistent grid-row transitions for Turn cards, Turn drawer rows, deployment failure details, and thread activity cards.
- Added a shared animated copy icon slot plus spring-based success milestone motion with reduced-motion fallbacks.
- Added motion boundary coverage for the audit findings.

## Why

- Closes YEF-851.
- The UI already had motion tokens and component animations, but several adjacent surfaces still changed state instantly. This makes the audited high-frequency interactions feel consistent without adding a new animation library.

## Verification

- Commands:
  - `vp exec bun test apps/web/tests/motion-audit-boundary.test.ts`
  - `vp run --filter @mosoo/web tc`
  - `vp run --filter @mosoo/web lint`
  - `vp run --filter @mosoo/web test`
- Manual steps:
  - N/A
- Not run:
  - N/A

## Impact

- User/API/contract changes:
  - Web UI motion polish only; no API or contract changes.
- Generated files / GraphQL / DB / lockfile:
  - N/A
- Env or config changes:
  - N/A
- Risk and rollback:
  - Low risk; changes are scoped to CSS/classes and local React rendering structure. Revert the commit to restore the previous instant state changes.

## Review

- Closest review areas:
  - `apps/web/src/shared/ui/session-events/*`
  - `apps/web/src/routes/threads/detail/view.tsx`
  - `apps/web/src/routes/app-overview/deploy/components/deployments-history.tsx`
- Known trade-offs:
  - The audit's delete-confirmation recommendation is intentionally not included here because it changes destructive-action behavior beyond motion polish.
