### PR TITLE
fix(ci): use canary alias for bun in deploy-try

### DIFF
--- a/.github/workflows/deploy-try.yml
+++ b/.github/workflows/deploy-try.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.4.0-canary.1
+          bun-version: canary
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
         with:


### PR DESCRIPTION
## Summary

- Change `deploy-try.yml` `bun-version` from `1.4.0-canary.1` to `canary`.

## Why

- `oven-sh/setup-bun` resolves an exact canary patch string as a GitHub release tag; `1.4.0-canary.1` is not published, so install fails before deploy.
- Other CI workflows already use the `canary` channel alias and successfully install Bun canary.

## Verification

- Commands:
  - `git diff --check` on the workflow change
  - Confirmed sibling workflows: `.github/workflows/pr-check.yml` and `.github/workflows/pr-commits-lint.yml` use `bun-version: canary`
- Manual steps:
  - N/A for local runtime; failed install was observed on [deploy-try run 29728563927](https://github.com/langgenius/mosoo/actions/runs/29728563927)
- Not run:
  - Full `just check` / live Cloudflare deploy (unchanged app code; post-merge re-run of `deploy/try` is the proof path)

## Impact

- User/API/contract changes: none
- Generated files / GraphQL / DB / lockfile: none
- Env or config changes: CI only (`deploy-try` Bun install channel)
- Risk and rollback: low; revert the one-line version pin if needed. Floating `canary` may move over time (same as other CI jobs).

## Review

- Closest review areas: `.github/workflows/deploy-try.yml` Bun setup step
- Known trade-offs: channel alias vs exact pin — exact pin was the breakage mode for unpublished canary tags