### PR TITLE
perf(api): wake public streams on committed events

### DIFF
--- a/apps/api/src/adapters/http/routes/public-api-route.ts
+++ b/apps/api/src/adapters/http/routes/public-api-route.ts
@@ -214,6 +214,7 @@ export function registerPublicApiRoute(app: Hono<ApiGatewayEnvironment>) {
       operation: async ({ caller, threadId }) => {
         const { createPublicThreadEventStream } = await loadPublicThreadService();
         const stream = await createPublicThreadEventStream({
+          bindings: c.env,
           caller,
           database: c.env.DB,
           limit: parseThreadEventsLimit(c.req.query("limit")),

--- a/apps/api/src/modules/public-api/public-thread-events.ts
+++ b/apps/api/src/modules/public-api/public-thread-events.ts
@@ -16,9 +16,11 @@ import { OpenAiPrivateCitationStreamFilter } from "agent-driver/provider-output"
 import { and, asc, desc, eq, gt, lt } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
+import { createErrorLogContext, logWarn } from "../../platform/cloudflare/logger";
 import { getAppDatabase } from "../../platform/db/drizzle";
 import { createSessionProcessEventsFromSessionEventRows } from "../sessions/application/session-process-events.service";
 import type { SessionEventProcessRow } from "../sessions/application/session-process-events.service";
+import { connectSessionPublicEventWebSocket } from "../sessions/infrastructure/session/client";
 import { publicInternalError, publicInvalidRequest, toPublicApiError } from "./public-api-errors";
 import { sanitizePublicOutput } from "./public-output-sanitization";
 import { admitPublicThreadReader } from "./public-thread-admission";
@@ -143,6 +145,112 @@ class PublicLiveEventRowProjector {
     }
 
     return output;
+  }
+}
+
+class PublicThreadEventWakeup {
+  #pending = false;
+  #socket: WebSocket | null;
+  #waiter: (() => void) | null = null;
+
+  constructor(socket: WebSocket | null) {
+    this.#socket = socket;
+    socket?.addEventListener("message", this.#handleMessage);
+    socket?.addEventListener("close", this.#handleSocketUnavailable);
+    socket?.addEventListener("error", this.#handleSocketUnavailable);
+  }
+
+  close(): void {
+    const socket = this.#socket;
+
+    this.#detachSocket();
+    this.#waiter?.();
+
+    if (socket !== null && socket.readyState < WebSocket.CLOSING) {
+      socket.close(1000, "public-event-stream.closed");
+    }
+  }
+
+  wait(timeoutMs: number, signal: AbortSignal | null | undefined): Promise<void> {
+    if (this.#pending) {
+      this.#pending = false;
+      return Promise.resolve();
+    }
+
+    if (signal?.aborted === true) {
+      return Promise.resolve();
+    }
+
+    const wakeController = new AbortController();
+    const wake = () => wakeController.abort();
+    let timer: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, timeoutMs);
+    });
+    const notified = new Promise<void>((resolve) => {
+      wakeController.signal.addEventListener("abort", () => resolve(), { once: true });
+    });
+    let detachAbort = () => {};
+    const aborted = new Promise<void>((resolve) => {
+      const handleAbort = () => resolve();
+
+      signal?.addEventListener("abort", handleAbort, { once: true });
+      detachAbort = () => signal?.removeEventListener("abort", handleAbort);
+    });
+
+    this.#waiter = wake;
+
+    return Promise.race([timeout, notified, aborted]).finally(() => {
+      clearTimeout(timer);
+      detachAbort();
+      if (this.#waiter === wake) {
+        this.#waiter = null;
+      }
+    });
+  }
+
+  readonly #handleMessage = () => {
+    if (this.#waiter !== null) {
+      this.#waiter();
+      return;
+    }
+
+    this.#pending = true;
+  };
+
+  readonly #handleSocketUnavailable = () => {
+    this.#detachSocket();
+    this.#waiter?.();
+  };
+
+  #detachSocket(): void {
+    const socket = this.#socket;
+
+    if (socket === null) {
+      return;
+    }
+
+    socket.removeEventListener("message", this.#handleMessage);
+    socket.removeEventListener("close", this.#handleSocketUnavailable);
+    socket.removeEventListener("error", this.#handleSocketUnavailable);
+    this.#socket = null;
+  }
+}
+
+async function connectPublicThreadEventWakeup(
+  request: StreamPublicThreadEventsRequest,
+  sessionId: SessionId,
+): Promise<PublicThreadEventWakeup> {
+  try {
+    return new PublicThreadEventWakeup(
+      await connectSessionPublicEventWebSocket(request.bindings, sessionId),
+    );
+  } catch (error) {
+    logWarn("public_thread.event_wakeup.connect_failed", {
+      ...createErrorLogContext(error),
+      sessionId,
+    });
+    return new PublicThreadEventWakeup(null);
   }
 }
 
@@ -399,12 +507,6 @@ function enqueueThreadEvents(input: {
   return enqueued;
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
 function isStreamStopped(input: {
   signal: AbortSignal | null | undefined;
   state: { cancelled: boolean };
@@ -428,11 +530,19 @@ export async function createPublicThreadEventStream(
 ): Promise<ReadableStream<Uint8Array>> {
   const limit = normalizePublicThreadEventsLimit(request.limit);
   const sessionId = await resolvePublicThreadEventSessionId(request);
-  const initialWindow = await readPublicThreadEventWindow({
-    database: request.database,
-    limit,
-    sessionId,
-  });
+  const wakeup = await connectPublicThreadEventWakeup(request, sessionId);
+  let initialWindow: PublicThreadEventWindow;
+
+  try {
+    initialWindow = await readPublicThreadEventWindow({
+      database: request.database,
+      limit,
+      sessionId,
+    });
+  } catch (error) {
+    wakeup.close();
+    throw error;
+  }
   const emittedEventIds = new Set<RuntimeEventId>();
   const state = {
     cancelled: false,
@@ -456,7 +566,7 @@ export async function createPublicThreadEventStream(
         });
 
         while (!isStreamStopped({ signal: request.signal, state })) {
-          await delay(THREAD_EVENT_STREAM_POLL_INTERVAL_MS);
+          await wakeup.wait(THREAD_EVENT_STREAM_POLL_INTERVAL_MS, request.signal);
 
           if (isStreamStopped({ signal: request.signal, state })) {
             break;
@@ -506,11 +616,13 @@ export async function createPublicThreadEventStream(
           `event: thread.error\ndata: ${JSON.stringify(toSseErrorPayload(error))}\n\n`,
         );
       } finally {
+        wakeup.close();
         controller.close();
       }
     },
     cancel() {
       state.cancelled = true;
+      wakeup.close();
     },
   });
 }

--- a/apps/api/src/modules/public-api/public-thread.types.ts
+++ b/apps/api/src/modules/public-api/public-thread.types.ts
@@ -33,5 +33,6 @@ export interface ListPublicThreadEventsRequest {
 }
 
 export interface StreamPublicThreadEventsRequest extends ListPublicThreadEventsRequest {
+  bindings: ApiBindings;
   signal?: AbortSignal | null | undefined;
 }

--- a/apps/api/src/modules/sessions/infrastructure/session/client.ts
+++ b/apps/api/src/modules/sessions/infrastructure/session/client.ts
@@ -64,6 +64,26 @@ export async function publishSessionViewerEvents(
   await getSessionStub(env, sessionId).publishEvents(sessionId, events);
 }
 
+export async function connectSessionPublicEventWebSocket(
+  env: ApiBindings,
+  sessionId: SessionId,
+): Promise<WebSocket> {
+  const response = await getSessionStub(env, sessionId).fetch(
+    createSessionDoRequest(sessionId, "/public-events/ws", {
+      headers: { Upgrade: "websocket" },
+      method: "GET",
+    }),
+  );
+  const socket = response.webSocket;
+
+  if (response.status !== 101 || socket === null) {
+    throw new Error(`Session public event socket upgrade failed with status ${response.status}.`);
+  }
+
+  socket.accept();
+  return socket;
+}
+
 export async function syncSessionViewerState(
   env: ApiBindings,
   sessionId: SessionId | null,

--- a/apps/api/src/modules/sessions/infrastructure/session/do.ts
+++ b/apps/api/src/modules/sessions/infrastructure/session/do.ts
@@ -10,6 +10,7 @@ import {
   runWithApiLogContext,
 } from "../../../../platform/cloudflare/logger";
 import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
+import { SessionPublicEventSocketHub } from "./public-event-socket-hub";
 import { json, toErrorMessage } from "./requests";
 import { SESSION_ID_HEADER } from "./socket-headers";
 import { SessionViewerSocketHub } from "./viewer-socket-hub";
@@ -19,11 +20,17 @@ export class Session extends DurableObject {
     mismatchMessage: "Session id does not match the active Durable Object.",
     requiredMessage: "Session id is required.",
   });
+  readonly #publicEventSockets: SessionPublicEventSocketHub;
   readonly #viewerSockets: SessionViewerSocketHub;
 
   constructor(ctx: DurableObjectState, env: ApiBindings) {
     super(ctx, env);
 
+    this.#publicEventSockets = new SessionPublicEventSocketHub({
+      ctx,
+      getSessionId: () => this.#identity.value,
+      withSessionLogContext: (fn) => this.#withSessionLogContext(fn),
+    });
     this.#viewerSockets = new SessionViewerSocketHub({
       ctx,
       env,
@@ -58,6 +65,10 @@ export class Session extends DurableObject {
         return this.#viewerSockets.connect(request);
       }
 
+      if (url.pathname === "/public-events/ws") {
+        return this.#publicEventSockets.connect(request);
+      }
+
       return json({ error: "Not Found" }, { status: 404 });
     } catch (error) {
       const message = toErrorMessage(error);
@@ -84,6 +95,10 @@ export class Session extends DurableObject {
       return;
     }
 
+    if (this.#publicEventSockets.owns(ws)) {
+      return;
+    }
+
     await this.#viewerSockets.handleSocketClose(ws, code, reason);
   }
 
@@ -92,11 +107,19 @@ export class Session extends DurableObject {
       return;
     }
 
+    if (this.#publicEventSockets.owns(ws)) {
+      return;
+    }
+
     this.#viewerSockets.handleSocketError(ws, error);
   }
 
   override async webSocketMessage(ws: WebSocket, message: ArrayBuffer | string): Promise<void> {
     if (this.#destroyed) {
+      return;
+    }
+
+    if (this.#publicEventSockets.owns(ws)) {
       return;
     }
 
@@ -118,6 +141,9 @@ export class Session extends DurableObject {
 
   async publishEvents(sessionId: string, events: AgUiSessionEvent[]): Promise<void> {
     this.#ensureActiveRpcSession(sessionId);
+    if (events.length > 0) {
+      this.#publicEventSockets.notifyEventsAvailable();
+    }
     await this.#viewerSockets.broadcastEvents(events);
   }
 
@@ -129,6 +155,7 @@ export class Session extends DurableObject {
   async closeViewers(sessionId: string, reason: string): Promise<void> {
     this.#ensureActiveRpcSession(sessionId);
     this.#viewerSockets.closeSockets(reason);
+    this.#publicEventSockets.closeSockets(reason);
   }
 
   async destroy(sessionId: string, reason: string): Promise<void> {
@@ -145,6 +172,7 @@ export class Session extends DurableObject {
   async #destroy(reason: string): Promise<void> {
     this.#destroyed = true;
     this.#viewerSockets.closeSockets(reason);
+    this.#publicEventSockets.closeSockets(reason);
     this.#identity.clear();
     await this.ctx.storage.deleteAlarm();
     await this.ctx.storage.deleteAll();

--- a/apps/api/src/modules/sessions/infrastructure/session/public-event-socket-hub.ts
+++ b/apps/api/src/modules/sessions/infrastructure/session/public-event-socket-hub.ts
@@ -1,0 +1,102 @@
+import { closeOpenSocket } from "../../../../platform/cloudflare/durable-object-support";
+import { createErrorLogContext, logError } from "../../../../platform/cloudflare/logger";
+import { json } from "./requests";
+
+declare const WebSocketPair: new () => [WebSocket, WebSocket];
+
+const PUBLIC_EVENT_SOCKET_TAG = "public-events";
+
+interface PublicEventSocketAttachment {
+  readonly role: "public-events";
+  readonly sessionId: string;
+}
+
+interface SessionPublicEventSocketHubOptions {
+  readonly ctx: DurableObjectState;
+  readonly getSessionId: () => string | null;
+  readonly withSessionLogContext: <T>(fn: () => T) => T;
+}
+
+function readAttachment(socket: WebSocket): PublicEventSocketAttachment | null {
+  const value: unknown = socket.deserializeAttachment();
+
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("role" in value) ||
+    value.role !== PUBLIC_EVENT_SOCKET_TAG ||
+    !("sessionId" in value) ||
+    typeof value.sessionId !== "string"
+  ) {
+    return null;
+  }
+
+  return { role: PUBLIC_EVENT_SOCKET_TAG, sessionId: value.sessionId };
+}
+
+export class SessionPublicEventSocketHub {
+  readonly #ctx: DurableObjectState;
+  readonly #getSessionId: () => string | null;
+  readonly #withSessionLogContext: <T>(fn: () => T) => T;
+
+  constructor(options: SessionPublicEventSocketHubOptions) {
+    this.#ctx = options.ctx;
+    this.#getSessionId = options.getSessionId;
+    this.#withSessionLogContext = options.withSessionLogContext;
+  }
+
+  connect(request: Request): Response {
+    if (request.headers.get("upgrade") !== "websocket") {
+      return json({ error: "WebSocket upgrade is required." }, { status: 426 });
+    }
+
+    const sessionId = this.#getSessionId();
+
+    if (sessionId === null) {
+      return json({ error: "Session id is required." }, { status: 400 });
+    }
+
+    const pair = new WebSocketPair();
+    const client = pair[0];
+    const server = pair[1];
+    const attachment: PublicEventSocketAttachment = {
+      role: PUBLIC_EVENT_SOCKET_TAG,
+      sessionId,
+    };
+
+    this.#ctx.acceptWebSocket(server, [PUBLIC_EVENT_SOCKET_TAG]);
+    server.serializeAttachment(attachment);
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  owns(socket: WebSocket): boolean {
+    return readAttachment(socket) !== null;
+  }
+
+  notifyEventsAvailable(): void {
+    for (const socket of this.#ctx.getWebSockets(PUBLIC_EVENT_SOCKET_TAG)) {
+      if (socket.readyState !== WebSocket.OPEN) {
+        continue;
+      }
+
+      try {
+        socket.send("events");
+      } catch (error) {
+        this.#withSessionLogContext(() => {
+          logError("session.public_event_socket.send_failed", {
+            ...createErrorLogContext(error),
+            sessionId: readAttachment(socket)?.sessionId ?? this.#getSessionId(),
+          });
+        });
+        closeOpenSocket(socket, 1011, "session.public-events.send-failed");
+      }
+    }
+  }
+
+  closeSockets(reason: string): void {
+    for (const socket of this.#ctx.getWebSockets(PUBLIC_EVENT_SOCKET_TAG)) {
+      closeOpenSocket(socket, 1008, reason);
+    }
+  }
+}

--- a/apps/api/tests/helpers/public-api-http-test-fixture.ts
+++ b/apps/api/tests/helpers/public-api-http-test-fixture.ts
@@ -269,6 +269,7 @@ export function createPublicHttpTestBindings(
     apiCommandQueue?: ApiCommandQueueStub;
     fileBucket?: R2Bucket;
     queue?: ChannelFinalDeliveryQueueStub;
+    sessionNamespace?: ApiBindings["Session"];
   } = {},
 ): Record<string, unknown> {
   return {
@@ -289,7 +290,7 @@ export function createPublicHttpTestBindings(
     SANDBOX_FILE_BUCKET_LOCAL: "true",
     SANDBOX_STATE_BUCKET: unavailableBinding<R2Bucket>("SANDBOX_STATE_BUCKET"),
     SANDBOX_STATE_BUCKET_NAME: "mosoo-sandbox-state",
-    Session: createOkDurableObjectNamespace(),
+    Session: options.sessionNamespace ?? createOkDurableObjectNamespace(),
     VAULT_ROOT_SECRET: "test-vault-secret",
     WEB_ORIGIN: "https://mosoo.ai",
   };

--- a/apps/api/tests/public-thread-api-fixtures.ts
+++ b/apps/api/tests/public-thread-api-fixtures.ts
@@ -186,3 +186,61 @@ export async function insertRuntimeEvent(
     })
     .run();
 }
+
+class PublicEventTestSocket extends EventTarget {
+  readyState = WebSocket.CONNECTING;
+
+  accept(): void {
+    this.readyState = WebSocket.OPEN;
+  }
+
+  close(): void {
+    if (this.readyState >= WebSocket.CLOSING) {
+      return;
+    }
+
+    this.readyState = WebSocket.CLOSED;
+    this.dispatchEvent(new Event("close"));
+  }
+
+  emit(): void {
+    this.dispatchEvent(new MessageEvent("message", { data: "events" }));
+  }
+}
+
+export function createPublicEventSessionNamespace(): {
+  binding: ApiBindings["Session"];
+  close: () => void;
+  emit: () => void;
+} {
+  const sockets = new Set<PublicEventTestSocket>();
+  const stub = {
+    closeViewers: async () => {},
+    destroy: async () => {},
+    fetch: async () => {
+      const socket = new PublicEventTestSocket();
+      sockets.add(socket);
+      return { status: 101, webSocket: socket as unknown as WebSocket } as Response;
+    },
+    publishEvents: async () => {
+      for (const socket of sockets) {
+        socket.emit();
+      }
+    },
+  };
+
+  return {
+    binding: {
+      get: () => stub,
+      idFromName: (name: string) => name,
+    } as unknown as ApiBindings["Session"],
+    close: () => {
+      for (const socket of sockets) {
+        socket.close();
+      }
+    },
+    emit: () => {
+      void stub.publishEvents();
+    },
+  };
+}

--- a/apps/api/tests/public-thread-api.e2e.test.ts
+++ b/apps/api/tests/public-thread-api.e2e.test.ts
@@ -21,6 +21,7 @@ import {
 import {
   OWNER_VIEWER,
   bearer,
+  createPublicEventSessionNamespace,
   createPublicThreadApiTestApp,
   expectArray,
   expectRecord,
@@ -935,6 +936,7 @@ describe("Public Thread API e2e", () => {
   test("streams Thread events as public SSE entries", async () => {
     const database = await createPublicHttpContractDatabase();
     const app = createPublicThreadApiTestApp();
+    const liveEvents = createPublicEventSessionNamespace();
 
     await withProviderProbeMock(async () => {
       const response = await requestPublicApi(
@@ -986,6 +988,7 @@ describe("Public Thread API e2e", () => {
         new Request(`https://api.example.com/api/v1/threads/${threadId}/events/stream?limit=1`, {
           headers: { Authorization: bearer(TOKENS.owner) },
         }),
+        { sessionNamespace: liveEvents.binding },
       );
       expect(streamResponse.status).toBe(200);
       expect(streamResponse.headers.get("Content-Type")).toContain("text/event-stream");
@@ -1056,14 +1059,17 @@ describe("Public Thread API e2e", () => {
       };
 
       const deltaCommittedAt = performance.now();
+      liveEvents.emit();
       const openDeltaText = await readUntil("id: 01J00000000000000000000014");
       const openDeltaMs = performance.now() - deltaCommittedAt;
 
-      expect(openDeltaMs).toBeLessThan(3_000);
+      expect(openDeltaMs).toBeLessThan(500);
       expect(openDeltaText).toContain("Live stream ");
       expect(openDeltaText).toContain("delta A");
       expect(openDeltaText).not.toContain("hidden");
       expect(openDeltaText).not.toContain("\uE200");
+
+      liveEvents.close();
 
       await insertRuntimeEvent(database, {
         kind: "message.completed",
@@ -1117,6 +1123,7 @@ describe("Public Thread API e2e", () => {
       expect(text).not.toContain("payload");
       expect(text).not.toContain("private-diagnostic");
       expect(text).not.toContain("traceId");
+      expect(text).not.toContain("event: thread.error");
     });
   }, 10_000);
 

--- a/apps/api/tests/session-public-event-socket-hub.test.ts
+++ b/apps/api/tests/session-public-event-socket-hub.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+import { SessionPublicEventSocketHub } from "../src/modules/sessions/infrastructure/session/public-event-socket-hub";
+
+class TestPublicEventSocket {
+  readonly sent: string[] = [];
+  readyState = WebSocket.OPEN;
+
+  deserializeAttachment(): unknown {
+    return { role: "public-events", sessionId: "session-1" };
+  }
+
+  send(message: string): void {
+    this.sent.push(message);
+  }
+}
+
+describe("SessionPublicEventSocketHub", () => {
+  test("notifies every open public event socket", () => {
+    const first = new TestPublicEventSocket();
+    const second = new TestPublicEventSocket();
+    const ctx = {
+      getWebSockets: (tag?: string) =>
+        tag === "public-events" ? ([first, second] as unknown as WebSocket[]) : ([] as WebSocket[]),
+    } as DurableObjectState;
+    const hub = new SessionPublicEventSocketHub({
+      ctx,
+      getSessionId: () => "session-1",
+      withSessionLogContext: (fn) => fn(),
+    });
+
+    hub.notifyEventsAvailable();
+
+    expect(first.sent).toEqual(["events"]);
+    expect(second.sent).toEqual(["events"]);
+  });
+});


### PR DESCRIPTION
## Summary
- wake Public API Thread SSE streams from the Session Durable Object when committed events become available
- keep D1 sequence reads as the source of truth and retain the 2-second poll as a repair fallback
- preserve private-citation filtering, terminal dedupe, and active-run recycle protection from the predecessor performance changes

## Before / after
Frozen staging screen (V3 → V4, 4 interleaved pairs / 8 cold runs):
- inter-chunk p95 median: **2057.8 ms → 526.2 ms (-74.4%)**
- tail completion median: **5147.3 ms → 4828.6 ms (-6.2%)**
- streamed chunks: **2/run → 5–7/run**
- semantics, identity, trace, cleanup: **8/8**; failed attempts: **0**

Final-source smoke (2 pairs / 4 cold runs):
- inter-chunk p95 median: **2073.4 ms → 697.4 ms (-66.4%)**
- paired TTFT median delta: **-6319.4 ms (23.3% faster)**; treated as a smoke result, not a causal cold-start claim
- semantics, identity, trace, cleanup: **4/4**; failed attempts: **0**

The larger screen's raw TTFT median regressed under a phase-1-only stack assignment, so this PR claims the directly controlled streaming-cadence gain only.

## Verification
- `just check` — 1018 tests, 0 failures; formatting, docs, lint, TypeScript, and GraphQL codegen checks passed
- focused Public Thread API + socket hub tests — 15 passed, 0 failed
- `just commit-check` — passed

## Stack note
GitHub ship policy only permits `main`/`release/*` PR bases. This branch therefore includes the predecessor commits from #366 and #367 until those PRs merge.
