### PR TITLE
refactor(agent-package): index archive path admission

### DIFF
--- a/pkgs/agent-package/src/archive-entry-admission.ts
+++ b/pkgs/agent-package/src/archive-entry-admission.ts
@@ -69,6 +69,7 @@ export function admitAgentPackageArchiveEntries(
   candidates: AgentPackageArchiveEntryCandidate[],
 ): AgentPackageArchiveAdmissionResult {
   const admittedEntries: AgentPackageArchiveEntry[] = [];
+  const descendantPathByAncestorPath = new Map<string, string>();
   const paths = new Map<string, AgentPackageArchiveEntry>();
   const filePaths = new Set<string>();
 
@@ -103,7 +104,7 @@ export function admitAgentPackageArchiveEntries(
     }
 
     if (entry.entryKind === "file") {
-      const descendantPath = findDescendantPath(entry.normalizedPath, paths);
+      const descendantPath = descendantPathByAncestorPath.get(entry.normalizedPath) ?? null;
 
       if (descendantPath !== null) {
         return archiveEntryAdmissionFailure({
@@ -117,6 +118,7 @@ export function admitAgentPackageArchiveEntries(
       filePaths.add(entry.normalizedPath);
     }
 
+    rememberAncestorPaths(entry.normalizedPath, descendantPathByAncestorPath);
     paths.set(entry.normalizedPath, entry);
     admittedEntries.push(entry);
   }
@@ -469,32 +471,35 @@ function throwArchiveReadError(failure: AgentPackageArchiveAdmissionFailure): ne
 }
 
 function findAncestorFilePath(path: string, filePaths: Set<string>): string | null {
-  const segments = path.split("/");
+  let slashIndex = path.indexOf("/");
 
-  for (let index = 1; index < segments.length; index += 1) {
-    const ancestorPath = segments.slice(0, index).join("/");
-
+  while (slashIndex !== -1) {
+    const ancestorPath = path.slice(0, slashIndex);
     if (filePaths.has(ancestorPath)) {
       return ancestorPath;
     }
+
+    slashIndex = path.indexOf("/", slashIndex + 1);
   }
 
   return null;
 }
 
-function findDescendantPath(
+function rememberAncestorPaths(
   path: string,
-  paths: Map<string, AgentPackageArchiveEntry>,
-): string | null {
-  const descendantPrefix = `${path}/`;
+  descendantPathByAncestorPath: Map<string, string>,
+): void {
+  let slashIndex = path.indexOf("/");
 
-  for (const existingPath of paths.keys()) {
-    if (existingPath.startsWith(descendantPrefix)) {
-      return existingPath;
+  while (slashIndex !== -1) {
+    const ancestorPath = path.slice(0, slashIndex);
+
+    if (!descendantPathByAncestorPath.has(ancestorPath)) {
+      descendantPathByAncestorPath.set(ancestorPath, path);
     }
-  }
 
-  return null;
+    slashIndex = path.indexOf("/", slashIndex + 1);
+  }
 }
 
 function findEndOfCentralDirectory(bytes: Uint8Array): number {

--- a/pkgs/agent-package/src/archive-path-policy.ts
+++ b/pkgs/agent-package/src/archive-path-policy.ts
@@ -12,6 +12,8 @@ interface ArchiveManifestCatalog {
   mcpServerNames: Set<string>;
 }
 
+type ArchiveSkillAssetRoots = ReadonlySet<string>;
+
 interface ArchivePathDeclaration {
   entryKind: "directory" | "file";
   path: string;
@@ -121,6 +123,7 @@ export function collectArchiveAdmissionIssues(input: {
 }): AgentResolutionIssue[] {
   const catalog = readArchiveManifestCatalog(input.manifestJson);
   const allowedPaths = createAllowedArchivePaths(input.agentPackage, catalog);
+  const skillAssetRoots = createManifestSkillAssetRoots(input.agentPackage);
   const issues: AgentResolutionIssue[] = collectArchiveDeclarationIssues(input.agentPackage);
 
   for (const path of Object.keys(input.entries)) {
@@ -139,7 +142,7 @@ export function collectArchiveAdmissionIssues(input: {
       continue;
     }
 
-    if (isAllowedArchivePath(path, allowedPaths, input.agentPackage)) {
+    if (isAllowedArchivePath(path, allowedPaths, input.agentPackage, skillAssetRoots)) {
       continue;
     }
 
@@ -258,6 +261,14 @@ export function createAllowedArchivePaths(
   return allowedPaths;
 }
 
+function createManifestSkillAssetRoots(agentPackage: AgentPackage): ArchiveSkillAssetRoots {
+  return new Set(
+    agentPackage.manifest.skills.map((skill) =>
+      skill.skillId.endsWith("/") ? skill.skillId : `${skill.skillId}/`,
+    ),
+  );
+}
+
 function readArchiveManifestCatalog(manifestJson: string): ArchiveManifestCatalog {
   const parsedManifest: unknown = JSON.parse(manifestJson);
   const mcpServerNames = new Set<string>();
@@ -295,7 +306,7 @@ function isAllowedArchivePath(
   path: string,
   allowedPaths: Set<string>,
   agentPackage: AgentPackage,
-  exportSkillAssetRoots?: Set<string>,
+  skillAssetRoots: ArchiveSkillAssetRoots = createManifestSkillAssetRoots(agentPackage),
 ): boolean {
   if (path.length === 0 || path.startsWith("/") || path.split("/").includes("..")) {
     return false;
@@ -305,24 +316,20 @@ function isAllowedArchivePath(
     return true;
   }
 
-  const skillRoots =
-    exportSkillAssetRoots ??
-    new Set(
-      agentPackage.manifest.skills.map((skill) =>
-        skill.skillId.endsWith("/") ? skill.skillId : `${skill.skillId}/`,
-      ),
-    );
+  return isAllowedSkillAssetPath(path, skillAssetRoots);
+}
 
-  for (const skillPath of skillRoots) {
-    if (!path.startsWith(skillPath)) {
-      continue;
-    }
+function isAllowedSkillAssetPath(path: string, skillAssetRoots: ArchiveSkillAssetRoots): boolean {
+  let slashIndex = path.indexOf("/");
 
-    const relativePath = path.slice(skillPath.length);
+  while (slashIndex !== -1) {
+    const candidateRoot = path.slice(0, slashIndex + 1);
 
-    if (relativePath.length > 0) {
+    if (candidateRoot.length < path.length && skillAssetRoots.has(candidateRoot)) {
       return true;
     }
+
+    slashIndex = path.indexOf("/", slashIndex + 1);
   }
 
   return false;

--- a/pkgs/agent-package/tests/archive-entry-admission.test.ts
+++ b/pkgs/agent-package/tests/archive-entry-admission.test.ts
@@ -170,6 +170,73 @@ describe("agent package archive entry admission", () => {
       "skills/demo/SKILL.md",
     ]);
   });
+
+  test("admits nested package assets under declared skill roots", () => {
+    const parsed = parseAgentPackageArchiveBytes(
+      createStoredZipArchive([
+        {
+          body: textToArchiveBytes(
+            createPackageManifestJson({
+              skills: [
+                { name: "Demo", path: "skills/demo/" },
+                { name: "Other", path: "skills/other/" },
+              ],
+            }),
+          ),
+          path: "manifest.json",
+        },
+        {
+          body: textToArchiveBytes('{"secretNames":[],"setupScript":""}'),
+          path: "environment/definition.json",
+        },
+        {
+          body: textToArchiveBytes("---\nname: Demo\n---\nUse this skill."),
+          path: "skills/demo/SKILL.md",
+        },
+        {
+          body: textToArchiveBytes("helper"),
+          path: "skills/demo/scripts/run.ts",
+        },
+        {
+          body: textToArchiveBytes("---\nname: Other\n---\nUse this skill."),
+          path: "skills/other/SKILL.md",
+        },
+      ]),
+    );
+
+    expect(parsed.package).not.toBeNull();
+    expect(parsed.package?.assets.map((asset) => asset.key).toSorted()).toEqual([
+      "skills/demo/SKILL.md",
+      "skills/demo/scripts/run.ts",
+      "skills/other/SKILL.md",
+    ]);
+  });
+
+  test("rejects package assets that point at a declared skill root", () => {
+    const parsed = parseAgentPackageArchiveBytes(
+      createStoredZipArchive([
+        {
+          body: textToArchiveBytes(
+            createPackageManifestJson({
+              skills: [{ name: "Demo", path: "skills/demo/" }],
+            }),
+          ),
+          path: "manifest.json",
+        },
+        {
+          body: textToArchiveBytes('{"secretNames":[],"setupScript":""}'),
+          path: "environment/definition.json",
+        },
+        {
+          body: textToArchiveBytes("not a directory entry"),
+          path: "skills/demo",
+        },
+      ]),
+    );
+
+    expect(parsed.package).toBeNull();
+    expect(parsed.issues[0]?.code).toBe("package.archive.entry_unsupported");
+  });
 });
 
 function createAgentPackageFixture(


### PR DESCRIPTION
## Summary

- Indexed agent package archive ancestor paths so descendant collision checks no longer scan every previously admitted path.
- Precomputed declared skill asset roots and check path prefixes by segment during package archive admission.
- Added archive admission tests for nested skill assets and root-path rejection.

## Why

- The complexity optimizer scan flagged archive path admission as a repeated-scan hotspot. Large package archives could re-scan prior entries and declared skill roots per path even though the checks only need prefix membership.


## Verification

- Commands:
  - `bun test pkgs/agent-package/tests/archive-entry-admission.test.ts`
  - `bun run --filter @mosoo/agent-package test`
  - `bun run --filter @mosoo/agent-package tc`
  - `bun run --filter @mosoo/agent-package lint`
  - `just fmt-check-path pkgs/agent-package/src/archive-entry-admission.ts`
  - `just fmt-check-path pkgs/agent-package/src/archive-path-policy.ts`
  - `just fmt-check-path pkgs/agent-package/tests/archive-entry-admission.test.ts`
  - `git diff --check`
  - `just commit-check`
  - `just check` (blocked by unrelated `apps/driver/tests/acp-file-system.test.ts` path assertion: expected `/tmp/...`, received `/private/tmp/...` on this macOS workspace)
- Manual steps: N/A
- Not run: N/A

## Impact

- User/API/contract changes: None.
- Generated files / GraphQL / DB / lockfile: None.
- Env or config changes: None.
- Risk and rollback: Low; path admission semantics are covered by existing and new archive parser tests. Revert the squash merge if needed.

## Review

- Closest review areas: `pkgs/agent-package/src/archive-entry-admission.ts`, `pkgs/agent-package/src/archive-path-policy.ts`.
- Known trade-offs: The full repo gate still needs the unrelated driver temp-path assertion fixed or normalized for macOS `/private/tmp` workspaces.