### PR TITLE
perf(api): overlap keep-alive with filesystem prepare

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-platform.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-platform.ts
@@ -46,15 +46,17 @@ export async function prepareRuntimeSubjectFilesystem(subject: SandboxHandle): P
   // port-readiness wait can stall ~120s; without a timeout the run wedges in `booting`
   // indefinitely until the next message reconciles it as `runtime.inactive`. Failing fast
   // surfaces a retryable `runtime.provision_failed` instead.
+  // The four RPCs are mutually independent: setKeepAlive configures the
+  // container lifetime while the mkdirs assert platform roots. Awaiting all of
+  // them keeps the explicit completion barrier for each call while removing
+  // the serial keep-alive wait from the first-token critical path.
   await withRuntimeProvisionTimeout(
-    (async (): Promise<void> => {
-      await subject.setKeepAlive(true);
-      await Promise.all([
-        subject.mkdir(SANDBOX_CACHE_PATH, { recursive: true }),
-        subject.mkdir(SANDBOX_MEMORY_PATH, { recursive: true }),
-        subject.mkdir(SANDBOX_SESSION_ROOT, { recursive: true }),
-      ]);
-    })(),
+    Promise.all([
+      subject.setKeepAlive(true),
+      subject.mkdir(SANDBOX_CACHE_PATH, { recursive: true }),
+      subject.mkdir(SANDBOX_MEMORY_PATH, { recursive: true }),
+      subject.mkdir(SANDBOX_SESSION_ROOT, { recursive: true }),
+    ]).then(() => undefined),
     "Runtime subject filesystem prepare",
   );
 }


### PR DESCRIPTION
## Summary

- `prepareRuntimeSubjectFilesystem` awaited `setKeepAlive(true)` before starting the three already-parallel platform-root `mkdir`s. The four container RPCs are mutually independent; they now run concurrently under the same provision timeout, keeping every explicit completion barrier (no fire-and-forget).

## Why

- Worker-log phase capture on the perf stacks shows `runtimeSubject.prepareFilesystem` is the dominant `prepare_run` phase: 4,841ms and 2,419ms in two probe runs (69–76% of the stage), with the serial keep-alive wait ahead of directory preparation.
- The same mechanism was previously validated in isolation by the perf lab: local 32-pair AB `-49.9%` on the phase (53.6ms → 26.9ms p50), and a staging pilot that removed a median **1.744s** serial wait per trace (each trace 1.577–2.273s), 8/8 identity/trace/semantics/cleanup. It was gated only on sample size, never refuted.
- Overnight 4-pair warm-ping screen vs the current main baseline (artifact `warm-ping-ab-v28-cand1-fs-concurrency-4pairs-20260721-v1.json`): see PR comment with the observed `prepare_run` paired deltas.

## Verification

- Commands: `bun run --filter @mosoo/api tc`, `bun run --filter @mosoo/api test` (1,039 pass), `bun run fmt:check:path -- <changed file>`, `bun run commit:check`.
- Manual steps: staging warm-ping screen (stage-a = main `77eb6a84`, stage-b = this branch), all runs correct output and cleanup.
- Not run: full `just check` locally; PR CI runs the repository gate.

## Impact

- User/API/contract changes: none. `setKeepAlive` remains explicitly awaited (observable completion, per Sandbox SDK 0.12.3 semantics where `configure()` is otherwise fire-and-forget).
- Generated files / GraphQL / DB / lockfile: none.
- Env or config changes: none.
- Risk and rollback: single-function reorder; revert restores the serial order.

## Review

- Closest review areas: `runtime-subject-platform.ts` — concurrency inside `withRuntimeProvisionTimeout`.
- Known trade-offs: keep-alive configuration now settles concurrently with directory asserts instead of strictly before them; both remain settled before any dependent work.
