### PR TITLE
refactor(web): optimize default runtime vendor lookup

### DIFF
--- a/apps/web/src/routes/agent/runtime-default.ts
+++ b/apps/web/src/routes/agent/runtime-default.ts
@@ -15,8 +15,8 @@ export interface DefaultAgentRuntimeSelection {
   readonly runtimeId: string;
 }
 
-function isVendorConfigured(credentials: readonly VendorCredential[], vendorId: string): boolean {
-  return credentials.some((credential) => credential.vendorId === vendorId);
+function toConfiguredVendorIds(credentials: readonly VendorCredential[]): ReadonlySet<string> {
+  return new Set(credentials.map((credential) => credential.vendorId));
 }
 
 function defaultModelForVendor(
@@ -47,9 +47,11 @@ function defaultModelForVendor(
 export function resolveDefaultAgentRuntime(
   credentials: readonly VendorCredential[],
 ): DefaultAgentRuntimeSelection | null {
+  const configuredVendorIds = toConfiguredVendorIds(credentials);
+
   for (const entry of PUBLIC_RUNTIME_CATALOG) {
     const configuredVendor = entry.vendors.find((vendor) =>
-      isVendorConfigured(credentials, vendor.vendorId),
+      configuredVendorIds.has(vendor.vendorId),
     );
 
     if (configuredVendor !== undefined) {

--- a/apps/web/tests/runtime-default.test.ts
+++ b/apps/web/tests/runtime-default.test.ts
@@ -48,4 +48,12 @@ describe("default agent runtime", () => {
       runtimeId: "acp-fallback",
     });
   });
+
+  test("keeps runtime catalog priority when multiple providers are configured", () => {
+    expect(resolveDefaultAgentRuntime([credential("deepseek"), credential("openai")])).toEqual({
+      model: "gpt-5.5",
+      provider: "openai",
+      runtimeId: "openai-runtime",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Build a `Set` of configured vendor IDs once before selecting the default Agent runtime.
- Add coverage that multiple configured providers still follow runtime catalog priority.

## Why

- Closes YEF-855.
- The previous selection path scanned credentials inside the runtime/vendor loop. Precomputing membership reduces the lookup from O(runtimes * vendors * credentials) to O(credentials + runtimes * vendors) while keeping the same first-match behavior.

## Verification

- Commands:
  - `bun test apps/web/tests/runtime-default.test.ts`
  - `bun run --filter @mosoo/web test`
  - `bun run --filter @mosoo/web tc`
  - `bun run --filter @mosoo/web lint`
  - `bun run fmt:check:path apps/web/src/routes/agent/runtime-default.ts apps/web/tests/runtime-default.test.ts`
- Manual steps: N/A
- Not run: Full root `bun run check`.

## Impact

- User/API/contract changes: No API or UX contract changes; default runtime selection keeps catalog priority.
- Generated files / GraphQL / DB / lockfile: N/A
- Env or config changes: N/A
- Risk and rollback: Low; rollback restores the previous linear credential scan.

## Review

- Closest review areas: Agent runtime default selection in the web create-agent flow.
- Known trade-offs: This is a targeted low-risk optimization; larger backend N+1 paths were left as follow-up candidates because they require deeper authorization-preserving batching.
