### PR TITLE
perf(runtime): keep cattle conversations open across terminal runs

### DIFF
--- a/apps/api/src/modules/runtime/domain/runtime-kind-policy.ts
+++ b/apps/api/src/modules/runtime/domain/runtime-kind-policy.ts
@@ -63,12 +63,15 @@ const RUNTIME_SUBJECT_IDLE_GRACE_MS = 5 * 60_000;
 
 // Cattle subjects are per-session sandboxes; tearing them down after every
 // terminal run made each follow-up turn in the same session pay the full
-// container boot (measured 2.4-4.8s vs ~0.3s on a warm container). A short
-// idle grace keeps the sandbox alive between turns while the kind-agnostic
-// inactive-deadline sweep still reclaims it shortly after the session goes
-// quiet. Cost ceiling: one extra <=90s of container residency per session
+// container boot (measured 2.4-4.8s vs ~0.3s on a warm container). The idle
+// grace keeps the sandbox — and, since conversations no longer close on run
+// terminal, the resident driver — alive between turns while the
+// kind-agnostic inactive-deadline sweep still reclaims it after the session
+// goes quiet. Five minutes matches the human read-think-type rhythm between
+// follow-up turns (90s covered only a third of observed gaps) and the pet
+// grace. Cost ceiling: one extra <=5min of container residency per session
 // after its last run.
-const CATTLE_SUBJECT_IDLE_GRACE_MS = 90_000;
+const CATTLE_SUBJECT_IDLE_GRACE_MS = 5 * 60_000;
 
 const SUBJECT_MEMORY_CHECKPOINT = {
   path: SANDBOX_MEMORY_PATH,

--- a/apps/api/src/modules/runtime/domain/runtime-kind-policy.ts
+++ b/apps/api/src/modules/runtime/domain/runtime-kind-policy.ts
@@ -101,7 +101,14 @@ export const RUNTIME_KIND_POLICIES = {
     },
     kind: "cattle",
     lease: {
-      closeOnRunTerminal: true,
+      // Keeping the conversation session open across terminal runs keeps the
+      // driver process (and its provider session) resident inside the idle
+      // grace window, so a follow-up turn skips the driver respawn that
+      // dominated the warm prepare path. The conversation idle sweep closes
+      // sessions quiet for longer than the subject grace, which arms the
+      // subject inactive deadline and hands reclamation to the existing
+      // maintenance chain.
+      closeOnRunTerminal: false,
     },
     nativeResume: {
       persistence: AGENT_KIND_RUNTIME_POLICIES.cattle.nativeResume.persistence,

--- a/apps/api/src/modules/runtime/domain/runtime-kind-policy.ts
+++ b/apps/api/src/modules/runtime/domain/runtime-kind-policy.ts
@@ -69,8 +69,11 @@ const RUNTIME_SUBJECT_IDLE_GRACE_MS = 5 * 60_000;
 // kind-agnostic inactive-deadline sweep still reclaims it after the session
 // goes quiet. Five minutes matches the human read-think-type rhythm between
 // follow-up turns (90s covered only a third of observed gaps) and the pet
-// grace. Cost ceiling: one extra <=5min of container residency per session
-// after its last run.
+// grace. Cost: the grace applies twice in series — the sweep waits it out as
+// the idle threshold, then the close arms the same grace as the subject's
+// inactive deadline — so worst-case container residency after the last run is
+// ~2x the grace (~10min), not one grace. Acceptable at current cattle volume;
+// shorten the post-close deadline for sweep-closes if that residency matters.
 const CATTLE_SUBJECT_IDLE_GRACE_MS = 5 * 60_000;
 
 const SUBJECT_MEMORY_CHECKPOINT = {

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-conversation-session-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-conversation-session-store.ts
@@ -11,6 +11,7 @@ import {
   mapReadyRuntimeSubjectBackup,
   readyConversationBackupTable,
   runLeaseQuery,
+  runLeaseQueryForListedSubject,
 } from "./runtime-subject-store-queries";
 import type {
   RuntimeConversationSessionRecord,
@@ -90,6 +91,39 @@ export async function getRuntimeConversationSessionState(
       .limit(1)
       .get()) ?? null
   );
+}
+
+// Session-scoped (cattle) conversations stay open across terminal runs so the
+// driver survives the idle grace. This lists the ones quiet past that grace so
+// the maintenance sweep can close them; the close path arms the subject
+// inactive deadline, which feeds the existing subject reclamation chain. Rows
+// with an active run lease are skipped — a long-running turn is not idle.
+export async function listIdleSessionScopedConversationSessions(
+  database: D1Database,
+  input: {
+    readonly idleSinceLte: number;
+    readonly limit: number;
+  },
+): Promise<Array<{ sandboxId: SandboxId; sessionId: SessionId }>> {
+  const appDb = getAppDatabase(database);
+
+  return appDb
+    .select({
+      sandboxId: sandboxSessionsTable.sandboxId,
+      sessionId: sandboxSessionsTable.sessionId,
+    })
+    .from(sandboxSessionsTable)
+    .innerJoin(sandboxesTable, eq(sandboxesTable.id, sandboxSessionsTable.sandboxId))
+    .where(
+      and(
+        eq(sandboxSessionsTable.status, "active"),
+        eq(sandboxesTable.kind, "cattle"),
+        sql`${sandboxSessionsTable.updatedAt} <= ${input.idleSinceLte}`,
+        notExists(runLeaseQueryForListedSubject(appDb)),
+      ),
+    )
+    .limit(input.limit)
+    .all();
 }
 
 export async function ensureRuntimeConversationSessionRecord(

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-conversation-session-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-conversation-session-store.ts
@@ -2,7 +2,7 @@ import type { RuntimeSubjectErrorCode } from "@mosoo/contracts/sandbox";
 import { sandboxesTable, sandboxSessionsTable, sessionsTable } from "@mosoo/db";
 import { createPlatformId } from "@mosoo/id";
 import type { SandboxId, SandboxSessionId, SessionId } from "@mosoo/id";
-import { and, desc, eq, inArray, notExists, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, lte, notExists, sql } from "drizzle-orm";
 
 import { getAppDatabase, runAppDatabaseBatch } from "../../../../platform/db/drizzle";
 import { toRuntimeSubjectStatusLifecycleEventName } from "../../domain/runtime-subject-lifecycle.machine";
@@ -124,6 +124,46 @@ export async function listIdleSessionScopedConversationSessions(
     )
     .limit(input.limit)
     .all();
+}
+
+// Atomically claim an idle cattle conversation for the sweep to close. Between
+// the sweep's LIST and its per-row close there is a window where a follow-up
+// turn can re-use the resident session (ensureSandboxConversationSession
+// refreshes updatedAt) before its run lease exists — the list-time lease guard
+// would miss it and the close would delete the session mid-run. This flips the
+// row active->closed only if it is STILL the same session instance
+// (cloudflare_session_id), still idle (updatedAt <= idleSinceLte), and still
+// lease-free. A refreshed updatedAt or a rebuilt session makes the claim fail,
+// so the caller skips it; once claimed, a follow-up sees status=closed and
+// rebuilds a fresh session, so the sweep only ever finalizes the stale one.
+export async function claimIdleSessionScopedConversationForClose(
+  database: D1Database,
+  input: {
+    readonly idleSinceLte: number;
+    readonly now: number;
+    readonly runtimeSubjectId: SandboxId;
+    readonly sandboxSessionId: SandboxSessionId;
+    readonly sessionId: SessionId;
+  },
+): Promise<boolean> {
+  const appDb = getAppDatabase(database);
+  const claimed = await appDb
+    .update(sandboxSessionsTable)
+    .set({ status: "closed", updatedAt: input.now })
+    .where(
+      and(
+        eq(sandboxSessionsTable.sessionId, input.sessionId),
+        eq(sandboxSessionsTable.sandboxId, input.runtimeSubjectId),
+        eq(sandboxSessionsTable.sandboxSessionId, input.sandboxSessionId),
+        eq(sandboxSessionsTable.status, "active"),
+        lte(sandboxSessionsTable.updatedAt, input.idleSinceLte),
+        notExists(runLeaseQuery(appDb, input.runtimeSubjectId)),
+      ),
+    )
+    .returning({ sessionId: sandboxSessionsTable.sessionId })
+    .get();
+
+  return claimed != null;
 }
 
 export async function ensureRuntimeConversationSessionRecord(

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service.ts
@@ -13,11 +13,13 @@ import { syncSessionViewerState } from "../../../sessions/application/session-vi
 import { RESCHEDULING_RECONNECT_WINDOW_MS } from "../../../sessions/domain/session-lifecycle";
 import { createSessionLifecycleTerminatedEvent } from "../../application/session-runs/session-run-view-events.service";
 import { reconcileStaleActiveSessionRuns } from "../../application/session-runs/stale-run-reconciliation.service";
+import { getRuntimeKindPolicy } from "../../domain/runtime-kind-policy";
 import { cleanupDriverInstances } from "../driver-instance/maintenance";
 import { repairRuntimeCommandRecords } from "../session-runs/runtime-command-store.repository";
 import { createSessionStatusTransitionPatch } from "../session-runs/session-lifecycle-projection.repository";
 import { setSessionRunStatus } from "../session-runs/session-run-store.repository";
 import type { SessionRunTransitionOutcome } from "../session-runs/session-run-store.repository";
+import { listIdleSessionScopedConversationSessions } from "./runtime-conversation-session-store";
 import {
   claimInactiveRuntimeSubject,
   listInactiveRuntimeSubjects,
@@ -246,6 +248,37 @@ export async function expireStaleReschedulingSessions(bindings: ApiBindings): Pr
   );
 }
 
+// Cattle conversations no longer close on run terminal (the resident driver is
+// what makes follow-up turns warm), so this sweep is what ends them: close the
+// ones quiet past the cattle idle grace, which arms the subject inactive
+// deadline and hands the container to the existing subject reclamation pass.
+async function closeIdleSessionScopedConversationSessions(
+  bindings: ApiBindings,
+  now: number,
+): Promise<void> {
+  const idleGraceMs = getRuntimeKindPolicy("cattle").subject.idleReleaseDelayMs;
+  const idle = await listIdleSessionScopedConversationSessions(bindings.DB, {
+    idleSinceLte: now - idleGraceMs,
+    limit: MAINTENANCE_BATCH_SIZE,
+  });
+
+  for (const conversation of idle) {
+    try {
+      const { closeSandboxConversationSession } = await import("../sandbox-session.service");
+      await closeSandboxConversationSession(bindings, {
+        sandboxId: conversation.sandboxId,
+        sessionId: conversation.sessionId,
+      });
+    } catch (error) {
+      logWarn("runtime.conversation.idle_close_failed", {
+        ...createErrorLogContext(error),
+        runtimeSubjectId: conversation.sandboxId,
+        sessionId: conversation.sessionId,
+      });
+    }
+  }
+}
+
 export async function runSandboxMaintenance(bindings: ApiBindings): Promise<void> {
   const now = Date.now();
 
@@ -264,6 +297,7 @@ export async function runSandboxMaintenance(bindings: ApiBindings): Promise<void
     limit: MAINTENANCE_BATCH_SIZE,
     staleUpdatedAtLte: now - MAINTENANCE_OPERATION_REPAIR_AFTER_MS,
   });
+  await closeIdleSessionScopedConversationSessions(bindings, now);
 
   const [candidates, repairCandidates] = await Promise.all([
     listInactiveRuntimeSubjects(bindings.DB, {

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service.ts
@@ -262,13 +262,6 @@ async function closeIdleSessionScopedConversationSessions(
     limit: MAINTENANCE_BATCH_SIZE,
   });
 
-  // TEMP-DEBUG(vc2): remove before merge — proves the sweep runs on staging.
-  logWarn("runtime.conversation.idle_sweep.debug", {
-    cutoff: now - idleGraceMs,
-    eligible: idle.length,
-    idleGraceMs,
-  });
-
   for (const conversation of idle) {
     try {
       const { closeSandboxConversationSession } = await import("../sandbox-session.service");

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service.ts
@@ -257,15 +257,20 @@ async function closeIdleSessionScopedConversationSessions(
   now: number,
 ): Promise<void> {
   const idleGraceMs = getRuntimeKindPolicy("cattle").subject.idleReleaseDelayMs;
+  const idleSinceLte = now - idleGraceMs;
   const idle = await listIdleSessionScopedConversationSessions(bindings.DB, {
-    idleSinceLte: now - idleGraceMs,
+    idleSinceLte,
     limit: MAINTENANCE_BATCH_SIZE,
   });
+  const { closeIdleCattleConversationSession } = await import("../sandbox-session.service");
 
   for (const conversation of idle) {
     try {
-      const { closeSandboxConversationSession } = await import("../sandbox-session.service");
-      await closeSandboxConversationSession(bindings, {
+      // Atomic claim inside: closes only if the row is still the same, idle,
+      // lease-free session — a follow-up turn that re-used it since the list
+      // snapshot makes the claim lose and is left running.
+      await closeIdleCattleConversationSession(bindings, {
+        idleSinceLte,
         sandboxId: conversation.sandboxId,
         sessionId: conversation.sessionId,
       });

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service.ts
@@ -262,6 +262,13 @@ async function closeIdleSessionScopedConversationSessions(
     limit: MAINTENANCE_BATCH_SIZE,
   });
 
+  // TEMP-DEBUG(vc2): remove before merge — proves the sweep runs on staging.
+  logWarn("runtime.conversation.idle_sweep.debug", {
+    cutoff: now - idleGraceMs,
+    eligible: idle.length,
+    idleGraceMs,
+  });
+
   for (const conversation of idle) {
     try {
       const { closeSandboxConversationSession } = await import("../sandbox-session.service");

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store.ts
@@ -1,4 +1,5 @@
 export {
+  claimIdleSessionScopedConversationForClose,
   ensureRuntimeConversationSessionRecord,
   getRuntimeConversationSession,
   getRuntimeConversationSessionState,

--- a/apps/api/src/modules/runtime/infrastructure/sandbox-session.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/sandbox-session.service.ts
@@ -1,4 +1,5 @@
 export {
+  closeIdleCattleConversationSession,
   closeSandboxConversationSession,
   ensureSandboxConversationSession,
 } from "./sandbox-session/sandbox-conversation-session.service";

--- a/apps/api/src/modules/runtime/infrastructure/sandbox-session/sandbox-conversation-session.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/sandbox-session/sandbox-conversation-session.service.ts
@@ -17,6 +17,7 @@ import {
 } from "../../domain/runtime-kind-policy";
 import type { RuntimeConversationSessionRecord } from "../runtime-subject-lifecycle/runtime-subject-store";
 import {
+  claimIdleSessionScopedConversationForClose,
   ensureRuntimeConversationSessionRecord,
   getRuntimeConversationSession,
   getRuntimeConversationSessionState,
@@ -24,6 +25,7 @@ import {
   recordRuntimeConversationSessionClosed,
   recordRuntimeConversationSessionError,
 } from "../runtime-subject-lifecycle/runtime-subject-store";
+import type { RuntimeConversationSessionState } from "../runtime-subject-lifecycle/runtime-subject-store";
 import { ensureSessionResourcesMounted } from "../session-resources/session-resource-mount.service";
 import { parseSandboxConversationOrigin } from "./sandbox-conversation-session-codec";
 import {
@@ -250,22 +252,83 @@ export async function closeSandboxConversationSession(
     return;
   }
 
+  // Force-close: session-end / cleanup callers must tear down regardless of
+  // idleness. The idle sweep uses closeIdleCattleConversationSession instead.
+  await finalizeSandboxConversationClose(bindings, {
+    sandboxId: input.sandboxId,
+    sessionId: input.sessionId,
+    state,
+  });
+}
+
+// Sweep-only close. Unlike closeSandboxConversationSession this does NOT
+// force-close: it atomically claims the row (active->closed) only if it is
+// still the same, still-idle, lease-free session, which closes the
+// LIST->CLOSE race where a follow-up turn re-uses the resident session before
+// its run lease exists. If the claim loses, the follow-up owns the session and
+// the sweep leaves it. Returns true when it closed the conversation.
+export async function closeIdleCattleConversationSession(
+  bindings: ApiBindings,
+  input: {
+    idleSinceLte: number;
+    sandboxId: SandboxId;
+    sessionId: SessionId;
+  },
+): Promise<boolean> {
+  const state = await getRuntimeConversationSessionState(bindings.DB, {
+    runtimeSubjectId: input.sandboxId,
+    sessionId: input.sessionId,
+  });
+
+  if (!state || state.status !== "active") {
+    return false;
+  }
+
+  const claimed = await claimIdleSessionScopedConversationForClose(bindings.DB, {
+    idleSinceLte: input.idleSinceLte,
+    now: currentTimestampMs(),
+    runtimeSubjectId: input.sandboxId,
+    sandboxSessionId: state.sandboxSessionId,
+    sessionId: input.sessionId,
+  });
+
+  if (!claimed) {
+    return false;
+  }
+
+  await finalizeSandboxConversationClose(bindings, {
+    sandboxId: input.sandboxId,
+    sessionId: input.sessionId,
+    state,
+  });
+
+  return true;
+}
+
+async function finalizeSandboxConversationClose(
+  bindings: ApiBindings,
+  input: {
+    sandboxId: SandboxId;
+    sessionId: SessionId;
+    state: RuntimeConversationSessionState;
+  },
+): Promise<void> {
   const now = currentTimestampMs();
   const { deleteActiveSandboxConversationSession } =
     await import("./sandbox-conversation-session-delete");
 
   await deleteActiveSandboxConversationSession(bindings, {
-    sandboxSessionId: state.sandboxSessionId,
+    sandboxSessionId: input.state.sandboxSessionId,
     sandboxId: input.sandboxId,
   });
 
-  if (state.agentId) {
+  if (input.state.agentId) {
     await appendRuntimeDiagnosticEvent(bindings, {
       eventName: RUNTIME_DIAGNOSTIC_EVENT.sandboxSessionDestroyed.name,
       sessionId: input.sessionId,
       value: {
         ...toRuntimeDiagnosticBaseValue({
-          agentId: state.agentId,
+          agentId: input.state.agentId,
           sessionId: input.sessionId,
         }),
         reason: "runtime_subject_session_closed",
@@ -275,7 +338,10 @@ export async function closeSandboxConversationSession(
   }
 
   await recordRuntimeConversationSessionClosed(bindings.DB, {
-    inactiveDeadlineAt: getRuntimeSubjectInactiveDeadline(getRuntimeKindPolicy(state.kind), now),
+    inactiveDeadlineAt: getRuntimeSubjectInactiveDeadline(
+      getRuntimeKindPolicy(input.state.kind),
+      now,
+    ),
     now,
     runtimeSubjectId: input.sandboxId,
     sessionId: input.sessionId,

--- a/apps/api/src/platform/cloudflare/create-api-worker.ts
+++ b/apps/api/src/platform/cloudflare/create-api-worker.ts
@@ -37,17 +37,14 @@ export function createApiWorker(): ExportedHandler<ApiBindings> {
       });
     },
     async queue(batch: MessageBatch, env: ApiBindings): Promise<void> {
-      if (batch.queue === "api-command" || batch.queue === "environment-artifact-build") {
-        const commandBatch = batch as MessageBatch<ApiCommandMessage>;
+      // Queue names are account-global, so isolated environments (the perf
+      // stacks) deploy prefixed copies like "mosoo-perf-stage-b-api-command".
+      // Route by suffix so a renamed queue still reaches its consumer instead
+      // of silently acking every batch unprocessed.
+      const isQueue = (name: string): boolean =>
+        batch.queue === name || batch.queue.endsWith(`-${name}`);
 
-        for (const message of commandBatch.messages) {
-          await processApiCommandMessage(env, message);
-        }
-
-        return;
-      }
-
-      if (batch.queue === "api-command-dlq") {
+      if (isQueue("api-command-dlq")) {
         const commandBatch = batch as MessageBatch<ApiCommandMessage>;
 
         for (const message of commandBatch.messages) {
@@ -57,7 +54,17 @@ export function createApiWorker(): ExportedHandler<ApiBindings> {
         return;
       }
 
-      if (batch.queue === "channel-final-delivery") {
+      if (isQueue("api-command") || isQueue("environment-artifact-build")) {
+        const commandBatch = batch as MessageBatch<ApiCommandMessage>;
+
+        for (const message of commandBatch.messages) {
+          await processApiCommandMessage(env, message);
+        }
+
+        return;
+      }
+
+      if (isQueue("channel-final-delivery")) {
         const { processChannelFinalDeliveryMessage } =
           await import("../../modules/channels/application/channel-final-delivery.service");
         const channelBatch = batch as MessageBatch<ChannelFinalDeliveryMessage>;

--- a/apps/api/tests/runtime-conversation-idle-sweep.test.ts
+++ b/apps/api/tests/runtime-conversation-idle-sweep.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+
+import { listIdleSessionScopedConversationSessions } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-conversation-session-store";
+import { SqliteD1Database } from "./helpers/sqlite-d1";
+
+const NOW = 1_000_000;
+const GRACE_MS = 90_000;
+
+function createDatabase(): SqliteD1Database {
+  const database = new SqliteD1Database();
+
+  database.execute(`
+    CREATE TABLE sandbox_session (
+      cloudflare_session_id text NOT NULL,
+      created_at integer NOT NULL,
+      cwd text NOT NULL,
+      origin_json text NOT NULL,
+      sandbox_id text NOT NULL,
+      session_id text PRIMARY KEY NOT NULL,
+      status text NOT NULL,
+      updated_at integer NOT NULL
+    );
+
+    CREATE TABLE sandbox (
+      id text PRIMARY KEY NOT NULL,
+      kind text NOT NULL
+    );
+
+    CREATE TABLE driver_instance (
+      id text PRIMARY KEY NOT NULL,
+      sandbox_id text NOT NULL
+    );
+
+    CREATE TABLE session_run (
+      id text PRIMARY KEY NOT NULL,
+      driver_instance_id text,
+      status text NOT NULL
+    );
+  `);
+
+  return database;
+}
+
+async function insertConversation(
+  database: D1Database,
+  input: {
+    readonly kind: string;
+    readonly sandboxId: string;
+    readonly sessionId: string;
+    readonly status: string;
+    readonly updatedAt: number;
+  },
+): Promise<void> {
+  await database
+    .prepare(
+      `INSERT INTO sandbox (id, kind) VALUES (?, ?)
+        ON CONFLICT (id) DO NOTHING`,
+    )
+    .bind(input.sandboxId, input.kind)
+    .run();
+  await database
+    .prepare(
+      `INSERT INTO sandbox_session (
+        cloudflare_session_id, created_at, cwd, origin_json, sandbox_id, session_id, status, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      `cf-${input.sessionId}`,
+      1,
+      "cwd",
+      "{}",
+      input.sandboxId,
+      input.sessionId,
+      input.status,
+      input.updatedAt,
+    )
+    .run();
+}
+
+async function insertActiveRunLease(
+  database: D1Database,
+  input: { readonly runId: string; readonly sandboxId: string },
+): Promise<void> {
+  await database
+    .prepare("INSERT INTO driver_instance (id, sandbox_id) VALUES (?, ?)")
+    .bind(`driver-${input.runId}`, input.sandboxId)
+    .run();
+  await database
+    .prepare("INSERT INTO session_run (id, driver_instance_id, status) VALUES (?, ?, ?)")
+    .bind(input.runId, `driver-${input.runId}`, "running")
+    .run();
+}
+
+describe("idle session-scoped conversation sweep", () => {
+  test("lists only idle active cattle conversations without a run lease", async () => {
+    const database = createDatabase();
+    await insertConversation(database, {
+      kind: "cattle",
+      sandboxId: "sb-idle",
+      sessionId: "session-idle",
+      status: "active",
+      updatedAt: NOW - GRACE_MS - 1,
+    });
+    await insertConversation(database, {
+      kind: "cattle",
+      sandboxId: "sb-fresh",
+      sessionId: "session-fresh",
+      status: "active",
+      updatedAt: NOW - 1_000,
+    });
+    await insertConversation(database, {
+      kind: "pet",
+      sandboxId: "sb-pet",
+      sessionId: "session-pet",
+      status: "active",
+      updatedAt: NOW - GRACE_MS - 1,
+    });
+    await insertConversation(database, {
+      kind: "cattle",
+      sandboxId: "sb-closed",
+      sessionId: "session-closed",
+      status: "closed",
+      updatedAt: NOW - GRACE_MS - 1,
+    });
+    await insertConversation(database, {
+      kind: "cattle",
+      sandboxId: "sb-busy",
+      sessionId: "session-busy",
+      status: "active",
+      updatedAt: NOW - GRACE_MS - 1,
+    });
+    await insertActiveRunLease(database, { runId: "run-busy", sandboxId: "sb-busy" });
+
+    const idle = await listIdleSessionScopedConversationSessions(database, {
+      idleSinceLte: NOW - GRACE_MS,
+      limit: 10,
+    });
+
+    expect(idle).toEqual([{ sandboxId: "sb-idle", sessionId: "session-idle" }]);
+  });
+});

--- a/apps/api/tests/runtime-conversation-idle-sweep.test.ts
+++ b/apps/api/tests/runtime-conversation-idle-sweep.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { listIdleSessionScopedConversationSessions } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-conversation-session-store";
+import {
+  claimIdleSessionScopedConversationForClose,
+  listIdleSessionScopedConversationSessions,
+} from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-conversation-session-store";
 import { SqliteD1Database } from "./helpers/sqlite-d1";
 
 const NOW = 1_000_000;
@@ -137,5 +140,70 @@ describe("idle session-scoped conversation sweep", () => {
     });
 
     expect(idle).toEqual([{ sandboxId: "sb-idle", sessionId: "session-idle" }]);
+  });
+
+  test("atomic claim closes an idle conversation but loses to any re-activation", async () => {
+    const database = createDatabase();
+    const idleSinceLte = NOW - GRACE_MS;
+    const claim = (sandboxId: string, sessionId: string, sandboxSessionId: string) =>
+      claimIdleSessionScopedConversationForClose(database, {
+        idleSinceLte,
+        now: NOW,
+        runtimeSubjectId: sandboxId as never,
+        sandboxSessionId: sandboxSessionId as never,
+        sessionId: sessionId as never,
+      });
+    const statusOf = async (sessionId: string) =>
+      (
+        await database
+          .prepare("SELECT status FROM sandbox_session WHERE session_id = ?")
+          .bind(sessionId)
+          .first<{ status: string }>()
+      )?.status;
+
+    // (1) still-idle, same session instance, no lease → claim wins, row closed.
+    await insertConversation(database, {
+      kind: "cattle",
+      sandboxId: "sb-a",
+      sessionId: "sess-a",
+      status: "active",
+      updatedAt: NOW - GRACE_MS - 1,
+    });
+    expect(await claim("sb-a", "sess-a", "cf-sess-a")).toBe(true);
+    expect(await statusOf("sess-a")).toBe("closed");
+
+    // (2) a follow-up refreshed updated_at past the grace → claim loses, untouched.
+    await insertConversation(database, {
+      kind: "cattle",
+      sandboxId: "sb-b",
+      sessionId: "sess-b",
+      status: "active",
+      updatedAt: NOW, // refreshed by ensureSandboxConversationSession
+    });
+    expect(await claim("sb-b", "sess-b", "cf-sess-b")).toBe(false);
+    expect(await statusOf("sess-b")).toBe("active");
+
+    // (3) the session was rebuilt (new cloudflare_session_id) → claim loses.
+    await insertConversation(database, {
+      kind: "cattle",
+      sandboxId: "sb-c",
+      sessionId: "sess-c",
+      status: "active",
+      updatedAt: NOW - GRACE_MS - 1,
+    });
+    expect(await claim("sb-c", "sess-c", "cf-STALE")).toBe(false);
+    expect(await statusOf("sess-c")).toBe("active");
+
+    // (4) an active run lease appeared → claim loses.
+    await insertConversation(database, {
+      kind: "cattle",
+      sandboxId: "sb-d",
+      sessionId: "sess-d",
+      status: "active",
+      updatedAt: NOW - GRACE_MS - 1,
+    });
+    await insertActiveRunLease(database, { runId: "run-d", sandboxId: "sb-d" });
+    expect(await claim("sb-d", "sess-d", "cf-sess-d")).toBe(false);
+    expect(await statusOf("sess-d")).toBe("active");
   });
 });


### PR DESCRIPTION
Closes the V-C2 (warm-floor) direction of #387.

## Problem

Production data (14d): 29/32 sessions receive their first message within 2s of creation — prewarm-on-create cannot beat the first-turn cold boot. The lever left is the follow-up turn, where the warm prepare path still paid ~4-5s because `closeOnRunTerminal` tore down the conversation session — and the driver process in it — after every cattle run. Per-run driver respawn also minted a fresh codex thread every turn, which scattered OpenAI's `prompt_cache_key` routing (codex keys it on its thread id; langgenius/mosoo-agent-driver#82).

## Change

1. **Cattle `closeOnRunTerminal: false`** — the conversation session and its resident driver survive between turns inside the idle grace.
2. **Conversation idle sweep** (piggybacks the existing minute maintenance): closes cattle conversations quiet past the grace; the existing close path arms the subject inactive deadline, so container reclamation rides the unchanged subject-sweep chain. Conversations holding an active run lease are never treated as idle. Pet is untouched.
3. **Cattle idle grace 90s → 5min** — 90s covered only a third of observed follow-up gaps; 5min matches the read-think-type rhythm and the pet grace.
4. **fix(api): route queue batches by name suffix** — found by this gate: queue names are account-global, so isolated stacks deploy prefixed queues (`mosoo-perf-stage-b-api-command`); the consumer matched bare names only and silently acked every batch unprocessed. Scheduled maintenance had therefore never run on prefixed stacks (it stopped on the perf stacks the moment they switched to prefixed queues on 07-20). Suffix match; bare production names behave exactly as before.

## Evidence (paired staging gate, openai instrument, stage-a=main `7aa09730` vs stage-b=this branch, same container image)

**4 batches × 8 pairs — 32/32 pairs faster:**

| batch | main median TTFT | branch median TTFT | paired Δ | wins |
|---|---|---|---|---|
| 1 | 7,861ms | 3,132ms | −4,730ms | 8/8 |
| 2 | 11,849ms | 3,183ms | −8,569ms | 8/8 |
| 3 | 10,586ms | 3,156ms | −7,408ms | 8/8 |
| 4 | 9,695ms | 3,517ms | −6,086ms | 8/8 |

- `prepare_run` warm median: **5.0–8.6s → ~1.0s** (990–1,053ms across batches); branch-side batch medians vary ±50ms while main wobbles ±2s (driver-respawn lottery removed).
- **Cache synergy confirmed**: 4 sequential same-thread runs, `cache_read` = [10112, 12160, 12160, 12160] (4/4 near-full) vs [0, 0, 12160, 0] on main under the identical experiment — resident driver ⇒ stable codex thread ⇒ stable `prompt_cache_key`.
- **Leak proof end-to-end** (after the queue fix revived staging maintenance): probe conversation closed by the sweep → subject deadline armed → subject reclaimed and row removed; all stray conversations converged to zero. No schema changes, no migrations.

Cost ceiling: one extra ≤5min of container residency per session after its last run (the container already lives through the old 90s grace; the delta is grace length only).

Verification: api tc green, 1,053 api tests pass (incl. new sweep filter test), fmt/lint green.