### PR TITLE
perf(api): skip redundant conversation record read on reuse

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/sandbox-session/sandbox-conversation-session.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/sandbox-session/sandbox-conversation-session.service.ts
@@ -129,15 +129,20 @@ export async function ensureSandboxConversationSession(
   const frozenOrigin = existingSession
     ? parseSandboxConversationOrigin(existingSession.originJson)
     : input.origin;
-  const sessionRecord = await measureOptional(input.timing, "conversation.ensureRecord", () =>
-    ensureRuntimeConversationSessionRecord(bindings.DB, {
-      cwd,
-      now,
-      originJson: JSON.stringify(frozenOrigin),
-      runtimeSubjectId: input.sandboxId,
-      sessionId: input.sessionId,
-    }),
-  );
+  // ensureRuntimeConversationSessionRecord only re-reads the row we already
+  // loaded above when a record exists (the sandbox-mismatch guard ran there
+  // too), so the round trip is only needed for first-time allocation.
+  const sessionRecord =
+    existingSession ??
+    (await measureOptional(input.timing, "conversation.ensureRecord", () =>
+      ensureRuntimeConversationSessionRecord(bindings.DB, {
+        cwd,
+        now,
+        originJson: JSON.stringify(frozenOrigin),
+        runtimeSubjectId: input.sandboxId,
+        sessionId: input.sessionId,
+      }),
+    ));
   const sandboxSessionId = continuation.sandboxSessionId ?? sessionRecord.sandboxSessionId;
 
   if (continuation.shouldRestoreCwd && existingSession) {


### PR DESCRIPTION
## Summary

- `ensureSandboxConversationSession` loaded the conversation record and then called `ensureRuntimeConversationSessionRecord`, which re-reads the same row and returns it unchanged whenever the record already exists (the sandbox-mismatch guard also already ran at the call site). Reuse the loaded record; keep the ensure round trip for first-time allocation only.
- `recordRuntimeConversationSessionActive` is deliberately untouched: it clears `inactiveDeadlineAt`, and skipping it could let an actively used pet subject be recycled by a stale idle countdown.

## Why

- Worker-log phase capture showed `conversation.ensureRecord` costing 127–142ms of D1 round trip on every run with an existing conversation record.
- Post-change capture on the same stack: the phase no longer occurs; `ensureSandboxConversationSession` dropped from 263–517ms to 195ms with correct output and cleanup.

## Verification

- Commands: `bun run --filter @mosoo/api tc`, `bun run --filter @mosoo/api test` (1,039 pass, 0 fail), `bun run fmt:check:path`, `bun run commit:check`.
- Manual steps: staging phase-level probe on the perf stack, before/after worker-log capture.
- Not run: full `just check` locally; PR CI runs the repository gate.

## Impact

- User/API/contract changes: none; identical returned record and guards.
- Generated files / GraphQL / DB / lockfile: none.
- Risk and rollback: pure read deduplication; revert restores the extra read.

## Review

- Closest review areas: `sandbox-conversation-session.service.ts` — the reuse branch and first-allocation branch.
- Known trade-offs: none identified; behavior identical by construction for existing records.