### PR TITLE
perf(api): skip live provider probe in run hydration

### DIFF
--- a/apps/api/src/modules/runtime/application/session-definition/hydrate-run-context.service.ts
+++ b/apps/api/src/modules/runtime/application/session-definition/hydrate-run-context.service.ts
@@ -295,9 +295,13 @@ async function hydrateRunContextFromSession(
   const snapshotEnvironment = buildSnapshotAgentEnvironment({
     environmentId: environmentSnapshot.environmentId,
   });
+  // No `bindings` here on purpose: passing them makes readiness run a live
+  // provider probe (GET /models plus a possible POST /chat/completions, 10s
+  // timeout each) on the first-token critical path. D1-backed checks still
+  // gate the run; broken credentials surface from the actual model call.
+  // Config/publish readiness callers keep the live probe.
   const agentReadiness = await computeAgentReadiness(bindings.DB, agent.ownerId, {
     agentId: agent.id,
-    bindings,
     environment: snapshotEnvironment,
     mcpServerIds: toolReferences.map((reference) => reference.serverId),
     model: binding.model,


### PR DESCRIPTION
## Summary

- Run-path context hydration no longer passes `bindings` into `computeAgentReadiness`, so readiness stops issuing a live provider probe (`GET /models` plus a possible `POST /chat/completions`, 10s timeout each) on the send-to-first-token critical path.
- Config, publish, and session-creation readiness callers keep the live probe unchanged.

## Why

- Every cache-miss hydration paid one or two synchronous provider HTTP round trips before the first token, with a 10–20s worst-case tail (`READINESS_PROVIDER_PROBE_TIMEOUT_MS`).
- Staging paired warm-ping screen (8 adjacent pairs, V5-lineage baseline vs candidate stack, 16/16 runs correct): `context_hydration` median 1,333ms → 242ms (−82%), with non-overlapping distributions across all runs (baseline 1,187–1,485ms, candidate 187–314ms). Artifact `warm-ping-ab-v26-v5-vs-v6v9a-8pairs-20260721-v1.json`, SHA-256 `b55494c79cca4c5e7ffe419cb07549d1a130346a1a722196339ea8f5a44a0359`. Paired end-to-end TTFT is intentionally not claimed (provider first-token variance dominates at this sample size).

## Verification

- Commands: `bun run --filter @mosoo/api tc`, `bun run --filter @mosoo/api test` (1,038 pass), `bun run fmt:check:path -- <changed file>`, `bun run lint`, `bun run commit:check`.
- Manual steps: staging warm-ping screen above (both dedicated perf stacks, correct `pong` output and thread cleanup on every run).
- Not run: full `just check` locally; PR CI runs the repository gate.

## Impact

- User/API/contract changes: a broken provider credential now surfaces from the actual model call instead of a pre-run readiness failure; all D1-backed readiness checks still gate dispatch.
- Generated files / GraphQL / DB / lockfile: none.
- Env or config changes: none.
- Risk and rollback: single call-site change; revert restores the probe.

## Review

- Closest review areas: `hydrate-run-context.service.ts` readiness call; `collectProviderProbeIssues` returning early without `bindings`.
- Known trade-offs: pre-run feedback for broken credentials moves to the run itself (real provider error instead of probe result).
