### PR TITLE
feat(api): add deep health probe for worker-to-d1 rtt

### DIFF
--- a/apps/api/src/adapters/http/routes/health-route.ts
+++ b/apps/api/src/adapters/http/routes/health-route.ts
@@ -3,10 +3,30 @@ import type { Hono } from "hono";
 import type { ApiGatewayEnvironment } from "../../../platform/cloudflare/worker-types";
 
 export function registerHealthRoute(app: Hono<ApiGatewayEnvironment>) {
-  app.get("/health", (c) =>
-    c.json({
+  app.get("/health", async (c) => {
+    if (c.req.query("deep") !== "1") {
+      return c.json({
+        name: c.env.APP_NAME,
+        ok: true,
+      });
+    }
+
+    // Three sequential round trips measure Worker->D1 RTT rather than
+    // throughput; placement drift between a Worker and its D1 instance is
+    // otherwise invisible and gets misdiagnosed as slow code.
+    const d1PingsMs: number[] = [];
+
+    for (let index = 0; index < 3; index += 1) {
+      const startedAtMs = Date.now();
+
+      await c.env.DB.prepare("SELECT 1").first();
+      d1PingsMs.push(Date.now() - startedAtMs);
+    }
+
+    return c.json({
+      d1PingsMs,
       name: c.env.APP_NAME,
       ok: true,
-    }),
-  );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- `GET /api/health?deep=1` returns three sequential timed `SELECT 1` round trips (`d1PingsMs`). Plain `/api/health` is unchanged.

## Why

- Placement drift between a Worker and its D1 instance is invisible today and gets misdiagnosed as slow code. The two identically configured staging perf stacks differ by ~70ms per D1 read (hydration stage delta ~0.69s over ~10 reads, driver_turn delta ~40ms over 2 writes, persistent across builds and crossover phases — artifacts `warm-ping-ab-v29-*`).
- First step of the placement-engineering direction in #387: make "is this stack badly placed" a number before touching location hints or Smart Placement.

## Verification

- Commands: `bun run --filter @mosoo/api tc`, `bun run --filter @mosoo/api test` (1,039 pass), `bun run fmt:check:path`.
- Manual steps: deployed to both staging perf stacks; probe readings reported in #387.
- Not run: full `just check` locally; PR CI runs the repository gate.

## Impact

- User/API/contract changes: additive query parameter on an existing public endpoint; three trivial reads per deep call.
- Generated files / GraphQL / DB / lockfile: none.
- Risk and rollback: read-only probe; revert removes the parameter.

## Review

- Closest review areas: `health-route.ts`; sequential (not parallel) pings are intentional — RTT, not throughput.