### PR TITLE
fix(docker): forward signals during migrations

### DIFF
--- a/docker/entrypoint.ts
+++ b/docker/entrypoint.ts
@@ -2,6 +2,8 @@
 import { randomUUID } from "node:crypto";
 import { chmod, mkdir, open, readFile, rename, rm, symlink } from "node:fs/promises";
 
+import { createProcessSupervisor } from "./process-supervisor";
+import type { ProcessSupervisor } from "./process-supervisor";
 import { buildDevVars, validateWebExposure } from "./runtime-config";
 
 const repositoryRoot = "/app";
@@ -69,60 +71,71 @@ async function preparePersistentState(): Promise<void> {
   }
 }
 
-async function runMigration(): Promise<void> {
+async function runMigration(supervisor: ProcessSupervisor): Promise<boolean> {
   log("Applying local D1 migrations.");
-  const migration = Bun.spawn(["bun", "run", "--filter", "@mosoo/api", "db:migrate:local"], {
-    cwd: repositoryRoot,
-    env: process.env,
-    stderr: "inherit",
-    stdout: "inherit",
-  });
-  const exitCode = await migration.exited;
+  const migration = supervisor.track(
+    Bun.spawn(["bun", "run", "--filter", "@mosoo/api", "db:migrate:local"], {
+      cwd: repositoryRoot,
+      env: process.env,
+      stderr: "inherit",
+      stdout: "inherit",
+    }),
+  );
+  let exitCode: number;
+  try {
+    exitCode = await migration.exited;
+  } finally {
+    supervisor.untrack(migration);
+  }
+  if (supervisor.stopping) {
+    return false;
+  }
   if (exitCode !== 0) {
     throw new Error(`Local D1 migration failed with exit code ${exitCode}.`);
   }
+  return true;
 }
 
 validateWebExposure(process.env);
 await preparePersistentState();
-await runMigration();
-
-const api = Bun.spawn(["bun", "apps/api/bin/dev-local.ts"], {
-  cwd: repositoryRoot,
-  env: process.env,
-  stderr: "inherit",
-  stdout: "inherit",
-});
-const web = Bun.spawn(["caddy", "run", "--config", `${repositoryRoot}/docker/Caddyfile`], {
-  cwd: repositoryRoot,
-  env: process.env,
-  stderr: "inherit",
-  stdout: "inherit",
-});
-
-let stopping = false;
-function stop(signal: NodeJS.Signals): void {
-  if (stopping) {
-    return;
-  }
-  stopping = true;
-  api.kill(signal);
-  web.kill(signal);
+const supervisor = createProcessSupervisor();
+const removeSignalHandlers = supervisor.installSignalHandlers();
+if (!(await runMigration(supervisor))) {
+  removeSignalHandlers();
+  process.exit(0);
 }
-process.on("SIGINT", () => stop("SIGINT"));
-process.on("SIGTERM", () => stop("SIGTERM"));
+
+const api = supervisor.track(
+  Bun.spawn(["bun", "apps/api/bin/dev-local.ts"], {
+    cwd: repositoryRoot,
+    env: process.env,
+    stderr: "inherit",
+    stdout: "inherit",
+  }),
+);
+const web = supervisor.track(
+  Bun.spawn(["caddy", "run", "--config", `${repositoryRoot}/docker/Caddyfile`], {
+    cwd: repositoryRoot,
+    env: process.env,
+    stderr: "inherit",
+    stdout: "inherit",
+  }),
+);
 
 const firstExit = await Promise.race([
   api.exited.then((exitCode) => ({ exitCode, processName: "API" })),
   web.exited.then((exitCode) => ({ exitCode, processName: "web server" })),
 ]);
 
-if (!stopping) {
+if (!supervisor.stopping) {
   process.stderr.write(
     `[mosoo/docker] ${firstExit.processName} exited unexpectedly with code ${firstExit.exitCode}.\n`,
   );
-  stop("SIGTERM");
+  supervisor.stop("SIGTERM");
 }
 
 await Promise.allSettled([api.exited, web.exited]);
-process.exit(firstExit.exitCode);
+supervisor.untrack(api);
+supervisor.untrack(web);
+removeSignalHandlers();
+process.exit(supervisor.receivedSignal === null ? firstExit.exitCode : 0);

--- a/docker/process-supervisor.ts
+++ b/docker/process-supervisor.ts
@@ -1,0 +1,88 @@
+export type ForwardedSignal = "SIGINT" | "SIGTERM";
+
+export interface ManagedProcess {
+  readonly exitCode: number | null;
+  kill(signal?: number | string): void;
+}
+
+export interface ProcessSupervisor {
+  readonly receivedSignal: ForwardedSignal | null;
+  readonly signal: ForwardedSignal | null;
+  readonly stopping: boolean;
+  installSignalHandlers(): () => void;
+  stop(signal: ForwardedSignal): void;
+  track<T extends ManagedProcess>(child: T): T;
+  untrack(child: ManagedProcess): void;
+}
+
+export function createProcessSupervisor(): ProcessSupervisor {
+  const activeChildren = new Set<ManagedProcess>();
+  let receivedSignal: ForwardedSignal | null = null;
+  let stopSignal: ForwardedSignal | null = null;
+
+  function forwardSignal(child: ManagedProcess, signal: ForwardedSignal): void {
+    if (child.exitCode !== null) {
+      return;
+    }
+    try {
+      child.kill(signal);
+    } catch (error) {
+      if (child.exitCode === null) {
+        throw error;
+      }
+    }
+  }
+
+  function stop(signal: ForwardedSignal): void {
+    if (stopSignal !== null) {
+      return;
+    }
+    stopSignal = signal;
+    for (const child of activeChildren) {
+      forwardSignal(child, signal);
+    }
+  }
+
+  function installSignalHandlers(): () => void {
+    const onSigint = (): void => {
+      receivedSignal = "SIGINT";
+      stop("SIGINT");
+    };
+    const onSigterm = (): void => {
+      receivedSignal = "SIGTERM";
+      stop("SIGTERM");
+    };
+    process.on("SIGINT", onSigint);
+    process.on("SIGTERM", onSigterm);
+    return () => {
+      process.off("SIGINT", onSigint);
+      process.off("SIGTERM", onSigterm);
+    };
+  }
+
+  function track<T extends ManagedProcess>(child: T): T {
+    activeChildren.add(child);
+    if (stopSignal !== null) {
+      forwardSignal(child, stopSignal);
+    }
+    return child;
+  }
+
+  return {
+    get receivedSignal() {
+      return receivedSignal;
+    },
+    get signal() {
+      return stopSignal;
+    },
+    get stopping() {
+      return stopSignal !== null;
+    },
+    installSignalHandlers,
+    stop,
+    track,
+    untrack(child) {
+      activeChildren.delete(child);
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-doctor:diff": "vp exec react-doctor apps/web --verbose --diff",
     "react-doctor:report": "vp exec react-doctor apps/web --json --json-compact --full --fail-on none",
     "tc": "vp run -r tc",
-    "test": "vp exec bun test config/commit-policy.test.ts scripts/validate-commit-message.test.ts scripts/docker-runtime-config.test.ts && vp run --filter @mosoo/api --filter agent-driver --filter @mosoo/web --filter @mosoo/ag-ui-session --filter @mosoo/agent-package --filter @mosoo/contracts --filter @mosoo/db --filter @mosoo/id --filter @mosoo/public-api-client --filter @mosoo/runtime-catalog --filter @mosoo/runtime-events --filter @mosoo/session-policy --filter @mosoo/skill-package test && vp run -w graphql:codegen:check"
+    "test": "vp exec bun test config/commit-policy.test.ts scripts/validate-commit-message.test.ts scripts/docker-runtime-config.test.ts scripts/docker-entrypoint-signal.test.ts && vp run --filter @mosoo/api --filter agent-driver --filter @mosoo/web --filter @mosoo/ag-ui-session --filter @mosoo/agent-package --filter @mosoo/contracts --filter @mosoo/db --filter @mosoo/id --filter @mosoo/public-api-client --filter @mosoo/runtime-catalog --filter @mosoo/runtime-events --filter @mosoo/session-policy --filter @mosoo/skill-package test && vp run -w graphql:codegen:check"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^7.2.0",

--- a/scripts/docker-entrypoint-signal.test.ts
+++ b/scripts/docker-entrypoint-signal.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createProcessSupervisor } from "../docker/process-supervisor";
+
+const repositoryRoot = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+const entrypoint = await Bun.file(join(repositoryRoot, "docker/entrypoint.ts")).text();
+const temporaryDirectories: string[] = [];
+
+async function waitForOutput(
+  process: Bun.Subprocess<"ignore", "pipe", "pipe">,
+  expected: string,
+): Promise<string> {
+  const reader = process.stdout.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+  while (!output.includes(expected)) {
+    const next = await Promise.race([
+      reader.read(),
+      Bun.sleep(5_000).then(() => {
+        throw new Error(`Timed out waiting for ${expected}. Output: ${output}`);
+      }),
+    ]);
+    if (next.done) {
+      const stderr = await new Response(process.stderr).text();
+      throw new Error(`Harness exited before ${expected}. stderr: ${stderr}`);
+    }
+    output += decoder.decode(next.value, { stream: true });
+  }
+  return output;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { force: true, recursive: true })),
+  );
+});
+
+describe("Docker entrypoint signal handling", () => {
+  test("does not treat an internal sibling shutdown as an externally received signal", () => {
+    const supervisor = createProcessSupervisor();
+
+    supervisor.stop("SIGTERM");
+
+    expect(supervisor.receivedSignal).toBeNull();
+  });
+
+  test("forwards SIGTERM to an active migration and exits within the grace period", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "mosoo-entrypoint-signal-"));
+    temporaryDirectories.push(directory);
+    const markerPath = join(directory, "migration.signal");
+    const harness = Bun.spawn(["bun", "scripts/fixtures/docker-entrypoint-signal-harness.ts"], {
+      cwd: repositoryRoot,
+      env: { ...process.env, MOSOO_SIGNAL_MARKER: markerPath },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    try {
+      await waitForOutput(harness, "HARNESS_READY\n");
+      harness.kill("SIGTERM");
+      const exitCode = await Promise.race([
+        harness.exited,
+        Bun.sleep(5_000).then(() => {
+          throw new Error("Harness did not stop within 5 seconds.");
+        }),
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(await readFile(markerPath, "utf8")).toBe("SIGTERM\n");
+    } finally {
+      if (harness.exitCode === null) {
+        harness.kill("SIGKILL");
+        await harness.exited;
+      }
+    }
+  });
+
+  test("installs signal forwarding before starting migrations", () => {
+    const installIndex = entrypoint.indexOf("installSignalHandlers()");
+    const migrationIndex = entrypoint.indexOf("await runMigration(");
+
+    expect(installIndex).toBeGreaterThan(-1);
+    expect(migrationIndex).toBeGreaterThan(installIndex);
+  });
+});

--- a/scripts/fixtures/docker-entrypoint-signal-harness.ts
+++ b/scripts/fixtures/docker-entrypoint-signal-harness.ts
@@ -1,0 +1,56 @@
+import { createProcessSupervisor } from "../../docker/process-supervisor";
+
+const markerPath = process.env["MOSOO_SIGNAL_MARKER"];
+if (!markerPath) {
+  throw new Error("MOSOO_SIGNAL_MARKER is required.");
+}
+
+const supervisor = createProcessSupervisor();
+const removeSignalHandlers = supervisor.installSignalHandlers();
+const migration = supervisor.track(
+  Bun.spawn(
+    [
+      "bun",
+      "-e",
+      `
+        import { writeFileSync } from "node:fs";
+        const markerPath = process.env["MOSOO_SIGNAL_MARKER"];
+        process.on("SIGTERM", () => {
+          writeFileSync(markerPath, "SIGTERM\\n", "utf8");
+          process.exit(0);
+        });
+        process.stdout.write("MIGRATION_READY\\n");
+        setInterval(() => {}, 1_000);
+      `,
+    ],
+    {
+      env: process.env,
+      stderr: "inherit",
+      stdout: "pipe",
+    },
+  ),
+);
+
+const reader = migration.stdout.getReader();
+const decoder = new TextDecoder();
+let output = "";
+while (!output.includes("MIGRATION_READY\n")) {
+  const chunk = await reader.read();
+  if (chunk.done) {
+    throw new Error("Migration exited before becoming ready.");
+  }
+  output += decoder.decode(chunk.value, { stream: true });
+}
+
+process.stdout.write("HARNESS_READY\n");
+const exitCode = await migration.exited;
+supervisor.untrack(migration);
+removeSignalHandlers();
+
+if (!supervisor.stopping) {
+  throw new Error(`Migration exited unexpectedly with code ${exitCode}.`);
+}
+if (supervisor.receivedSignal !== "SIGTERM") {
+  throw new Error(`Expected external SIGTERM, received ${supervisor.receivedSignal ?? "none"}.`);
+}
+process.stdout.write("HARNESS_STOPPED\n");


### PR DESCRIPTION
## Summary
- install entrypoint signal handlers before local D1 migrations start
- track the active migration, API, and Caddy children through one supervisor
- abort startup cleanly after a migration-time stop instead of launching services
- add a real-process regression test that blocks migration and verifies SIGTERM forwarding and bounded exit

## Verification
- `vp lint docker/entrypoint.ts docker/process-supervisor.ts scripts/docker-entrypoint-signal.test.ts scripts/fixtures/docker-entrypoint-signal-harness.ts`
- `vp exec bun test config/commit-policy.test.ts scripts/validate-commit-message.test.ts scripts/docker-runtime-config.test.ts scripts/docker-entrypoint-signal.test.ts` (29 passed)
- `just commit-check`
