### PR TITLE
feat(skills): filter unavailable skills.sh entries

### DIFF
--- a/apps/api/src/adapters/http/routes/skill-route.ts
+++ b/apps/api/src/adapters/http/routes/skill-route.ts
@@ -97,9 +97,11 @@ export function registerSkillRoute(app: Hono<ApiGatewayEnvironment>) {
       const perPage = c.req.query("perPage");
       const query = c.req.query("q");
       const view = c.req.query("view");
+      const availableOnly = c.req.query("availableOnly");
 
       return c.json(
         await listSkillsShCatalog(c.env, {
+          ...(availableOnly !== undefined ? { availableOnly } : {}),
           ...(page !== undefined ? { page } : {}),
           ...(perPage !== undefined ? { perPage } : {}),
           ...(query !== undefined ? { query } : {}),

--- a/apps/api/src/modules/skills/application/skills-sh-catalog.service.ts
+++ b/apps/api/src/modules/skills/application/skills-sh-catalog.service.ts
@@ -29,6 +29,7 @@ const MAX_CATALOG_PER_PAGE = 60;
 const MIN_SEARCH_LENGTH = 2;
 
 interface ListSkillsShCatalogInput {
+  availableOnly?: string;
   page?: string;
   perPage?: string;
   query?: string;
@@ -90,6 +91,7 @@ export async function listSkillsShCatalog(
   bindings: ApiBindings,
   input: ListSkillsShCatalogInput,
 ): Promise<SkillsShCatalogResult> {
+  const availableOnly = parseBoolean(input.availableOnly, false);
   const view = parseCatalogView(input.view);
   const page = parseInteger(input.page, 0, 0, Number.MAX_SAFE_INTEGER);
   const perPage = parseInteger(input.perPage, DEFAULT_CATALOG_PER_PAGE, 1, MAX_CATALOG_PER_PAGE);
@@ -97,10 +99,10 @@ export async function listSkillsShCatalog(
   const token = readSkillsShApiToken(bindings);
 
   if (token !== null) {
-    return listSkillsShCatalogFromApi({ page, perPage, query, token, view });
+    return listSkillsShCatalogFromApi({ availableOnly, page, perPage, query, token, view });
   }
 
-  return listSkillsShCatalogFromPublicPage({ page, perPage, query, view });
+  return listSkillsShCatalogFromPublicPage({ availableOnly, page, perPage, query, view });
 }
 
 export async function createSkillFromSkillsSh(
@@ -121,6 +123,7 @@ export async function createSkillFromSkillsSh(
 }
 
 async function listSkillsShCatalogFromApi(input: {
+  availableOnly: boolean;
   page: number;
   perPage: number;
   query: string | null;
@@ -145,7 +148,10 @@ async function listSkillsShCatalogFromApi(input: {
 
   const payload = await fetchSkillsShJson(url, input.token);
   const data = isRecord(payload) && Array.isArray(payload["data"]) ? payload["data"] : [];
-  const skills = data.map(parseSkillsShApiSkill).filter(isNonNull);
+  const parsedSkills = data.map(parseSkillsShApiSkill).filter(isNonNull);
+  const skills = input.availableOnly
+    ? parsedSkills.filter((skill) => isSkillsShCatalogSkillAvailable(skill, true))
+    : parsedSkills;
   const pagination = isRecord(payload) ? payload["pagination"] : null;
   const total = readApiTotal(pagination, searchQuery === null ? null : payload);
   const hasMore =
@@ -168,6 +174,7 @@ async function listSkillsShCatalogFromApi(input: {
 }
 
 async function listSkillsShCatalogFromPublicPage(input: {
+  availableOnly: boolean;
   page: number;
   perPage: number;
   query: string | null;
@@ -183,10 +190,14 @@ async function listSkillsShCatalogFromPublicPage(input: {
   const catalog = parseSkillsShPublicCatalog(await response.text());
   const query =
     input.query !== null && input.query.length >= MIN_SEARCH_LENGTH ? input.query : null;
-  const filtered =
+  const queryFiltered =
     query === null ? catalog.skills : filterPublicCatalogSkills(catalog.skills, query);
+  const catalogSkills = queryFiltered.map(toCatalogSkillFromPublic);
+  const filtered = input.availableOnly
+    ? catalogSkills.filter((skill) => isSkillsShCatalogSkillAvailable(skill, false))
+    : catalogSkills;
   const start = input.page * input.perPage;
-  const skills = filtered.slice(start, start + input.perPage).map(toCatalogSkillFromPublic);
+  const skills = filtered.slice(start, start + input.perPage);
 
   return {
     authConfigured: false,
@@ -197,7 +208,7 @@ async function listSkillsShCatalogFromPublicPage(input: {
     query,
     skills,
     source: "public-page",
-    total: query === null ? catalog.total : filtered.length,
+    total: query === null && !input.availableOnly ? catalog.total : filtered.length,
     view: input.view,
   };
 }
@@ -553,6 +564,21 @@ function readSkillsShApiToken(bindings: ApiBindings): string | null {
   const token = bindings.SKILLS_SH_API_TOKEN?.trim() || bindings.VERCEL_OIDC_TOKEN?.trim() || "";
 
   return token.length > 0 ? token : null;
+}
+
+function isSkillsShCatalogSkillAvailable(
+  skill: Pick<SkillsShCatalogSkill, "sourceType">,
+  authConfigured: boolean,
+): boolean {
+  return authConfigured || skill.sourceType === "github";
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  return value === "true" || value === "1";
 }
 
 function parseCatalogView(value: string | undefined): SkillsShCatalogView {

--- a/apps/api/tests/skills-sh-catalog.test.ts
+++ b/apps/api/tests/skills-sh-catalog.test.ts
@@ -149,6 +149,58 @@ describe("skills.sh catalog", () => {
     ]);
   });
 
+  test("filters public-page skills to installable entries when available-only is requested", async () => {
+    globalThis.fetch = async (input) => {
+      const url = typeof input === "string" ? input : input.url;
+
+      expect(url).toBe("https://www.skills.sh/trending");
+
+      return new Response(
+        publicCatalogHtml(
+          [
+            {
+              installs: 10,
+              name: "React Native",
+              skillId: "react-native",
+              source: "expo/skills",
+            },
+            {
+              installs: 9,
+              name: "Lark Approval",
+              skillId: "lark-approval",
+              source: "open.feishu.cn",
+            },
+          ],
+          2,
+        ),
+      );
+    };
+
+    const result = await listSkillsShCatalog({} as ApiBindings, {
+      availableOnly: "true",
+      perPage: "10",
+      view: "trending",
+    });
+
+    expect(result.authConfigured).toBe(false);
+    expect(result.source).toBe("public-page");
+    expect(result.total).toBe(1);
+    expect(result.skills).toEqual([
+      {
+        id: "expo/skills/react-native",
+        installUrl: "https://github.com/expo/skills",
+        installs: 10,
+        isDuplicate: false,
+        isOfficial: false,
+        name: "React Native",
+        slug: "react-native",
+        source: "expo/skills",
+        sourceType: "github",
+        url: "https://www.skills.sh/expo/skills/react-native",
+      },
+    ]);
+  });
+
   test("resolves a GitHub target for one-click fallback installs", () => {
     expect(
       resolveSkillsShGitHubInstallTarget({

--- a/apps/web/src/domains/skill/api/skill-client.ts
+++ b/apps/web/src/domains/skill/api/skill-client.ts
@@ -234,6 +234,7 @@ export async function publishSkillPackage(input: {
 }
 
 export async function listSkillsShCatalog(input: {
+  availableOnly: boolean;
   page: number;
   perPage: number;
   query: string;
@@ -244,6 +245,7 @@ export async function listSkillsShCatalog(input: {
     perPage: String(input.perPage),
     view: input.view,
   });
+  params.set("availableOnly", String(input.availableOnly));
   const query = input.query.trim();
 
   if (query.length > 0) {

--- a/apps/web/src/domains/skill/query/skill-queries.ts
+++ b/apps/web/src/domains/skill/query/skill-queries.ts
@@ -12,8 +12,13 @@ import { fetchSkillSource, listAppSkills, listSkillsShCatalog } from "../api/ski
 
 export const skillKeys = {
   all: ["skill"] as const,
-  catalog: (view: SkillsShCatalogView, query: string, page: number, perPage: number) =>
-    [...skillKeys.catalogs(), view, query, page, perPage] as const,
+  catalog: (
+    view: SkillsShCatalogView,
+    query: string,
+    page: number,
+    perPage: number,
+    availableOnly: boolean,
+  ) => [...skillKeys.catalogs(), view, query, page, perPage, availableOnly] as const,
   catalogs: () => [...skillKeys.all, "skills-sh-catalog"] as const,
   detail: (skillId: string) => [...skillKeys.details(), skillId] as const,
   details: () => [...skillKeys.all, "detail"] as const,
@@ -32,6 +37,7 @@ export function useAppSkillsQuery(appId: string | null): UseQueryResult<SkillSum
 }
 
 export function useSkillsShCatalogQuery(input: {
+  availableOnly: boolean;
   enabled?: boolean;
   page: number;
   perPage: number;
@@ -42,12 +48,19 @@ export function useSkillsShCatalogQuery(input: {
     enabled: input.enabled ?? true,
     queryFn: async () =>
       listSkillsShCatalog({
+        availableOnly: input.availableOnly,
         page: input.page,
         perPage: input.perPage,
         query: input.query,
         view: input.view,
       }),
-    queryKey: skillKeys.catalog(input.view, input.query, input.page, input.perPage),
+    queryKey: skillKeys.catalog(
+      input.view,
+      input.query,
+      input.page,
+      input.perPage,
+      input.availableOnly,
+    ),
     staleTime: 60_000,
   });
 }

--- a/apps/web/src/routes/integrations/skills/skills-sh-catalog.tsx
+++ b/apps/web/src/routes/integrations/skills/skills-sh-catalog.tsx
@@ -25,6 +25,7 @@ import {
   DialogTitle,
 } from "@/shared/ui/dialog";
 import { EmptyState } from "@/shared/ui/empty-state";
+import { Switch } from "@/shared/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 import { isTruthy } from "../../../shared/lib/truthiness";
@@ -33,6 +34,7 @@ import type { useSkillRegistry } from "./use-skill-registry";
 const CATALOG_PER_PAGE = 24;
 
 interface SkillsShCatalogState {
+  availableOnly: boolean;
   error: string | null;
   installingId: string | null;
   page: number;
@@ -45,10 +47,12 @@ type SkillsShCatalogAction =
   | { type: "installStart"; id: string }
   | { type: "installSuccess" }
   | { type: "resetPage" }
+  | { type: "setAvailableOnly"; availableOnly: boolean }
   | { type: "setPage"; page: number }
   | { type: "setView"; view: SkillsShCatalogView };
 
 const SKILLS_SH_CATALOG_INITIAL_STATE: SkillsShCatalogState = {
+  availableOnly: true,
   error: null,
   installingId: null,
   page: 0,
@@ -70,6 +74,8 @@ function skillsShCatalogReducer(
       return { ...state, error: null, installingId: null };
     case "resetPage":
       return { ...state, page: 0 };
+    case "setAvailableOnly":
+      return { ...state, availableOnly: action.availableOnly, page: 0 };
     case "setPage":
       return { ...state, page: Math.max(action.page, 0) };
     case "setView":
@@ -88,9 +94,10 @@ export function SkillsShCatalog({
 }) {
   const [state, dispatch] = useReducer(skillsShCatalogReducer, SKILLS_SH_CATALOG_INITIAL_STATE);
   const [confirmingSkill, setConfirmingSkill] = useState<SkillsShCatalogSkill | null>(null);
-  const { error, installingId, page, view } = state;
+  const { availableOnly, error, installingId, page, view } = state;
   const trimmedSearch = search.trim();
   const catalogQuery = useSkillsShCatalogQuery({
+    availableOnly,
     enabled: isTruthy(registry.appId),
     page,
     perPage: CATALOG_PER_PAGE,
@@ -167,6 +174,20 @@ export function SkillsShCatalog({
             }}
           />
         </div>
+
+        <label
+          className="border-border bg-card text-fg-2 inline-flex h-8 items-center gap-2 rounded-md border px-2.5 text-[12.5px] font-medium"
+          htmlFor="skills-sh-show-available-only"
+        >
+          <Switch
+            checked={availableOnly}
+            id="skills-sh-show-available-only"
+            onCheckedChange={(checked) => {
+              dispatch({ availableOnly: checked, type: "setAvailableOnly" });
+            }}
+          />
+          Show available only
+        </label>
 
         <div className="flex-1" />
 
@@ -277,8 +298,8 @@ function SkillsShSourceTooltip({ source }: { source: "api" | "public-page" }) {
       </TooltipTrigger>
       <TooltipContent side="bottom" align="end" className="max-w-[280px] text-left">
         {source === "api"
-          ? "Discover results are sourced from the skills.sh API."
-          : "Discover results are sourced from the public skills.sh directory."}
+          ? "Discover results are sourced from the skills.sh API, so Well-known entries can be installed directly."
+          : "Discover results are sourced from the public skills.sh directory. GitHub skills can install directly; Well-known entries need server-side skills.sh API access."}
       </TooltipContent>
     </Tooltip>
   );
@@ -391,6 +412,7 @@ function SkillsShCatalogCard({
   skill: SkillsShCatalogSkill;
 }) {
   const installable = authConfigured || skill.sourceType === "github";
+  const installRequiresApi = !installable && skill.sourceType === "well-known";
 
   return (
     <article className="border-border bg-card hover:border-border-strong flex min-h-[168px] min-w-0 flex-col gap-3 rounded-lg border p-4 transition-all hover:shadow-sm">
@@ -423,24 +445,46 @@ function SkillsShCatalogCard({
           <span className="font-mono tabular-nums">{formatCatalogCount(skill.installs)}</span>{" "}
           installs
         </div>
-        <Button
-          size="sm"
-          variant={installed ? "outline" : "default"}
-          disabled={installed || installing || !installable}
-          onClick={onInstall}
-          title={installable ? undefined : "Requires skills.sh API access"}
-        >
-          {installed ? (
-            <>
-              <Check className="size-3.5" />
-              Installed
-            </>
-          ) : installing ? (
-            "Installing…"
-          ) : (
-            "Install"
-          )}
-        </Button>
+        {installRequiresApi ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                size="sm"
+                aria-disabled="true"
+                aria-label={`Cannot install ${skill.name}: skills.sh API access is required`}
+                className="hover:bg-primary cursor-not-allowed opacity-40 active:scale-100"
+                onClick={(event) => {
+                  event.preventDefault();
+                }}
+              >
+                API required
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top" align="end" className="max-w-[280px] text-left">
+              This Well-known entry needs server-side skills.sh API access before Mosoo can download
+              its files. GitHub-sourced skills can install without it.
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          <Button
+            size="sm"
+            variant={installed ? "outline" : "default"}
+            disabled={installed || installing}
+            onClick={onInstall}
+          >
+            {installed ? (
+              <>
+                <Check className="size-3.5" />
+                Installed
+              </>
+            ) : installing ? (
+              "Installing…"
+            ) : (
+              "Install"
+            )}
+          </Button>
+        )}
       </div>
     </article>
   );


### PR DESCRIPTION
## Summary

Adds a default-on `Show available only` control to the skills.sh Discover page so unavailable Well-known entries are hidden unless the user opts into seeing them.

Also clarifies unavailable Well-known installs by showing `API required` with a tooltip instead of a disabled `Install` button.

## Validation

- `just tc-package @mosoo/web`
- `just tc-package @mosoo/api`
- `just test-file apps/api/tests/skills-sh-catalog.test.ts`
- `just lint`
- Playwright local smoke: default-on `Show available only` hides `open.feishu.cn` Well-known entries; turning it off shows `API required` entries.
