### PR TITLE
feat(docker): add production deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Runtime state and generated secrets
+/data/
+apps/api/.dev.vars
+apps/api/.wrangler/
+
+# Local dependencies and build outputs
+node_modules/
+**/node_modules/
+**/dist/
+**/.tmp/
+.tmp/
+
+# Source control and local tooling
+.git/
+.github/
+.hermes/
+.idea/
+.vscode/
+.dockerignore
+Dockerfile
+docs/
+examples/
+README.md
+CONTRIBUTING.md
+compose.yaml
+
+# Test and local artifacts
+coverage/
+playwright-report/
+test-results/
+**/tests/
+*.log
+*.eml
+
+# Local environment files
+.env
+.env.*

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,108 @@
+name: Container Image
+
+on:
+  pull_request:
+    paths:
+      - .dockerignore
+      - .github/workflows/container-image.yml
+      - Dockerfile
+      - compose.yaml
+      - config/**
+      - docker/**
+      - package.json
+      - bun.lock
+      - apps/**
+      - pkgs/**
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build linux/amd64 and linux/arm64
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 1
+          submodules: true
+          persist-credentials: false
+
+      - name: Validate Compose configuration
+        run: docker compose --env-file docker/.env.example config --quiet
+
+      - name: Validate Caddy configuration
+        run: |
+          docker run --rm \
+            --env MOSOO_WEB_BIND_IP=127.0.0.1 \
+            --env MOSOO_WEB_PORT=8080 \
+            --volume "$PWD/docker:/etc/mosoo-caddy:ro" \
+            caddy:2.10.2-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d \
+            caddy validate --config /etc/mosoo-caddy/Caddyfile --adapter caddyfile
+          docker run --rm \
+            --env MOSOO_RUNTIME_BIND_IP=172.17.0.1 \
+            --env MOSOO_RUNTIME_CONTROL_PORT=8787 \
+            --env WRANGLER_DEV_PORT=8788 \
+            --volume "$PWD/docker:/etc/mosoo-caddy:ro" \
+            caddy:2.10.2-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d \
+            caddy validate --config /etc/mosoo-caddy/runtime-gateway.Caddyfile --adapter caddyfile
+
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=auto
+          tags: |
+            type=raw,value=edge,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+
+      - name: Build and publish image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            VCS_REF=${{ github.sha }}
+          cache-from: type=gha,scope=mosoo-container
+          cache-to: type=gha,mode=max,scope=mosoo-container
+          provenance: mode=max
+          sbom: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+# syntax=docker/dockerfile:1.7
+
+ARG BUN_IMAGE=oven/bun:canary@sha256:b33cef99f3aca8cdeeedc4dcb71773422abe6cff9972846114b8adf10e8e2233
+ARG NODE_IMAGE=node:22-bookworm-slim@sha256:6c74791e557ce11fc957704f6d4fe134a7bc8d6f5ca4403205b2966bd488f6b3
+ARG DOCKER_CLI_IMAGE=docker:29-cli@sha256:be132a9f282288de4afaf63379dff75711fda0147c6b72a9df44e51841402144
+ARG CADDY_IMAGE=caddy:2.10.2-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d
+
+FROM ${NODE_IMAGE} AS node-runtime
+FROM ${DOCKER_CLI_IMAGE} AS docker-cli
+FROM ${CADDY_IMAGE} AS caddy
+
+FROM ${BUN_IMAGE} AS build
+WORKDIR /app
+
+COPY . .
+RUN bun install --frozen-lockfile && bun run build
+
+FROM ${BUN_IMAGE} AS runtime
+ARG BUILD_DATE
+ARG VERSION=dev
+ARG VCS_REF
+
+LABEL org.opencontainers.image.title="Mosoo" \
+      org.opencontainers.image.description="Self-hosted Mosoo agent runtime" \
+      org.opencontainers.image.source="https://github.com/langgenius/mosoo" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+# The base image pins the Debian repository snapshot; package revisions vary by architecture.
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates curl tini \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=node-runtime /usr/local/bin/node /opt/node/bin/node
+ENV PATH="/opt/node/bin:${PATH}"
+COPY . .
+RUN --mount=type=cache,id=mosoo-bun-runtime-cache,target=/root/.bun/install/cache,from=build,source=/root/.bun/install/cache,sharing=locked \
+    bun install --frozen-lockfile --filter @mosoo/api --filter agent-driver \
+    && test -x /app/apps/api/node_modules/.bin/wrangler \
+    && node --version \
+    && bun --version
+COPY --from=build /app/apps/driver/dist /app/apps/driver/dist
+COPY --from=build /app/apps/web/dist /app/apps/web/dist
+COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
+COPY --from=docker-cli /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
+COPY --from=caddy /usr/bin/caddy /usr/local/bin/caddy
+
+ENV MOSOO_DATA_DIR=/data \
+    MOSOO_API_DEV_DOCKER_HOST=unix:///var/run/docker.sock \
+    MOSOO_API_DEV_USE_DEFAULT_DOCKER=1 \
+    MOSOO_RUNTIME_CONTROL_ORIGIN=http://172.17.0.1:8787 \
+    MOSOO_WEB_BIND_IP=127.0.0.1 \
+    MOSOO_WEB_PORT=8080 \
+    WRANGLER_DEV_IP=127.0.0.1 \
+    WRANGLER_DEV_PORT=8788 \
+    WEB_ORIGIN=http://localhost:8080
+
+VOLUME ["/data", "/app/apps/api/.wrangler"]
+EXPOSE 8080
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10m --retries=5 \
+  CMD web_host="${MOSOO_WEB_BIND_IP:-127.0.0.1}"; \
+  case "${web_host}" in \
+    "0.0.0.0") web_host="127.0.0.1" ;; \
+    "::") web_host="[::1]" ;; \
+    *:*) web_host="[${web_host}]" ;; \
+  esac; \
+  curl --fail --silent --show-error --max-time 4 "http://${web_host}:${MOSOO_WEB_PORT:-8080}/api/health"
+
+ENTRYPOINT ["/usr/bin/tini", "--", "bun", "/app/docker/entrypoint.ts"]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,25 @@ Product and engineering references:
 
 https://github.com/user-attachments/assets/4a4bbaab-c192-4462-99e0-020eab966fff
 
+## Docker Deployment
+
+The supported Compose deployment targets a dedicated **Linux Docker host**. Mosoo uses the host network namespace so Workerd can publish Sandbox listeners on Docker's bridge gateway; the control-plane API itself remains loopback-only.
+
+```bash
+install -m 600 docker/.env.example .env
+# For remote access, set WEB_ORIGIN to the public browser origin and
+# MOSOO_WEB_BIND_IP to the host address that should accept traffic.
+docker compose pull
+docker compose up -d --wait
+curl --fail http://127.0.0.1:8080/api/health
+```
+
+The safe default listens only on `127.0.0.1`. Startup fails closed if a loopback `WEB_ORIGIN` is combined with a non-loopback listener, because that combination would expose Mosoo's local-development login endpoint. Put TLS and public access behind a trusted host-level reverse proxy, or set both values explicitly for direct exposure.
+
+If Docker's bridge gateway is not `172.17.0.1`, update `MOSOO_RUNTIME_BIND_IP` and `MOSOO_RUNTIME_CONTROL_ORIGIN` together. The Mosoo container controls dynamic Sandbox containers and therefore needs root-equivalent access to a Docker daemon. Use a dedicated host; prefer a dedicated rootless daemon or constrained socket proxy where compatible, and restrict access to the daemon and `.env` file.
+
+Before upgrades, back up both named volumes: `mosoo_data` stores generated secrets and Caddy state, while `mosoo_wrangler` stores local Wrangler/D1 state. Restore both volumes together before starting the replacement stack. Sandbox containers are Docker-managed runtime state and are not included in either volume.
+
 ## Local Development
 
 Prerequisites:

--- a/apps/api/bin/dev-local.ts
+++ b/apps/api/bin/dev-local.ts
@@ -10,12 +10,14 @@ declare const Bun: BunRuntime;
 const scriptDir = decodeURIComponent(new URL(".", import.meta.url).pathname).replace(/\/$/u, "");
 const apiDir = `${scriptDir}/..`;
 const repoRoot = `${apiDir}/../..`;
-const vpBin = `${repoRoot}/node_modules/.bin/vp`;
+const apiVpBin = `${apiDir}/node_modules/.bin/vp`;
+const vpBin = (await Bun.file(apiVpBin).exists()) ? apiVpBin : `${repoRoot}/node_modules/.bin/vp`;
 const wranglerBin = `${apiDir}/node_modules/.bin/wrangler`;
 const DOCKER_HOST_ENV_KEY = "DOCKER_HOST";
 const DEV_DOCKER_HOST_ENV_KEY = "MOSOO_API_DEV_DOCKER_HOST";
 const DEV_RUNTIME_PROXY_HOST_ENV_KEY = "MOSOO_API_DEV_RUNTIME_PROXY_HOST";
 const RUNTIME_CONTROL_ORIGIN_ENV_KEY = "MOSOO_RUNTIME_CONTROL_ORIGIN";
+const SKIP_DRIVER_BUILD_ENV_KEY = "MOSOO_API_DEV_SKIP_DRIVER_BUILD";
 const LARK_SIDECAR_DISABLED_ENV_KEY = "MOSOO_LARK_SIDECAR_DISABLED";
 const LARK_SIDECAR_SECRET_ENV_KEY = "MOSOO_LARK_SIDECAR_SECRET";
 const SCRUB_HOST_PROXY_ENV_KEY = "MOSOO_API_DEV_SCRUB_HOST_PROXY";
@@ -437,17 +439,50 @@ async function run(
     stdin: "inherit",
     stdout: "inherit",
   });
-  return { code: await child.exited };
+  const onSigint = () => {
+    try {
+      child.kill("SIGINT");
+    } catch {
+      // The child may have exited between signal delivery and forwarding.
+    }
+  };
+  const onSigterm = () => {
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // The child may have exited between signal delivery and forwarding.
+    }
+  };
+  process.on("SIGINT", onSigint);
+  process.on("SIGTERM", onSigterm);
+  try {
+    return { code: await child.exited };
+  } finally {
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
+  }
 }
 
-const buildResult = await run(vpBin, ["run", "--filter", "agent-driver", "build"], {
-  cwd: repoRoot,
-});
-if (buildResult.code !== 0) {
-  process.exit(getExitCode(buildResult));
+if (getHostEnv()[SKIP_DRIVER_BUILD_ENV_KEY]?.trim() === "1") {
+  const driverBundlePath = `${repoRoot}/apps/driver/dist/driver.mjs`;
+  if (!(await Bun.file(driverBundlePath).exists())) {
+    writeStderr(
+      `[mosoo/api] ${SKIP_DRIVER_BUILD_ENV_KEY}=1 but ${driverBundlePath} does not exist.`,
+    );
+    process.exit(1);
+  }
+  writeStderr(`[mosoo/api] Using prebuilt agent driver at ${driverBundlePath}.`);
+} else {
+  const buildResult = await run(vpBin, ["run", "--filter", "agent-driver", "build"], {
+    cwd: repoRoot,
+  });
+  if (buildResult.code !== 0) {
+    process.exit(getExitCode(buildResult));
+  }
 }
 
 const wranglerEnv = await createWranglerDevEnv();
+const wranglerIp = wranglerEnv.WRANGLER_DEV_IP?.trim() ?? "0.0.0.0";
 const wranglerPort = wranglerEnv.WRANGLER_DEV_PORT?.trim() ?? "8787";
 const webDevPort = wranglerEnv.WEB_DEV_PORT?.trim() ?? "5173";
 const webOrigin = resolveDevWebOrigin(wranglerEnv);
@@ -488,7 +523,7 @@ const wranglerResult = await run(
     "dev",
     "--local",
     "--ip",
-    "0.0.0.0",
+    wranglerIp,
     "--port",
     wranglerPort,
     "--var",

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,82 @@
+name: mosoo
+
+services:
+  mosoo:
+    image: ${MOSOO_IMAGE:-ghcr.io/langgenius/mosoo:edge}
+    build:
+      context: .
+      args:
+        BUILD_DATE: ${BUILD_DATE:-}
+        VCS_REF: ${VCS_REF:-}
+        VERSION: ${VERSION:-dev}
+    restart: unless-stopped
+    stop_grace_period: 30s
+    # Wrangler's local container engine asks Docker to publish ephemeral ports
+    # on the daemon bridge gateway. Sharing the host network namespace lets the
+    # workerd process bind those gateway addresses while the API stays loopback-only.
+    network_mode: host
+    environment:
+      WEB_ORIGIN: ${WEB_ORIGIN:-http://localhost:8080}
+      MOSOO_WEB_BIND_IP: "${MOSOO_WEB_BIND_IP:-127.0.0.1}"
+      MOSOO_WEB_PORT: ${MOSOO_WEB_PORT:-8080}
+      MOSOO_RUNTIME_CONTROL_ORIGIN: ${MOSOO_RUNTIME_CONTROL_ORIGIN:-http://172.17.0.1:8787}
+      MOSOO_API_DEV_DOCKER_HOST: unix:///var/run/docker.sock
+      MOSOO_API_DEV_SKIP_DRIVER_BUILD: "1"
+      MOSOO_API_DEV_USE_DEFAULT_DOCKER: "1"
+      WRANGLER_DEV_IP: "127.0.0.1"
+      WRANGLER_DEV_PORT: "${MOSOO_API_PORT:-8788}"
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-}
+      RUNTIME_ACTION_TOKEN_SECRET: ${RUNTIME_ACTION_TOKEN_SECRET:-}
+      VAULT_ROOT_SECRET: ${VAULT_ROOT_SECRET:-}
+      GOOGLE_OAUTH_CLIENT_ID: ${GOOGLE_OAUTH_CLIENT_ID:-}
+      GOOGLE_OAUTH_CLIENT_SECRET: ${GOOGLE_OAUTH_CLIENT_SECRET:-}
+      SKILLS_SH_API_TOKEN: ${SKILLS_SH_API_TOKEN:-}
+      VERCEL_OIDC_TOKEN: ${VERCEL_OIDC_TOKEN:-}
+      WECHAT_ILINK_BASE_URL: ${WECHAT_ILINK_BASE_URL:-}
+      CLOUDFLARE_ACCOUNT_ID: ${CLOUDFLARE_ACCOUNT_ID:-}
+      CLOUDFLARE_API_TOKEN: ${CLOUDFLARE_API_TOKEN:-}
+      CLOUDFLARE_ZONE_ID: ${CLOUDFLARE_ZONE_ID:-}
+      R2_ACCESS_KEY_ID: ${R2_ACCESS_KEY_ID:-}
+      R2_SECRET_ACCESS_KEY: ${R2_SECRET_ACCESS_KEY:-}
+    volumes:
+      - mosoo_data:/data
+      - mosoo_wrangler:/app/apps/api/.wrangler
+      - ${MOSOO_DOCKER_SOCKET_PATH:-/var/run/docker.sock}:/var/run/docker.sock
+
+  runtime-gateway:
+    image: ${MOSOO_RUNTIME_GATEWAY_IMAGE:-caddy:2.10.2-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d}
+    restart: unless-stopped
+    network_mode: host
+    depends_on:
+      mosoo:
+        condition: service_healthy
+    command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]
+    read_only: true
+    cap_drop:
+      - ALL
+    # The official Caddy binary carries this file capability; without it in the
+    # bounding set Linux rejects execve even though this gateway uses port 8787.
+    cap_add:
+      - NET_BIND_SERVICE
+    environment:
+      MOSOO_RUNTIME_BIND_IP: ${MOSOO_RUNTIME_BIND_IP:-172.17.0.1}
+      MOSOO_RUNTIME_CONTROL_PORT: ${MOSOO_RUNTIME_CONTROL_PORT:-8787}
+      WRANGLER_DEV_PORT: "${MOSOO_API_PORT:-8788}"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'gateway_host="$${MOSOO_RUNTIME_BIND_IP:-172.17.0.1}"; case "$${gateway_host}" in "0.0.0.0") gateway_host="127.0.0.1" ;; "::") gateway_host="[::1]" ;; *:*) gateway_host="[$${gateway_host}]" ;; esac; wget -qO- "http://$${gateway_host}:$${MOSOO_RUNTIME_CONTROL_PORT:-8787}/healthz"',
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+    volumes:
+      - ./docker/runtime-gateway.Caddyfile:/etc/caddy/Caddyfile:ro
+    tmpfs:
+      - /config:size=16m,mode=0700
+      - /data:size=16m,mode=0700
+
+volumes:
+  mosoo_data:
+  mosoo_wrangler:

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,39 @@
+# Public web listener and browser origin. Change these when running behind a
+# reverse proxy or when port 8080 is already in use on the Docker host.
+MOSOO_WEB_BIND_IP=127.0.0.1
+MOSOO_WEB_PORT=8080
+WEB_ORIGIN=http://localhost:8080
+
+# Host address used only by sandbox containers to call the runtime driver API.
+# Linux Docker's default bridge gateway is usually 172.17.0.1. Override the
+# bind address, port, and callback origin together when using another socket.
+MOSOO_RUNTIME_BIND_IP=172.17.0.1
+MOSOO_RUNTIME_CONTROL_PORT=8787
+MOSOO_RUNTIME_CONTROL_ORIGIN=http://172.17.0.1:8787
+
+# Loopback-only API port shared by Mosoo's web proxy and runtime gateway.
+MOSOO_API_PORT=8788
+
+# Host Unix socket mounted for Wrangler's local container runtime. This can be
+# changed for rootless Docker or another local Docker context.
+MOSOO_DOCKER_SOCKET_PATH=/var/run/docker.sock
+
+# Optional fixed secrets. Leave empty on the first boot to generate persistent
+# 32-byte values in the mosoo_data volume.
+BETTER_AUTH_SECRET=
+RUNTIME_ACTION_TOKEN_SECRET=
+VAULT_ROOT_SECRET=
+
+# Optional OAuth and integration credentials.
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+SKILLS_SH_API_TOKEN=
+VERCEL_OIDC_TOKEN=
+WECHAT_ILINK_BASE_URL=
+
+# Optional Cloudflare/R2 credentials for features that use remote object storage.
+CLOUDFLARE_ACCOUNT_ID=
+CLOUDFLARE_API_TOKEN=
+CLOUDFLARE_ZONE_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,0 +1,19 @@
+{
+	auto_https off
+	admin off
+}
+
+:{$MOSOO_WEB_PORT:8080} {
+	bind {$MOSOO_WEB_BIND_IP:127.0.0.1}
+	encode zstd gzip
+
+	handle /api* {
+		reverse_proxy 127.0.0.1:{$WRANGLER_DEV_PORT:8788}
+	}
+
+	handle {
+		root * /app/apps/web/dist
+		try_files {path} /index.html
+		file_server
+	}
+}

--- a/docker/entrypoint.ts
+++ b/docker/entrypoint.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env bun
+import { randomUUID } from "node:crypto";
+import { chmod, mkdir, open, readFile, rename, rm, symlink } from "node:fs/promises";
+
+import { buildDevVars, validateWebExposure } from "./runtime-config";
+
+const repositoryRoot = "/app";
+const dataDirectory = process.env["MOSOO_DATA_DIR"]?.trim() || "/data";
+const persistedDevVarsPath = `${dataDirectory}/.dev.vars`;
+const workerDevVarsPath = `${repositoryRoot}/apps/api/.dev.vars`;
+
+function log(message: string): void {
+  process.stdout.write(`[mosoo/docker] ${message}\n`);
+}
+
+async function readExistingDevVars(): Promise<string> {
+  try {
+    return await readFile(persistedDevVarsPath, "utf8");
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return "";
+    }
+    throw error;
+  }
+}
+
+async function writeDevVarsAtomically(content: string): Promise<void> {
+  const temporaryDevVarsPath = `${persistedDevVarsPath}.tmp-${process.pid}-${randomUUID()}`;
+  let renamed = false;
+  try {
+    const file = await open(temporaryDevVarsPath, "wx", 0o600);
+    try {
+      await file.writeFile(content, "utf8");
+      await file.sync();
+    } finally {
+      await file.close();
+    }
+    await chmod(temporaryDevVarsPath, 0o600);
+    await rename(temporaryDevVarsPath, persistedDevVarsPath);
+    renamed = true;
+
+    const directory = await open(dataDirectory, "r");
+    try {
+      await directory.sync();
+    } finally {
+      await directory.close();
+    }
+  } finally {
+    if (!renamed) {
+      await rm(temporaryDevVarsPath, { force: true });
+    }
+  }
+}
+
+async function preparePersistentState(): Promise<void> {
+  await mkdir(dataDirectory, { recursive: true });
+  const existingContent = await readExistingDevVars();
+  const built = buildDevVars(existingContent, process.env);
+  if (built.content !== existingContent) {
+    await writeDevVarsAtomically(built.content);
+  }
+  await chmod(persistedDevVarsPath, 0o600);
+
+  await rm(workerDevVarsPath, { force: true });
+  await symlink(persistedDevVarsPath, workerDevVarsPath);
+
+  if (built.generatedKeys.length > 0) {
+    log(`Generated persistent secrets: ${built.generatedKeys.join(", ")}.`);
+  }
+}
+
+async function runMigration(): Promise<void> {
+  log("Applying local D1 migrations.");
+  const migration = Bun.spawn(["bun", "run", "--filter", "@mosoo/api", "db:migrate:local"], {
+    cwd: repositoryRoot,
+    env: process.env,
+    stderr: "inherit",
+    stdout: "inherit",
+  });
+  const exitCode = await migration.exited;
+  if (exitCode !== 0) {
+    throw new Error(`Local D1 migration failed with exit code ${exitCode}.`);
+  }
+}
+
+validateWebExposure(process.env);
+await preparePersistentState();
+await runMigration();
+
+const api = Bun.spawn(["bun", "apps/api/bin/dev-local.ts"], {
+  cwd: repositoryRoot,
+  env: process.env,
+  stderr: "inherit",
+  stdout: "inherit",
+});
+const web = Bun.spawn(["caddy", "run", "--config", `${repositoryRoot}/docker/Caddyfile`], {
+  cwd: repositoryRoot,
+  env: process.env,
+  stderr: "inherit",
+  stdout: "inherit",
+});
+
+let stopping = false;
+function stop(signal: NodeJS.Signals): void {
+  if (stopping) {
+    return;
+  }
+  stopping = true;
+  api.kill(signal);
+  web.kill(signal);
+}
+process.on("SIGINT", () => stop("SIGINT"));
+process.on("SIGTERM", () => stop("SIGTERM"));
+
+const firstExit = await Promise.race([
+  api.exited.then((exitCode) => ({ exitCode, processName: "API" })),
+  web.exited.then((exitCode) => ({ exitCode, processName: "web server" })),
+]);
+
+if (!stopping) {
+  process.stderr.write(
+    `[mosoo/docker] ${firstExit.processName} exited unexpectedly with code ${firstExit.exitCode}.\n`,
+  );
+  stop("SIGTERM");
+}
+
+await Promise.allSettled([api.exited, web.exited]);
+process.exit(firstExit.exitCode);

--- a/docker/runtime-config.ts
+++ b/docker/runtime-config.ts
@@ -1,0 +1,164 @@
+const REQUIRED_DEV_VAR_KEYS = [
+  "BETTER_AUTH_SECRET",
+  "RUNTIME_ACTION_TOKEN_SECRET",
+  "VAULT_ROOT_SECRET",
+] as const;
+
+const OPTIONAL_DEV_VAR_KEYS = [
+  "CLOUDFLARE_ACCOUNT_ID",
+  "CLOUDFLARE_API_TOKEN",
+  "CLOUDFLARE_ZONE_ID",
+  "GOOGLE_OAUTH_CLIENT_ID",
+  "GOOGLE_OAUTH_CLIENT_SECRET",
+  "R2_ACCESS_KEY_ID",
+  "R2_SECRET_ACCESS_KEY",
+  "SKILLS_SH_API_TOKEN",
+  "VERCEL_OIDC_TOKEN",
+  "WECHAT_ILINK_BASE_URL",
+] as const;
+
+const MANAGED_DEV_VAR_KEYS = [...REQUIRED_DEV_VAR_KEYS, ...OPTIONAL_DEV_VAR_KEYS] as const;
+
+export interface BuiltDevVars {
+  readonly content: string;
+  readonly generatedKeys: readonly string[];
+}
+
+function isLoopbackHost(value: string): boolean {
+  const host = value
+    .toLowerCase()
+    .replace(/\.$/u, "")
+    .replace(/^\[|\]$/gu, "");
+  return (
+    host === "localhost" || host.endsWith(".localhost") || host === "::1" || host.startsWith("127.")
+  );
+}
+
+export function validateWebExposure(
+  environment: Readonly<Record<string, string | undefined>>,
+): void {
+  const bindAddress = environment.MOSOO_WEB_BIND_IP?.trim() || "127.0.0.1";
+  const rawOrigin = environment.WEB_ORIGIN?.trim() || "http://localhost:8080";
+  let origin: URL;
+  try {
+    origin = new URL(rawOrigin);
+  } catch {
+    throw new Error("WEB_ORIGIN must be an absolute http(s) URL.");
+  }
+  if (origin.protocol !== "http:" && origin.protocol !== "https:") {
+    throw new Error("WEB_ORIGIN must be an absolute http(s) URL.");
+  }
+  if (isLoopbackHost(origin.hostname) && !isLoopbackHost(bindAddress)) {
+    throw new Error(
+      `WEB_ORIGIN=${rawOrigin} with MOSOO_WEB_BIND_IP=${bindAddress} would expose the development login backdoor. Use a public WEB_ORIGIN or bind the web listener to loopback.`,
+    );
+  }
+}
+
+function parseValue(rawValue: string, key: string): string {
+  const value = rawValue.trim();
+  if (value.startsWith('"')) {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (typeof parsed !== "string") {
+        throw new Error("not a string");
+      }
+      return parsed;
+    } catch {
+      throw new Error(`${key} has an invalid quoted value`);
+    }
+  }
+
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+}
+
+function parseDevVars(content: string): Map<string, string> {
+  const values = new Map<string, string>();
+
+  for (const line of content.split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const match = /^([A-Z][A-Z0-9_]*)\s*=\s*(.*)$/u.exec(trimmed);
+    if (match === null) {
+      throw new Error(`Invalid Docker dev vars line: ${line}`);
+    }
+
+    const key = match[1];
+    const rawValue = match[2];
+    if (key === undefined || rawValue === undefined) {
+      throw new Error(`Invalid Docker dev vars line: ${line}`);
+    }
+    if (values.has(key)) {
+      throw new Error(`Duplicate Docker dev var: ${key}`);
+    }
+
+    values.set(key, parseValue(rawValue, key));
+  }
+
+  return values;
+}
+
+function assertSingleLine(key: string, value: string): void {
+  if (value.includes("\n") || value.includes("\r")) {
+    throw new Error(`${key} must not contain a newline`);
+  }
+}
+
+export function createSecret(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+export function buildDevVars(
+  existingContent: string,
+  environment: Readonly<Record<string, string | undefined>>,
+  generateSecret: () => string = createSecret,
+): BuiltDevVars {
+  const values = parseDevVars(existingContent);
+  const generatedKeys: string[] = [];
+
+  for (const key of MANAGED_DEV_VAR_KEYS) {
+    const override = environment[key];
+    const required = REQUIRED_DEV_VAR_KEYS.includes(key as (typeof REQUIRED_DEV_VAR_KEYS)[number]);
+
+    if (override !== undefined && (override.trim().length > 0 || !required)) {
+      assertSingleLine(key, override);
+      values.set(key, override);
+      continue;
+    }
+
+    const existing = values.get(key) ?? "";
+    assertSingleLine(key, existing);
+    if (required) {
+      if (existing.trim().length === 0) {
+        const generated = generateSecret();
+        assertSingleLine(key, generated);
+        values.set(key, generated);
+        generatedKeys.push(key);
+      }
+      continue;
+    }
+
+    if (!values.has(key)) {
+      values.set(key, "");
+    }
+  }
+
+  const content = `${[...values.entries()]
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+    .join("\n")}\n`;
+
+  return { content, generatedKeys };
+}

--- a/docker/runtime-gateway.Caddyfile
+++ b/docker/runtime-gateway.Caddyfile
@@ -1,0 +1,16 @@
+{
+	auto_https off
+	admin off
+}
+
+:{$MOSOO_RUNTIME_CONTROL_PORT:8787} {
+	bind {$MOSOO_RUNTIME_BIND_IP:172.17.0.1}
+	respond /healthz 200
+
+	@driver path /api/driver /api/driver/*
+	handle @driver {
+		reverse_proxy 127.0.0.1:{$WRANGLER_DEV_PORT:8788}
+	}
+
+	respond 404
+}

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "driver:submodule:smoke": "vp exec bun scripts/check-driver-submodule-cutover.ts",
     "e2e": "bun e2e/cli.ts",
     "env:init": "vp run --filter @mosoo/api env:init",
-    "fmt": "vp fmt --write config scripts vite.config.ts justfile apps pkgs e2e --ignore-path .gitignore",
-    "fmt:check": "vp fmt --check config scripts vite.config.ts justfile apps pkgs e2e --ignore-path .gitignore",
+    "fmt": "vp fmt --write config docker scripts vite.config.ts justfile apps pkgs e2e --ignore-path .gitignore",
+    "fmt:check": "vp fmt --check config docker scripts vite.config.ts justfile apps pkgs e2e --ignore-path .gitignore",
     "fmt:check:path": "vp fmt --check --ignore-path .gitignore",
     "graphql:codegen": "vp exec tsx node_modules/.bin/graphql-codegen --config config/graphql-codegen.ts",
     "commit:check": "vp exec bun scripts/validate-commit-range.ts origin/main HEAD",
@@ -30,12 +30,12 @@
     "help-docs-index": "bun scripts/generate-help-docs-index.ts",
     "hooks:install": "vp exec prek -c config/prek.toml install",
     "knip": "vp exec knip --config config/knip.jsonc",
-    "lint": "vp run -w cf:types && vp lint vite.config.ts config/bun-script-types.d.ts config/vite-plus.shared.ts scripts apps pkgs e2e",
+    "lint": "vp run -w cf:types && vp lint vite.config.ts config/bun-script-types.d.ts config/vite-plus.shared.ts docker scripts apps pkgs e2e",
     "react-doctor": "vp exec react-doctor apps/web --full",
     "react-doctor:diff": "vp exec react-doctor apps/web --verbose --diff",
     "react-doctor:report": "vp exec react-doctor apps/web --json --json-compact --full --fail-on none",
     "tc": "vp run -r tc",
-    "test": "vp exec bun test config/commit-policy.test.ts scripts/validate-commit-message.test.ts && vp run --filter @mosoo/api --filter agent-driver --filter @mosoo/web --filter @mosoo/ag-ui-session --filter @mosoo/agent-package --filter @mosoo/contracts --filter @mosoo/db --filter @mosoo/id --filter @mosoo/public-api-client --filter @mosoo/runtime-catalog --filter @mosoo/runtime-events --filter @mosoo/session-policy --filter @mosoo/skill-package test && vp run -w graphql:codegen:check"
+    "test": "vp exec bun test config/commit-policy.test.ts scripts/validate-commit-message.test.ts scripts/docker-runtime-config.test.ts && vp run --filter @mosoo/api --filter agent-driver --filter @mosoo/web --filter @mosoo/ag-ui-session --filter @mosoo/agent-package --filter @mosoo/contracts --filter @mosoo/db --filter @mosoo/id --filter @mosoo/public-api-client --filter @mosoo/runtime-catalog --filter @mosoo/runtime-events --filter @mosoo/session-policy --filter @mosoo/skill-package test && vp run -w graphql:codegen:check"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^7.2.0",

--- a/scripts/docker-runtime-config.test.ts
+++ b/scripts/docker-runtime-config.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+import { buildDevVars, validateWebExposure } from "../docker/runtime-config";
+
+const compose = readFileSync(new URL("../compose.yaml", import.meta.url), "utf8");
+const dockerfile = readFileSync(new URL("../Dockerfile", import.meta.url), "utf8");
+const webCaddyfile = readFileSync(new URL("../docker/Caddyfile", import.meta.url), "utf8");
+const runtimeGatewayCaddyfile = readFileSync(
+  new URL("../docker/runtime-gateway.Caddyfile", import.meta.url),
+  "utf8",
+);
+const entrypoint = readFileSync(new URL("../docker/entrypoint.ts", import.meta.url), "utf8");
+const devLocal = readFileSync(new URL("../apps/api/bin/dev-local.ts", import.meta.url), "utf8");
+
+describe("Docker runtime config", () => {
+  test("generates stable required secrets and keeps optional values empty", () => {
+    let sequence = 0;
+    const result = buildDevVars("", {}, () => `generated-${++sequence}`);
+
+    expect(result.generatedKeys).toEqual([
+      "BETTER_AUTH_SECRET",
+      "RUNTIME_ACTION_TOKEN_SECRET",
+      "VAULT_ROOT_SECRET",
+    ]);
+    expect(result.content).toContain('BETTER_AUTH_SECRET="generated-1"');
+    expect(result.content).toContain('RUNTIME_ACTION_TOKEN_SECRET="generated-2"');
+    expect(result.content).toContain('VAULT_ROOT_SECRET="generated-3"');
+    expect(result.content).toContain('GOOGLE_OAUTH_CLIENT_ID=""');
+  });
+
+  test("preserves generated secrets across restarts and applies explicit overrides", () => {
+    const existing = [
+      'BETTER_AUTH_SECRET="auth-stable"',
+      'RUNTIME_ACTION_TOKEN_SECRET="runtime-stable"',
+      'VAULT_ROOT_SECRET="vault-stable"',
+      'GOOGLE_OAUTH_CLIENT_ID="old-client"',
+      "",
+    ].join("\n");
+
+    const result = buildDevVars(
+      existing,
+      {
+        GOOGLE_OAUTH_CLIENT_ID: "new-client",
+        GOOGLE_OAUTH_CLIENT_SECRET: 'secret with "quotes"',
+      },
+      () => {
+        throw new Error("must not regenerate stable required values");
+      },
+    );
+
+    expect(result.generatedKeys).toEqual([]);
+    expect(result.content).toContain('BETTER_AUTH_SECRET="auth-stable"');
+    expect(result.content).toContain('RUNTIME_ACTION_TOKEN_SECRET="runtime-stable"');
+    expect(result.content).toContain('VAULT_ROOT_SECRET="vault-stable"');
+    expect(result.content).toContain('GOOGLE_OAUTH_CLIENT_ID="new-client"');
+    expect(result.content).toContain('GOOGLE_OAUTH_CLIENT_SECRET="secret with \\"quotes\\""');
+  });
+
+  test("clears a persisted optional value when an explicit empty override is provided", () => {
+    const existing = [
+      'BETTER_AUTH_SECRET="auth-stable"',
+      'RUNTIME_ACTION_TOKEN_SECRET="runtime-stable"',
+      'VAULT_ROOT_SECRET="vault-stable"',
+      'GOOGLE_OAUTH_CLIENT_ID="old-client"',
+      "",
+    ].join("\n");
+
+    const result = buildDevVars(existing, { GOOGLE_OAUTH_CLIENT_ID: "" }, () => "unused");
+
+    expect(result.content).toContain('GOOGLE_OAUTH_CLIENT_ID=""');
+    expect(result.content).not.toContain("old-client");
+  });
+
+  test("rejects multiline values instead of writing an ambiguous dotenv file", () => {
+    expect(() =>
+      buildDevVars("", { GOOGLE_OAUTH_CLIENT_SECRET: "first\nsecond" }, () => "generated-secret"),
+    ).toThrow("GOOGLE_OAUTH_CLIENT_SECRET must not contain a newline");
+  });
+
+  test("does not replace a stable required secret with whitespace", () => {
+    const existing = [
+      'BETTER_AUTH_SECRET="auth-stable"',
+      'RUNTIME_ACTION_TOKEN_SECRET="runtime-stable"',
+      'VAULT_ROOT_SECRET="vault-stable"',
+      "",
+    ].join("\n");
+
+    const result = buildDevVars(existing, { BETTER_AUTH_SECRET: "   " }, () => "unused");
+
+    expect(result.content).toContain('BETTER_AUTH_SECRET="auth-stable"');
+  });
+
+  test("fails closed when a loopback development origin is exposed publicly", () => {
+    expect(() =>
+      validateWebExposure({
+        MOSOO_WEB_BIND_IP: "0.0.0.0",
+        WEB_ORIGIN: "http://localhost:8080",
+      }),
+    ).toThrow("would expose the development login backdoor");
+    expect(() =>
+      validateWebExposure({
+        MOSOO_WEB_BIND_IP: "::",
+        WEB_ORIGIN: "http://127.0.0.1:8080",
+      }),
+    ).toThrow("would expose the development login backdoor");
+
+    expect(() =>
+      validateWebExposure({
+        MOSOO_WEB_BIND_IP: "127.0.0.1",
+        WEB_ORIGIN: "http://localhost:8080",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateWebExposure({
+        MOSOO_WEB_BIND_IP: "0.0.0.0",
+        WEB_ORIGIN: "https://mosoo.example.com",
+      }),
+    ).not.toThrow();
+  });
+
+  test("atomically persists secrets and enforces owner-only permissions at every boot", () => {
+    expect(entrypoint).toContain("await file.sync()");
+    expect(entrypoint).toContain("await rename(temporaryDevVarsPath, persistedDevVarsPath)");
+    expect(entrypoint).toContain("await chmod(persistedDevVarsPath, 0o600)");
+  });
+
+  test("shares the Docker daemon host network without exposing the internal API", () => {
+    expect(compose.match(/network_mode: host/gu)).toHaveLength(2);
+    expect(compose).not.toContain("\n    ports:");
+    expect(compose).toContain('WRANGLER_DEV_IP: "127.0.0.1"');
+    expect(compose).toContain('WRANGLER_DEV_PORT: "${MOSOO_API_PORT:-8788}"');
+
+    expect(dockerfile).toContain("MOSOO_WEB_BIND_IP=127.0.0.1");
+    expect(dockerfile).toContain('web_host="${MOSOO_WEB_BIND_IP:-127.0.0.1}"');
+    expect(dockerfile).toContain('"0.0.0.0") web_host="127.0.0.1"');
+    expect(dockerfile).toContain('"::") web_host="[::1]"');
+    expect(dockerfile).toContain('*:*) web_host="[${web_host}]"');
+    expect(dockerfile).toContain('"http://${web_host}:${MOSOO_WEB_PORT:-8080}/api/health"');
+    expect(dockerfile).not.toContain('"http://127.0.0.1:${MOSOO_WEB_PORT:-8080}/api/health"');
+    expect(compose).toContain('MOSOO_WEB_BIND_IP: "${MOSOO_WEB_BIND_IP:-127.0.0.1}"');
+    expect(webCaddyfile).toContain(":{$MOSOO_WEB_PORT:8080}");
+    expect(webCaddyfile).toContain("bind {$MOSOO_WEB_BIND_IP:127.0.0.1}");
+    expect(webCaddyfile).toContain("reverse_proxy 127.0.0.1:{$WRANGLER_DEV_PORT:8788}");
+
+    expect(runtimeGatewayCaddyfile).toContain(":{$MOSOO_RUNTIME_CONTROL_PORT:8787}");
+    expect(runtimeGatewayCaddyfile).toContain("bind {$MOSOO_RUNTIME_BIND_IP:172.17.0.1}");
+    expect(runtimeGatewayCaddyfile).toContain("reverse_proxy 127.0.0.1:{$WRANGLER_DEV_PORT:8788}");
+    expect(compose).toContain('"0.0.0.0") gateway_host="127.0.0.1"');
+    expect(compose).toContain('"::") gateway_host="[::1]"');
+    expect(compose).toContain('*:*) gateway_host="[$${gateway_host}]"');
+    expect(compose).toContain("/config:size=16m,mode=0700");
+    expect(compose).toContain("/data:size=16m,mode=0700");
+  });
+
+  test("lets Docker pin Wrangler to loopback while preserving the dev default", () => {
+    expect(devLocal).toContain(
+      'const wranglerIp = wranglerEnv.WRANGLER_DEV_IP?.trim() ?? "0.0.0.0";',
+    );
+    expect(devLocal).toContain("Bun.file(apiVpBin).exists()");
+    expect(devLocal).toContain("`${repoRoot}/node_modules/.bin/vp`");
+    expect(devLocal).toContain('"--ip",\n    wranglerIp,');
+    expect(devLocal).toContain('process.on("SIGTERM", onSigterm)');
+    expect(devLocal).toContain('child.kill("SIGTERM")');
+  });
+});


### PR DESCRIPTION
## Summary

- add a multi-stage Mosoo runtime image and a Linux host-network Compose deployment
- keep Wrangler loopback-only while exposing a narrow Caddy runtime gateway for dynamic Sandbox callbacks
- generate and atomically persist required local runtime secrets, migrations, and Wrangler state
- add safe listener defaults, deployment validation, health checks, GHCR publishing automation, and operator documentation

## Why

- self-hosted Mosoo needs a reproducible deployment that includes the web UI, API, Driver, Workerd, dynamic Docker Sandboxes, and persistent local state
- Docker bridge Sandboxes must be able to call the Workerd control routes without exposing the full API publicly

## Verification

- Commands:
  - `vp fmt --check README.md apps/api/bin/dev-local.ts compose.yaml docker scripts/docker-runtime-config.test.ts .github/workflows/container-image.yml --ignore-path .gitignore`
  - `vp lint apps/api/bin/dev-local.ts docker scripts/docker-runtime-config.test.ts .github/workflows/container-image.yml`
  - `bun test scripts/docker-runtime-config.test.ts` — 9 passed, 0 failed
  - `docker compose --env-file docker/.env.example config --quiet`
  - Caddy validation for both `docker/Caddyfile` and `docker/runtime-gateway.Caddyfile`
  - production image build on a constrained Linux builder — `sha256:7405d8e5d4cf741c5d1e45045875f3d2a32c41ff957e9d34de9ed4e2cb5868be`, 569,822,995 bytes
- Manual steps:
  - Compose services reached `healthy`; public `/api/health` returned `{"name":"mosoo","ok":true}`
  - unsafe `WEB_ORIGIN=http://localhost:*` plus `MOSOO_WEB_BIND_IP=0.0.0.0` failed closed before startup
  - default listener was reachable on host loopback and not reachable through the host public address
  - Wrangler `8788` and runtime gateway `8787` were not publicly reachable
  - gateway forwarded `/api/driver/socket` (426 from both gateway and direct API) and denied `/api/health` (404 vs direct 200)
  - persisted `.dev.vars` was mode 0600, had no leftover temporary file, and retained the same SHA-256 after restart
  - SIGTERM shutdown completed in 1 second with exit 0 and no OOM; restart returned to `healthy`
  - host-network Agent E2E provisioned a Sandbox and completed two assistant replies; the later security-hardening pass did not alter Agent protocol behavior
  - all temporary containers, volumes, images, builder state, and test credentials were removed
- Not run:
  - full monorepo test suite; the production build, targeted Docker tests, Compose/Caddy validation, and end-to-end runtime path were exercised

## Impact

- User/API/contract changes: adds supported Docker deployment; no public API schema change
- Generated files / GraphQL / DB / lockfile: no generated API files or lockfile changes; existing D1 migrations run at container startup
- Env or config changes: adds documented `MOSOO_*`, Wrangler, OAuth, Cloudflare, R2, and optional integration variables in `docker/.env.example`
- Risk and rollback: the Mosoo container has root-equivalent access to a Docker daemon and host networking; deployment is limited to a dedicated Linux host and defaults to loopback-only web access. Roll back by stopping the Compose project and restoring both named volumes with the prior image/config.

## Review

- Closest review areas: Docker socket/host-network trust boundary, Caddy route isolation, secret persistence, Workerd/Sandbox callback networking, and image publishing permissions
- Known trade-offs: dynamic Sandbox management requires Docker daemon control; dedicated rootless Docker or a compatible constrained socket proxy is preferred where available
