### PR TITLE
perf(api): trim run accept path and guard losing hydration failures

### DIFF
--- a/apps/api/src/modules/api-command/application/api-command-processor.ts
+++ b/apps/api/src/modules/api-command/application/api-command-processor.ts
@@ -390,6 +390,7 @@ async function processSessionRunDispatchCommand(
     bindings,
     input: {
       attachmentIds: payload.attachmentIds,
+      dispatchSource: "queue",
       prompt: payload.prompt,
       queuedAtMs: payload.queuedAtMs,
       session: payload.session,

--- a/apps/api/src/modules/runtime/application/session-runs/dispatch-queued-run.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/dispatch-queued-run.service.ts
@@ -78,6 +78,7 @@ async function failQueuedSessionRunBeforeDispatch(
 interface DispatchQueuedSessionRunInput {
   accessViewer?: AuthenticatedViewer;
   attachmentIds: FileId[];
+  dispatchSource: "inline" | "queue";
   prompt: string;
   queuedAtMs: number;
   session: {
@@ -99,20 +100,27 @@ export async function dispatchQueuedSessionRun(
   request: DispatchQueuedSessionRunRequest,
 ): Promise<UserWarning[]> {
   const { bindings, input, requestUrl, viewer } = request;
-  const runState = await getSessionRunState(bindings.DB, input.sessionRunId);
 
-  if (!runState) {
-    throw new Error("Session run not found.");
-  }
+  // Inline dispatch starts inside the request that just created the queued
+  // run, so re-reading its status is a wasted D1 round trip. Queue delivery
+  // can arrive late or duplicated and must still skip stale runs.
+  if (input.dispatchSource === "queue") {
+    const runState = await getSessionRunState(bindings.DB, input.sessionRunId);
 
-  if (runState.status !== "queued") {
-    logInfo("session.run.context_hydration.skipped", {
-      runId: input.sessionRunId,
-      sessionId: input.session.id,
-      status: runState.status,
-      traceId: input.traceId,
-    });
-    return [];
+    if (!runState) {
+      throw new Error("Session run not found.");
+    }
+
+    if (runState.status !== "queued") {
+      logInfo("session.run.context_hydration.skipped", {
+        dispatchSource: input.dispatchSource,
+        runId: input.sessionRunId,
+        sessionId: input.session.id,
+        status: runState.status,
+        traceId: input.traceId,
+      });
+      return [];
+    }
   }
 
   const hydrationTiming = createRuntimeTimingRecorder({
@@ -169,6 +177,7 @@ export async function dispatchQueuedSessionRun(
 
   logInfo("session.run.context_hydrated", {
     cacheHit: resolved.hydrated.cacheHit,
+    dispatchSource: input.dispatchSource,
     hydrationLatencyMs: hydrationSnapshot.totalMs,
     queuedToHydratedMs: hydrationSnapshot.completedAtMs - input.queuedAtMs,
     runId: input.sessionRunId,

--- a/apps/api/src/modules/runtime/application/session-runs/dispatch-queued-run.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/dispatch-queued-run.service.ts
@@ -35,8 +35,12 @@ async function failQueuedSessionRunBeforeDispatch(
     message,
     retryable: false,
   } as const;
+  // Only fail the run while it is still queued. Once another dispatcher CASed
+  // it to booting, this path is a losing contender and its hydration error
+  // must not tear down the run the winner is provisioning.
   const failedRun = await updateSessionRunStatusIfActive(bindings.DB, {
     error: runError,
+    expectedCurrentStatus: "queued",
     runId: input.sessionRunId,
     status: "failed",
   });
@@ -44,7 +48,7 @@ async function failQueuedSessionRunBeforeDispatch(
   if (!failedRun) {
     const state = await getSessionRunState(bindings.DB, input.sessionRunId);
 
-    logWarn("session.run.context_hydration.failed.after-terminal", {
+    logWarn("session.run.context_hydration.failed.run-not-queued", {
       message,
       runId: input.sessionRunId,
       sessionId: input.sessionId,

--- a/apps/api/src/modules/runtime/application/session-runs/queue-run.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/queue-run.service.ts
@@ -85,8 +85,6 @@ export async function queueSessionRun(request: QueueSessionRunRequest): Promise<
   const { bindings, input, requestUrl, viewer } = request;
   const queueStartedAtMs = Date.now();
 
-  await reconcileStaleActiveSessionRun(bindings.DB, input.session.id);
-
   const runtimeId = getSupportedRuntimeId(input.session.runtime_id);
   const viewerId: AccountId = parsePlatformId(viewer.id, "viewer id");
 
@@ -94,19 +92,24 @@ export async function queueSessionRun(request: QueueSessionRunRequest): Promise<
     throw new Error(`Unsupported runtime: ${input.session.runtime_id}.`);
   }
 
-  const executionPlan = await getSessionExecutionPlan(bindings.DB, input.session.id);
-  await resolveReadyEnvironmentPackageArtifact(
-    bindings,
-    input.session.app_id,
-    executionPlan.environment.packagesJson,
-  );
-
-  await fileStore.ensureSessionAttachments(
-    bindings,
-    input.accessViewer ?? viewer,
-    input.session.id,
-    input.attachmentIds,
-  );
+  // Pre-admission guards are independent; run them concurrently instead of
+  // paying three serial D1 round trips before the run row exists.
+  await Promise.all([
+    reconcileStaleActiveSessionRun(bindings.DB, input.session.id),
+    getSessionExecutionPlan(bindings.DB, input.session.id).then((executionPlan) =>
+      resolveReadyEnvironmentPackageArtifact(
+        bindings,
+        input.session.app_id,
+        executionPlan.environment.packagesJson,
+      ),
+    ),
+    fileStore.ensureSessionAttachments(
+      bindings,
+      input.accessViewer ?? viewer,
+      input.session.id,
+      input.attachmentIds,
+    ),
+  ]);
 
   const createRunResult = await createSessionRunRecordIfSessionIdle(bindings.DB, {
     agentId: input.session.agent_id,
@@ -198,6 +201,7 @@ export async function queueSessionRun(request: QueueSessionRunRequest): Promise<
       bindings,
       input: {
         attachmentIds: input.attachmentIds,
+        dispatchSource: "inline",
         prompt: input.prompt,
         queuedAtMs,
         session: { id: input.session.id, app_id: input.session.app_id },

--- a/apps/api/src/modules/runtime/application/session-runs/session-run-state.repository.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/session-run-state.repository.ts
@@ -63,12 +63,16 @@ export async function updateSessionRunStatusIfActive(
   database: D1Database,
   input: {
     error?: RunError | null;
+    expectedCurrentStatus?: SessionRunSummary["status"];
     runId: SessionRunId;
     status: SessionRunSummary["status"];
   },
 ): Promise<SessionRunSummary | null> {
   const outcome = await setSessionRunStatus(database, {
     ...(input.error !== undefined ? { error: input.error } : {}),
+    ...(input.expectedCurrentStatus !== undefined
+      ? { expectedCurrentStatus: input.expectedCurrentStatus }
+      : {}),
     runId: input.runId,
     source: "api",
     status: input.status,

--- a/apps/api/src/modules/runtime/infrastructure/session-runs/session-run-write.repository.ts
+++ b/apps/api/src/modules/runtime/infrastructure/session-runs/session-run-write.repository.ts
@@ -43,6 +43,11 @@ type SessionRunStatusUpdateInput = {
 };
 
 type UpdateSessionRunStatusInput = SessionRunStatusUpdateInput & {
+  /**
+   * Reject the transition unless the run is currently in this status. The
+   * check is atomic with the write via the status_seq optimistic guard.
+   */
+  expectedCurrentStatus?: SessionRunStatus;
   preserveSessionLifecycle?: boolean;
   runId: SessionRunId;
 };
@@ -118,7 +123,7 @@ export type SessionRunTransitionOutcome =
   | {
       currentStatus: SessionRunStatus;
       kind: "rejected";
-      reason: "illegal_transition";
+      reason: "illegal_transition" | "unexpected_current_status";
       targetStatus: SessionRunStatus;
     }
   | {
@@ -627,6 +632,15 @@ async function transitionSessionRunStatus(
     return {
       kind: "rejected",
       reason: "not_found",
+      targetStatus: input.status,
+    };
+  }
+
+  if (input.expectedCurrentStatus !== undefined && current.status !== input.expectedCurrentStatus) {
+    return {
+      currentStatus: current.status,
+      kind: "rejected",
+      reason: "unexpected_current_status",
       targetStatus: input.status,
     };
   }

--- a/apps/api/tests/send-agent-session-events.test.ts
+++ b/apps/api/tests/send-agent-session-events.test.ts
@@ -414,6 +414,7 @@ describe("send agent session events", () => {
         bindings: createPublicHttpTestBindings(database) as ApiBindings,
         input: {
           attachmentIds: [PUBLIC_API_TEST_IDS.file],
+          dispatchSource: "queue",
           prompt: "This duplicate delivery must not hydrate.",
           queuedAtMs: nowMs,
           session: {
@@ -594,6 +595,7 @@ describe("send agent session events", () => {
         bindings,
         input: {
           attachmentIds: [PUBLIC_API_TEST_IDS.file],
+          dispatchSource: "queue",
           prompt: "Use the attached file.",
           queuedAtMs: nowMs,
           session: {
@@ -654,6 +656,7 @@ describe("send agent session events", () => {
         bindings,
         input: {
           attachmentIds: [PUBLIC_API_TEST_IDS.fileAlt],
+          dispatchSource: "queue",
           prompt: "Use the attached file.",
           queuedAtMs: nowMs,
           session: {

--- a/apps/api/tests/send-agent-session-events.test.ts
+++ b/apps/api/tests/send-agent-session-events.test.ts
@@ -689,6 +689,71 @@ describe("send agent session events", () => {
     expect(row?.error_message).toContain("is not available for this session");
   });
 
+  test("keeps a dispatched run untouched when a losing hydration fails", async () => {
+    const database = await createPublicHttpContractDatabase();
+    await insertOwnerSession(database);
+    const nowMs = nowMsForTest();
+    const traceId = "loser-hydration-trace";
+    const bindings = createPublicHttpTestBindings(database) as ApiBindings;
+
+    await insertQueuedRunFixture(database, {
+      nowMs,
+      runId: PUBLIC_API_TEST_IDS.run,
+      traceId,
+    });
+    // A winning dispatcher already CASed the run out of queued.
+    await database
+      .prepare("UPDATE session_run SET status = 'booting' WHERE id = ?")
+      .bind(PUBLIC_API_TEST_IDS.run)
+      .run();
+    await insertSessionFileRecord(database, {
+      etag: null,
+      fileId: PUBLIC_API_TEST_IDS.fileAlt,
+      mimeType: "text/markdown",
+      name: "summary.md",
+      nowMs,
+      sessionKind: "artifact",
+      size: 23,
+      status: "ready",
+    });
+
+    await expect(
+      dispatchQueuedSessionRun({
+        bindings,
+        input: {
+          attachmentIds: [PUBLIC_API_TEST_IDS.fileAlt],
+          dispatchSource: "inline",
+          prompt: "Use the attached file.",
+          queuedAtMs: nowMs,
+          session: {
+            app_id: PUBLIC_API_TEST_IDS.app,
+            id: PUBLIC_API_TEST_IDS.ownerSession,
+          },
+          sessionRunId: PUBLIC_API_TEST_IDS.run,
+          traceId,
+        },
+        requestUrl: `https://api.example.com/api/v1/sessions/${PUBLIC_API_TEST_IDS.ownerSession}/events`,
+        viewer: {
+          email: "owner@example.com",
+          emailVerified: true,
+          id: PUBLIC_API_TEST_IDS.ownerAccount,
+          imageUrl: null,
+          name: "Owner",
+        },
+      }),
+    ).rejects.toThrow("is not available for this session");
+
+    const row = await database
+      .prepare("SELECT status, error_code FROM session_run WHERE id = ?")
+      .bind(PUBLIC_API_TEST_IDS.run)
+      .first<{ error_code: string | null; status: string }>();
+
+    expect(row).toEqual({
+      error_code: null,
+      status: "booting",
+    });
+  });
+
   test("rejects participant sends when the viewer is not the session creator", async () => {
     const database = await createPublicHttpContractDatabase();
     await insertOwnerSession(database);


### PR DESCRIPTION
## Summary

- Run the three pre-admission guards (stale-run reconcile, execution plan plus package artifact, attachment readiness) concurrently instead of as serial D1 round trips.
- Inline dispatch skips the run-state re-read — it starts inside the request that just created the queued run — while queue delivery keeps the stale-run guard from #369. Both entry points now log `dispatchSource`, closing the attribution gap called out in the latency analysis.
- Hydration failures may only fail a run that is still `queued`, enforced atomically through a new `expectedCurrentStatus` precondition in the run transition machinery (optimistic `status_seq` guard). A losing dispatch contender can no longer tear down a run the winner is already provisioning; a focused regression test covers the booting-run case.

## Why

- The accept segment (user message → hydration start) measured 1.581s in the production `ping` latency trace, dominated by serial D1 round trips.
- The same analysis identified the duplicate-hydration race window and the loser-fails-winner hazard (`failQueuedSessionRunBeforeDispatch` could fail an actively provisioning run on credential/attachment jitter).
- Staging paired warm-ping screen (with the probe-removal PR in the same candidate stack): `context_hydration` median 242ms vs 1,333ms baseline across 8 pairs, 16/16 runs correct. Artifact `warm-ping-ab-v26-v5-vs-v6v9a-8pairs-20260721-v1.json`, SHA-256 `b55494c79cca4c5e7ffe419cb07549d1a130346a1a722196339ea8f5a44a0359`.

## Verification

- Commands: `bun run --filter @mosoo/api tc`, `bun run --filter @mosoo/api test` (1,039 pass, including the new "keeps a dispatched run untouched when a losing hydration fails"), `bun run fmt:check:path -- <changed files>`, `bun run lint`, `bun run commit:check`.
- Manual steps: staging warm-ping screen above.
- Not run: full `just check` locally; PR CI runs the repository gate.

## Impact

- User/API/contract changes: none externally; the run transition outcome union gains an additive `unexpected_current_status` rejected reason.
- Observability: log event `session.run.context_hydration.failed.after-terminal` renamed to `session.run.context_hydration.failed.run-not-queued` (saved queries on the old name go quiet); hydration logs gain `dispatchSource`.
- Generated files / GraphQL / DB / lockfile: none.
- Risk and rollback: no schema changes; revert restores serial guards and the previous failure semantics.

## Review

- Closest review areas: guard placement in `dispatch-queued-run.service.ts`; `expectedCurrentStatus` in `session-run-write.repository.ts` (atomicity via the existing `status_seq` optimistic guard); `Promise.all` failure semantics in `queue-run.service.ts` (first rejection wins, all guards still settle).
- Known trade-offs: pre-admission guard errors now surface in non-deterministic order.
