### PR TITLE
refactor(api): optimize custom credential model lookup

### DIFF
--- a/apps/api/src/modules/vendor-credentials/application/vendor-credential-custom-models.ts
+++ b/apps/api/src/modules/vendor-credentials/application/vendor-credential-custom-models.ts
@@ -33,8 +33,11 @@ export function findCustomCredentialRowForModel(
   rows: readonly VendorCredentialRow[],
   modelId: string,
 ): VendorCredentialRow | null {
-  return (
-    listEffectiveCustomCredentialModelRows(rows).find((entry) => entry.modelId === modelId)?.row ??
-    null
-  );
+  for (const row of [...rows].toSorted(compareCredentialRows)) {
+    if ((parseCredentialModels(row.modelsJson) ?? []).includes(modelId)) {
+      return row;
+    }
+  }
+
+  return null;
 }

--- a/apps/api/tests/vendor-credential-custom-models.test.ts
+++ b/apps/api/tests/vendor-credential-custom-models.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import type { PlatformId, AppId, VendorCredentialId } from "@mosoo/id";
+
+import {
+  findCustomCredentialRowForModel,
+  listEffectiveCustomCredentialModelRows,
+} from "../src/modules/vendor-credentials/application/vendor-credential-custom-models";
+import type { VendorCredentialRow } from "../src/modules/vendor-credentials/application/vendor-credential.types";
+
+function credentialRow(input: {
+  id: string;
+  modelsJson: string[] | null;
+  name: string;
+}): VendorCredentialRow {
+  return {
+    apiBase: null,
+    apiKeySecretId: `${input.id}-secret` as PlatformId,
+    id: input.id as VendorCredentialId,
+    isDefault: false,
+    modelsJson: input.modelsJson,
+    name: input.name,
+    appId: "app-1" as AppId,
+    vendorId: "openai-compatible",
+  };
+}
+
+describe("vendor credential custom models", () => {
+  test("lists effective custom credential models using sorted credential precedence", () => {
+    const secondary = credentialRow({
+      id: "credential-b",
+      modelsJson: ["shared-model", "secondary-only"],
+      name: "B Custom",
+    });
+    const primary = credentialRow({
+      id: "credential-a",
+      modelsJson: ["shared-model", "primary-only"],
+      name: "A Custom",
+    });
+
+    expect(listEffectiveCustomCredentialModelRows([secondary, primary])).toEqual([
+      { modelId: "shared-model", row: primary },
+      { modelId: "primary-only", row: primary },
+      { modelId: "secondary-only", row: secondary },
+    ]);
+  });
+
+  test("finds the first sorted credential for a model without requiring a full effective list", () => {
+    const secondary = credentialRow({
+      id: "credential-b",
+      modelsJson: ["target-model"],
+      name: "B Custom",
+    });
+    const primary = credentialRow({
+      id: "credential-a",
+      modelsJson: ["target-model"],
+      name: "A Custom",
+    });
+
+    expect(findCustomCredentialRowForModel([secondary, primary], "target-model")).toBe(primary);
+    expect(findCustomCredentialRowForModel([secondary, primary], "missing-model")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes YEF-860

## Summary

- Installed and used the `complexity-optimizer` skill for a codebase scan.
- Optimized custom OpenAI-compatible credential model lookup to return the first sorted matching credential directly instead of building the full effective custom model list first.
- Added focused tests for duplicate-model precedence and missing-model lookup behavior.

## Why

- The scanner surfaced many broad leads; the credential lookup was a low-risk application path with existing coverage.
- Runtime API key resolution only needs one matching credential, so materializing every effective custom model row adds avoidable parsing/allocation work after a match is already known.

## Verification

- Commands:
  - `bun test apps/api/tests/vendor-credential-custom-models.test.ts apps/api/tests/vendor-credential-runtime-selection.test.ts apps/api/tests/runtime-openai-compatible-models.test.ts apps/api/tests/available-models.test.ts`
  - `bun run fmt:check:path -- apps/api/src/modules/vendor-credentials/application/vendor-credential-custom-models.ts apps/api/tests/vendor-credential-custom-models.test.ts`
  - `bun run --filter @mosoo/api lint`
  - `bun run --filter @mosoo/api tc`
  - `bun run --filter @mosoo/api test`
- Manual steps: N/A
- Not run: Root workspace `bun run check`; API package lint/type/tests were run.

## Impact

- User/API/contract changes: N/A
- Generated files / GraphQL / DB / lockfile: N/A
- Env or config changes: N/A
- Risk and rollback: Low; rollback restores the previous full-list lookup path.

## Review

- Closest review areas:
  - `apps/api/src/modules/vendor-credentials/application/vendor-credential-custom-models.ts`
  - `apps/api/tests/vendor-credential-custom-models.test.ts`
- Known trade-offs:
  - Worst-case lookup still sorts credentials to preserve current precedence, but successful lookups avoid constructing the complete effective model list.
