### PR TITLE
chore(brand): lowercase standalone mosoo brand mentions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -76,7 +76,7 @@ body:
       placeholder: |
         Browser:
         OS:
-        Mosoo version or commit:
+        mosoo version or commit:
         Local or production:
 
   - type: dropdown

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Mosoo Contributing Guide
+# mosoo Contributing Guide
 
-Mosoo is still in alpha exploration, and the repository moves quickly. This document only describes the development and contribution flow that is currently real and usable in this repository, avoiding stale instructions inherited from older versions.
+mosoo is still in alpha exploration, and the repository moves quickly. This document only describes the development and contribution flow that is currently real and usable in this repository, avoiding stale instructions inherited from older versions.
 
 ## Before You Start
 
@@ -118,7 +118,7 @@ Local development notes:
   `just db-regen`, review the regenerated SQL, then run `just db-reset-local`
   to prove the migration chain against a fresh local database.
 - External MCP services used during Preview choose their own documented local
-  port; Mosoo does not reserve a `5180+` range for them.
+  port; mosoo does not reserve a `5180+` range for them.
 - Before asserting port conflicts or performance problems, measure with `lsof`, `curl`, timing, or another reproducible command.
 - On macOS, API dev auto-selects `$HOME/.docker/run/docker.sock` when present,
   even if `DOCKER_HOST` was inherited. Set
@@ -153,7 +153,7 @@ just test-file apps/api/tests/session-run-cancel.test.ts
 
 ## Database And Migrations
 
-Mosoo uses generated Drizzle migrations for local and production D1:
+mosoo uses generated Drizzle migrations for local and production D1:
 
 - The schema source of truth is `pkgs/db/src/schema/**`.
 - The generated chain currently consists of one squashed baseline,

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 <p align="center">
-  <img src="https://github.com/user-attachments/assets/4986c4b8-28fa-45ea-9be9-78c1c7133128" alt="Mosoo" width="96" height="96" />
+  <img src="https://github.com/user-attachments/assets/4986c4b8-28fa-45ea-9be9-78c1c7133128" alt="mosoo" width="96" height="96" />
 </p>
 
-# Mosoo
+# mosoo
 
 **An open-source agent runtime for coding agents.**
 
 Run OpenAI Codex, Claude Agent SDK, and OpenCode behind API endpoints in isolated AI agent sandboxes.
 
-Mosoo provides a Cloudflare-native control plane to stream tool activity, inspect Run history, and keep Threads and files across executions. It is self-hostable in your own account.
+mosoo provides a Cloudflare-native control plane to stream tool activity, inspect Run history, and keep Threads and files across executions. It is self-hostable in your own account.
 
-Your application remains yours. Its backend owns product behavior and end-user access. Mosoo focuses on Agent execution and lifecycle; App Deployment is a separate Alpha surface, not the core product contract.
+Your application remains yours. Its backend owns product behavior and end-user access. mosoo focuses on Agent execution and lifecycle; App Deployment is a separate Alpha surface, not the core product contract.
 
 ```text
 configure Agent + Skills + MCP + provider
   -> preview and publish an Agent version
-  -> call it from a backend or the Mosoo console
+  -> call it from a backend or the mosoo console
   -> stream events, handle permission requests, inspect files and usage
   -> continue a durable Thread across Runs
 ```
 
 <p align="center">
-  <a href="https://try.mosoo.ai">Try Mosoo</a> ·
+  <a href="https://try.mosoo.ai">Try mosoo</a> ·
   <a href="https://mosoo.ai">Website</a> ·
   <a href="https://mosoo.ai/docs">API Documentation</a> ·
-  <a href="https://github.com/langgenius/mosoo-connector">Mosoo Connector</a>
+  <a href="https://github.com/langgenius/mosoo-connector">mosoo Connector</a>
 </p>
 
 ## Agent Runtime and API: What Works Today
@@ -37,11 +37,11 @@ configure Agent + Skills + MCP + provider
 
 ## Who It Is For
 
-Mosoo is for developers extending Codex, Claude Agent SDK, OpenCode, or another coding agent into products and automations who do not want to operate a separate agent runtime, Sandbox service, session store, file pipeline, and Agent API for every integration.
+mosoo is for developers extending Codex, Claude Agent SDK, OpenCode, or another coding agent into products and automations who do not want to operate a separate agent runtime, Sandbox service, session store, file pipeline, and Agent API for every integration.
 
 ## Product Status
 
-Mosoo is in Alpha. The managed runtime and Agent API surfaces above are shipped and covered by repository tests, but production reliability and external adoption have not been proven. Public APIs and product behavior may still change.
+mosoo is in Alpha. The managed runtime and Agent API surfaces above are shipped and covered by repository tests, but production reliability and external adoption have not been proven. Public APIs and product behavior may still change.
 
 Product and engineering references:
 
@@ -52,7 +52,7 @@ Product and engineering references:
 
 ## Example: Build a Codex Agent API
 
-[Codex Pet](./examples/use-cases/codex-pet.md) shows a published Mosoo Agent integrated into an existing product backend through the Thread API. The same API can expose Agents backed by Claude Agent SDK or OpenCode.
+[Codex Pet](./examples/use-cases/codex-pet.md) shows a published mosoo Agent integrated into an existing product backend through the Thread API. The same API can expose Agents backed by Claude Agent SDK or OpenCode.
 
 https://github.com/user-attachments/assets/4a4bbaab-c192-4462-99e0-020eab966fff
 
@@ -87,7 +87,7 @@ curl http://localhost:5173/api/health
 curl http://localhost:8787/api/health
 ```
 
-API health is `/api/health`, not `/health`. The Mosoo control-plane development login uses OTP; under local loopback origins, addresses ending with `@mosoo.ai` skip that OTP and log in directly.
+API health is `/api/health`, not `/health`. The mosoo control-plane development login uses OTP; under local loopback origins, addresses ending with `@mosoo.ai` skip that OTP and log in directly.
 
 If setup fails, start with the focused recipe: submodule issues use `git submodule update --init`, missing local secrets use `just env-init`, and D1 schema errors use `just db-migrate`. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full workflow and verification expectations.
 

--- a/apps/api/src/adapters/http/routes/public-api-openapi-components.ts
+++ b/apps/api/src/adapters/http/routes/public-api-openapi-components.ts
@@ -54,7 +54,7 @@ export function createPublicApiOpenApiComponents() {
     schemas: PUBLIC_API_OPENAPI_SCHEMAS,
     securitySchemes: {
       accessToken: {
-        bearerFormat: "Mosoo Access Token",
+        bearerFormat: "mosoo Access Token",
         description:
           "Use Authorization: Bearer mst_... . Access Tokens identify an account and do not carry scopes.",
         scheme: "bearer",

--- a/apps/api/src/adapters/http/routes/public-api-openapi.ts
+++ b/apps/api/src/adapters/http/routes/public-api-openapi.ts
@@ -400,7 +400,7 @@ export function createPublicApiOpenApiDocument(origin: string): PublicApiOpenApi
       }),
       post: operation({
         description:
-          "Creates a Thread and the backing AgentSession. If input is present, Mosoo also queues the initial Run. If input is omitted, the Thread is immediately visible with IDLE status and no run. Access Token callers are attributed to the token owner.",
+          "Creates a Thread and the backing AgentSession. If input is present, mosoo also queues the initial Run. If input is omitted, the Thread is immediately visible with IDLE status and no run. Access Token callers are attributed to the token owner.",
         parameters: [exampleAgentIdParameter, idempotencyKeyParameter],
         requestBody: jsonRequestBodyExamples(
           { $ref: "#/components/schemas/CreateThreadRequest" },
@@ -582,8 +582,8 @@ export function createPublicApiOpenApiDocument(origin: string): PublicApiOpenApi
     components: createPublicApiOpenApiComponents(),
     info: {
       description:
-        "Public HTTPS API for creating and retrieving Threads on Mosoo Agent API Endpoints. v1 resource identifiers are bare ULIDs, not prefixed IDs. Access Tokens identify the account caller. Runtime execution resolves the Agent API Endpoint owner's capabilities while the Thread is attributed to the token owner.",
-      title: "Mosoo Public Thread API",
+        "Public HTTPS API for creating and retrieving Threads on mosoo Agent API Endpoints. v1 resource identifiers are bare ULIDs, not prefixed IDs. Access Tokens identify the account caller. Runtime execution resolves the Agent API Endpoint owner's capabilities while the Thread is attributed to the token owner.",
+      title: "mosoo Public Thread API",
       version: PUBLIC_API_VERSION,
     },
     openapi: "3.1.0",

--- a/apps/api/src/modules/auth/application/cli-oauth-device.service.ts
+++ b/apps/api/src/modules/auth/application/cli-oauth-device.service.ts
@@ -228,7 +228,7 @@ function normalizeProvider(value: string | undefined): "google" {
     throw new CliOAuthDeviceError(
       400,
       "unsupported_provider",
-      "Mosoo CLI OAuth supports google only.",
+      "mosoo CLI OAuth supports google only.",
     );
   }
   return "google";

--- a/apps/api/src/modules/auth/infrastructure/auth-email.ts
+++ b/apps/api/src/modules/auth/infrastructure/auth-email.ts
@@ -81,26 +81,26 @@ function buildOtpMessage(type: string, otp: string): { subject: string; text: st
   switch (type) {
     case "sign-in": {
       return {
-        subject: "Your Mosoo sign-in code",
-        text: `Your Mosoo sign-in code is ${otp}. It expires in 10 minutes.`,
+        subject: "Your mosoo sign-in code",
+        text: `Your mosoo sign-in code is ${otp}. It expires in 10 minutes.`,
       };
     }
     case "email-verification": {
       return {
-        subject: "Verify your Mosoo email",
-        text: `Your Mosoo email verification code is ${otp}. It expires in 10 minutes.`,
+        subject: "Verify your mosoo email",
+        text: `Your mosoo email verification code is ${otp}. It expires in 10 minutes.`,
       };
     }
     case "forget-password": {
       return {
-        subject: "Your Mosoo password reset code",
-        text: `Your Mosoo password reset code is ${otp}. It expires in 10 minutes.`,
+        subject: "Your mosoo password reset code",
+        text: `Your mosoo password reset code is ${otp}. It expires in 10 minutes.`,
       };
     }
     default: {
       return {
-        subject: "Your Mosoo verification code",
-        text: `Your Mosoo verification code is ${otp}. It expires in 10 minutes.`,
+        subject: "Your mosoo verification code",
+        text: `Your mosoo verification code is ${otp}. It expires in 10 minutes.`,
       };
     }
   }

--- a/apps/api/src/modules/channels/application/channel-agent-reply.ts
+++ b/apps/api/src/modules/channels/application/channel-agent-reply.ts
@@ -1,6 +1,6 @@
 import type { AgentId, SessionId, SessionRunId } from "@mosoo/id";
 
-export const CHANNEL_AGENT_FAILURE_TEXT = "Mosoo is having trouble responding. Try again later.";
+export const CHANNEL_AGENT_FAILURE_TEXT = "mosoo is having trouble responding. Try again later.";
 
 export function buildChannelSessionLink(input: {
   agentId: AgentId;
@@ -19,7 +19,7 @@ export function buildChannelWorkingText(input: {
   sessionLink: string;
 }): string {
   const target = input.linkLabel ? `<${input.sessionLink}|${input.linkLabel}>` : input.sessionLink;
-  return `Mosoo session created: ${target}. Agent is working...`;
+  return `mosoo session created: ${target}. Agent is working...`;
 }
 
 export type ChannelAgentReplyResult =

--- a/apps/api/src/modules/channels/application/channel-final-delivery-reply.ts
+++ b/apps/api/src/modules/channels/application/channel-final-delivery-reply.ts
@@ -29,7 +29,7 @@ function truncateReplyText(input: { maxLength: number; text: string }): string {
     return input.text;
   }
 
-  return `${input.text.slice(0, input.maxLength - 70)}\n\n[Mosoo reply truncated. Open the session for the full output.]`;
+  return `${input.text.slice(0, input.maxLength - 70)}\n\n[mosoo reply truncated. Open the session for the full output.]`;
 }
 
 function buildAgentReplyText(input: {
@@ -48,10 +48,10 @@ function buildAgentReplyText(input: {
     case "completed": {
       return replyText
         ? `${input.sessionLabel}\n\n${replyText}`
-        : `${input.sessionLabel}\n\nAgent completed. Open Mosoo for the full output.`;
+        : `${input.sessionLabel}\n\nAgent completed. Open mosoo for the full output.`;
     }
     case "failed": {
-      return `${input.sessionLabel}\n\nAgent run failed: ${replyText ?? "Open Mosoo for details."}`;
+      return `${input.sessionLabel}\n\nAgent run failed: ${replyText ?? "Open mosoo for details."}`;
     }
     case "timeout": {
       return replyText
@@ -60,9 +60,9 @@ function buildAgentReplyText(input: {
             "",
             replyText,
             "",
-            "Agent is still running. Open Mosoo for the latest output.",
+            "Agent is still running. Open mosoo for the latest output.",
           ].join("\n")
-        : `${input.sessionLabel}\n\nAgent is still running. Open Mosoo for the latest output.`;
+        : `${input.sessionLabel}\n\nAgent is still running. Open mosoo for the latest output.`;
     }
     default: {
       throw new Error("Unsupported channel final delivery result status.");
@@ -95,7 +95,7 @@ async function sendDiscordFinalReply(input: {
       maxLength: 1900,
       result: input.result,
       sessionId: input.sessionId,
-      sessionLabel: `Mosoo session ${input.sessionId}`,
+      sessionLabel: `mosoo session ${input.sessionId}`,
     }),
   });
 }
@@ -127,7 +127,7 @@ async function sendSlackFinalReply(input: {
     maxLength: 3500,
     result: input.result,
     sessionId: input.sessionId,
-    sessionLabel: `Mosoo session <${sessionLink}|${input.sessionId}>`,
+    sessionLabel: `mosoo session <${sessionLink}|${input.sessionId}>`,
   });
 
   if (input.payload.workingMessage) {
@@ -173,7 +173,7 @@ async function sendLarkFinalReply(input: {
       maxLength: null,
       result: input.result,
       sessionId: input.sessionId,
-      sessionLabel: `Mosoo session ${input.sessionId}`,
+      sessionLabel: `mosoo session ${input.sessionId}`,
     }),
   });
 }
@@ -203,7 +203,7 @@ async function sendTelegramFinalReply(input: {
       maxLength: 3900,
       result: input.result,
       sessionId: input.sessionId,
-      sessionLabel: `Mosoo session ${input.sessionId}`,
+      sessionLabel: `mosoo session ${input.sessionId}`,
     }),
   });
 }
@@ -228,7 +228,7 @@ async function sendWeChatFinalReply(input: {
       maxLength: 3000,
       result: input.result,
       sessionId: input.sessionId,
-      sessionLabel: `Mosoo session ${input.sessionId}`,
+      sessionLabel: `mosoo session ${input.sessionId}`,
     }),
   });
 }

--- a/apps/api/src/modules/cost/domain/cost-pricing.ts
+++ b/apps/api/src/modules/cost/domain/cost-pricing.ts
@@ -215,7 +215,7 @@ const MODEL_PRICING: readonly ModelPricingScheduleEntry[] = [
     provider: "minimax",
     vendor: "MiniMax",
   }),
-  // Keep legacy upstream provider IDs for usage rows written before Mosoo provider IDs were canonical.
+  // Keep legacy upstream provider IDs for usage rows written before mosoo provider IDs were canonical.
   providerPricing({
     cacheReadUsdPerMillion: 0.125,
     cacheWriteUsdPerMillion: 1.875,

--- a/apps/api/src/modules/mcp/application/mcp-oauth-client-registration.service.ts
+++ b/apps/api/src/modules/mcp/application/mcp-oauth-client-registration.service.ts
@@ -38,7 +38,7 @@ export async function registerDynamicOAuthClient(
 
   const response = await fetch(metadata.registration_endpoint, {
     body: JSON.stringify({
-      client_name: "Mosoo MCP",
+      client_name: "mosoo MCP",
       grant_types: ["authorization_code", "refresh_token"],
       redirect_uris: [redirectUri],
       response_types: ["code"],

--- a/apps/api/src/modules/skills/application/skills-sh-catalog.service.ts
+++ b/apps/api/src/modules/skills/application/skills-sh-catalog.service.ts
@@ -234,7 +234,7 @@ async function loadSkillPackageFromSkillsSh(
   }
 
   throw new SkillRequestError(
-    "This skills.sh skill requires server-side skills.sh API access before Mosoo can install it.",
+    "This skills.sh skill requires server-side skills.sh API access before mosoo can install it.",
     400,
   );
 }

--- a/apps/api/tests/agent-channel-binding-fixtures.ts
+++ b/apps/api/tests/agent-channel-binding-fixtures.ts
@@ -48,7 +48,7 @@ const LARK_BOT_INFO_OK_RESPONSE = {
   code: 0,
   data: {
     bot: {
-      app_name: "Mosoo Bot",
+      app_name: "mosoo Bot",
       open_id: "lark-bot-open-id",
     },
   },
@@ -80,7 +80,7 @@ const LARK_APP_REGISTRATION_POLL_OK_RESPONSE = {
 const TELEGRAM_GET_ME_OK_RESPONSE = {
   ok: true,
   result: {
-    first_name: "Mosoo",
+    first_name: "mosoo",
     id: 12345,
     username: "mosoo_bot",
   },

--- a/apps/api/tests/agent-package-file-import.test.ts
+++ b/apps/api/tests/agent-package-file-import.test.ts
@@ -425,7 +425,7 @@ describe("agent package file import", () => {
       bindings,
       fileId,
       message:
-        "Runtime setting sandbox_mode is managed by Mosoo platform policy and cannot be set here.",
+        "Runtime setting sandbox_mode is managed by mosoo platform policy and cannot be set here.",
     });
   });
 

--- a/apps/api/tests/app-overview.test.ts
+++ b/apps/api/tests/app-overview.test.ts
@@ -431,7 +431,7 @@ describe("App overview", () => {
 
     expect(overview.activeOrganization).toMatchObject({
       id: fixture.ids.organizationId,
-      name: "Mosoo API Test",
+      name: "mosoo API Test",
     });
     expect(overview.apps).toMatchObject({
       hasMore: false,

--- a/apps/api/tests/channel-final-delivery-fetch-fixtures.ts
+++ b/apps/api/tests/channel-final-delivery-fetch-fixtures.ts
@@ -73,7 +73,7 @@ export function installTelegramFetch(
       return Response.json({
         ok: true,
         result: {
-          first_name: "Mosoo Telegram",
+          first_name: "mosoo Telegram",
           id: 9001,
           is_bot: true,
           username: "mosoo_telegram_bot",
@@ -157,7 +157,7 @@ export function installLarkFetch(input: {
     if (requestUrl === "https://open.feishu.cn/open-apis/bot/v3/info") {
       return Response.json({
         bot: {
-          app_name: "Mosoo Lark",
+          app_name: "mosoo Lark",
           open_id: "ou_bot",
         },
         code: 0,

--- a/apps/api/tests/channel-final-delivery-scheduling.test.ts
+++ b/apps/api/tests/channel-final-delivery-scheduling.test.ts
@@ -69,7 +69,7 @@ describe("channel final delivery scheduling", () => {
       expect(telegramBodies).toEqual([
         {
           chat_id: "42",
-          text: `Mosoo session ${seed.sessionId}\n\nFinal answer`,
+          text: `mosoo session ${seed.sessionId}\n\nFinal answer`,
         },
       ]);
       expect(job).toEqual({
@@ -111,7 +111,7 @@ describe("channel final delivery scheduling", () => {
       expect(discordRequests.map((request) => request.body)).toEqual([
         {
           allowed_mentions: { parse: [] },
-          content: `Mosoo session ${seed.sessionId}\n\nFinal answer`,
+          content: `mosoo session ${seed.sessionId}\n\nFinal answer`,
         },
       ]);
       expect(job).toEqual({
@@ -265,7 +265,7 @@ describe("channel final delivery scheduling", () => {
       expect(telegramBodies).toEqual([
         {
           chat_id: "42",
-          text: `Mosoo session ${seed.sessionId}\n\nFinal answer`,
+          text: `mosoo session ${seed.sessionId}\n\nFinal answer`,
         },
       ]);
       expect(job).toEqual({
@@ -445,7 +445,7 @@ describe("channel final delivery scheduling", () => {
         return Response.json({
           ok: true,
           result: {
-            first_name: "Mosoo Telegram",
+            first_name: "mosoo Telegram",
             id: 9001,
             is_bot: true,
             username: "mosoo_telegram_bot",

--- a/apps/api/tests/discord-channel-adapter.test.ts
+++ b/apps/api/tests/discord-channel-adapter.test.ts
@@ -186,7 +186,7 @@ describe("Discord channel adapter", () => {
         {
           allowed_mentions: { parse: [] },
           content:
-            "Mosoo session created: https://mosoo.ai/agent/01J00000000000000000000009?tab=consume&sessionId=session-1. Agent is working...",
+            "mosoo session created: https://mosoo.ai/agent/01J00000000000000000000009?tab=consume&sessionId=session-1. Agent is working...",
         },
       ]);
       expect(finalDeliveryJobs).toEqual([

--- a/apps/api/tests/helpers/api-test-fixture.ts
+++ b/apps/api/tests/helpers/api-test-fixture.ts
@@ -126,7 +126,7 @@ export class ApiTestClient {
     );
 
     if (!response.ok) {
-      throw new Error(`Mosoo.ai test login failed with status ${response.status}.`);
+      throw new Error(`mosoo.ai test login failed with status ${response.status}.`);
     }
 
     return (await response.json()) as MosooAiBackdoorResponse;
@@ -748,7 +748,7 @@ async function seedApiTestFixture(database: D1Database): Promise<void> {
         updated_at
       ) VALUES (?, ?, ?, ?, ?)`,
     )
-    .bind(1, API_TEST_VIEWER.id, API_TEST_IDS.organizationId, "Mosoo API Test", 1)
+    .bind(1, API_TEST_VIEWER.id, API_TEST_IDS.organizationId, "mosoo API Test", 1)
     .run();
 
   await database

--- a/apps/api/tests/helpers/public-api-http-test-fixture.ts
+++ b/apps/api/tests/helpers/public-api-http-test-fixture.ts
@@ -274,7 +274,7 @@ export function createPublicHttpTestBindings(
   return {
     APP_NAME: "mosoo",
     AUTH_EMAIL: unavailableBinding<SendEmail>("AUTH_EMAIL"),
-    AUTH_EMAIL_FROM: "Mosoo AUTH <auth@mosoo.ai>",
+    AUTH_EMAIL_FROM: "mosoo AUTH <auth@mosoo.ai>",
     BETTER_AUTH_SECRET: "test-secret",
     API_COMMAND_QUEUE: options.apiCommandQueue ?? createApiCommandQueueStub(),
     CHANNEL_FINAL_DELIVERY_QUEUE: options.queue ?? createChannelFinalDeliveryQueueStub(),
@@ -332,7 +332,7 @@ export async function createPublicHttpContractDatabase(): Promise<SqliteD1Databa
       createdAt: nowMs,
       creatorAccountId: PUBLIC_API_TEST_IDS.ownerAccount,
       id: PUBLIC_API_TEST_IDS.organization,
-      name: "Mosoo Test Org",
+      name: "mosoo Test Org",
       updatedAt: nowMs,
     })
     .run();

--- a/apps/api/tests/lark-channel-adapter.test.ts
+++ b/apps/api/tests/lark-channel-adapter.test.ts
@@ -224,7 +224,7 @@ describe("Lark channel adapter", () => {
       expect(requestBodies).toEqual([
         {
           content: JSON.stringify({
-            text: "Mosoo session created: https://mosoo.ai/agent/01J00000000000000000000009?tab=consume&sessionId=session-1. Agent is working...",
+            text: "mosoo session created: https://mosoo.ai/agent/01J00000000000000000000009?tab=consume&sessionId=session-1. Agent is working...",
           }),
           msg_type: "text",
         },

--- a/apps/api/tests/lark-channel-events-route.test.ts
+++ b/apps/api/tests/lark-channel-events-route.test.ts
@@ -104,7 +104,7 @@ async function withLarkFetchMock<T>(operation: () => Promise<T>): Promise<T> {
       return Response.json({
         code: 0,
         bot: {
-          app_name: "Mosoo Feishu",
+          app_name: "mosoo Feishu",
           open_id: "ou_bot",
         },
       });

--- a/apps/api/tests/multi-provider-channel-session.test.ts
+++ b/apps/api/tests/multi-provider-channel-session.test.ts
@@ -31,7 +31,7 @@ async function withProviderFetchMock<T>(operation: () => Promise<T>): Promise<T>
       return Response.json({
         ok: true,
         result: {
-          first_name: "Mosoo Telegram",
+          first_name: "mosoo Telegram",
           id: 9001,
           is_bot: true,
           username: "mosoo_telegram_bot",
@@ -55,7 +55,7 @@ async function withProviderFetchMock<T>(operation: () => Promise<T>): Promise<T>
     ) {
       return Response.json({
         bot: {
-          app_name: "Mosoo Lark",
+          app_name: "mosoo Lark",
           open_id: "ou_bot",
         },
         code: 0,
@@ -89,7 +89,7 @@ describe("multi-provider channel sessions", () => {
       expect(binding).toMatchObject({
         agentId: "01J00000000000000000000009",
         displayMetadata: {
-          bot_first_name: "Mosoo Telegram",
+          bot_first_name: "mosoo Telegram",
           bot_username: "mosoo_telegram_bot",
         },
         externalBotId: "9001",
@@ -243,7 +243,7 @@ describe("multi-provider channel sessions", () => {
 
       expect(binding).toMatchObject({
         displayMetadata: {
-          app_name: "Mosoo Lark",
+          app_name: "mosoo Lark",
           bot_open_id: "ou_bot",
           domain: "feishu",
         },

--- a/apps/api/tests/personal-access-token.test.ts
+++ b/apps/api/tests/personal-access-token.test.ts
@@ -132,7 +132,7 @@ describe("personal access tokens", () => {
     expect(response.status).toBe(201);
   });
 
-  test("generates Mosoo access tokens with the MST prefix", async () => {
+  test("generates mosoo access tokens with the MST prefix", async () => {
     const database = createPersonalTokenDatabase();
 
     const response = await createPersonalAccessToken(database, VIEWER, {

--- a/apps/api/tests/runtime-vendor-env-vars.test.ts
+++ b/apps/api/tests/runtime-vendor-env-vars.test.ts
@@ -210,7 +210,7 @@ describe("runtime vendor env vars", () => {
     },
   );
 
-  test("rewrites Mosoo Zhipu model prefix to OpenCode's Z.ai provider id", () => {
+  test("rewrites mosoo Zhipu model prefix to OpenCode's Z.ai provider id", () => {
     const envVars = buildRuntimeVendorEnvVars({
       credential: {
         apiBase: null,

--- a/apps/api/tests/telegram-channel-adapter.test.ts
+++ b/apps/api/tests/telegram-channel-adapter.test.ts
@@ -192,7 +192,7 @@ describe("Telegram channel adapter", () => {
       expect(requestBodies).toEqual([
         {
           chat_id: "42",
-          text: "Mosoo session created: https://mosoo.ai/agent/01J00000000000000000000009?tab=consume&sessionId=session-1. Agent is working...",
+          text: "mosoo session created: https://mosoo.ai/agent/01J00000000000000000000009?tab=consume&sessionId=session-1. Agent is working...",
         },
       ]);
       expect(finalDeliveryJobs).toEqual([

--- a/apps/api/tests/telegram-channel-events-route.test.ts
+++ b/apps/api/tests/telegram-channel-events-route.test.ts
@@ -47,7 +47,7 @@ async function withTelegramFetchMock<T>(operation: () => Promise<T>): Promise<T>
       return Response.json({
         ok: true,
         result: {
-          first_name: "Mosoo Telegram",
+          first_name: "mosoo Telegram",
           id: 9001,
           is_bot: true,
           username: "mosoo_telegram_bot",

--- a/apps/api/tests/wechat-channel-connection-fixtures.ts
+++ b/apps/api/tests/wechat-channel-connection-fixtures.ts
@@ -175,7 +175,7 @@ export function createWeChatDmMessage(input: {
   return {
     context_token: input.contextToken ?? "ctx-secret",
     from_user_id: input.fromUserId ?? "peer-1",
-    item_list: [{ text_item: { text: input.text ?? "hello Mosoo" }, type: 1 }],
+    item_list: [{ text_item: { text: input.text ?? "hello mosoo" }, type: 1 }],
     message_id: input.messageId ?? 123,
     message_state: 2,
     message_type: 1,

--- a/apps/api/tests/wechat-channel-connection-persistence.test.ts
+++ b/apps/api/tests/wechat-channel-connection-persistence.test.ts
@@ -202,7 +202,7 @@ describe("WeChat channel runtime persistence", () => {
       clientId: "reply-client-1",
       fetchImpl,
       peerId: "peer-1",
-      text: "reply from Mosoo",
+      text: "reply from mosoo",
     });
 
     expect(sendRequests).toHaveLength(1);
@@ -212,7 +212,7 @@ describe("WeChat channel runtime persistence", () => {
       msg: {
         client_id: "reply-client-1",
         context_token: "ctx-secret",
-        item_list: [{ text_item: { text: "reply from Mosoo" }, type: 1 }],
+        item_list: [{ text_item: { text: "reply from mosoo" }, type: 1 }],
         to_user_id: "peer-1",
       },
     });

--- a/apps/api/tests/wechat-channel-connection.test.ts
+++ b/apps/api/tests/wechat-channel-connection.test.ts
@@ -18,7 +18,7 @@ describe("WeChat channel connection scaffold", () => {
           context_token: "ctx-secret",
           create_time_ms: 1779646500000,
           from_user_id: "peer-1",
-          item_list: [{ text_item: { text: "hello Mosoo" }, type: 1 }],
+          item_list: [{ text_item: { text: "hello mosoo" }, type: 1 }],
           message_id: 123,
           message_state: 2,
           message_type: 1,
@@ -52,7 +52,7 @@ describe("WeChat channel connection scaffold", () => {
         contextTokenValue: "ctx-secret",
         toUserId: "peer-1",
       },
-      text: "hello Mosoo",
+      text: "hello mosoo",
     });
 
     if (!trigger) {

--- a/apps/api/tests/wechat-channel-final-delivery.test.ts
+++ b/apps/api/tests/wechat-channel-final-delivery.test.ts
@@ -104,7 +104,7 @@ describe("WeChat channel final delivery", () => {
         runId: sessionCommand.runId,
         seq: 2,
         sessionId: sessionCommand.sessionId,
-        text: "Final answer from Mosoo",
+        text: "Final answer from mosoo",
       });
       const jobId = await enqueueChannelFinalDeliveryJob(
         bindings,
@@ -149,7 +149,7 @@ describe("WeChat channel final delivery", () => {
           item_list: [
             {
               text_item: {
-                text: `Mosoo session ${sessionCommand.sessionId}\n\nFinal answer from Mosoo`,
+                text: `mosoo session ${sessionCommand.sessionId}\n\nFinal answer from mosoo`,
               },
               type: 1,
             },

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -17,7 +17,7 @@ head_sampling_rate = 1
 [vars]
 APP_NAME = "mosoo"
 WEB_ORIGIN = "http://localhost:5173"
-AUTH_EMAIL_FROM = "Mosoo AUTH <auth@mosoo.ai>"
+AUTH_EMAIL_FROM = "mosoo AUTH <auth@mosoo.ai>"
 FILE_BUCKET_NAME = "mosoo-file"
 BACKUP_BUCKET_NAME = "mosoo-sandbox-state"
 SANDBOX_STATE_BUCKET_NAME = "mosoo-sandbox-state"
@@ -143,7 +143,7 @@ head_sampling_rate = 0.1
 [env.prod.vars]
 APP_NAME = "mosoo"
 WEB_ORIGIN = "https://try.mosoo.ai"
-AUTH_EMAIL_FROM = "Mosoo AUTH <auth@mosoo.ai>"
+AUTH_EMAIL_FROM = "mosoo AUTH <auth@mosoo.ai>"
 FILE_BUCKET_NAME = "mosoo-file"
 BACKUP_BUCKET_NAME = "mosoo-sandbox-state"
 SANDBOX_STATE_BUCKET_NAME = "mosoo-sandbox-state"

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -1,6 +1,6 @@
 # Design
 
-Visual system for the Mosoo web app. Tokens are the source of truth and live in
+Visual system for the mosoo web app. Tokens are the source of truth and live in
 `src/shared/styles/app.css` (`:root`, `.dark`, and the `@theme inline` Tailwind bridge).
 This document describes them; the CSS implements them.
 
@@ -33,7 +33,7 @@ Selection fills are neutral (`--color-brand-light` = ink-50), not green washes.
 **Rule:** product semantic colors consume Tailwind token classes (`text-fg-2`,
 `bg-paper-200`, `border-border-strong`, `bg-accent-soft`, etc.). External brand
 art, the terminal palette, and deterministic avatar palettes may use fixed colors
-when they are not expressing a Mosoo semantic state.
+when they are not expressing a mosoo semantic state.
 
 ## Typography
 

--- a/apps/web/PRODUCT.md
+++ b/apps/web/PRODUCT.md
@@ -14,7 +14,7 @@ tools like GitHub, Linear, and Vercel is assumed; the UI should feel native to t
 
 ## Product Purpose
 
-Mosoo is an open-source Agent Cloud. It lets developers deploy, configure, run,
+mosoo is an open-source Agent Cloud. It lets developers deploy, configure, run,
 and debug agents through OpenAI runtime, Claude Agent SDK, and OpenCode/DeepSeek
 via ACP in isolated sandboxes, then ship them to users. The current Web console is organized as
 App Overview / Runs / Agents / Config, plus account Settings; App Usage lives in App

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -9,13 +9,13 @@
     />
     <!-- Matches --bg (--paper-100) so browser chrome blends with the app surface. -->
     <meta name="theme-color" content="#fbfbfc" />
-    <meta property="og:title" content="Mosoo" />
+    <meta property="og:title" content="mosoo" />
     <meta
       property="og:description"
       content="Open-source agent runtime for coding agents. Run OpenAI Codex, Claude Agent SDK, and OpenCode behind API endpoints in isolated sandboxes."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="Mosoo" />
+    <meta property="og:site_name" content="mosoo" />
     <meta name="twitter:card" content="summary" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <!-- Preload the primary UI font so it streams in parallel with the CSS/JS
@@ -31,7 +31,7 @@
       type="font/woff2"
       crossorigin="anonymous"
     />
-    <title>Mosoo</title>
+    <title>mosoo</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -242,7 +242,7 @@ function MobileNavigation({
           <ExpandSidebarIcon className="size-5" />
           <span className="text-xs font-semibold">Menu</span>
         </button>
-        <img src="/brand/logo-wordmark-onlight.svg" alt="Mosoo" className="block h-5" />
+        <img src="/brand/logo-wordmark-onlight.svg" alt="mosoo" className="block h-5" />
         {title ? (
           <h1 className="text-fg-1 ml-auto truncate text-sm font-semibold">{title}</h1>
         ) : null}
@@ -257,7 +257,7 @@ function MobileNavigation({
         <SheetContent className="bg-sidebar data-[closed]:slide-out-to-left data-[open]:slide-in-from-left right-auto left-0 flex w-[min(20rem,calc(100vw-2rem))] max-w-none flex-col p-3">
           <SheetTitle className="sr-only">Navigation</SheetTitle>
           <div className="flex h-11 shrink-0 items-center px-1.5">
-            <img src="/brand/logo-wordmark-onlight.svg" alt="Mosoo" className="block h-[22px]" />
+            <img src="/brand/logo-wordmark-onlight.svg" alt="mosoo" className="block h-[22px]" />
           </div>
           <nav
             className="flex min-h-0 flex-1 flex-col overflow-y-auto pt-2 [&_a]:min-h-11 [&_button]:min-h-11"
@@ -324,7 +324,7 @@ function ConsoleShell({
           {collapsed ? null : (
             <img
               src="/brand/logo-wordmark-onlight.svg"
-              alt="Mosoo"
+              alt="mosoo"
               className="sidebar-label-enter block h-[22px]"
             />
           )}
@@ -417,7 +417,7 @@ export function OrgLayout({ children }: { children: ReactNode }) {
       <header className="border-border-soft hidden shrink-0 border-b md:flex">
         <div className="flex min-h-[76px] w-[224px] shrink-0 items-center gap-2 px-4">
           <Link to="/apps" aria-label="Apps" className="flex items-center">
-            <img src="/brand/logo-mark.svg" alt="Mosoo" className="block size-6" />
+            <img src="/brand/logo-mark.svg" alt="mosoo" className="block size-6" />
           </Link>
           {activeOrganization === null ? null : (
             <>

--- a/apps/web/src/app/document-title.tsx
+++ b/apps/web/src/app/document-title.tsx
@@ -3,7 +3,7 @@ import { matchPath, useLocation } from "react-router-dom";
 
 import { useAppSession } from "./session-provider";
 
-const PRODUCT_NAME = "Mosoo";
+const PRODUCT_NAME = "mosoo";
 
 type DocumentTitleScope = "app" | "global" | "org";
 

--- a/apps/web/src/features/help/help-docs-dialog.tsx
+++ b/apps/web/src/features/help/help-docs-dialog.tsx
@@ -77,7 +77,7 @@ function HelpDocsDialogContent({ onOpenChange }: { onOpenChange: (open: boolean)
       <DialogHeader className="sr-only">
         <DialogTitle>Help &amp; docs</DialogTitle>
         <DialogDescription>
-          Search the Mosoo documentation hosted at mosoo.ai/docs.
+          Search the mosoo documentation hosted at mosoo.ai/docs.
         </DialogDescription>
       </DialogHeader>
 

--- a/apps/web/src/features/session-chat/assistant-ui/convert-session-message.ts
+++ b/apps/web/src/features/session-chat/assistant-ui/convert-session-message.ts
@@ -2,7 +2,7 @@ import type { ThreadMessageLike } from "@assistant-ui/react";
 import type { SessionViewMessage, SessionViewSegment } from "@mosoo/ag-ui-session";
 
 // Assistant content parts we emit for assistant-ui. The tool-call part keeps the
-// Mosoo `path` on `args` so the ported tool card can render it; permission status
+// mosoo `path` on `args` so the ported tool card can render it; permission status
 // is resolved separately in the renderer (see session-permission-context).
 type AssistantContentPart =
   | { type: "text"; text: string }
@@ -15,7 +15,7 @@ type AssistantContentPart =
       result?: string;
     };
 
-// Collapses Mosoo's flat segment stream into assistant-ui content parts.
+// Collapses mosoo's flat segment stream into assistant-ui content parts.
 // Consecutive text segments merge into one markdown part; tool_use absorbs its
 // matching tool_result (paired by toolCallId). Order is preserved exactly. This
 // is the relocated `sessionMessageSegmentsToBlocks` logic — the only behavioural

--- a/apps/web/src/features/session-chat/assistant-ui/session-message-parts.tsx
+++ b/apps/web/src/features/session-chat/assistant-ui/session-message-parts.tsx
@@ -7,7 +7,7 @@ import { Markdown } from "@/shared/ui/markdown";
 
 import { SessionToolPart } from "./session-tool-part";
 
-// Assistant text renders through Mosoo's hardened Markdown (sanitize/harden,
+// Assistant text renders through mosoo's hardened Markdown (sanitize/harden,
 // <img> disallowed), streaming-animated while the part is still running.
 const AssistantText: TextMessagePartComponent = ({ status, text }) => (
   <Markdown streaming={status.type === "running"}>{text}</Markdown>

--- a/apps/web/src/features/session-chat/assistant-ui/session-thread-composer.tsx
+++ b/apps/web/src/features/session-chat/assistant-ui/session-thread-composer.tsx
@@ -78,7 +78,7 @@ function SessionResourceChips({
 
 // Composer rebuilt on assistant-ui's ComposerPrimitive. Slim single-line input
 // that grows; submit/cancel + Enter / Shift+Enter come from the primitive. The
-// Mosoo upload button, resource-mention chips, and error card are preserved as
+// mosoo upload button, resource-mention chips, and error card are preserved as
 // custom children. The mention pipeline runs in onNew/onSend (see
 // agent-session-panel), so this composer only collects the typed text.
 export function SessionThreadComposer({

--- a/apps/web/src/features/session-chat/assistant-ui/session-tool-part.tsx
+++ b/apps/web/src/features/session-chat/assistant-ui/session-tool-part.tsx
@@ -5,7 +5,7 @@ import { ToolCallCard } from "../tool-call-card";
 import type { ToolCall } from "../tool-call-card";
 import { useSessionPermissionForToolCall } from "./session-permission-context";
 
-// Renders every assistant-ui tool-call part via the existing Mosoo tool card
+// Renders every assistant-ui tool-call part via the existing mosoo tool card
 // (registered as `tools.Override`). Status is re-derived: a matching permission
 // request wins (needs_approval), otherwise a present result or a completed part
 // status means done, else it is still running.

--- a/apps/web/src/routes/agent/components/settings-dialog-channels-view.tsx
+++ b/apps/web/src/routes/agent/components/settings-dialog-channels-view.tsx
@@ -455,7 +455,7 @@ export function AgentSettingsChannelsView({
           </DialogHeader>
           <div className="text-muted-foreground space-y-2 text-sm">
             <p>The Agent will no longer respond in the connected channel surface.</p>
-            <p>Existing Mosoo Sessions keep their channel source metadata.</p>
+            <p>Existing mosoo Sessions keep their channel source metadata.</p>
             <p>To recover, create a new binding and paste the credentials again.</p>
           </div>
           <DialogFooter>

--- a/apps/web/src/routes/agent/lifecycle/distribution-info.ts
+++ b/apps/web/src/routes/agent/lifecycle/distribution-info.ts
@@ -111,7 +111,7 @@ export function buildAgentInstructionPrompt(
 
   return `# Instruction for LLM: ${agent.name}
 
-Use this \`.md\` instruction with a coding agent that needs to control or use this Mosoo agent programmatically.
+Use this \`.md\` instruction with a coding agent that needs to control or use this mosoo agent programmatically.
 
 ## Generated variables
 
@@ -135,7 +135,7 @@ ${description}
 
 ## Programmatic control
 
-1. Create a Mosoo API token in the console if one is not already available.
+1. Create a mosoo API token in the console if one is not already available.
 2. Store it locally as \`MOSOO_API_TOKEN\`.
 3. Create a thread by sending a user message to \`MOSOO_CREATE_THREAD_URL\` with a bearer token.
 4. Persist the returned thread and run identifiers so follow-up calls can continue the same work.

--- a/apps/web/src/routes/agent/lifecycle/publish-menu.tsx
+++ b/apps/web/src/routes/agent/lifecycle/publish-menu.tsx
@@ -151,7 +151,7 @@ export function PublishMenu({
           <div className="flex min-w-0 flex-col">
             <span className="text-[13px] font-medium">Thread</span>
             <span className="text-muted-foreground text-[11.5px] leading-snug">
-              Start a thread with this agent in Mosoo.
+              Start a thread with this agent in mosoo.
             </span>
           </div>
         </DropdownMenuItem>

--- a/apps/web/src/routes/agent/lifecycle/publish-success-modal.tsx
+++ b/apps/web/src/routes/agent/lifecycle/publish-success-modal.tsx
@@ -55,7 +55,7 @@ export function PublishSuccessModal({
             <div className="flex items-start gap-3">
               <Globe className="text-fg-3 mt-0.5 size-4 shrink-0" />
               <div className="min-w-0 flex-1">
-                <div className="text-foreground text-[13px] font-medium">Try in Mosoo</div>
+                <div className="text-foreground text-[13px] font-medium">Try in mosoo</div>
                 <div className="text-fg-2 mt-0.5 text-[12px]">Start a Thread with this agent.</div>
               </div>
               <Button

--- a/apps/web/src/routes/app-overview/app-overview-install.tsx
+++ b/apps/web/src/routes/app-overview/app-overview-install.tsx
@@ -11,7 +11,7 @@ import { CopyCheckIcon } from "@/shared/ui/copy-check-icon";
 const INSTALL_COMMAND = "curl -fsSL https://install.mosoo.ai/install.sh | bash";
 const API_TOKENS_PATH = "/settings/access-tokens";
 const READY_STEPS = [
-  "Installs Mosoo CLI",
+  "Installs mosoo CLI",
   "Installs the @mosoo skill",
   "Signs in to cloud and runs doctor",
 ] as const;
@@ -47,11 +47,11 @@ export function AppOverviewInstallGuide(): ReactElement {
     <section className="py-8 sm:py-10">
       <div className="mx-auto flex max-w-3xl flex-col items-center text-center">
         <h2 className="text-foreground text-3xl font-semibold tracking-tight sm:text-4xl">
-          Build agent app with <span className="text-[rgb(111_211_4)]">Mosoo</span> in your coding
+          Build agent app with <span className="text-[rgb(111_211_4)]">mosoo</span> in your coding
           agent
         </h2>
         <p className="text-muted-foreground mt-3 max-w-2xl text-base leading-7">
-          One command installs Mosoo CLI and the @mosoo skill, signs in to try.mosoo.ai, and checks
+          One command installs mosoo CLI and the @mosoo skill, signs in to try.mosoo.ai, and checks
           cloud readiness.
         </p>
 

--- a/apps/web/src/routes/app-overview/deploy/components/deploy-repo-card.tsx
+++ b/apps/web/src/routes/app-overview/deploy/components/deploy-repo-card.tsx
@@ -97,7 +97,7 @@ export function DeployRepoCard({
         <h2 className="text-fg-1 text-sm font-semibold">Deploy from a public GitHub repo</h2>
       </div>
       <p className="text-fg-3 mt-1.5 text-[13.5px] leading-relaxed">
-        Mosoo pulls your default branch HEAD, builds it, and binds your agents.
+        mosoo pulls your default branch HEAD, builds it, and binds your agents.
       </p>
       <div className="mt-4">
         <RepoDeployForm deploying={deploying} serverError={serverError} onDeploy={onDeploy} />

--- a/apps/web/src/routes/app-overview/deploy/deploy-console-data.ts
+++ b/apps/web/src/routes/app-overview/deploy/deploy-console-data.ts
@@ -25,7 +25,7 @@ import type { DeploymentRunOutcome } from "./deployment-status";
 export type AgentExposure = "public_thread";
 
 export interface BoundAgentVM {
-  /** Mosoo agent id, e.g. "agt_3kf". */
+  /** mosoo agent id, e.g. "agt_3kf". */
   id: string;
   name: string;
   expose: AgentExposure;
@@ -66,13 +66,13 @@ export interface DeploymentVM {
   repoUrl: string;
   defaultBranch: string;
   /**
-   * Mosoo-managed production URL reserved for this deployment. It may exist
+   * mosoo-managed production URL reserved for this deployment. It may exist
    * before a deploy succeeds, so the console can show the production pipe
    * independently from the current run status.
    */
   plannedUrl: string | null;
   /**
-   * Mosoo-managed URL currently serving production traffic. `null` until a run
+   * mosoo-managed URL currently serving production traffic. `null` until a run
    * has reached the live state.
    */
   liveUrl: string | null;

--- a/apps/web/src/routes/cli-auth/cli-auth.route.tsx
+++ b/apps/web/src/routes/cli-auth/cli-auth.route.tsx
@@ -37,7 +37,7 @@ export function CliAuthPage() {
           <div className="min-w-0 flex-1">
             <h1 className="text-fg-1 text-lg font-semibold">Authorize CLI access</h1>
             <p className="text-fg-2 mt-2 text-sm leading-6">
-              Connect this browser session to the Mosoo CLI request below.
+              Connect this browser session to the mosoo CLI request below.
             </p>
             <div className="border-border-default bg-bg-sunken text-fg-1 mt-4 rounded-md border px-3 py-2 font-mono text-sm">
               {code || "Missing code"}

--- a/apps/web/src/routes/integrations/skills/skills-sh-catalog.tsx
+++ b/apps/web/src/routes/integrations/skills/skills-sh-catalog.tsx
@@ -462,7 +462,7 @@ function SkillsShCatalogCard({
               </Button>
             </TooltipTrigger>
             <TooltipContent side="top" align="end" className="max-w-[280px] text-left">
-              This Well-known entry needs server-side skills.sh API access before Mosoo can download
+              This Well-known entry needs server-side skills.sh API access before mosoo can download
               its files. GitHub-sourced skills can install without it.
             </TooltipContent>
           </Tooltip>

--- a/apps/web/src/routes/login/topbar.tsx
+++ b/apps/web/src/routes/login/topbar.tsx
@@ -4,8 +4,8 @@ import type { ReactElement } from "react";
 
 function Brand(): ReactElement {
   return (
-    <span aria-label="Mosoo" className="inline-flex items-center">
-      <img src="/brand/logo-wordmark-onlight.svg" alt="Mosoo" className="block h-[22px]" />
+    <span aria-label="mosoo" className="inline-flex items-center">
+      <img src="/brand/logo-wordmark-onlight.svg" alt="mosoo" className="block h-[22px]" />
     </span>
   );
 }
@@ -18,7 +18,7 @@ export function LoginAuthTopbar(): ReactElement {
         className="text-fg-2 hover:text-fg-1 flex items-center gap-1.5 text-[13px] font-semibold transition-colors"
       >
         <ArrowLeft className="size-3.5" />
-        Back to Mosoo
+        Back to mosoo
       </a>
       <Brand />
       <div className="w-[100px]" />

--- a/apps/web/src/routes/onboarding/onboarding.route.tsx
+++ b/apps/web/src/routes/onboarding/onboarding.route.tsx
@@ -146,14 +146,14 @@ function OnboardingErrorScreen({ error, onRetry }: { error: string | null; onRet
   return (
     <div className="bg-background fixed inset-0 flex flex-col">
       <div className="flex items-center px-4 py-5 sm:px-8">
-        <span className="text-xl font-light tracking-tight">Mosoo</span>
+        <span className="text-xl font-light tracking-tight">mosoo</span>
       </div>
 
       <div className="flex flex-1 items-center justify-center">
         <div className="w-full max-w-[520px] px-6">
           <h2 className="text-foreground text-center text-2xl font-semibold">App setup failed</h2>
           <p className="text-muted-foreground mt-2 text-center text-sm">
-            {isTruthy(error) ? error : "Mosoo could not create your default App."}
+            {isTruthy(error) ? error : "mosoo could not create your default App."}
           </p>
 
           <div className="mt-6">

--- a/apps/web/src/shared/config/help-docs.ts
+++ b/apps/web/src/shared/config/help-docs.ts
@@ -1,4 +1,4 @@
-// Index of the Mosoo help documentation hosted at https://mosoo.ai/docs.
+// Index of the mosoo help documentation hosted at https://mosoo.ai/docs.
 //
 // The `HELP_DOCS` array below is generated from the site's public documentation
 // manifest (https://mosoo.ai/docs/llms.txt). To refresh it after the docs change,
@@ -25,7 +25,7 @@ export interface HelpDoc {
 
 export const HELP_DOCS: readonly HelpDoc[] = [
   // <generated:help-docs> -- do not edit by hand; see header comment.
-  { section: "Getting started", title: "Mosoo Public Thread API", url: "https://mosoo.ai/docs/" },
+  { section: "Getting started", title: "mosoo Public Thread API", url: "https://mosoo.ai/docs/" },
   { section: "Getting started", title: "Quickstart", url: "https://mosoo.ai/docs/quickstart" },
   {
     section: "Getting started",
@@ -55,7 +55,7 @@ export const HELP_DOCS: readonly HelpDoc[] = [
   },
   {
     section: "Getting started",
-    title: "Mosoo API for coding agents",
+    title: "mosoo API for coding agents",
     url: "https://mosoo.ai/docs/coding-agents",
   },
   { section: "CLI", title: "CLI", url: "https://mosoo.ai/docs/cli/overview" },

--- a/apps/web/tests/agent-publish-success-boundary.test.ts
+++ b/apps/web/tests/agent-publish-success-boundary.test.ts
@@ -9,8 +9,8 @@ describe("agent publish success boundary", () => {
   test("keeps the Thread entry in the modal body without the footer Try CTA", () => {
     const source = readSource("../src/routes/agent/lifecycle/publish-success-modal.tsx");
 
-    expect(source.match(/Try in Mosoo/g)?.length ?? 0).toBe(1);
-    expect(source).toContain("Try in Mosoo");
+    expect(source.match(/Try in mosoo/g)?.length ?? 0).toBe(1);
+    expect(source).toContain("Try in mosoo");
     expect(source).toContain("Start a Thread with this agent.");
     expect(source).toContain("globalThis.location.assign(distribution.threadsPath)");
 

--- a/apps/web/tests/app-overview-boundary.test.ts
+++ b/apps/web/tests/app-overview-boundary.test.ts
@@ -46,7 +46,7 @@ describe("App overview boundary", () => {
     expect(installSource).toContain("bg-[rgb(111_211_4)]");
     expect(installSource).toContain("hover:bg-[rgb(111_211_4)]");
     expect(installSource).toContain("curl -fsSL https://install.mosoo.ai/install.sh | bash");
-    expect(installSource).toContain("Installs Mosoo CLI");
+    expect(installSource).toContain("Installs mosoo CLI");
     expect(installSource).toContain("Installs the @mosoo skill");
     expect(installSource).toContain("Signs in to cloud and runs doctor");
     expect(installSource).toContain("try.mosoo.ai");

--- a/apps/web/tests/document-title.test.ts
+++ b/apps/web/tests/document-title.test.ts
@@ -7,20 +7,20 @@ describe("document title", () => {
     expect(
       resolveDocumentTitle({
         activeAppName: "Default App",
-        activeOrganizationName: "Mosoo Org",
+        activeOrganizationName: "mosoo Org",
         pathname: "/integrations/skills",
       }),
-    ).toBe("Skills | Default App | Mosoo");
+    ).toBe("Skills | Default App | mosoo");
   });
 
   test("uses the current Organization name for Org-layer pages", () => {
     expect(
       resolveDocumentTitle({
         activeAppName: "Default App",
-        activeOrganizationName: "Mosoo Org",
+        activeOrganizationName: "mosoo Org",
         pathname: "/apps",
       }),
-    ).toBe("Apps | Mosoo Org | Mosoo");
+    ).toBe("Apps | mosoo Org | mosoo");
   });
 
   test("keeps unauthenticated routes scoped to the product", () => {
@@ -30,7 +30,7 @@ describe("document title", () => {
         activeOrganizationName: null,
         pathname: "/login",
       }),
-    ).toBe("Sign in | Mosoo");
+    ).toBe("Sign in | mosoo");
   });
 
   test("falls back to the active App before the product name for unknown App paths", () => {
@@ -40,6 +40,6 @@ describe("document title", () => {
         activeOrganizationName: null,
         pathname: "/unexpected",
       }),
-    ).toBe("Default App | Mosoo");
+    ).toBe("Default App | mosoo");
   });
 });

--- a/apps/web/tests/file-preview.test.ts
+++ b/apps/web/tests/file-preview.test.ts
@@ -24,10 +24,10 @@ describe("file preview", () => {
   });
 
   test("parses quoted CSV cells and line breaks", () => {
-    expect(parseDelimitedText('name,note\n"Mosoo, Inc.","line 1\nline 2"', ",")).toEqual({
+    expect(parseDelimitedText('name,note\n"mosoo, Inc.","line 1\nline 2"', ",")).toEqual({
       rows: [
         ["name", "note"],
-        ["Mosoo, Inc.", "line 1\nline 2"],
+        ["mosoo, Inc.", "line 1\nline 2"],
       ],
       truncated: false,
     });

--- a/apps/web/tests/runtime-default.test.ts
+++ b/apps/web/tests/runtime-default.test.ts
@@ -41,7 +41,7 @@ describe("default agent runtime", () => {
     });
   });
 
-  test("uses the Mosoo Zhipu provider identity when only Zhipu is configured", () => {
+  test("uses the mosoo Zhipu provider identity when only Zhipu is configured", () => {
     expect(resolveDefaultAgentRuntime([credential("zhipu")])).toEqual({
       model: "glm-4.7",
       provider: "zhipu",

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,8 +1,8 @@
-# Mosoo Spec
+# mosoo Spec
 
-Status: canonical product contract for the current Mosoo Alpha direction.
+Status: canonical product contract for the current mosoo Alpha direction.
 
-This document defines what Mosoo is building and the boundaries it guarantees. It supersedes older App-hosting, Deployable Repo, Release, Workspace, and Organization-governance language whenever they disagree. Current product notes and code remain the authority for what is shipped today.
+This document defines what mosoo is building and the boundaries it guarantees. It supersedes older App-hosting, Deployable Repo, Release, Workspace, and Organization-governance language whenever they disagree. Current product notes and code remain the authority for what is shipped today.
 
 This Spec is deliberately narrower than a general-purpose application platform. Exact API schemas, manifest fields, quotas, and internal topology belong in implementation contracts.
 
@@ -10,31 +10,31 @@ This Spec is deliberately narrower than a general-purpose application platform. 
 
 Coding agents are useful on a developer's machine. Turning one into a dependable product capability requires a runtime, isolated execution, durable work history, files, streaming events, provider credentials, permission handling, usage visibility, and an API that survives beyond one local session.
 
-Mosoo is an open-source runtime and control plane for configuring, running, and integrating coding agents. It normalizes OpenAI, Claude Agent SDK, and OpenCode execution behind one managed lifecycle while the Builder keeps ownership of the application, its business logic, and its end users.
+mosoo is an open-source runtime and control plane for configuring, running, and integrating coding agents. It normalizes OpenAI, Claude Agent SDK, and OpenCode execution behind one managed lifecycle while the Builder keeps ownership of the application, its business logic, and its end users.
 
 The product loop is:
 
 ```text
 Agent Manifest + Skills + MCP + provider credential
   -> Preview and publish an Agent version
-  -> call the Agent from a trusted backend or the Mosoo console
+  -> call the Agent from a trusted backend or the mosoo console
   -> isolated Run with streamed events and explicit permission requests
   -> durable Thread, files, outcomes, and usage records
 ```
 
-Mosoo's wedge is the managed coding-agent runtime and Agent API. It is not an AI app builder, a general workflow builder, an end-user identity service, or a promise to host an application's ordinary frontend and backend.
+mosoo's wedge is the managed coding-agent runtime and Agent API. It is not an AI app builder, a general workflow builder, an end-user identity service, or a promise to host an application's ordinary frontend and backend.
 
 ### Evidence status
 
 - The current repository implements normalized runtime adapters, isolated Sandbox execution, durable Threads, Runs, events, files, Agent versions, and an App-owner API.
 - Existing coding-agent tools solve local execution but leave product developers responsible for runtime integration and lifecycle infrastructure.
-- Mosoo has not yet proved production reliability, external adoption, or willingness to pay. Alpha validates the product hypothesis; it is not evidence of product-market fit.
+- mosoo has not yet proved production reliability, external adoption, or willingness to pay. Alpha validates the product hypothesis; it is not evidence of product-market fit.
 
 ## 2. Target User And Job
 
 ### Builder
 
-A Builder configures a coding Agent in Mosoo and integrates it into a product or automation. The Builder may be an independent developer, operator, or small internal-tools team, but is not expected to be an agent-runtime infrastructure specialist.
+A Builder configures a coding Agent in mosoo and integrates it into a product or automation. The Builder may be an independent developer, operator, or small internal-tools team, but is not expected to be an agent-runtime infrastructure specialist.
 
 The Builder's job is:
 
@@ -42,25 +42,25 @@ The Builder's job is:
 
 ### App Owner
 
-The App Owner is the Builder responsible for the Mosoo App and its Agents. In Alpha, one Mosoo Account owns an App. Team ownership, roles, invitations, and transfer are later extensions.
+The App Owner is the Builder responsible for the mosoo App and its Agents. In Alpha, one mosoo Account owns an App. Team ownership, roles, invitations, and transfer are later extensions.
 
 ### End User
 
-An End User may trigger Agent work through the Builder's product, but Mosoo does not represent or authenticate that person today. The Builder's trusted backend enforces end-user access and maps its users to Mosoo Threads.
+An End User may trigger Agent work through the Builder's product, but mosoo does not represent or authenticate that person today. The Builder's trusted backend enforces end-user access and maps its users to mosoo Threads.
 
-### Mosoo Account
+### mosoo Account
 
-A Mosoo Account authenticates the Builder to the Mosoo control plane. It is never reused as an End User identity. An Organization may remain an internal billing or tenancy shell, but it is not the business-user model of integrations.
+A mosoo Account authenticates the Builder to the mosoo control plane. It is never reused as an End User identity. An Organization may remain an internal billing or tenancy shell, but it is not the business-user model of integrations.
 
 ## 3. Design Principles
 
-1. **Mosoo owns Agent execution, not the Builder's application.** Product code, business state, and end-user access remain with the Builder.
+1. **mosoo owns Agent execution, not the Builder's application.** Product code, business state, and end-user access remain with the Builder.
 2. **One runtime contract spans supported agents.** Runtime-specific protocols are normalized before they reach product integrations.
 3. **The Agent Manifest is the reproducible configuration.** Runtime, model, instructions, Skills, MCP connections, and Environment resolve from saved configuration rather than a developer's laptop.
 4. **A Thread is the durable work boundary.** Messages, Runs, public events, and managed files remain addressable across individual executions.
 5. **A Run is one observable execution.** Console and API entry points produce the same lifecycle records.
 6. **Sandbox state is explicit.** Temporary execution state is not confused with durable Threads, files, Agent configuration, or bounded Assistant continuity.
-7. **The public API is backend-to-backend.** App-owner tokens stay on trusted servers; Mosoo does not claim App User authentication.
+7. **The public API is backend-to-backend.** App-owner tokens stay on trusted servers; mosoo does not claim App User authentication.
 8. **High-impact side effects are mediated.** Permission requests and confirmation gates are enforceable runtime boundaries, not prompt conventions.
 9. **Usage is observable, not billing truth.** Recorded model usage supports operational decisions without pretending to replace provider invoices.
 10. **Do not broaden the product to hide missing proof.** App hosting, broad provider matrices, channels, governance, and recovery become promises only after their user-visible paths are proven.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,15 +2,15 @@
 
 ## 1. Vision And Principles
 
-Mosoo provides an App-scoped control plane for configuring, publishing, running, and observing coding Agents through the console and Public Thread API.
+mosoo provides an App-scoped control plane for configuring, publishing, running, and observing coding Agents through the console and Public Thread API.
 
-The product boundary is managed Agent execution. Builders keep ownership of their application and end-user identity; Mosoo owns runtime adaptation, Sandbox lifecycle, durable Thread and Run records, managed files, credentials, events, and usage visibility. App Deployment is a separate Alpha surface and does not define the runtime or API contract. In the current construction phase, assume one human owns one Organization: Organization is the account / billing / tenant shell, and App is the code, data, product, and console boundary. App owns concrete resources directly; it does not introduce a generic Service entity, `services` table, or polymorphic `service.kind`. Additional operational controls are extension paths for the same architecture, not default complexity for the current community edition.
+The product boundary is managed Agent execution. Builders keep ownership of their application and end-user identity; mosoo owns runtime adaptation, Sandbox lifecycle, durable Thread and Run records, managed files, credentials, events, and usage visibility. App Deployment is a separate Alpha surface and does not define the runtime or API contract. In the current construction phase, assume one human owns one Organization: Organization is the account / billing / tenant shell, and App is the code, data, product, and console boundary. App owns concrete resources directly; it does not introduce a generic Service entity, `services` table, or polymorphic `service.kind`. Additional operational controls are extension paths for the same architecture, not default complexity for the current community edition.
 
 To support lightweight deployment, fast iteration, and future governance expansion, the architecture embraces Serverless and edge computing and follows these baseline principles:
 
 - **Vectorized API design**: Core business APIs, especially northbound GraphQL, internal Worker RPC, and data mutation surfaces, should accept arrays of target entity IDs by default where it is natural. This reduces network round trips and gives the data layer room for batch writes and deletes.
 - **Single ULID business identifier system**: The control plane, execution plane, internal RPC, and public APIs use server-generated ULIDs as canonical business and protocol identifiers. At persistence boundaries, ULIDs are stored and indexed as strings to preserve distributed generation performance and time-sortability.
-- **Observability native**: Mosoo emits Vestig structured logs and wide events, propagates W3C `traceparent` context across supported HTTP and Driver control boundaries, and enables Cloudflare Workers native logs and traces. Correlation is explicit at implemented boundaries; the architecture does not claim blanket OpenTelemetry instrumentation for database, queue, or Worker RPC calls.
+- **Observability native**: mosoo emits Vestig structured logs and wide events, propagates W3C `traceparent` context across supported HTTP and Driver control boundaries, and enables Cloudflare Workers native logs and traces. Correlation is explicit at implemented boundaries; the architecture does not claim blanket OpenTelemetry instrumentation for database, queue, or Worker RPC calls.
 - **Minimal Web / API / Driver topology**: The system is split by build and deployment boundary into three top-level planes: Web, API, and Driver.
 
 ---
@@ -29,7 +29,7 @@ The architecture is built on the Cloudflare platform and uses a Serverless shape
   as session artifacts. Sandbox private state backups use a separate backup
   bucket and must not be mixed with user-visible file prefixes.
 - **Execution sandbox: Cloudflare Sandbox / Containers**. Heterogeneous Agents run in container-image-backed isolated environments, with Sandbox APIs and Durable Object boundaries controlling runtime lifecycle.
-- **Secondary App deployment: Mosoo-managed Cloudflare Pages / Workers**. App Deployment clones and builds a public GitHub repository in an isolated Sandbox, then publishes the resulting Web artifact with Mosoo platform credentials. D1 stores the App-owned Deployment and DeploymentRun records, while the successful artifact receives a Mosoo-owned URL. This is an independent Alpha capability, not App runtime or part of the core Agent API promise.
+- **Secondary App deployment: mosoo-managed Cloudflare Pages / Workers**. App Deployment clones and builds a public GitHub repository in an isolated Sandbox, then publishes the resulting Web artifact with mosoo platform credentials. D1 stores the App-owned Deployment and DeploymentRun records, while the successful artifact receives a mosoo-owned URL. This is an independent Alpha capability, not App runtime or part of the core Agent API promise.
 - **Configuration editing**. Owner-side Agent configuration is currently edited through Preview, which combines the writable configuration form with in-context test chat. There is no dedicated `AgentBuilderSystemAgent` topology in the current codebase. Future configuration assistance must remain a control-plane feature and must not enter the full Sandbox / Driver runtime path.
 
 ---
@@ -91,7 +91,7 @@ graph TD
 
     FileBucket[(R2 FILE_BUCKET<br/>Session & internal file objects)]
     SandboxStateBucket[(R2 SANDBOX_STATE_BUCKET<br/>Sandbox State Objects)]
-    DeployedApp[Cloudflare Pages / Workers<br/>Mosoo-owned App URL]
+    DeployedApp[Cloudflare Pages / Workers<br/>mosoo-owned App URL]
 
     Client <==> |HTTPS: App Shell / Assets| WebWorker
     Client <==> |HTTPS: Same-Origin /api/*| Ingress
@@ -101,7 +101,7 @@ graph TD
     Runtime --> |Checkpoint / Restore selected Pet paths| SandboxStateBucket
     File --> |Session Snapshots / File Objects| FileBucket
     Deployment --> |Build public repository| CF_Sandbox
-    Deployment --> |Publish with Mosoo credentials| DeployedApp
+    Deployment --> |Publish with mosoo credentials| DeployedApp
 
     classDef web fill:#e3f2fd,stroke:#1565c0,stroke-width:2px;
     classDef api fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px;
@@ -139,7 +139,7 @@ Except for runtime boundaries such as Session Durable Objects and Sandbox instan
    - **Default App provisioning**: Onboarding / Organization provisioning creates a default App. If the Organization has exactly one App, the console routes directly into that App instead of forcing an App picker.
    - **Agent and resource ownership**: Agents, Threads / Sessions, Environments, Skills, MCP servers, Provider credentials, Channels, file records, Agent exposure state, App Deployments and DeploymentRuns, Agent runtime logs/state, and app-scoped cost are App-owned resources. The current UI keeps Agent logs/runtime operations on Agent detail and App Usage under App Settings; it does not expose a generic App health/log console.
    - **No generic Service entity**: Do not add a unified `services` table, polymorphic `service.kind`, or generic Service CRUD for concrete App resources. If a future Web/API runtime, database service, worker process, or scheduled job is needed, model it with an explicit noun and lifecycle.
-   - **App Deployment**: One active Deployment per App records the public GitHub source and its DeploymentRuns. Build and publish work is asynchronous. Successful runs expose a Mosoo-owned Cloudflare Pages or Workers URL under the configured App deployment domain. Users do not bring their own Cloudflare account in the current flow.
+   - **App Deployment**: One active Deployment per App records the public GitHub source and its DeploymentRuns. Build and publish work is asynchronous. Successful runs expose a mosoo-owned Cloudflare Pages or Workers URL under the configured App deployment domain. Users do not bring their own Cloudflare account in the current flow.
    - **Access boundary**: App access maps to the single Organization owner for this phase. No secondary principal model is part of the first cut.
 
 3. **Agent Plane**
@@ -174,7 +174,7 @@ Except for runtime boundaries such as Session Durable Objects and Sandbox instan
    - Login selects the account's Organization shell, then routes to the default App when the Organization has exactly one App. The system no longer maintains `account.origin_organization_id` or an "Origin Org for life" concept.
 
 7. **Auth Service**
-   - Authentication is built on Better Auth. Supported authentication methods are **Google OAuth** and **Email OTP**. Both can create or sign in to the same email-backed Account; Email OTP is the fallback when Google is unavailable. Mosoo has no password or password-recovery flow. Passkey (WebAuthn) is a planned future option but is not enabled in the current build.
+   - Authentication is built on Better Auth. Supported authentication methods are **Google OAuth** and **Email OTP**. Both can create or sign in to the same email-backed Account; Email OTP is the fallback when Google is unavailable. mosoo has no password or password-recovery flow. Passkey (WebAuthn) is a planned future option but is not enabled in the current build.
    - The same verified email across providers maps to the same Account.
    - CLI and other programmatic clients authenticate through a device authorization flow, not a separate login method. `POST /api/auth/cli/start` returns a `device_code`, a short `user_code`, and a `/cli-auth` verification URI; the user confirms inside an authenticated web session via `POST /api/auth/cli/confirm`, and the client polls `POST /api/auth/cli/token` until it receives a one-time `Bearer` token. The issued token is a Personal Access Token, so CLI access reuses the Account identity already established by Google OAuth or Email OTP rather than introducing a new credential type.
    - The current version does not support passwords, magic links, federated identity, directory sync, domain-based routing, or invite/request flows. Post-auth resolver logic outside the single-owner App path is not part of V1.
@@ -207,7 +207,7 @@ The **Agent Driver** is a top-level independently built execution component beca
      Driver protocol runtime, and not user-selectable. New provider integrations
      must add a real Driver backend and declare capabilities and gaps in Runtime
      Catalog before admission.
-   - **Boot configuration injection**: Runtime writes the complete boot payload to a private Sandbox file and passes the file path through `MOSOO_DRIVER_BOOT_PAYLOAD_FILE`. The payload carries `controlUrl`, a one-time boot token, `traceparent`, Driver identity, and the frozen execution spec. The Driver removes the file after reading it. Mosoo's runtime path does not send this configuration through standard input.
+   - **Boot configuration injection**: Runtime writes the complete boot payload to a private Sandbox file and passes the file path through `MOSOO_DRIVER_BOOT_PAYLOAD_FILE`. The payload carries `controlUrl`, a one-time boot token, `traceparent`, Driver identity, and the frozen execution spec. The Driver removes the file after reading it. mosoo's runtime path does not send this configuration through standard input.
    - **Control flow establishment**: The Driver does not listen on a sandbox-local control port. It actively opens an authenticated WebSocket to the payload's `controlUrl`, currently `/api/driver/socket`. The API Worker hands the upgrade to the `DriverConnection` binding, whose `DriverInstance` Durable Object owns the socket and ORPC command/event lifecycle. Runtime talks to that Durable Object for readiness, commands, status, and cleanup. Protocol v1 still carries a required `driverControlPort` field for legacy diagnostics, but neither side binds that port and new integrations must not depend on it; removal needs a versioned API/Driver rollout. Authentication, routing, App access checks, and asset boundaries remain in Worker / Runtime.
    - **Multi-Session isolation**: `AgentSession` is the product-level conversation boundary. Cloudflare Sandbox and container processes are execution resource boundaries. If multiple long-lived Driver / Agent processes in one Sandbox need stronger process, filesystem, or environment isolation, evaluate user-space container tooling such as `bubblewrap` inside the container for narrower per-session namespaces.
 

--- a/docs/for-human-prd.md
+++ b/docs/for-human-prd.md
@@ -1,11 +1,11 @@
 ---
 name: for-human-prd
-description: Mirror an existing Mosoo PRD into a high-readability for-human companion that preserves user intent while removing implementation detail. Use when a PRD needs a plain-language companion under `docs/prd/`, or when the user asks for a "for human" / "human-readable" PRD.
+description: Mirror an existing mosoo PRD into a high-readability for-human companion that preserves user intent while removing implementation detail. Use when a PRD needs a plain-language companion under `docs/prd/`, or when the user asks for a "for human" / "human-readable" PRD.
 ---
 
 # For-Human PRD Companion
 
-Turn an already-shaped Mosoo PRD into a readable companion for PMs, founders, designers, GTM teammates, and future reviewers.
+Turn an already-shaped mosoo PRD into a readable companion for PMs, founders, designers, GTM teammates, and future reviewers.
 
 This does not replace [`good-prd.md`](./good-prd.md). The full PRD remains the implementation contract; the for-human companion is the product story mirror.
 

--- a/docs/pm-reverse-interview.md
+++ b/docs/pm-reverse-interview.md
@@ -16,10 +16,10 @@ A PM handed an engineering-language question cannot make a product judgment; all
 
 ### 1.1 A Historical Anti-pattern: Q12
 
-> **Historical Q12 phrasing (not a current Mosoo contract)**: For the list of env var keys that affect PATH / auth (e.g. `OPENAI_API_KEY`), are they hard-coded by the platform or self-reported by the Driver? This determines the source of truth for deciding when a maintenance restart is triggered. The scope is a "field name → restart kind" mapping table in the Driver protocol layer, so the PRD does not need to choose the implementation owner. The product layer only needs to define which configuration changes interrupt the user's active work and what recovery they see.
+> **Historical Q12 phrasing (not a current mosoo contract)**: For the list of env var keys that affect PATH / auth (e.g. `OPENAI_API_KEY`), are they hard-coded by the platform or self-reported by the Driver? This determines the source of truth for deciding when a maintenance restart is triggered. The scope is a "field name → restart kind" mapping table in the Driver protocol layer, so the PRD does not need to choose the implementation owner. The product layer only needs to define which configuration changes interrupt the user's active work and what recovery they see.
 
 This example preserves the questioning mistake, not its old implementation
-details. Do not infer a runtime state-directory layout or a currently open Mosoo
+details. Do not infer a runtime state-directory layout or a currently open mosoo
 decision from it; those contracts must come from the current architecture and
 code.
 

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -4,7 +4,7 @@ These pages are short, code-checked product snapshots for non-engineers. Each
 one explains why a capability exists, what people can do today, and its visible
 limits. They are not implementation specifications.
 
-Read [Mosoo Spec](../SPEC.md) for the target product direction. When a product
+Read [mosoo Spec](../SPEC.md) for the target product direction. When a product
 note, the Spec, and current code disagree, do not guess: verify the behavior and
 update the stale note. Exact APIs, data shapes, and runtime topology belong in
 their machine-readable contracts, code, or [Architecture](../architecture.md).

--- a/docs/prd/agent-endpoint-mvp.md
+++ b/docs/prd/agent-endpoint-mvp.md
@@ -4,15 +4,15 @@ Status: shipped as a current integration surface.
 
 ## Purpose
 
-Builders can use an Agent configured in Mosoo inside an existing product or
+Builders can use an Agent configured in mosoo inside an existing product or
 automation. Publishing makes the Agent callable from the Builder's backend,
-while Mosoo handles execution, Threads, and files. The Builder does not need to
+while mosoo handles execution, Threads, and files. The Builder does not need to
 build and operate the Agent's execution system.
 
 ## Who it is for
 
-This surface is for a Mosoo App owner integrating their own backend. Current
-calls use an API token tied to the owner's Mosoo account. They cannot represent
+This surface is for a mosoo App owner integrating their own backend. Current
+calls use an API token tied to the owner's mosoo account. They cannot represent
 individual people using the Builder's product.
 
 ## How it works
@@ -23,7 +23,7 @@ individual people using the Builder's product.
 3. A backend can start a Thread with a message and optional files, follow up,
    observe results as they arrive, stop work, and manage the Thread and files.
 
-Mosoo runs the published Agent settings; callers cannot customize the Agent for
+mosoo runs the published Agent settings; callers cannot customize the Agent for
 individual requests. Re-publishing updates future Threads, while an existing
 Thread keeps the configuration it started with.
 

--- a/docs/prd/agent-manifest.md
+++ b/docs/prd/agent-manifest.md
@@ -1,16 +1,16 @@
 # Agent Manifest
 
-Status: available in the current Alpha console. The [Mosoo Spec](../SPEC.md) defines how this configuration fits the managed Agent runtime.
+Status: available in the current Alpha console. The [mosoo Spec](../SPEC.md) defines how this configuration fits the managed Agent runtime.
 
 ## What problem it solves
 
 An Agent needs a durable description of what it is and how it should behave. Without one, owners would have to manage each runtime's private files and remember which model, instructions, and integrations belong together.
 
-The Agent Manifest is that saved description. It gives Mosoo one user-readable source for configuring, testing, publishing, copying, and sharing an Agent. It is a product concept, not a file most users edit.
+The Agent Manifest is that saved description. It gives mosoo one user-readable source for configuring, testing, publishing, copying, and sharing an Agent. It is a product concept, not a file most users edit.
 
 ## Who uses it and how
 
-An App owner configures an Agent in Preview while testing it in the adjacent chat. The form covers identity and behavior—name, description, runtime, model, and system prompt—plus capabilities such as built-in tools, Skills, MCP servers, and an Environment. Mosoo shows setup problems; missing required dependencies prevent Preview or Publish until repaired.
+An App owner configures an Agent in Preview while testing it in the adjacent chat. The form covers identity and behavior—name, description, runtime, model, and system prompt—plus capabilities such as built-in tools, Skills, MCP servers, and an Environment. mosoo shows setup problems; missing required dependencies prevent Preview or Publish until repaired.
 
 Owners can also:
 
@@ -22,4 +22,4 @@ Owners can also:
 
 Sharing preserves portable configuration, not a complete running machine. Credentials and secret values do not travel. Skills may be included, while MCP servers and Environments may need to be reconnected or selected after import. Forking does not copy sessions, usage history, logs, login state, or live runtime state.
 
-The saved Manifest remains authoritative for Mosoo-managed updates. Changes made directly inside a Pet Agent's debug Terminal are not written back, and the current console does not compare or adopt that runtime state. Runtime-specific advanced settings are limited and are not portable between runtimes.
+The saved Manifest remains authoritative for mosoo-managed updates. Changes made directly inside a Pet Agent's debug Terminal are not written back, and the current console does not compare or adopt that runtime state. Runtime-specific advanced settings are limited and are not portable between runtimes.

--- a/docs/prd/agent-package-import-export-fork.md
+++ b/docs/prd/agent-package-import-export-fork.md
@@ -5,7 +5,7 @@ Status: available with limits.
 ## Why it exists
 
 App owners often need to reuse an Agent without rebuilding its setup or
-changing a working original. Mosoo lets them carry the portable parts of an
+changing a working original. mosoo lets them carry the portable parts of an
 Agent in a `.agent` file, or make a separate copy inside the same App.
 
 This is useful for moving a reusable setup between Apps, sharing it with
@@ -14,12 +14,12 @@ Agent intact.
 
 ## How to use it
 
-- **Export:** Open Agent settings and choose **Export agent**. Mosoo downloads a
+- **Export:** Open Agent settings and choose **Export agent**. mosoo downloads a
   `.agent` file.
 - **Import:** On the Agents page, choose **Import package** and select a
-  `.agent` file. Mosoo creates an editable draft in the selected App, reports
+  `.agent` file. mosoo creates an editable draft in the selected App, reports
   anything that needs attention, and lets the owner open the draft.
-- **Fork:** Open Agent settings and choose **Fork agent**. Mosoo creates a new
+- **Fork:** Open Agent settings and choose **Fork agent**. mosoo creates a new
   draft in the same App; the original Agent remains unchanged.
 
 ## Current limits
@@ -30,5 +30,5 @@ and packaged Skills can travel with it.
 A `.agent` file is not an App backup or a snapshot of a running Agent. It does
 not carry credentials, conversations, logs, usage history, or live runtime
 state. External connections must be reconnected, and imported Environment
-choices or secrets may need to be configured again. Mosoo shows known issues
+choices or secrets may need to be configured again. mosoo shows known issues
 after import or fork, but owners finish repairs in the normal Agent editor.

--- a/docs/prd/agent-service-identity.md
+++ b/docs/prd/agent-service-identity.md
@@ -4,7 +4,7 @@ Status: core behavior is shipped, with known console gaps.
 
 ## Why this exists
 
-A Builder can improve an Agent after people have started using it. Without a stable identity and saved versions, every edit could send users to a new Agent or silently change an existing conversation. Mosoo keeps the published Agent recognizable while separating its past and current behavior.
+A Builder can improve an Agent after people have started using it. Without a stable identity and saved versions, every edit could send users to a new Agent or silently change an existing conversation. mosoo keeps the published Agent recognizable while separating its past and current behavior.
 
 ## Who uses it
 

--- a/docs/prd/agent-session-api.md
+++ b/docs/prd/agent-session-api.md
@@ -1,21 +1,21 @@
 # Agent Work History
 
-Status: implemented foundation in Alpha and part of the managed runtime contract in the [Mosoo Spec](../SPEC.md).
+Status: implemented foundation in Alpha and part of the managed runtime contract in the [mosoo Spec](../SPEC.md).
 
 ## Why It Exists
 
-Agent work can begin in the Mosoo console or through a developer integration. Without one durable history, requests, follow-ups, results, and failures would be scattered across those entry points.
+Agent work can begin in the mosoo console or through a developer integration. Without one durable history, requests, follow-ups, results, and failures would be scattered across those entry points.
 
-Mosoo keeps each interaction as a record of work. This lets an App owner understand what happened, return later, and continue when appropriate without needing to understand the temporary execution environment behind the Agent.
+mosoo keeps each interaction as a record of work. This lets an App owner understand what happened, return later, and continue when appropriate without needing to understand the temporary execution environment behind the Agent.
 
 ## Who It Is For
 
-Builders and App owners use this history directly to start, monitor, and revisit Agent work. Developer integrations benefit from the same continuity without needing a Mosoo console account for every interaction.
+Builders and App owners use this history directly to start, monitor, and revisit Agent work. Developer integrations benefit from the same continuity without needing a mosoo console account for every interaction.
 
 ## Experience Today
 
 - In the console, an owner chooses a published Agent, describes the desired outcome, and may attach files.
-- Mosoo shows the request, Agent responses, work status, and available process or file activity.
+- mosoo shows the request, Agent responses, work status, and available process or file activity.
 - The owner can add a follow-up, archive completed work, or delete it.
 - A published Agent's developer integration can create, read, list, and continue work.
 
@@ -25,4 +25,4 @@ The current console still calls this history a **Thread** in several screens whi
 
 Each record belongs to one App and one Agent. The Agent version and settings selected when it starts remain attached to that history. Recorded messages and managed files are durable; temporary processes and unrecorded files are not.
 
-These paths exist in the current repository and have automated coverage, but Mosoo remains in Alpha. Production reliability and external adoption have not yet been proven. Channel delivery exists in code but is not currently a reachable end-to-end user feature; see [Channels](./channels.md).
+These paths exist in the current repository and have automated coverage, but mosoo remains in Alpha. Production reliability and external adoption have not yet been proven. Channel delivery exists in code but is not currently a reachable end-to-end user feature; see [Channels](./channels.md).

--- a/docs/prd/agent-terminal.md
+++ b/docs/prd/agent-terminal.md
@@ -15,7 +15,7 @@ Agent.
 
 ## How to use it
 
-Open an Assistant Agent in the Mosoo console and select **Terminal**. Mosoo shows the
+Open an Assistant Agent in the mosoo console and select **Terminal**. mosoo shows the
 connection status and offers a reconnect action. The first connection may take a few
 seconds while the Agent's environment wakes up.
 
@@ -28,5 +28,5 @@ changes through the Agent's normal configuration and publishing flows.
 - Only the Agent owner can open the Terminal.
 - Task Agents do not show it because their environments are temporary.
 - Terminal changes may disappear after an environment is reset, rebuilt, or replaced.
-- Mosoo does not promise a specific folder layout, source-code checkout, or set of
+- mosoo does not promise a specific folder layout, source-code checkout, or set of
   maintenance commands inside the Terminal.

--- a/docs/prd/agent-type.md
+++ b/docs/prd/agent-type.md
@@ -4,7 +4,7 @@ Status: available in the current Agent Preview flow.
 
 ## Why this matters
 
-Mosoo supports two Agent types because users need different kinds of continuity. Some Agents should feel like ongoing teammates; others should start each job cleanly so unrelated work does not share temporary state. The App owner chooses the type based on that user expectation, not on the model or provider.
+mosoo supports two Agent types because users need different kinds of continuity. Some Agents should feel like ongoing teammates; others should start each job cleanly so unrelated work does not share temporary state. The App owner chooses the type based on that user expectation, not on the model or provider.
 
 ## The two choices
 

--- a/docs/prd/app-boundary.md
+++ b/docs/prd/app-boundary.md
@@ -1,10 +1,10 @@
 # App Boundary
 
-Status: shipped resource and ownership boundary. [Mosoo Spec](../SPEC.md) defines the managed Agent runtime contract.
+Status: shipped resource and ownership boundary. [mosoo Spec](../SPEC.md) defines the managed Agent runtime contract.
 
 ## Problem
 
-Builders previously had to understand Mosoo through separate Agents and scattered resources. The App boundary gives them one place to see and operate the product they are building.
+Builders previously had to understand mosoo through separate Agents and scattered resources. The App boundary gives them one place to see and operate the product they are building.
 
 Runs, Agents, files, configuration, usage, and deployment stay attached to that App, so switching Apps does not blur ownership or context.
 
@@ -14,7 +14,7 @@ This experience serves a single Builder who owns and operates each App. The same
 
 ## User Flow
 
-After first sign-in, Mosoo creates a default App and opens it.
+After first sign-in, mosoo creates a default App and opens it.
 
 The Builder can create or switch Apps from the Apps page. Inside an App, they can review activity, manage Agents and files, configure supporting resources, and view App settings and usage.
 
@@ -30,6 +30,6 @@ The current deployment publishes a website while Agent operations remain a separ
 
 ## User-Visible Boundary
 
-An App is the Builder's product container in Mosoo. Its resources, activity, settings, usage, and deployed site are kept separate from other Apps.
+An App is the Builder's product container in mosoo. Its resources, activity, settings, usage, and deployed site are kept separate from other Apps.
 
 The baseline is single-owner and does not offer organization-wide catalogs or collaboration. Use the Spec for new runtime and integration promises.

--- a/docs/prd/app-deployment.md
+++ b/docs/prd/app-deployment.md
@@ -1,19 +1,19 @@
 # App Deployment
 
-Status: implemented secondary Alpha surface. It is not part of the core managed Agent runtime contract in the [Mosoo Spec](../SPEC.md).
+Status: implemented secondary Alpha surface. It is not part of the core managed Agent runtime contract in the [mosoo Spec](../SPEC.md).
 
 ## Why It Matters
 
-A Builder may want a simple way to share a supported website alongside a Mosoo Agent. App Deployment covers that secondary use case: publish a supported public repository to a Mosoo-managed URL and operate that site from the App Overview.
+A Builder may want a simple way to share a supported website alongside a mosoo Agent. App Deployment covers that secondary use case: publish a supported public repository to a mosoo-managed URL and operate that site from the App Overview.
 
 ## Who Uses It
 
-The Builder who owns the App controls deployment. App Users only encounter the resulting site; they do not see Mosoo's deployment controls. The current baseline supports one owner and one deployed site per App.
+The Builder who owns the App controls deployment. App Users only encounter the resulting site; they do not see mosoo's deployment controls. The current baseline supports one owner and one deployed site per App.
 
 ## User Flow
 
 1. From App Overview, the Builder enters a public GitHub repository and starts deployment.
-2. Mosoo uses the repository's default branch and checks whether the project is a supported static or request-handling web app. Unsupported or unclear projects fail with an explanation.
+2. mosoo uses the repository's default branch and checks whether the project is a supported static or request-handling web app. Unsupported or unclear projects fail with an explanation.
 3. Overview shows the attempt as **Deploying**, **Successful**, or **Failed**. After success, the Builder can open the live site and review earlier attempts.
 4. The Builder can publish the latest default branch again, change the source repository, or delete the deployment. A failed later attempt does not hide the last successful URL. Deletion removes the hosted site and its Agent access, but never changes the GitHub repository.
 
@@ -25,4 +25,4 @@ When a bound capability is accepted, the Run records the App, Agent, Deployment,
 
 The console flow, deployment processing, history, retry, and deletion are implemented. Repository evidence does not prove a successful real production deployment or recovery exercise, so the honest claim is **implemented**, not **production-proven**.
 
-App Deployment is not the canonical Mosoo product wedge. Today's baseline publishes one supported public repository to a Mosoo-owned URL. It does not itself provide App User authentication, durable backend state, schedules, recovery, private repositories, custom domains, branch previews, automatic deployment, or rollback.
+App Deployment is not the canonical mosoo product wedge. Today's baseline publishes one supported public repository to a mosoo-owned URL. It does not itself provide App User authentication, durable backend state, schedules, recovery, private repositories, custom domains, branch previews, automatic deployment, or rollback.

--- a/docs/prd/channels.md
+++ b/docs/prd/channels.md
@@ -8,7 +8,7 @@ no provider has a recorded live-account smoke test.
 
 App owners want a published Agent to answer people in the messaging tools they
 already use. External participants should be able to ask for help without
-creating a Mosoo account or leaving their current conversation.
+creating a mosoo account or leaving their current conversation.
 
 ## People
 
@@ -23,10 +23,10 @@ creating a Mosoo account or leaving their current conversation.
 2. The owner connects Slack, Lark / Feishu, Telegram, Discord, or personal
    WeChat and confirms which Agent should answer.
 3. An external participant sends a direct message or supported mention.
-4. Mosoo starts a new Agent conversation for a new external thread, or
+4. mosoo starts a new Agent conversation for a new external thread, or
    continues the existing conversation for a follow-up.
 5. The Agent's response returns to the same external thread. Disconnecting the
-   channel stops new messages while preserving existing Mosoo conversations.
+   channel stops new messages while preserving existing mosoo conversations.
 
 ## Current availability
 
@@ -42,4 +42,4 @@ creating a Mosoo account or leaving their current conversation.
   is still required for each provider.
 
 External participants remain external identities. They do not gain access to
-the App, the Mosoo console, or private Web conversations.
+the App, the mosoo console, or private Web conversations.

--- a/docs/prd/cost-dashboard.md
+++ b/docs/prd/cost-dashboard.md
@@ -21,9 +21,9 @@ The current user is the single owner of the selected App. App Users cannot see t
 
 ## Current availability and visible boundaries
 
-The shipped view uses model-call usage recorded by Mosoo. For recognized models, dollar amounts are estimates calculated from observed tokens and Mosoo's reference prices. For an unknown model, Mosoo may retain a reported USD amount; without one, usage remains visible and the model is marked for pricing attention, but the event contributes $0, so totals can be understated.
+The shipped view uses model-call usage recorded by mosoo. For recognized models, dollar amounts are estimates calculated from observed tokens and mosoo's reference prices. For an unknown model, mosoo may retain a reported USD amount; without one, usage remains visible and the model is marked for pricing attention, but the event contributes $0, so totals can be understated.
 
-This view is not a Provider invoice or a Mosoo charge. It does not reconcile taxes, credits, discounts, subscriptions, or infrastructure costs. **All** can include usage types that have no separate filter. On an Agent's Cost tab, the latest seven usage events are shown and currently are not limited by the selected time range. Budgets, alerts, invoices, and payment controls are not available here.
+This view is not a Provider invoice or a mosoo charge. It does not reconcile taxes, credits, discounts, subscriptions, or infrastructure costs. **All** can include usage types that have no separate filter. On an Agent's Cost tab, the latest seven usage events are shown and currently are not limited by the selected time range. Budgets, alerts, invoices, and payment controls are not available here.
 
 ## Historical ledger reconciliation
 
@@ -36,4 +36,4 @@ The API can audit model calls created before atomic model-call and usage-ledger 
 - Missing driver identity, usage metadata, published revision, or run context is reported as indeterminate instead of being inferred from mutable current state.
 - Calls created before the current raw-detail window, invalid stored usage values, and events that may already exist under a historical driver identity are also indeterminate; repair never normalizes or guesses through these states.
 
-Operators should begin with `audit`, inspect the structured `cost.ledger_reconciliation.page_completed` logs, enable `repair` only after reviewing those classifications, and unset the variable after the intended reconciliation run. This workflow repairs locally provable ledger gaps; it does not compare Mosoo estimates with a Provider invoice.
+Operators should begin with `audit`, inspect the structured `cost.ledger_reconciliation.page_completed` logs, enable `repair` only after reviewing those classifications, and unset the variable after the intended reconciliation run. This workflow repairs locally provable ledger gaps; it does not compare mosoo estimates with a Provider invoice.

--- a/docs/prd/credentials.md
+++ b/docs/prd/credentials.md
@@ -15,7 +15,7 @@ The App owner manages credentials. Agents in that same App may use them when the
 1. Open the active App's Providers or MCP servers page.
 2. Add the provider key or authorize the MCP connection. Provider keys can be named, edited, tested, chosen as the default, and deleted. MCP connections can be connected, revoked, disabled, edited, and deleted.
 3. Select the provider and model or MCP connection while configuring an Agent.
-4. Run the Agent. Mosoo supplies only a matching credential from that App. If none exists, or ownership does not match, setup or the run stops with a configuration error instead of using another App's secret.
+4. Run the Agent. mosoo supplies only a matching credential from that App. If none exists, or ownership does not match, setup or the run stops with a configuration error instead of using another App's secret.
 5. When moving an Agent package to another App, reconnect credentials there; packages do not carry secrets.
 
 ## Current Availability and Boundaries

--- a/docs/prd/default-consumption-surface.md
+++ b/docs/prd/default-consumption-surface.md
@@ -1,10 +1,10 @@
 # Runs and Threads
 
-Status: available in the current Mosoo web console as the human-facing view of managed Agent work.
+Status: available in the current mosoo web console as the human-facing view of managed Agent work.
 
 ## Product value
 
-Runs is Mosoo's built-in task inbox. It lets an App owner send meaningful work to an Agent, leave while it runs, then return to review or continue it without connecting another channel.
+Runs is mosoo's built-in task inbox. It lets an App owner send meaningful work to an Agent, leave while it runs, then return to review or continue it without connecting another channel.
 
 The sidebar entry is **Runs**. Inside that surface, each task is a **Thread**: the page title is **Threads**, creation says **New thread**, and detail views keep the Thread name. A Thread can contain another execution when the user follows up.
 

--- a/docs/prd/environment.md
+++ b/docs/prd/environment.md
@@ -14,8 +14,8 @@ The App owner creates and manages Environments for Agents in one App. App Users 
 
 1. On the Environments page, the owner creates a reusable setup with packages, a startup script, and environment variables.
 2. The owner can make one Environment the App default. In the Agent editor, they can select another Environment or create one without leaving the flow.
-3. When a new Session is created, Mosoo captures the Environment selected at that moment. If the Agent has no explicit selection, Mosoo uses the App default.
-4. Mosoo prepares exact-version npm and PyPI packages once, stores the isolated dependency prefix as a Sandbox Backup, and restores it before the Agent starts. The custom setup script then runs with those package paths available. A package build, restore, script, or required variable failure prevents startup rather than running with an incomplete setup.
+3. When a new Session is created, mosoo captures the Environment selected at that moment. If the Agent has no explicit selection, mosoo uses the App default.
+4. mosoo prepares exact-version npm and PyPI packages once, stores the isolated dependency prefix as a Sandbox Backup, and restores it before the Agent starts. The custom setup script then runs with those package paths available. A package build, restore, script, or required variable failure prevents startup rather than running with an incomplete setup.
 5. Later Environment edits apply only to Sessions created afterward; an in-progress Session keeps the version it started with.
 
 ## What works today
@@ -24,7 +24,7 @@ The Web UI supports listing, searching, creating, editing, setting a default, an
 
 Secret values are encrypted after saving. The editor shows only a masked hint for an existing value, never the full stored value; leaving it blank preserves it.
 
-Package declarations accept public npm and PyPI packages with exact versions. They are prepared asynchronously and reused within the same App when the declarations and artifact ABI are unchanged. A Session freezes its package declarations, so later Environment edits do not change an existing Session. Package managers never run on the Task provisioning hot path, and Mosoo does not fall back to runtime installation when an artifact is unavailable.
+Package declarations accept public npm and PyPI packages with exact versions. They are prepared asynchronously and reused within the same App when the declarations and artifact ABI are unchanged. A Session freezes its package declarations, so later Environment edits do not change an existing Session. Package managers never run on the Task provisioning hot path, and mosoo does not fall back to runtime installation when an artifact is unavailable.
 
 npm artifacts expose package CLIs through `PATH` and CommonJS packages through `NODE_PATH`. Node.js ESM bare imports do not use `NODE_PATH`; projects that need `import "package"` must install that dependency in the project itself. PyPI artifacts expose console scripts through `PATH` and modules through `PYTHONPATH`.
 

--- a/docs/prd/files-api-contract.md
+++ b/docs/prd/files-api-contract.md
@@ -2,7 +2,7 @@
 
 Status: product behavior now lives in [Thread Files](./session-files.md).
 
-This page remains only to keep old links useful. Mosoo currently treats durable
+This page remains only to keep old links useful. mosoo currently treats durable
 files as Thread attachments or recorded Agent artifacts, not as a general App
 file library. Read **Thread Files** for the user flow, availability, deletion
 behavior, and current limits. Exact public request shapes belong in the API

--- a/docs/prd/mcp-interaction.md
+++ b/docs/prd/mcp-interaction.md
@@ -4,7 +4,7 @@ Status: available in the console for App-owned remote MCP servers and Agent use.
 
 ## Why It Matters
 
-Mosoo Agents become more useful when they can act in products such as GitHub, Linear, or a Builder's own server. An App owner should connect once, share it with selected Agents, and keep credentials out of Agent configuration.
+mosoo Agents become more useful when they can act in products such as GitHub, Linear, or a Builder's own server. An App owner should connect once, share it with selected Agents, and keep credentials out of Agent configuration.
 
 ## Who It Is For
 
@@ -22,6 +22,6 @@ The Builder who owns an App configures MCP. App Users benefit when an Agent uses
 
 The complete add-to-use path is available for remote HTTPS MCP servers. Binding before authorization is allowed, but does not make tools usable.
 
-“Connected” means Mosoo has an active stored credential; it does not prove the server or its tools work. There is no standalone connection test or tool browser, so failures appear when an Agent first uses the server.
+“Connected” means mosoo has an active stored credential; it does not prove the server or its tools work. There is no standalone connection test or tool browser, so failures appear when an Agent first uses the server.
 
-Credentials are encrypted, are never shown again after entry, and stay inside their App. Mosoo gives Agents temporary, connection-specific access rather than revealing the stored secret. Exporting or forking an Agent does not carry credentials; the destination App must reconnect. Local-process servers, cross-App sharing, a connector marketplace, and tool-level selection are not available.
+Credentials are encrypted, are never shown again after entry, and stay inside their App. mosoo gives Agents temporary, connection-specific access rather than revealing the stored secret. Exporting or forking an Agent does not carry credentials; the destination App must reconnect. Local-process servers, cross-App sharing, a connector marketplace, and tool-level selection are not available.

--- a/docs/prd/public-task-api.md
+++ b/docs/prd/public-task-api.md
@@ -2,5 +2,5 @@
 
 Status: superseded.
 
-Mosoo no longer has a public Task API.
+mosoo no longer has a public Task API.
 Use [Public Thread API Surface](./public-thread-api-surface.md) instead.

--- a/docs/prd/public-thread-api-surface.md
+++ b/docs/prd/public-thread-api-surface.md
@@ -6,7 +6,7 @@ exact HTTP contract is the
 
 ## Why it exists
 
-Builders need to use a Mosoo Agent from their own product without learning how
+Builders need to use a mosoo Agent from their own product without learning how
 it runs. The Public Thread API makes each conversation or job a durable Thread
 that an integration can start, follow, continue, and recover.
 
@@ -14,7 +14,7 @@ that an integration can start, follow, continue, and recover.
 
 - An App owner connects an exposed Agent to a server-side integration.
 - An App user may trigger that integration, but does not authenticate directly
-  with Mosoo today.
+  with mosoo today.
 
 ## User flow
 
@@ -35,8 +35,8 @@ Agent's API Access panel shows its identifier, token creation, and API reference
 
 - Access Tokens belong to the App owner. The Agent must be exposed, owned by
   that same owner, and remain inside the same App.
-- Mosoo does not yet represent the integration's end users. Every public Thread
-  is attributed to the App owner's Mosoo account, so the integration must
+- mosoo does not yet represent the integration's end users. Every public Thread
+  is attributed to the App owner's mosoo account, so the integration must
   enforce end-user access and maintain its own user-to-Thread mapping.
 - Tokens are backend secrets and are not suitable for browser or mobile clients
   that cannot keep them private.

--- a/docs/prd/runtime-catalog.md
+++ b/docs/prd/runtime-catalog.md
@@ -1,10 +1,10 @@
 # Runtime Choice
 
-Status: current core runtime surface under the canonical [Mosoo Spec](../SPEC.md).
+Status: current core runtime surface under the canonical [mosoo Spec](../SPEC.md).
 
 ## Value
 
-Mosoo lets a Builder run an Agent Workload without learning how each model provider starts or operates it. Runtime choice exists to make supported workloads launch reliably; it is not a marketplace.
+mosoo lets a Builder run an Agent Workload without learning how each model provider starts or operates it. Runtime choice exists to make supported workloads launch reliably; it is not a marketplace.
 
 ## Users and problem
 

--- a/docs/prd/runtime-session-kernel.md
+++ b/docs/prd/runtime-session-kernel.md
@@ -4,7 +4,7 @@ Status: available in the current Preview experience, with the limits below.
 
 ## Why this matters
 
-An Agent configuration is useful only when a Builder can prove that it works. Mosoo should make that proof quick and understandable: show whether the Agent is ready, stream real work, and distinguish a setup problem from an interrupted execution without requiring infrastructure knowledge.
+An Agent configuration is useful only when a Builder can prove that it works. mosoo should make that proof quick and understandable: show whether the Agent is ready, stream real work, and distinguish a setup problem from an interrupted execution without requiring infrastructure knowledge.
 
 ## Who uses it
 
@@ -19,7 +19,7 @@ Builders and App Owners are the primary users. They configure and test an App's 
 
 ## Current availability
 
-Preview runs real sessions for the runtime choices currently offered by Mosoo; it is not a mock chat. The shipped surface covers readiness blockers, streaming responses, tool activity, cancellation, stopped sessions, and diagnostics. Live success still depends on valid setup and an available provider.
+Preview runs real sessions for the runtime choices currently offered by mosoo; it is not a mock chat. The shipped surface covers readiness blockers, streaming responses, tool activity, cancellation, stopped sessions, and diagnostics. Live success still depends on valid setup and an available provider.
 
 ## User-visible boundaries
 

--- a/docs/prd/runtime-state-operations.md
+++ b/docs/prd/runtime-state-operations.md
@@ -4,12 +4,12 @@ Status: Apply Changes and Reset agent-state are available in the web console. Hi
 
 ## Why This Matters
 
-Builders need to improve a live Agent without guessing whether conversations will change or work will be lost. Mosoo separates routine saves, interruption, sandbox replacement, and destructive recovery so risk is visible before action.
+Builders need to improve a live Agent without guessing whether conversations will change or work will be lost. mosoo separates routine saves, interruption, sandbox replacement, and destructive recovery so risk is visible before action.
 
 ## Current User Flow
 
 - Edits that need no Assistant runtime action save automatically. Existing conversations keep their original settings; new conversations use the saved settings.
-- For a published Assistant Agent, runtime-impacting edits show **Apply changes** in Preview. Confirmation explains whether Mosoo will restart the Agent process or recreate the sandbox. Either action can cancel running work.
+- For a published Assistant Agent, runtime-impacting edits show **Apply changes** in Preview. Confirmation explains whether mosoo will restart the Agent process or recreate the sandbox. Either action can cancel running work.
 - Restart keeps the current sandbox and stops the current Agent process. It starts again on later use.
 - Recreate first checkpoints long-term memory and eligible, non-terminated conversation workspaces, then removes the sandbox. Recovery occurs when the Agent is next used. A failed checkpoint prevents removal of the old sandbox.
 - **Reset agent-state** appears only for Assistant Agents under Settings > Danger zone. The Builder must type the Agent name to confirm.
@@ -19,4 +19,4 @@ Builders need to improve a live Agent without guessing whether conversations wil
 
 Reset is irreversible once clearing begins. It removes long-term memory, per-conversation runtime state, and stored vendor resume references for affected conversations, then destroys the sandbox, including local logins, caches, installed packages, and other files outside eligible checkpointed conversation workspaces. Agent settings, Skills, connected tools and credentials, explicit conversation files, transcripts, logs, and cost history remain. If Reset fails after clearing starts, some state may already be gone.
 
-There is no Hibernate button. Mosoo may automatically recycle an idle Assistant sandbox using the same checkpoint boundary as Recreate. Task Agent sandboxes are temporary and are recycled after each run without Assistant-style runtime-state continuity.
+There is no Hibernate button. mosoo may automatically recycle an idle Assistant sandbox using the same checkpoint boundary as Recreate. Task Agent sandboxes are temporary and are recycled after each run without Assistant-style runtime-state continuity.

--- a/docs/prd/session-files.md
+++ b/docs/prd/session-files.md
@@ -20,9 +20,9 @@ saved.
 1. A Builder attaches files while starting a Thread or from an Agent session
    chat. An integration can attach a file when starting a Thread or sending a
    later message.
-2. An attachment belongs to that Thread. Mosoo only promises to give the Agent
+2. An attachment belongs to that Thread. mosoo only promises to give the Agent
    files explicitly selected for the current message.
-3. Outputs that Mosoo records from the Agent appear as artifacts in the same
+3. Outputs that mosoo records from the Agent appear as artifacts in the same
    Thread. When an Agent reply links to a recorded `outputs/` file, selecting
    that link opens the artifact in a Thread preview drawer with a download
    action.

--- a/docs/prd/session-lifecycle.md
+++ b/docs/prd/session-lifecycle.md
@@ -20,7 +20,7 @@ they create or continue work for an end user.
    that already happened.
 3. When an attempt completes or fails, the conversation and saved files remain readable. The
    user can send a follow-up. Preview offers retry actions for some provider checks and send
-   failures. After an unexpected runtime loss, Mosoo reports the failure but does not
+   failures. After an unexpected runtime loss, mosoo reports the failure but does not
    automatically replay the request; the user must deliberately resend it.
 4. **Archive** moves the Thread out of active work. Its history and saved files stay readable,
    but messages and file changes are blocked. In the Console, sending a follow-up restores the

--- a/docs/prd/session-log.md
+++ b/docs/prd/session-log.md
@@ -1,6 +1,6 @@
 # Session Log
 
-Status: available in the current Mosoo console under each Agent's Logs tab.
+Status: available in the current mosoo console under each Agent's Logs tab.
 
 ## Why it matters
 

--- a/docs/prd/skill-interaction.md
+++ b/docs/prd/skill-interaction.md
@@ -9,7 +9,7 @@ A Skill lets a Builder reuse trusted instructions and supporting files across Ag
 ## Current user flow
 
 1. Open **Skills** in the active App.
-2. Choose **Add skill**. Upload a `.md`, `.zip`, or `.skill` file, or import from GitHub or skills.sh. Mosoo previews the name, description, and author before adding it.
+2. Choose **Add skill**. Upload a `.md`, `.zip`, or `.skill` file, or import from GitHub or skills.sh. mosoo previews the name, description, and author before adding it.
 3. Open a Skill card to read its main instructions. From this view, the owner can download, fork, or uninstall it.
 4. Open an Agent, add one or more Skills from that App, and save the Agent.
 5. When a new Session starts, its attached Skills become available to the Agent. The Agent reads a Skill only when the task calls for it.

--- a/e2e/lib/runtime-progress.ts
+++ b/e2e/lib/runtime-progress.ts
@@ -123,7 +123,7 @@ export function assertRuntimeSignalCoverage(
         options.fix ??
         "Attach `createRuntimeSignalCollector(...).attachToPage(page)` before navigation, add feature checkpoints / resource samples, or record a live-smoke-only gap in the PR / handoff evidence.",
       what: `Runtime signal collection is missing required coverage: ${summary.missingCategories.join(", ")}.`,
-      why: "Lecture 11 and the Mosoo harness contract require the harness to collect lifecycle, feature path, data flow, resource utilization, and error context signals instead of relying on agent-written logs.",
+      why: "Lecture 11 and the mosoo harness contract require the harness to collect lifecycle, feature path, data flow, resource utilization, and error context signals instead of relying on agent-written logs.",
     }),
   );
 }

--- a/examples/use-cases/codex-pet.md
+++ b/examples/use-cases/codex-pet.md
@@ -1,8 +1,8 @@
 # Codex Pet — Agent as API
 
-Codex Pet shows how a workflow built in a coding IDE can become a reusable Mosoo-managed Agent exposed through an API.
+Codex Pet shows how a workflow built in a coding IDE can become a reusable mosoo-managed Agent exposed through an API.
 
-A builder publishes a Pet Agent with an avatar-generation skill, then copies its generated **Instruction for LLM** into Codex. Codex uses that instruction to integrate the Mosoo Thread API into an existing product backend. The finished app accepts one avatar and returns a validated ZIP containing all nine Codex Pet animation states.
+A builder publishes a Pet Agent with an avatar-generation skill, then copies its generated **Instruction for LLM** into Codex. Codex uses that instruction to integrate the mosoo Thread API into an existing product backend. The finished app accepts one avatar and returns a validated ZIP containing all nine Codex Pet animation states.
 
 ```text
 publish Agent -> copy Instruction for LLM -> integrate from Codex

--- a/pkgs/contracts/src/http/public-api-openapi.contract.ts
+++ b/pkgs/contracts/src/http/public-api-openapi.contract.ts
@@ -334,7 +334,7 @@ export const PUBLIC_API_OPENAPI_SCHEMAS = {
     properties: {
       client_external_ref: {
         description:
-          "Optional caller-owned reference (for example an external ticket key) stored on the Thread for correlation. Not unique and not validated by Mosoo.",
+          "Optional caller-owned reference (for example an external ticket key) stored on the Thread for correlation. Not unique and not validated by mosoo.",
         maxLength: PUBLIC_THREAD_CLIENT_EXTERNAL_REF_MAX_LENGTH,
         type: "string",
       },

--- a/pkgs/public-api-client/src/index.ts
+++ b/pkgs/public-api-client/src/index.ts
@@ -822,7 +822,7 @@ export class MosooPublicThreadClient {
     throw new MosooPublicApiError({
       body,
       code: payload.code,
-      message: payload.message ?? `Mosoo Public API request failed with HTTP ${response.status}.`,
+      message: payload.message ?? `mosoo Public API request failed with HTTP ${response.status}.`,
       status: response.status,
     });
   }

--- a/pkgs/runtime-catalog/catalog/runtime-catalog.jsonc
+++ b/pkgs/runtime-catalog/catalog/runtime-catalog.jsonc
@@ -1,5 +1,5 @@
 {
-  // Hand-authored source of truth for Mosoo runtime, provider, model, and runtime-display
+  // Hand-authored source of truth for mosoo runtime, provider, model, and runtime-display
   // metadata. Do not edit src/catalog.generated.ts directly; regenerate it from this file.
   "modelDefaults": {
     "anthropic": "claude-sonnet-5",

--- a/pkgs/runtime-catalog/src/runtime-advanced-settings.ts
+++ b/pkgs/runtime-catalog/src/runtime-advanced-settings.ts
@@ -292,7 +292,7 @@ export function validateRuntimeAdvancedSettings(input: {
           ? {
               code: "runtime_settings_security_boundary",
               key,
-              message: `Runtime setting ${key} is managed by Mosoo platform policy and cannot be set here.`,
+              message: `Runtime setting ${key} is managed by mosoo platform policy and cannot be set here.`,
             }
           : {
               code: "runtime_settings_unsupported",

--- a/pkgs/runtime-catalog/src/runtime-catalog.ts
+++ b/pkgs/runtime-catalog/src/runtime-catalog.ts
@@ -69,7 +69,7 @@ export interface RuntimeCatalogOpenCodeProvider {
   readonly name: string;
   readonly npmPackage: string;
   /**
-   * Provider id expected by OpenCode for this adapter. Mosoo keeps its own
+   * Provider id expected by OpenCode for this adapter. mosoo keeps its own
    * product-facing provider id in `vendorId`; this field is only for rendered
    * OpenCode config/model ids when upstream uses a different provider key.
    */

--- a/pkgs/runtime-catalog/tests/runtime-model-identity-admission.test.ts
+++ b/pkgs/runtime-catalog/tests/runtime-model-identity-admission.test.ts
@@ -292,7 +292,7 @@ describe("runtime catalog identity admission", () => {
     expect(getRuntimeDisplayColor("openai-runtime")).toBe("#7A9DFF");
   });
 
-  test("keeps Mosoo Zhipu identity while rendering OpenCode with the Z.ai provider id", () => {
+  test("keeps mosoo Zhipu identity while rendering OpenCode with the Z.ai provider id", () => {
     expect(VENDOR_ZHIPU.vendorId).toBe("zhipu");
     expect(VENDOR_ZHIPU.modelSource).toMatchObject({
       kind: "models.dev",


### PR DESCRIPTION
## Summary

- Mechanically replace every standalone-word `Mosoo` brand mention with all-lowercase `mosoo` (233 replacements across 97 files: docs, web UI strings, OpenAPI descriptions, error messages, comments).
- `MOSOO_*` environment variables / constants and `Mosoo`-prefixed code identifiers (e.g. `MosooCustomEvent`) are intentionally unchanged — they are naming-convention identifiers, not brand exposure.

## Why

- Brand style: the product name is written all-lowercase (`mosoo`) wherever it is displayed or mentioned (internal tracker YEF-879).

## Verification

- Commands: `vp run -w tc` (pass, 18 tasks), `vp run -w test` (pass, 16 tasks), `bun scripts/check-doc-links.ts` (pass, 42 files)
- Manual steps: confirmed zero standalone `Mosoo` occurrences remain; the only remaining non-lowercase forms are `MOSOO_*` env vars and `Mosoo`-prefixed identifiers.
- Not run: deploy checks (N/A)

## Impact

- User/API/contract changes: user-visible copy now renders the brand as `mosoo` (web app product name, OpenAPI/description strings, docs). No route, schema, or behavior changes.
- Generated files / GraphQL / DB / lockfile: OpenAPI/GraphQL codegen re-run reproduces the committed content exactly; no lockfile changes.
- Env or config changes: none (`MOSOO_*` env vars untouched).
- Risk and rollback: text-casing-only change; revert the single commit to roll back.

## Review

- Closest review areas: public API OpenAPI description strings, web app UI strings.
- Known trade-offs: sentence-initial `mosoo` is intentional per the all-lowercase brand rule. Downstream snapshot repos (mosoo-docs, mosoo-website) have matching PRs; merge this one first so their scheduled OpenAPI syncs pull lowercased text.
