### PR TITLE
perf(web): avoid quadratic session-stream queue drains

### DIFF
--- a/apps/web/src/domains/runtime/session-stream/session-stream-render-scheduler.ts
+++ b/apps/web/src/domains/runtime/session-stream/session-stream-render-scheduler.ts
@@ -47,6 +47,7 @@ export class SessionStreamRenderScheduler {
   #frameHandle: number | null = null;
   readonly #host: SessionStreamRenderSchedulerHost;
   #queue: QueuedSessionEvent[] = [];
+  #queueOffset = 0;
   #timeoutHandle: number | null = null;
 
   public constructor(
@@ -60,6 +61,7 @@ export class SessionStreamRenderScheduler {
   public clear(): void {
     this.#cancelPending();
     this.#queue = [];
+    this.#queueOffset = 0;
   }
 
   public enqueue(sessionId: string, event: AgUiSessionEvent): void {
@@ -87,7 +89,13 @@ export class SessionStreamRenderScheduler {
     const events: AgUiSessionEvent[] = [];
     const remaining: QueuedSessionEvent[] = [];
 
-    for (const item of this.#queue) {
+    for (let index = this.#queueOffset; index < this.#queue.length; index += 1) {
+      const item = this.#queue[index];
+
+      if (!item) {
+        continue;
+      }
+
       if (item.sessionId === sessionId) {
         events.push(item.event);
       } else {
@@ -96,6 +104,7 @@ export class SessionStreamRenderScheduler {
     }
 
     this.#queue = remaining;
+    this.#queueOffset = 0;
 
     if (events.length > 0) {
       if (!this.#apply(sessionId, events)) {
@@ -106,6 +115,7 @@ export class SessionStreamRenderScheduler {
           })),
           ...this.#queue,
         ];
+        this.#queueOffset = 0;
       }
     }
 
@@ -147,41 +157,62 @@ export class SessionStreamRenderScheduler {
           event,
           sessionId: batch.sessionId,
         })),
-        ...this.#queue,
+        ...this.#queue.slice(this.#queueOffset),
       ];
+      this.#queueOffset = 0;
     }
 
     this.#schedule();
+  }
+
+  #compactConsumedQueue(): void {
+    if (this.#queueOffset === 0) {
+      return;
+    }
+
+    if (this.#queueOffset >= this.#queue.length) {
+      this.#queue = [];
+      this.#queueOffset = 0;
+      return;
+    }
+
+    if (
+      this.#queueOffset >= MAX_EVENTS_PER_FRAME * 4 &&
+      this.#queueOffset * 2 >= this.#queue.length
+    ) {
+      this.#queue = this.#queue.slice(this.#queueOffset);
+      this.#queueOffset = 0;
+    }
   }
 
   #takeFrameBatch(): {
     events: AgUiSessionEvent[];
     sessionId: string;
   } | null {
-    const first = this.#queue[0];
+    const first = this.#queue[this.#queueOffset];
 
     if (!first) {
+      this.#compactConsumedQueue();
       return null;
     }
 
     const { sessionId } = first;
     const events: AgUiSessionEvent[] = [];
-    let consumedQueueItems = 0;
+    let nextQueueOffset = this.#queueOffset;
 
-    while (consumedQueueItems < this.#queue.length && events.length < MAX_EVENTS_PER_FRAME) {
-      const item = this.#queue[consumedQueueItems];
+    while (nextQueueOffset < this.#queue.length && events.length < MAX_EVENTS_PER_FRAME) {
+      const item = this.#queue[nextQueueOffset];
 
       if (!item || item.sessionId !== sessionId) {
         break;
       }
 
       events.push(item.event);
-      consumedQueueItems += 1;
+      nextQueueOffset += 1;
     }
 
-    if (consumedQueueItems > 0) {
-      this.#queue.splice(0, consumedQueueItems);
-    }
+    this.#queueOffset = nextQueueOffset;
+    this.#compactConsumedQueue();
 
     return { events, sessionId };
   }

--- a/apps/web/tests/session-stream-render-scheduler.test.ts
+++ b/apps/web/tests/session-stream-render-scheduler.test.ts
@@ -95,6 +95,40 @@ describe("session stream render scheduler", () => {
     ).toEqual(["ab", "c"]);
   });
 
+  test("flushes only undelivered events after a partial frame drain", () => {
+    const { frameCallbacks, host } = createManualHost();
+    const applied: { events: AgUiSessionEvent[]; sessionId: string }[] = [];
+    const scheduler = new SessionStreamRenderScheduler((sessionId, events) => {
+      applied.push({ events, sessionId });
+      return true;
+    }, host);
+    const sessionOneEvents = Array.from({ length: 600 }, (_unused, index) =>
+      textEvent(`a-${index}`),
+    );
+
+    scheduler.enqueueMany("session-1", sessionOneEvents);
+    scheduler.enqueueMany("session-2", [textEvent("b")]);
+    frameCallbacks.shift()?.();
+    scheduler.flushNow("session-2");
+    drainFrames(frameCallbacks);
+
+    expect(applied.map((batch) => batch.sessionId)).toEqual([
+      "session-1",
+      "session-2",
+      "session-1",
+    ]);
+    expect(applied.map((batch) => batch.events.length)).toEqual([512, 1, 88]);
+    expect(
+      applied
+        .flatMap((batch) => batch.events)
+        .map((event) => (event.type === "TEXT_MESSAGE_CONTENT" ? event.delta : "")),
+    ).toEqual([
+      ...sessionOneEvents.slice(0, 512).map((event) => event.delta),
+      "b",
+      ...sessionOneEvents.slice(512).map((event) => event.delta),
+    ]);
+  });
+
   test("delivers mixed event types in arrival order", () => {
     const { frameCallbacks, host } = createManualHost();
     const types: string[] = [];
@@ -135,6 +169,34 @@ describe("session stream render scheduler", () => {
 
     expect(rejectNextBatch).toBe(false);
     expect(appliedDeltas.join("")).toBe("x".repeat(1300));
+  });
+
+  test("requeues a rejected batch after compacting consumed events", () => {
+    const { frameCallbacks, host } = createManualHost();
+    const appliedDeltas: string[] = [];
+    let applyAttempts = 0;
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      applyAttempts += 1;
+
+      if (applyAttempts === 4) {
+        return false;
+      }
+
+      for (const event of events) {
+        if (event.type === "TEXT_MESSAGE_CONTENT") {
+          appliedDeltas.push(event.delta);
+        }
+      }
+
+      return true;
+    }, host);
+    const events = Array.from({ length: 3000 }, (_unused, index) => textEvent(`chunk-${index}`));
+
+    scheduler.enqueueMany("session-1", events);
+    drainFrames(frameCallbacks);
+
+    expect(applyAttempts).toBe(7);
+    expect(appliedDeltas).toEqual(events.map((event) => event.delta));
   });
 
   test("drains through the timeout fallback when frames never fire", () => {


### PR DESCRIPTION
## Summary

- Replaced session stream render scheduler front-splice drains with an offset-backed queue and amortized compaction.
- Added regression coverage for flushing after a compaction and rejected-batch requeue so complete event order is preserved.

## Why

- Long streaming sessions are drained across multiple animation frames. Splicing from the front on each frame repeatedly shifted remaining queued events, making large bursts trend toward O(n^2). The offset-backed path keeps normal drains O(n) total while preserving per-session ordering and rejected-batch requeue behavior.

## Verification

- Commands:
  - `just fmt-check-path apps/web/src/domains/runtime/session-stream/session-stream-render-scheduler.ts`
  - `just fmt-check-path apps/web/tests/session-stream-render-scheduler.test.ts`
  - `just test-file apps/web/tests/session-stream-render-scheduler.test.ts`
  - `just tc-package @mosoo/web`
  - `just test-package @mosoo/web`
  - `just commit-check`
  - `just check`
- Manual steps: N/A
- Not run: N/A

## Impact

- User/API/contract changes: No API or contract changes; streaming UI queue drains avoid repeated array shifts during large event bursts.
- Generated files / GraphQL / DB / lockfile: N/A
- Env or config changes: N/A
- Risk and rollback: Low; localized scheduler queue internals. Roll back this commit if stream batching regresses.

## Review

- Closest review areas: Web session stream render scheduler drain, flush, and rejected-batch requeue behavior.
- Known trade-offs: The static scanner still flags normal loops/map calls in this file; this patch targets the actual repeated front-array shift hotspot.