### PR TITLE
perf(api): give cattle subjects a short idle grace

### DIFF
--- a/apps/api/src/modules/runtime/domain/runtime-kind-policy.ts
+++ b/apps/api/src/modules/runtime/domain/runtime-kind-policy.ts
@@ -61,6 +61,15 @@ export interface RuntimeKindPolicy {
 
 const RUNTIME_SUBJECT_IDLE_GRACE_MS = 5 * 60_000;
 
+// Cattle subjects are per-session sandboxes; tearing them down after every
+// terminal run made each follow-up turn in the same session pay the full
+// container boot (measured 2.4-4.8s vs ~0.3s on a warm container). A short
+// idle grace keeps the sandbox alive between turns while the kind-agnostic
+// inactive-deadline sweep still reclaims it shortly after the session goes
+// quiet. Cost ceiling: one extra <=90s of container residency per session
+// after its last run.
+const CATTLE_SUBJECT_IDLE_GRACE_MS = 90_000;
+
 const SUBJECT_MEMORY_CHECKPOINT = {
   path: SANDBOX_MEMORY_PATH,
   type: "subject_memory",
@@ -104,7 +113,7 @@ export const RUNTIME_KIND_POLICIES = {
       terminalTarget: AGENT_KIND_RUNTIME_POLICIES.cattle.terminal.target,
     },
     subject: {
-      idleReleaseDelayMs: 0,
+      idleReleaseDelayMs: CATTLE_SUBJECT_IDLE_GRACE_MS,
       scope: AGENT_KIND_RUNTIME_POLICIES.cattle.subject.scope,
       subjectKind: AGENT_KIND_RUNTIME_POLICIES.cattle.subject.scope,
     },


### PR DESCRIPTION
## Summary

- Cattle `idleReleaseDelayMs` goes from 0 to 90s. Terminal-run release no longer recycles the per-session sandbox immediately; the existing kind-agnostic inactive-deadline sweep (the pet path) reclaims it once the session stays quiet.

## Why

- With instant recycle, every follow-up turn in the same session paid the full container boot: `prepareFilesystem` measured 2.4–4.8s cold vs ~0.3s warm, and a warm-container run measured `prepare_run` 1,335ms vs 4–6s cold.
- 4-pair staging screen (same stack, before/after windows): TTFT 7,606/7,846/8,277/8,571ms (**median 8.06s**, previously 10.6–11.9s medians) with `prepare_run` collapsing to 3,511–3,809ms and variance shrinking from ±3s to ±0.5s; 4/4 pairs faster, 10/10 runs correct.

## Verification

- Commands: `bun run --filter @mosoo/api tc`, `bun run --filter @mosoo/api test` (1,039 pass), `bun run fmt:check:path`.
- Manual steps: staging screen above on the dedicated perf stacks.
- Not run: full `just check` locally; PR CI runs the repository gate.

## Impact

- **Deliberate semantics note**: consecutive cattle turns within the 90s window now observe the same per-session sandbox (including workspace files), which matches the documented cattle contract ("Independent sandbox per session") — instant recycle was resetting state mid-session. After the grace expires the sandbox is reclaimed exactly as before.
- Cost ceiling: one extra <=90s of container residency per session after its last run, bounded by max_instances.
- Generated files / GraphQL / DB / lockfile: none.
- Risk and rollback: single policy value; revert restores instant recycle. The maintenance-vs-active-run race is guarded by the existing lease recheck at the destructive transition.

## Review

- Closest review areas: `runtime-kind-policy.ts`; `recycleReleasedTerminalRuntimeLeaseIfNeeded` early-return now applies to cattle; deadline written by the conversation-close path.
- Known trade-offs: residency cost vs boot elimination; grace length (90s) is a starting value, tunable with usage data.