### PR TITLE
perf(api): defer boot payload config traces off provision path

### DIFF
--- a/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/dispatch-run.service.ts
@@ -120,6 +120,9 @@ export async function dispatchSessionRun(
   const sandboxId = input.profile.sandbox.id;
   let driverInstanceId: DriverInstanceId | null = null;
   let prepareTimingEventPromise: Promise<void> = Promise.resolve();
+  // Boot-payload config traces are owner-debug telemetry; they persist off the
+  // provision critical path and settle with the post-dispatch awaits.
+  let pendingBootPayloadEvents: Promise<void> = Promise.resolve();
   let runLease: RuntimeExecutionPlaneRunLease | null = null;
 
   try {
@@ -160,25 +163,41 @@ export async function dispatchSessionRun(
         onBootPayloadPrepared: async ({ bootPayload }) => {
           const configTraceValue = buildSessionConfigTraceValue(bootPayload);
 
-          await appendSessionRuntimeEvents({
-            bindings,
-            events: [
-              createSessionRuntimeEvent({
-                kind: "runtime.config.updated",
-                payload: configTraceValue,
-                runId: input.sessionRunId,
+          pendingBootPayloadEvents = pendingBootPayloadEvents
+            .then(() =>
+              appendSessionRuntimeEvents({
+                bindings,
+                events: [
+                  createSessionRuntimeEvent({
+                    kind: "runtime.config.updated",
+                    payload: configTraceValue,
+                    runId: input.sessionRunId,
+                    sessionId: input.sessionId,
+                    traceId: input.traceId,
+                    visibility: "owner_debug",
+                  }),
+                ],
+                sessionId: input.sessionId,
+              }),
+            )
+            .then(() =>
+              appendBootPayloadRuntimeEvents(bindings, {
+                bootPayload,
                 sessionId: input.sessionId,
                 traceId: input.traceId,
-                visibility: "owner_debug",
               }),
-            ],
-            sessionId: input.sessionId,
-          });
-          await appendBootPayloadRuntimeEvents(bindings, {
-            bootPayload,
-            sessionId: input.sessionId,
-            traceId: input.traceId,
-          });
+            )
+            .then(
+              () => undefined,
+              (error: unknown) => {
+                logWarn("session.run.config_trace.append_failed", {
+                  message: error instanceof Error ? error.message : String(error),
+                  runId: input.sessionRunId,
+                  sessionId: input.sessionId,
+                  traceId: input.traceId,
+                });
+              },
+            );
         },
         profile: input.profile,
         resolvedMcpServers: input.resolvedMcpServers,
@@ -229,6 +248,7 @@ export async function dispatchSessionRun(
       });
       await Promise.all([
         prepareTimingEventPromise,
+        pendingBootPayloadEvents,
         appendSessionRuntimeTimingEventBestEffort({
           bindings,
           timing: dispatchTimingSnapshot,
@@ -240,6 +260,7 @@ export async function dispatchSessionRun(
 
     const handlePreReadyRetry = async (failure: Error, retriesRemaining: number): Promise<void> => {
       await prepareTimingEventPromise;
+      await pendingBootPayloadEvents;
       prepareTimingEventPromise = Promise.resolve();
 
       logWarn("session.run.dispatch.pre_ready_retry", {
@@ -286,6 +307,7 @@ export async function dispatchSessionRun(
     });
   } catch (error) {
     await prepareTimingEventPromise;
+    await pendingBootPayloadEvents;
 
     if (error instanceof SessionRunNoLongerActiveError) {
       if (isTruthy(driverInstanceId)) {


### PR DESCRIPTION
## Summary

- `onBootPayloadPrepared` awaited two owner-debug telemetry appends (the `runtime.config.updated` trace and the boot payload diagnostics) inside driver provisioning. They now chain onto a tracked promise settled with the post-dispatch telemetry awaits, and on every retry/failure path; append failures degrade to a structured warning instead of failing the run.

## Why

- Worker-log phase capture showed `driver.provision.onBootPayloadPrepared` costing a stable ~270ms (262/279ms) on every driver provision, all of it owner-debug persistence on the first-token critical path.
- Post-change phase capture on the same stack: **0ms / 0ms / 0ms** across three probe runs, all with correct output and cleanup; `driver.provision` dropped accordingly.

## Verification

- Commands: `bun run --filter @mosoo/api tc`, `bun run --filter @mosoo/api test` (1,039 pass), `bun run fmt:check:path`, `bun run commit:check`.
- Manual steps: staging phase-level probe (3 pings) on the perf stack, before/after worker-log capture.
- Not run: full `just check` locally; PR CI runs the repository gate.

## Impact

- User/API/contract changes: none. Config traces remain persisted; ordering between the two appends preserved by chaining.
- Generated files / GraphQL / DB / lockfile: none.
- Risk and rollback: telemetry persistence failures now log `session.run.config_trace.append_failed` instead of failing provisioning; revert restores the awaited behavior.

## Review

- Closest review areas: `dispatch-run.service.ts` pendingBootPayloadEvents lifecycle (settled in post-dispatch awaits, retry path, and outer catch).
- Known trade-offs: a run that fails before the deferred append settles still awaits it in the catch path, so no telemetry is lost silently.