### PR TITLE
perf(web): defer tooltip loading on public routes

### DIFF
--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/shared/ui/dropdown-menu";
 import { Separator } from "@/shared/ui/separator";
 import { Sheet, SheetContent, SheetTitle } from "@/shared/ui/sheet";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/shared/ui/tooltip";
 
 import { AccountMenu } from "./account-menu";
 import { createHugeicon } from "./hugeicon";
@@ -393,14 +393,16 @@ export function Layout({ children }: { children: ReactNode }) {
   }
 
   return (
-    <ConsoleShell
-      collapsed={collapsed}
-      mobileSidebar={(closeNavigation) => appSidebar(false, closeNavigation)}
-      onToggleCollapsed={toggleCollapsed}
-      sidebar={appSidebar(collapsed)}
-    >
-      {children}
-    </ConsoleShell>
+    <TooltipProvider>
+      <ConsoleShell
+        collapsed={collapsed}
+        mobileSidebar={(closeNavigation) => appSidebar(false, closeNavigation)}
+        onToggleCollapsed={toggleCollapsed}
+        sidebar={appSidebar(collapsed)}
+      >
+        {children}
+      </ConsoleShell>
+    </TooltipProvider>
   );
 }
 
@@ -413,41 +415,43 @@ export function OrgLayout({ children }: { children: ReactNode }) {
   const headerTitle = getOrgHeaderTitle(location.pathname);
 
   return (
-    <div className="bg-background flex h-dvh flex-col">
-      <header className="border-border-soft hidden shrink-0 border-b md:flex">
-        <div className="flex min-h-[76px] w-[224px] shrink-0 items-center gap-2 px-4">
-          <Link to="/apps" aria-label="Apps" className="flex items-center">
-            <img src="/brand/logo-mark.svg" alt="mosoo" className="block size-6" />
-          </Link>
-          {activeOrganization === null ? null : (
-            <>
-              <span className="text-fg-muted text-base font-light">/</span>
-              <span className="text-foreground max-w-[144px] truncate text-sm font-semibold">
-                {activeOrganization.name}
-              </span>
-            </>
-          )}
-        </div>
-        {headerTitle === null ? null : (
-          <div className="flex min-w-0 flex-1 items-center px-8">
-            <h1 className="text-foreground truncate text-2xl font-semibold tracking-normal">
-              {headerTitle}
-            </h1>
+    <TooltipProvider>
+      <div className="bg-background flex h-dvh flex-col">
+        <header className="border-border-soft hidden shrink-0 border-b md:flex">
+          <div className="flex min-h-[76px] w-[224px] shrink-0 items-center gap-2 px-4">
+            <Link to="/apps" aria-label="Apps" className="flex items-center">
+              <img src="/brand/logo-mark.svg" alt="mosoo" className="block size-6" />
+            </Link>
+            {activeOrganization === null ? null : (
+              <>
+                <span className="text-fg-muted text-base font-light">/</span>
+                <span className="text-foreground max-w-[144px] truncate text-sm font-semibold">
+                  {activeOrganization.name}
+                </span>
+              </>
+            )}
           </div>
-        )}
-      </header>
-      <MobileNavigation
-        renderNavigation={() => <OrgNavigation collapsed={false} pathname={location.pathname} />}
-        title={headerTitle}
-      />
-      <div className="flex min-h-0 flex-1">
-        <aside className="border-border-soft hidden w-[224px] shrink-0 flex-col border-r px-3 py-4 md:flex">
-          <OrgNavigation collapsed={false} pathname={location.pathname} />
-          <div className="flex-1" />
-          <ConsoleSidebarFooter collapsed={false} />
-        </aside>
-        <main className="min-w-0 flex-1 overflow-hidden">{children}</main>
+          {headerTitle === null ? null : (
+            <div className="flex min-w-0 flex-1 items-center px-8">
+              <h1 className="text-foreground truncate text-2xl font-semibold tracking-normal">
+                {headerTitle}
+              </h1>
+            </div>
+          )}
+        </header>
+        <MobileNavigation
+          renderNavigation={() => <OrgNavigation collapsed={false} pathname={location.pathname} />}
+          title={headerTitle}
+        />
+        <div className="flex min-h-0 flex-1">
+          <aside className="border-border-soft hidden w-[224px] shrink-0 flex-col border-r px-3 py-4 md:flex">
+            <OrgNavigation collapsed={false} pathname={location.pathname} />
+            <div className="flex-1" />
+            <ConsoleSidebarFooter collapsed={false} />
+          </aside>
+          <main className="min-w-0 flex-1 overflow-hidden">{children}</main>
+        </div>
       </div>
-    </div>
+    </TooltipProvider>
   );
 }

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from "react";
 import { BrowserRouter } from "react-router-dom";
 
 import { ProductAnalyticsProvider } from "@/analytics/product-analytics-provider";
-import { TooltipProvider } from "@/shared/ui/tooltip";
 
 import { appQueryClient } from "./query-client";
 import { AppSessionProvider } from "./session-provider";
@@ -11,13 +10,11 @@ import { AppSessionProvider } from "./session-provider";
 export function AppProviders({ children }: { children: ReactNode }) {
   return (
     <QueryClientProvider client={appQueryClient}>
-      <TooltipProvider>
-        <BrowserRouter>
-          <AppSessionProvider>
-            <ProductAnalyticsProvider>{children}</ProductAnalyticsProvider>
-          </AppSessionProvider>
-        </BrowserRouter>
-      </TooltipProvider>
+      <BrowserRouter>
+        <AppSessionProvider>
+          <ProductAnalyticsProvider>{children}</ProductAnalyticsProvider>
+        </AppSessionProvider>
+      </BrowserRouter>
     </QueryClientProvider>
   );
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -131,7 +131,7 @@ const webConfig = {
         // of re-downloading ~150 KB of unchanged framework code baked into the
         // entry. The framework and its peers share one chunk so React stays a
         // single instance and there is no cross-chunk import waterfall.
-        advancedChunks: {
+        codeSplitting: {
           groups: [
             {
               name: "framework",


### PR DESCRIPTION
## Summary

- Move the shared TooltipProvider out of the root AppProviders tree.
- Scope TooltipProvider to the authenticated App and Org shells where tooltip UI is actually rendered.
- Keep public routes from eagerly loading Base UI tooltip code during boot.
- Use the current Vite+ `codeSplitting` option without deprecated configuration.

## Why

- Public pages such as /login and callback routes do not render tooltips, but the root provider made them download tooltip runtime code anyway.
- The production web build now emits a much smaller root entry chunk: 28.81 kB instead of 147.23 kB.

## Verification

- Commands:
  - `bun run --filter @mosoo/web build`
  - `bun run fmt:check:path -- apps/web/src/app/providers.tsx apps/web/src/app/app-shell.tsx`
  - `bun run --filter @mosoo/web tc`
  - `bun run --filter @mosoo/web lint`
  - `bun run --filter @mosoo/web test`
  - `just commit-check`
  - `TMPDIR=/private/tmp just check`
- Manual steps:
  - Served the production web build with `bun run --filter @mosoo/web preview -- --host 127.0.0.1 --port 4173 --strictPort`.
  - Measured 22 canonical routes with Playwright against the production preview and mocked same-origin GraphQL. Worst browser Navigation Timing `loadEventEnd`: 19.4 ms.
- Not run:
  - N/A

## Impact

- User/API/contract changes:
  - No user-facing behavior, API, or contract changes.
- Generated files / GraphQL / DB / lockfile:
  - N/A
- Env or config changes:
  - N/A
- Risk and rollback:
  - Low. The provider is still present around all authenticated shell content; rollback is reverting this commit.

## Review

- Closest review areas:
  - `apps/web/src/app/providers.tsx`
  - `apps/web/src/app/app-shell.tsx`
  - `apps/web/vite.config.ts`
- Known trade-offs:
  - New public routes that add tooltip UI will need their own provider or an intentional provider placement change.