### PR TITLE
fix(channels): index channel bindings by provider

### DIFF
--- a/apps/web/src/routes/agent/components/channel-binding-index.ts
+++ b/apps/web/src/routes/agent/components/channel-binding-index.ts
@@ -1,0 +1,15 @@
+import type { AgentChannelBindingFieldsFragment } from "@/gql/graphql";
+
+export function indexChannelBindingsByProvider(
+  bindings: readonly AgentChannelBindingFieldsFragment[],
+): ReadonlyMap<string, AgentChannelBindingFieldsFragment> {
+  const byProvider = new Map<string, AgentChannelBindingFieldsFragment>();
+
+  for (const binding of bindings) {
+    if (!byProvider.has(binding.provider)) {
+      byProvider.set(binding.provider, binding);
+    }
+  }
+
+  return byProvider;
+}

--- a/apps/web/src/routes/agent/components/channels-list-widget.tsx
+++ b/apps/web/src/routes/agent/components/channels-list-widget.tsx
@@ -1,8 +1,10 @@
 import { ChevronRight, CircleCheck } from "lucide-react";
+import { useMemo } from "react";
 
 import type { AgentChannelBindingFieldsFragment } from "@/gql/graphql";
 import { ChannelBrandIcon } from "@/shared/ui/channel-brand-icon";
 
+import { indexChannelBindingsByProvider } from "./channel-binding-index";
 import { DISTRIBUTION_CHANNELS } from "./settings-dialog-model";
 import type { ChannelId } from "./settings-dialog-model";
 
@@ -26,11 +28,15 @@ export function ChannelsListWidget({
   isPublished: boolean;
   onOpenChannelView: (channelId: ChannelId) => void;
 }) {
+  const channelBindingByProvider = useMemo(
+    () => indexChannelBindingsByProvider(channelBindings),
+    [channelBindings],
+  );
+
   return (
     <ul className="divide-border-subtle border-border bg-background divide-y rounded-md border">
       {DISTRIBUTION_CHANNELS.map((channel) => {
-        const connected =
-          channel.enabled && channelBindings.some((binding) => binding.provider === channel.id);
+        const connected = channel.enabled && channelBindingByProvider.has(channel.id);
         const statusLabel = !channel.enabled
           ? "Soon"
           : connected

--- a/apps/web/src/routes/agent/components/settings-dialog-channels-view.tsx
+++ b/apps/web/src/routes/agent/components/settings-dialog-channels-view.tsx
@@ -10,7 +10,7 @@ import {
   Trash2,
   TriangleAlert,
 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import type { AgentChannelBindingFieldsFragment } from "@/gql/graphql";
 import { toChannelBindingId } from "@/routes/typed-id";
@@ -27,6 +27,7 @@ import {
   DialogTitle,
 } from "@/shared/ui/dialog";
 
+import { indexChannelBindingsByProvider } from "./channel-binding-index";
 import { resolveChannelWebhookOrigin } from "./channel-webhook-origin";
 import type { ChannelInlineSetupAgent } from "./settings-dialog-channel-agent";
 import { DiscordChannelInlineSetup } from "./settings-dialog-discord-setup";
@@ -318,8 +319,11 @@ export function AgentSettingsChannelsView({
   selectedChannelId: ChannelId;
 }) {
   const selectedChannel = DISTRIBUTION_CHANNELS.find((channel) => channel.id === selectedChannelId);
-  const selectedBinding =
-    channelBindings.find((binding) => binding.provider === selectedChannelId) ?? null;
+  const channelBindingByProvider = useMemo(
+    () => indexChannelBindingsByProvider(channelBindings),
+    [channelBindings],
+  );
+  const selectedBinding = channelBindingByProvider.get(selectedChannelId) ?? null;
   const [confirmRemoveBinding, setConfirmRemoveBinding] =
     useState<AgentChannelBindingFieldsFragment | null>(null);
 
@@ -353,7 +357,7 @@ export function AgentSettingsChannelsView({
       <div className="border-border-subtle flex min-h-0 flex-1 border-t">
         <nav className="border-border-subtle bg-muted/20 w-[180px] shrink-0 overflow-y-auto border-r py-2">
           {DISTRIBUTION_CHANNELS.map((channel) => {
-            const connected = channelBindings.some((binding) => binding.provider === channel.id);
+            const connected = channelBindingByProvider.has(channel.id);
             const isActive = selectedChannelId === channel.id;
             return (
               <button

--- a/apps/web/tests/channel-binding-index.test.ts
+++ b/apps/web/tests/channel-binding-index.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AgentChannelBindingFieldsFragment } from "../src/gql/graphql";
+import { indexChannelBindingsByProvider } from "../src/routes/agent/components/channel-binding-index";
+
+function channelBinding(
+  id: string,
+  provider: AgentChannelBindingFieldsFragment["provider"],
+): AgentChannelBindingFieldsFragment {
+  return {
+    id,
+    provider,
+  } as AgentChannelBindingFieldsFragment;
+}
+
+describe("channel binding provider index", () => {
+  test("indexes bindings by provider and preserves first-match selection", () => {
+    const slack = channelBinding("binding-slack", "slack");
+    const firstTelegram = channelBinding("binding-telegram-1", "telegram");
+    const secondTelegram = channelBinding("binding-telegram-2", "telegram");
+
+    const byProvider = indexChannelBindingsByProvider([slack, firstTelegram, secondTelegram]);
+
+    expect(byProvider.has("slack")).toBe(true);
+    expect(byProvider.get("slack")).toBe(slack);
+    expect(byProvider.get("telegram")).toBe(firstTelegram);
+  });
+});


### PR DESCRIPTION
Closes YEF-913

## Summary

- Added a small provider index for Agent channel bindings.
- Reused that index in the compact channel list and full channel settings view instead of scanning bindings for each rendered channel.
- Added focused coverage that preserves the previous first-match behavior for duplicate provider rows.

## Why

- The complexity scan flagged repeated lookup patterns; this UI render path was a low-risk O(channels * bindings) candidate.
- Precomputing a provider map makes connected-state and selected-binding lookup O(channels + bindings) while keeping behavior stable.

## Verification

- Commands:
  - `bun run fmt:check:path -- apps/web/src/routes/agent/components/channel-binding-index.ts apps/web/src/routes/agent/components/settings-dialog-channels-view.tsx apps/web/src/routes/agent/components/channels-list-widget.tsx apps/web/tests/channel-binding-index.test.ts`
  - `just test-file apps/web/tests/channel-binding-index.test.ts`
  - `just tc-package @mosoo/web`
  - `bun run --filter @mosoo/web lint`
  - `just commit-check`
- Manual steps: N/A
- Not run:
  - Full `just check` did not pass locally because `apps/driver/tests/acp-file-system.test.ts` expected a `/tmp/...` path while macOS reported `/private/tmp/...`; the failure is outside the web channel binding change.

## Impact

- User/API/contract changes: No API or visible behavior changes.
- Generated files / GraphQL / DB / lockfile: None.
- Env or config changes: None.
- Risk and rollback: Low risk; rollback by reverting the helper and restoring direct `find` / `some` scans.

## Review

- Closest review areas: `apps/web/src/routes/agent/components/channels-list-widget.tsx`, `apps/web/src/routes/agent/components/settings-dialog-channels-view.tsx`, `apps/web/src/routes/agent/components/channel-binding-index.ts`.
- Known trade-offs: The helper intentionally preserves the old first-match behavior when duplicate bindings exist for one provider.
