### PR TITLE
perf(api): trim warm dispatch critical path

### DIFF
--- a/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
@@ -123,8 +123,8 @@ export async function dispatchSessionRun(
   let runLease: RuntimeExecutionPlaneRunLease | null = null;
 
   try {
-    await ensureSessionRunIsActive(bindings.DB, input.sessionRunId);
-
+    // acquireSessionRunDispatch CASes queued -> booting and returns null for
+    // every other state, so a separate pre-check read is redundant.
     const bootingRun = await acquireSessionRunDispatch(bindings.DB, input.sessionRunId);
 
     if (!bootingRun) {
@@ -144,13 +144,14 @@ export async function dispatchSessionRun(
 
     // Only the dispatch winner writes run state; the losing path above must
     // stay write-free so it cannot fail a run the winner is provisioning.
-    await persistSessionRunSkills(bindings.DB, input.sessionRunId, input.resolvedSkills);
-
-    await appendSessionRuntimeEvents({
-      bindings,
-      events: [createSessionRunUpdatedEvent(bootingRun, input.sessionId)],
-      sessionId: input.sessionId,
-    });
+    await Promise.all([
+      persistSessionRunSkills(bindings.DB, input.sessionRunId, input.resolvedSkills),
+      appendSessionRuntimeEvents({
+        bindings,
+        events: [createSessionRunUpdatedEvent(bootingRun, input.sessionId)],
+        sessionId: input.sessionId,
+      }),
+    ]);
 
     const attemptPrepareAndDispatch = async (): Promise<RuntimeExecutionPlaneRunLease> => {
       const preparedRunLease = await executionPlane.prepareRun(bindings, requestUrl, {
@@ -217,17 +218,22 @@ export async function dispatchSessionRun(
           sessionRunId: input.sessionRunId,
         }),
       );
+      // Snapshot before the readiness/telemetry awaits so the published
+      // driver_turn stage measures command dispatch only.
+      const dispatchTimingSnapshot = dispatchTiming.snapshot();
       const readyTiming = await preparedRunLease.readiness();
       await ensureSessionRunIsActive(bindings.DB, input.sessionRunId);
       prepareTimingEventPromise = appendSessionRuntimeTimingEventBestEffort({
         bindings,
         timing: readyTiming,
       });
-      await prepareTimingEventPromise;
-      await appendSessionRuntimeTimingEventBestEffort({
-        bindings,
-        timing: dispatchTiming.snapshot(),
-      });
+      await Promise.all([
+        prepareTimingEventPromise,
+        appendSessionRuntimeTimingEventBestEffort({
+          bindings,
+          timing: dispatchTimingSnapshot,
+        }),
+      ]);
 
       return preparedRunLease;
     };

--- a/apps/api/src/modules/runtime/infrastructure/execution-plane/sandbox-execution-plane-adapter.ts
+++ b/apps/api/src/modules/runtime/infrastructure/execution-plane/sandbox-execution-plane-adapter.ts
@@ -139,6 +139,10 @@ class SandboxExecutionPlaneAdapter implements RuntimeExecutionPlaneAdapter {
       executionSession: null,
       subject: null,
     };
+    // Success diagnostics are owner-debug, persist-only (deliver: false) and
+    // swallow their own errors; keep them off the first-token critical path and
+    // settle them before the lease is returned.
+    let pendingDiagnostics: Promise<unknown> = Promise.resolve();
 
     try {
       const timing = createRuntimeTimingRecorder({
@@ -149,7 +153,7 @@ class SandboxExecutionPlaneAdapter implements RuntimeExecutionPlaneAdapter {
         traceId: input.traceId,
       });
       const runtimeSubjectLifecycle = createRuntimeSubjectLifecycleService(bindings);
-      await appendRuntimeDiagnosticEvent(bindings, {
+      pendingDiagnostics = appendRuntimeDiagnosticEvent(bindings, {
         eventName: RUNTIME_DIAGNOSTIC_EVENT.sandboxProvisioningStarted.name,
         sessionId: input.sessionId,
         value: {
@@ -173,15 +177,19 @@ class SandboxExecutionPlaneAdapter implements RuntimeExecutionPlaneAdapter {
         }),
       );
       handles.subject = sandbox;
-      await appendRuntimeDiagnosticEvent(bindings, {
-        eventName: RUNTIME_DIAGNOSTIC_EVENT.sandboxProvisioningCompleted.name,
-        sessionId: input.sessionId,
-        value: {
-          ...runtimeBase,
-          coldStartMs: sandboxProvisioningTimer.elapsedMs(),
-          sandboxId,
-        },
-      });
+      const provisioningCompletedValue = {
+        ...runtimeBase,
+        coldStartMs: sandboxProvisioningTimer.elapsedMs(),
+        sandboxId,
+      };
+      // Chain after the started event so the two diagnostics keep their order.
+      pendingDiagnostics = pendingDiagnostics.then(() =>
+        appendRuntimeDiagnosticEvent(bindings, {
+          eventName: RUNTIME_DIAGNOSTIC_EVENT.sandboxProvisioningCompleted.name,
+          sessionId: input.sessionId,
+          value: provisioningCompletedValue,
+        }),
+      );
       sandboxProvisioned = true;
 
       const executionSession = await timing.measure("ensureSandboxConversationSession", () =>
@@ -230,6 +238,8 @@ class SandboxExecutionPlaneAdapter implements RuntimeExecutionPlaneAdapter {
       }
       const initialDriverPhaseCount = driver.timing.phases.length;
 
+      await pendingDiagnostics;
+
       return {
         driverInstanceId: driver.driverInstanceId,
         readiness: async () => {
@@ -247,6 +257,7 @@ class SandboxExecutionPlaneAdapter implements RuntimeExecutionPlaneAdapter {
         },
       };
     } catch (error) {
+      await pendingDiagnostics;
       if (!sandboxProvisioned) {
         await appendRuntimeDiagnosticEvent(bindings, {
           eventName: RUNTIME_DIAGNOSTIC_EVENT.sandboxProvisioningFailed.name,


### PR DESCRIPTION
## Summary

- Keep the two sandbox-provisioning success diagnostics (persist-only, owner-debug, error-swallowing) off the first-token critical path; they run concurrently with provisioning, keep their relative order by chaining, and settle before the run lease returns (and before any failure diagnostic).
- Drop the redundant pre-CAS run-state read — the queued→booting CAS already rejects every other state, and the null branch keeps the same skip logging.
- Persist the skill snapshot and the booting event in parallel.
- Snapshot the published `driver_turn` stage immediately after command dispatch so it stops including readiness waits and telemetry persistence; the prepare and dispatch timing events then append in parallel (both after the driver command is already written).

## Why

- The production `ping` latency trace shows the pre-model control plane dominating TTFT; the CAS-to-prepare gap alone was 1.397s of serial D1 writes, and the published `driver_turn` (1.218s) mostly measured telemetry rather than dispatch (~0.3s real).
- Staging paired warm-ping screen (8 pairs, 16/16 correct): candidate `driver_turn` median 156ms vs 3,009ms baseline — predominantly the semantics correction — and the deferred writes remove awaited D1 round trips from the critical path. Artifact `warm-ping-ab-v26-v5-vs-v6v9a-8pairs-20260721-v1.json`, SHA-256 `b55494c79cca4c5e7ffe419cb07549d1a130346a1a722196339ea8f5a44a0359`.

## Verification

- Commands: `bun run --filter @mosoo/api tc`, `bun run --filter @mosoo/api test` (1,038 pass), `bun run fmt:check:path -- <changed files>`, `bun run lint`, `bun run commit:check`.
- Manual steps: staging warm-ping screen above (this branch deployed as part of the candidate stack).
- Not run: full `just check` locally; PR CI runs the repository gate.

## Impact

- **Metric semantics change**: published `driver_turn` stage totals drop sharply (staging median 3.0s → 0.15s) because they no longer include readiness and telemetry persistence; `prepare_run` totals also shrink slightly with the deferred diagnostics. Cross-version dashboards must compare end-to-end TTFT, not stage totals.
- User/API/contract changes: none.
- Generated files / GraphQL / DB / lockfile: none.
- Risk and rollback: reorder-only change; revert restores the serial awaits and old stage semantics.

## Review

- Closest review areas: `pendingDiagnostics` lifecycle in `sandbox-execution-plane-adapter.ts` (settled before lease return and on the failure path, order preserved by chaining); CAS skip-path logging in `dispatch-run.service.ts`.
- Known trade-offs: provisioning diagnostics persist concurrently with provisioning work instead of strictly before it.
