### PR TITLE
fix(web): unthrottle session stream rendering

### DIFF
--- a/apps/web/src/domains/runtime/session-stream/session-stream-render-scheduler.ts
+++ b/apps/web/src/domains/runtime/session-stream/session-stream-render-scheduler.ts
@@ -1,15 +1,15 @@
-import type { AgUiSessionEvent, TextMessageContentEvent } from "@mosoo/ag-ui-session";
+import type { AgUiSessionEvent } from "@mosoo/ag-ui-session";
 
 interface QueuedSessionEvent {
-  enqueuedAt: number;
   event: AgUiSessionEvent;
   sessionId: string;
 }
 
 export interface SessionStreamRenderSchedulerHost {
   cancelFrame: (handle: number) => void;
-  now: () => number;
+  cancelTimeout: (handle: number) => void;
   requestFrame: (callback: () => void) => number;
+  requestTimeout: (callback: () => void, delayMs: number) => number;
 }
 
 export type SessionStreamRenderSchedulerApply = (
@@ -17,103 +17,29 @@ export type SessionStreamRenderSchedulerApply = (
   events: AgUiSessionEvent[],
 ) => boolean;
 
-const SMOOTH_TEXT_CHARS_PER_FRAME = 24;
-const CATCH_UP_TEXT_CHARS_PER_FRAME = 96;
-const SURGE_TEXT_CHARS_PER_FRAME = 256;
-const CATCH_UP_TEXT_QUEUE_CHARS = 320;
-const SURGE_TEXT_QUEUE_CHARS = 1200;
-const CATCH_UP_OLDEST_TEXT_MS = 300;
-const SURGE_OLDEST_TEXT_MS = 900;
-const MAX_IMMEDIATE_EVENTS_PER_FRAME = 160;
-const MIN_SEMANTIC_SLICE_CHARS = 4;
-const PREFERRED_TEXT_BOUNDARIES = new Set([
-  "\n",
-  "\r",
-  "\t",
-  " ",
-  ",",
-  ".",
-  "!",
-  "?",
-  ";",
-  ":",
-  ")",
-  "]",
-  "}",
-  "，",
-  "。",
-  "！",
-  "？",
-  "；",
-  "：",
-  "、",
-  "）",
-  "】",
-  "》",
-]);
+// Flood guard only: bounds a single React commit during pathological event
+// storms. Everything queued for the session is otherwise delivered on the
+// next frame — requestAnimationFrame batching is the smoothing; an artificial
+// per-frame character budget just throttles visible streaming.
+const MAX_EVENTS_PER_FRAME = 512;
+
+// requestAnimationFrame stops firing when the window is hidden, occluded, or
+// battery-throttled. Without a timer fallback the queue silently starves and
+// the transcript freezes while the socket keeps receiving events.
+const THROTTLED_FRAME_FALLBACK_MS = 50;
 
 function createBrowserFrameSchedulerHost(): SessionStreamRenderSchedulerHost {
   return {
     cancelFrame: (handle) => {
       globalThis.cancelAnimationFrame(handle);
     },
-    now: () => performance.now(),
+    cancelTimeout: (handle) => {
+      globalThis.clearTimeout(handle);
+    },
     requestFrame: (callback) => globalThis.requestAnimationFrame(callback),
+    requestTimeout: (callback, delayMs) =>
+      globalThis.setTimeout(callback, delayMs) as unknown as number,
   };
-}
-
-function isTextContentEvent(event: AgUiSessionEvent): event is TextMessageContentEvent {
-  return event.type === "TEXT_MESSAGE_CONTENT";
-}
-
-function sliceTextContentEvent(
-  event: TextMessageContentEvent,
-  budget: number,
-): {
-  consumed: TextMessageContentEvent;
-  remaining: TextMessageContentEvent | null;
-} {
-  const sliceLength = preferredTextSliceLength(event.delta, budget);
-  const consumedDelta = event.delta.slice(0, sliceLength);
-  const remainingDelta = event.delta.slice(sliceLength);
-
-  return {
-    consumed: { ...event, delta: consumedDelta },
-    remaining: remainingDelta.length > 0 ? { ...event, delta: remainingDelta } : null,
-  };
-}
-
-function preferredTextSliceLength(delta: string, budget: number): number {
-  if (delta.length <= budget) {
-    return delta.length;
-  }
-
-  const hardEnd = codePointSliceEnd(delta, budget);
-  const minSemanticEnd = Math.min(hardEnd, MIN_SEMANTIC_SLICE_CHARS);
-
-  for (let index = hardEnd; index >= minSemanticEnd; index -= 1) {
-    if (PREFERRED_TEXT_BOUNDARIES.has(delta.charAt(index - 1))) {
-      return index;
-    }
-  }
-
-  return hardEnd;
-}
-
-function codePointSliceEnd(text: string, budget: number): number {
-  let end = 0;
-
-  for (const character of text) {
-    const nextEnd = end + character.length;
-
-    if (nextEnd > budget) {
-      return end > 0 ? end : nextEnd;
-    }
-
-    end = nextEnd;
-  }
-
-  return text.length;
 }
 
 export class SessionStreamRenderScheduler {
@@ -121,6 +47,7 @@ export class SessionStreamRenderScheduler {
   #frameHandle: number | null = null;
   readonly #host: SessionStreamRenderSchedulerHost;
   #queue: QueuedSessionEvent[] = [];
+  #timeoutHandle: number | null = null;
 
   public constructor(
     apply: SessionStreamRenderSchedulerApply,
@@ -131,11 +58,7 @@ export class SessionStreamRenderScheduler {
   }
 
   public clear(): void {
-    if (this.#frameHandle !== null) {
-      this.#host.cancelFrame(this.#frameHandle);
-      this.#frameHandle = null;
-    }
-
+    this.#cancelPending();
     this.#queue = [];
   }
 
@@ -148,11 +71,8 @@ export class SessionStreamRenderScheduler {
       return;
     }
 
-    const enqueuedAt = this.#host.now();
-
     for (const event of events) {
       this.#queue.push({
-        enqueuedAt,
         event,
         sessionId,
       });
@@ -162,10 +82,7 @@ export class SessionStreamRenderScheduler {
   }
 
   public flushNow(sessionId: string): void {
-    if (this.#frameHandle !== null) {
-      this.#host.cancelFrame(this.#frameHandle);
-      this.#frameHandle = null;
-    }
+    this.#cancelPending();
 
     const events: AgUiSessionEvent[] = [];
     const remaining: QueuedSessionEvent[] = [];
@@ -184,7 +101,6 @@ export class SessionStreamRenderScheduler {
       if (!this.#apply(sessionId, events)) {
         this.#queue = [
           ...events.map((event) => ({
-            enqueuedAt: this.#host.now(),
             event,
             sessionId,
           })),
@@ -196,15 +112,30 @@ export class SessionStreamRenderScheduler {
     this.#schedule();
   }
 
+  #cancelPending(): void {
+    if (this.#frameHandle !== null) {
+      this.#host.cancelFrame(this.#frameHandle);
+      this.#frameHandle = null;
+    }
+
+    if (this.#timeoutHandle !== null) {
+      this.#host.cancelTimeout(this.#timeoutHandle);
+      this.#timeoutHandle = null;
+    }
+  }
+
   #schedule(): void {
-    if (this.#frameHandle !== null || this.#queue.length === 0) {
+    if (this.#frameHandle !== null || this.#timeoutHandle !== null || this.#queue.length === 0) {
       return;
     }
 
-    this.#frameHandle = this.#host.requestFrame(() => {
-      this.#frameHandle = null;
+    const drain = () => {
+      this.#cancelPending();
       this.#drainFrame();
-    });
+    };
+
+    this.#frameHandle = this.#host.requestFrame(drain);
+    this.#timeoutHandle = this.#host.requestTimeout(drain, THROTTLED_FRAME_FALLBACK_MS);
   }
 
   #drainFrame(): void {
@@ -213,7 +144,6 @@ export class SessionStreamRenderScheduler {
     if (batch && batch.events.length > 0 && !this.#apply(batch.sessionId, batch.events)) {
       this.#queue = [
         ...batch.events.map((event) => ({
-          enqueuedAt: this.#host.now(),
           event,
           sessionId: batch.sessionId,
         })),
@@ -236,52 +166,17 @@ export class SessionStreamRenderScheduler {
 
     const { sessionId } = first;
     const events: AgUiSessionEvent[] = [];
-    let textBudget: number | null = null;
-    let immediateEvents = 0;
     let consumedQueueItems = 0;
 
-    while (consumedQueueItems < this.#queue.length) {
+    while (consumedQueueItems < this.#queue.length && events.length < MAX_EVENTS_PER_FRAME) {
       const item = this.#queue[consumedQueueItems];
 
       if (!item || item.sessionId !== sessionId) {
         break;
       }
 
-      if (isTextContentEvent(item.event)) {
-        if (item.event.delta.length === 0) {
-          consumedQueueItems += 1;
-          continue;
-        }
-
-        textBudget ??= this.#textBudgetForSession(sessionId);
-
-        if (textBudget <= 0) {
-          break;
-        }
-
-        const sliced = sliceTextContentEvent(item.event, textBudget);
-        events.push(sliced.consumed);
-        textBudget -= sliced.consumed.delta.length;
-
-        if (sliced.remaining) {
-          this.#queue[consumedQueueItems] = {
-            ...item,
-            event: sliced.remaining,
-          };
-          break;
-        }
-
-        consumedQueueItems += 1;
-        continue;
-      }
-
       events.push(item.event);
       consumedQueueItems += 1;
-      immediateEvents += 1;
-
-      if (immediateEvents >= MAX_IMMEDIATE_EVENTS_PER_FRAME && events.length > 0) {
-        break;
-      }
     }
 
     if (consumedQueueItems > 0) {
@@ -289,30 +184,5 @@ export class SessionStreamRenderScheduler {
     }
 
     return { events, sessionId };
-  }
-
-  #textBudgetForSession(sessionId: string): number {
-    const now = this.#host.now();
-    let oldestTextAge = 0;
-    let queuedTextChars = 0;
-
-    for (const item of this.#queue) {
-      if (item.sessionId !== sessionId || !isTextContentEvent(item.event)) {
-        continue;
-      }
-
-      queuedTextChars += item.event.delta.length;
-      oldestTextAge = Math.max(oldestTextAge, now - item.enqueuedAt);
-
-      if (queuedTextChars >= SURGE_TEXT_QUEUE_CHARS || oldestTextAge >= SURGE_OLDEST_TEXT_MS) {
-        return SURGE_TEXT_CHARS_PER_FRAME;
-      }
-    }
-
-    if (queuedTextChars >= CATCH_UP_TEXT_QUEUE_CHARS || oldestTextAge >= CATCH_UP_OLDEST_TEXT_MS) {
-      return CATCH_UP_TEXT_CHARS_PER_FRAME;
-    }
-
-    return SMOOTH_TEXT_CHARS_PER_FRAME;
   }
 }

--- a/apps/web/tests/session-stream-render-scheduler.test.ts
+++ b/apps/web/tests/session-stream-render-scheduler.test.ts
@@ -5,28 +5,29 @@ import type { AgUiSessionEvent } from "@mosoo/ag-ui-session";
 import type { SessionStreamRenderSchedulerHost } from "../src/domains/runtime/session-stream/session-stream-render-scheduler";
 import { SessionStreamRenderScheduler } from "../src/domains/runtime/session-stream/session-stream-render-scheduler";
 
-function createManualFrameHost(): {
-  callbacks: (() => void)[];
-  getNowCalls: () => number;
+function createManualHost(): {
+  frameCallbacks: (() => void)[];
   host: SessionStreamRenderSchedulerHost;
+  timeoutCallbacks: (() => void)[];
 } {
-  const callbacks: (() => void)[] = [];
-  let nowCalls = 0;
+  const frameCallbacks: (() => void)[] = [];
+  const timeoutCallbacks: (() => void)[] = [];
 
   return {
-    callbacks,
-    getNowCalls: () => nowCalls,
+    frameCallbacks,
     host: {
       cancelFrame: () => {},
-      now: () => {
-        nowCalls += 1;
-        return 0;
-      },
+      cancelTimeout: () => {},
       requestFrame: (callback) => {
-        callbacks.push(callback);
-        return callbacks.length;
+        frameCallbacks.push(callback);
+        return frameCallbacks.length;
+      },
+      requestTimeout: (callback) => {
+        timeoutCallbacks.push(callback);
+        return timeoutCallbacks.length;
       },
     },
+    timeoutCallbacks,
   };
 }
 
@@ -52,26 +53,27 @@ function stateDeltaEvent(): AgUiSessionEvent {
 }
 
 describe("session stream render scheduler", () => {
-  test("drains long text queues without dropping or reordering chunks", () => {
-    const { callbacks, host } = createManualFrameHost();
+  test("delivers every queued text chunk unthrottled and in order", () => {
+    const { frameCallbacks, host } = createManualHost();
     const batches: AgUiSessionEvent[][] = [];
     const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
       batches.push(events);
       return true;
     }, host);
-    const events = Array.from({ length: 300 }, () => textEvent("x"));
+    const events = Array.from({ length: 600 }, (_unused, index) => textEvent(`chunk-${index}`));
 
     scheduler.enqueueMany("session-1", events);
-    drainFrames(callbacks);
+    drainFrames(frameCallbacks);
 
-    expect(batches.length).toBeGreaterThan(1);
+    // 600 events exceed one frame's flood guard, never more than two frames.
+    expect(batches.length).toBe(2);
     expect(
       batches.flat().map((event) => (event.type === "TEXT_MESSAGE_CONTENT" ? event.delta : "")),
-    ).toEqual(Array.from({ length: 300 }, () => "x"));
+    ).toEqual(events.map((event) => (event.type === "TEXT_MESSAGE_CONTENT" ? event.delta : "")));
   });
 
   test("keeps another session queued while flushing the first session", () => {
-    const { callbacks, host } = createManualFrameHost();
+    const { frameCallbacks, host } = createManualHost();
     const applied: { events: AgUiSessionEvent[]; sessionId: string }[] = [];
     const scheduler = new SessionStreamRenderScheduler((sessionId, events) => {
       applied.push({ events, sessionId });
@@ -81,7 +83,7 @@ describe("session stream render scheduler", () => {
     scheduler.enqueueMany("session-1", [textEvent("a"), textEvent("b")]);
     scheduler.enqueueMany("session-2", [textEvent("c")]);
     scheduler.flushNow("session-1");
-    drainFrames(callbacks);
+    drainFrames(frameCallbacks);
 
     expect(applied.map((batch) => batch.sessionId)).toEqual(["session-1", "session-2"]);
     expect(
@@ -93,30 +95,24 @@ describe("session stream render scheduler", () => {
     ).toEqual(["ab", "c"]);
   });
 
-  test("does not scan the text budget for non-text backlogs", () => {
-    const { callbacks, getNowCalls, host } = createManualFrameHost();
-    let applied = 0;
+  test("delivers mixed event types in arrival order", () => {
+    const { frameCallbacks, host } = createManualHost();
+    const types: string[] = [];
     const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
-      applied += events.length;
+      for (const event of events) {
+        types.push(event.type);
+      }
       return true;
     }, host);
 
-    scheduler.enqueueMany(
-      "session-1",
-      Array.from({ length: 500 }, () => stateDeltaEvent()),
-    );
+    scheduler.enqueueMany("session-1", [textEvent("a"), stateDeltaEvent(), textEvent("b")]);
+    drainFrames(frameCallbacks);
 
-    expect(getNowCalls()).toBe(1);
-
-    drainFrames(callbacks);
-
-    expect(applied).toBe(500);
-    expect(getNowCalls()).toBe(1);
+    expect(types).toEqual(["TEXT_MESSAGE_CONTENT", "STATE_DELTA", "TEXT_MESSAGE_CONTENT"]);
   });
 
-  test("requeues a failed partial text slice without losing content", () => {
-    const { callbacks, host } = createManualFrameHost();
-    const content = "x".repeat(1300);
+  test("requeues a rejected batch without losing content", () => {
+    const { frameCallbacks, host } = createManualHost();
     const appliedDeltas: string[] = [];
     let rejectNextBatch = true;
     const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
@@ -134,10 +130,29 @@ describe("session stream render scheduler", () => {
       return true;
     }, host);
 
-    scheduler.enqueueMany("session-1", [textEvent(content)]);
-    drainFrames(callbacks);
+    scheduler.enqueueMany("session-1", [textEvent("x".repeat(1300))]);
+    drainFrames(frameCallbacks);
 
     expect(rejectNextBatch).toBe(false);
-    expect(appliedDeltas.join("")).toBe(content);
+    expect(appliedDeltas.join("")).toBe("x".repeat(1300));
+  });
+
+  test("drains through the timeout fallback when frames never fire", () => {
+    const { host, timeoutCallbacks } = createManualHost();
+    const appliedDeltas: string[] = [];
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      for (const event of events) {
+        if (event.type === "TEXT_MESSAGE_CONTENT") {
+          appliedDeltas.push(event.delta);
+        }
+      }
+      return true;
+    }, host);
+
+    scheduler.enqueueMany("session-1", [textEvent("hidden"), textEvent("window")]);
+    // requestAnimationFrame is throttled or paused: only the timer fires.
+    drainFrames(timeoutCallbacks);
+
+    expect(appliedDeltas).toEqual(["hidden", "window"]);
   });
 });


### PR DESCRIPTION
## Summary

- Remove the per-frame character budget and boundary slicing from the session stream render scheduler: everything queued for the session is delivered on the next frame (requestAnimationFrame batching is the smoothing), with a 512-events-per-frame flood guard for pathological storms.
- Add a 50ms timer fallback alongside requestAnimationFrame so a throttled or paused rAF (hidden/occluded window, battery saver) cannot starve the transcript while the socket keeps receiving events.

## Why

Two production Preview complaints after server TTFT dropped to a few seconds:

1. Visible streaming crawled (~24 chars/frame smooth tier, backward punctuation slicing shrinking CJK slices further), and every slice committed a fresh React state, re-rendering the growing message per frame — the artificial typewriter became the dominant visible latency now that the server is fast.
2. Replies visible in Logs but not in Preview: the queue drains only on rAF; when the browser throttles or pauses frames the transcript freezes despite live socket delivery. The timer fallback keeps output flowing in that mode.

## Verification

- Commands: `bun run --filter @mosoo/web tc`, `bun run --filter @mosoo/web test` (182 pass), `bun run fmt:check:path`.
- Manual steps: pending production deploy verification on try.mosoo.ai Preview (fast gpt-5.5 stream).
- Not run: full `just check` locally; PR CI runs the repository gate.

## Impact

- User/API/contract changes: deliberate UX change — text renders as fast as it arrives instead of a paced typewriter reveal.
- Generated files / GraphQL / DB / lockfile: none.
- Risk and rollback: scheduler-local; revert restores paced rendering. Scheduler host interface gains cancelTimeout/requestTimeout (single consumer updated).

## Review

- Closest review areas: `session-stream-render-scheduler.ts` (drain and dual-arm scheduling), rewritten unit tests incl. the timeout-fallback path.
- Known trade-offs: a very large single delta now commits in one frame; bounded by the flood guard and typical delta sizes.