### PR TITLE
feat(analytics): add PostHog product funnels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ no_proxy=localhost,127.0.0.1,::1
 WEB_DEV_PORT=5173
 WRANGLER_DEV_PORT=
 API_PROXY_TARGET=
+# Optional PostHog Cloud product analytics. Use one project for browser and API events.
+VITE_POSTHOG_PROJECT_KEY=
+VITE_POSTHOG_API_HOST=https://us.i.posthog.com
+POSTHOG_PROJECT_KEY=
+POSTHOG_API_HOST=https://us.i.posthog.com
 # Container-to-API callbacks when requests enter through a public tunnel.
 MOSOO_RUNTIME_CONTROL_ORIGIN=
 

--- a/.github/workflows/deploy-try.yml
+++ b/.github/workflows/deploy-try.yml
@@ -64,6 +64,11 @@ jobs:
           ../../node_modules/.bin/vp exec wrangler queues list
 
       - name: Build deploy artifacts
+        env:
+          VITE_MOSOO_DEPLOYMENT_MODE: cloud
+          VITE_MOSOO_ENVIRONMENT: production
+          VITE_POSTHOG_API_HOST: https://us.i.posthog.com
+          VITE_POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
         run: |
           ./node_modules/.bin/vp run --filter agent-driver build
           ./node_modules/.bin/vp run --filter @mosoo/web build

--- a/.github/workflows/deploy-try.yml
+++ b/.github/workflows/deploy-try.yml
@@ -91,6 +91,10 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          VITE_MOSOO_DEPLOYMENT_MODE: cloud
+          VITE_MOSOO_ENVIRONMENT: production
+          VITE_POSTHOG_API_HOST: https://us.i.posthog.com
+          VITE_POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
         run: just deploy
 
       - name: Verify

--- a/apps/api/src/modules/agents/application/agent-command.service.ts
+++ b/apps/api/src/modules/agents/application/agent-command.service.ts
@@ -10,6 +10,10 @@ import { createPlatformId } from "@mosoo/id";
 import type { AgentId } from "@mosoo/id";
 import { eq } from "drizzle-orm";
 
+import {
+  captureServerProductEvent,
+  SERVER_PRODUCT_ANALYTICS_EVENTS,
+} from "../../../platform/analytics/product-analytics";
 import type { ApiBindings } from "../../../platform/cloudflare/worker-types";
 import { getAppDatabase, runAppDatabaseBatch } from "../../../platform/db/drizzle";
 import { forbiddenError } from "../../../platform/errors";
@@ -69,7 +73,14 @@ function stableStringify(value: unknown): string {
 }
 
 export async function createAgent(
-  bindings: Pick<ApiBindings, "DB">,
+  bindings: Pick<
+    ApiBindings,
+    | "DB"
+    | "MOSOO_DEPLOYMENT_MODE"
+    | "MOSOO_ENVIRONMENT"
+    | "POSTHOG_API_HOST"
+    | "POSTHOG_PROJECT_KEY"
+  >,
   viewer: AuthenticatedViewer,
   input: CreateAgentInput,
 ): Promise<Agent> {
@@ -119,6 +130,17 @@ export async function createAgent(
   await replaceAgentSkills(database, agentId, skillIds, timestampMs);
 
   const createdAgent = await getAgentRow(database, agentId);
+  await captureServerProductEvent(bindings, {
+    distinctId: viewer.id,
+    event: SERVER_PRODUCT_ANALYTICS_EVENTS.agentCreated,
+    properties: {
+      agent_id: agentId,
+      app_id: appId,
+      agent_kind: input.kind,
+      provider: input.provider,
+      runtime_id: runtimeId,
+    },
+  });
 
   return toAgentModel(database, viewer, createdAgent);
 }

--- a/apps/api/src/modules/apps/application/app-provisioning.service.ts
+++ b/apps/api/src/modules/apps/application/app-provisioning.service.ts
@@ -3,6 +3,11 @@ import { appsTable } from "@mosoo/db";
 import { createPlatformId } from "@mosoo/id";
 import type { AppId, OrganizationId } from "@mosoo/id";
 
+import {
+  captureServerProductEvent,
+  SERVER_PRODUCT_ANALYTICS_EVENTS,
+} from "../../../platform/analytics/product-analytics";
+import type { ApiBindings } from "../../../platform/cloudflare/worker-types";
 import { getAppDatabase } from "../../../platform/db/drizzle";
 import { validationError } from "../../../platform/errors";
 import { currentTimestampMs } from "../../../time";
@@ -21,10 +26,18 @@ interface CreateAppInput {
 // onboarding default-App provisioning (insert App row + default Environment).
 // Kept out of app.service to avoid an apps <-> environments cycle.
 export async function createApp(
-  database: D1Database,
+  bindings: Pick<
+    ApiBindings,
+    | "DB"
+    | "MOSOO_DEPLOYMENT_MODE"
+    | "MOSOO_ENVIRONMENT"
+    | "POSTHOG_API_HOST"
+    | "POSTHOG_PROJECT_KEY"
+  >,
   viewer: AuthenticatedViewer,
   input: CreateAppInput,
 ): Promise<AppSummary> {
+  const database = bindings.DB;
   await ensureOrganizationOwnership(database, viewer.id, input.organizationId);
 
   const name = normalizeAppName(input.name);
@@ -49,6 +62,15 @@ export async function createApp(
     .run();
 
   await createAppEnvironmentDefaults({ DB: database }, { actorId: viewer.id, appId, timestampMs });
+  await captureServerProductEvent(bindings, {
+    distinctId: viewer.id,
+    event: SERVER_PRODUCT_ANALYTICS_EVENTS.appCreated,
+    properties: {
+      app_id: appId,
+      organization_id: input.organizationId,
+      source: "manual",
+    },
+  });
 
   return toAppSummary(await getAppRow(database, appId));
 }

--- a/apps/api/src/modules/apps/graphql/app-graphql.ts
+++ b/apps/api/src/modules/apps/graphql/app-graphql.ts
@@ -61,7 +61,7 @@ export const appGraphQLModule = {
   ...appGraphQLSpec,
   authenticatedMutationResolvers: {
     createApp: async (_parent, args: CreateAppArgs, context) =>
-      createApp(context.bindings.DB, context.viewer, args.input),
+      createApp(context.bindings, context.viewer, args.input),
     deleteAppDeployment: async (_parent, args: DeleteAppDeploymentArgs, context) =>
       deleteAppDeployment(context.bindings, context.viewer, args.input),
     deployApp: async (_parent, args: DeployAppArgs, context) =>

--- a/apps/api/src/modules/auth/infrastructure/better-auth.ts
+++ b/apps/api/src/modules/auth/infrastructure/better-auth.ts
@@ -12,6 +12,10 @@ import type { BetterAuthPlugin } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { emailOTP } from "better-auth/plugins/email-otp";
 
+import {
+  captureServerProductEvent,
+  SERVER_PRODUCT_ANALYTICS_EVENTS,
+} from "../../../platform/analytics/product-analytics";
 import { logInfo, logWarn } from "../../../platform/cloudflare/logger";
 import { getAppDatabase } from "../../../platform/db/drizzle";
 import type { AuthEmailBindings } from "./auth-email";
@@ -22,6 +26,10 @@ export interface AuthBindings extends AuthEmailBindings {
   readonly BETTER_AUTH_SECRET?: string;
   readonly GOOGLE_OAUTH_CLIENT_ID?: string;
   readonly GOOGLE_OAUTH_CLIENT_SECRET?: string;
+  readonly MOSOO_DEPLOYMENT_MODE?: string;
+  readonly MOSOO_ENVIRONMENT?: string;
+  readonly POSTHOG_API_HOST?: string;
+  readonly POSTHOG_PROJECT_KEY?: string;
   readonly WEB_ORIGIN: string;
 }
 
@@ -110,6 +118,12 @@ function createAppAuth(bindings: AuthBindings) {
           before: async (user) => ({
             data: serializeAccountTimestampFields(user),
           }),
+          after: async (user) => {
+            await captureServerProductEvent(bindings, {
+              distinctId: user.id,
+              event: SERVER_PRODUCT_ANALYTICS_EVENTS.signupCompleted,
+            });
+          },
         },
         update: {
           before: async (user) => ({

--- a/apps/api/src/modules/onboarding/application/onboarding.service.ts
+++ b/apps/api/src/modules/onboarding/application/onboarding.service.ts
@@ -2,6 +2,11 @@ import type { BootstrapOnboardingInput, OnboardingStatus } from "@mosoo/contract
 import { organizationsTable } from "@mosoo/db";
 import { desc, eq } from "drizzle-orm";
 
+import {
+  captureServerProductEvent,
+  SERVER_PRODUCT_ANALYTICS_EVENTS,
+} from "../../../platform/analytics/product-analytics";
+import type { ApiBindings } from "../../../platform/cloudflare/worker-types";
 import { getAppDatabase } from "../../../platform/db/drizzle";
 import type { AuthenticatedViewer } from "../../auth/application/viewer-auth.service";
 import { provisionOrganizationWithOwner } from "../../organizations/application/organization-provisioning.service";
@@ -54,10 +59,18 @@ export async function getOnboardingStatus(
 }
 
 export async function bootstrapOnboarding(
-  database: D1Database,
+  bindings: Pick<
+    ApiBindings,
+    | "DB"
+    | "MOSOO_DEPLOYMENT_MODE"
+    | "MOSOO_ENVIRONMENT"
+    | "POSTHOG_API_HOST"
+    | "POSTHOG_PROJECT_KEY"
+  >,
   viewer: AuthenticatedViewer,
   input: BootstrapOnboardingInput,
 ): Promise<OnboardingStatus> {
+  const database = bindings.DB;
   const currentStatus = await getOnboardingStatus(database, viewer);
 
   if (currentStatus.completed) {
@@ -69,6 +82,12 @@ export async function bootstrapOnboarding(
   const organization = await provisionOrganizationWithOwner(database, viewer, {
     makeActive: true,
     name: organizationName,
+  });
+
+  await captureServerProductEvent(bindings, {
+    distinctId: viewer.id,
+    event: SERVER_PRODUCT_ANALYTICS_EVENTS.onboardingCompleted,
+    properties: { organization_id: organization.id },
   });
 
   return {

--- a/apps/api/src/modules/onboarding/graphql/onboarding-graphql.ts
+++ b/apps/api/src/modules/onboarding/graphql/onboarding-graphql.ts
@@ -10,6 +10,6 @@ export const onboardingGraphQLModule = {
   ...onboardingGraphQLSpec,
   authenticatedMutationResolvers: {
     onboardingBootstrap: async (_parent, args: BootstrapOnboardingArgs, context) =>
-      bootstrapOnboarding(context.bindings.DB, context.viewer, args.input),
+      bootstrapOnboarding(context.bindings, context.viewer, args.input),
   },
 } satisfies GraphQLModule;

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/event-persistence.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/event-persistence.ts
@@ -2,6 +2,10 @@ import { sessionsTable } from "@mosoo/db";
 import type { DriverInstanceId } from "@mosoo/id";
 import { and, eq, isNull } from "drizzle-orm";
 
+import {
+  captureServerProductEvent,
+  SERVER_PRODUCT_ANALYTICS_EVENTS,
+} from "../../../../platform/analytics/product-analytics";
 import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
 import { getAppDatabase } from "../../../../platform/db/drizzle";
 import { currentTimestampMs } from "../../../../time";
@@ -303,6 +307,23 @@ export async function persistProjectedRuntimeDriverEvents(
       runId: link.sessionRunId,
       source: "driver",
       status: "waiting_input",
+    });
+  }
+
+  if (
+    completedTransition !== undefined &&
+    runTransitionOutcome?.kind === "applied" &&
+    link.executionOwnerId !== null
+  ) {
+    await captureServerProductEvent(bindings, {
+      distinctId: link.executionOwnerId,
+      event: SERVER_PRODUCT_ANALYTICS_EVENTS.taskSucceeded,
+      properties: {
+        agent_id: link.agentId,
+        app_id: link.appId,
+        run_id: link.sessionRunId,
+        session_id: link.sessionId,
+      },
     });
   }
 

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/event-types.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/event-types.ts
@@ -2,7 +2,15 @@ import type { SessionUsageSummary } from "@mosoo/ag-ui-session";
 import type { AgentKind } from "@mosoo/contracts/agent";
 import type { SandboxSubjectKind } from "@mosoo/contracts/sandbox";
 import type { SessionRunStatus } from "@mosoo/contracts/session-run";
-import type { AccountId, AgentId, PlatformId, SandboxId, SessionId, SessionRunId } from "@mosoo/id";
+import type {
+  AccountId,
+  AgentId,
+  AppId,
+  PlatformId,
+  SandboxId,
+  SessionId,
+  SessionRunId,
+} from "@mosoo/id";
 import type { RuntimeEventEnvelope } from "@mosoo/runtime-events";
 
 import type {
@@ -14,6 +22,7 @@ export type { SessionLiveState };
 
 export interface RuntimeSessionLink {
   agentId: AgentId | null;
+  appId: AppId | null;
   callerId: PlatformId | null;
   creatorId: PlatformId | null;
   executionOwnerId: AccountId | null;

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/session-link.repository.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/session-link.repository.ts
@@ -12,6 +12,7 @@ import {
 import type {
   AccountId,
   AgentId,
+  AppId,
   DriverInstanceId,
   PlatformId,
   SandboxId,
@@ -28,6 +29,7 @@ import type { RuntimeSessionLink } from "./event-types";
 
 interface RuntimeSessionLinkRow {
   agent_id: AgentId | null;
+  app_id: AppId | null;
   agent_owner_account_id: AccountId | null;
   caller_account_id: AccountId | null;
   creator_account_id: PlatformId | null;
@@ -91,6 +93,7 @@ export async function getRuntimeSessionLink(
     (await getAppDatabase(database)
       .select({
         agent_id: sessionsTable.agentId,
+        app_id: sessionsTable.appId,
         agent_owner_account_id: agentsTable.ownerId,
         caller_account_id: sessionRunsTable.createdByAccountId,
         creator_account_id: sessionsTable.creatorAccountId,
@@ -119,6 +122,7 @@ export async function getRuntimeSessionLink(
 
   return {
     agentId: row?.agent_id ?? null,
+    appId: row?.app_id ?? null,
     callerId: principals.callerId,
     creatorId: row?.creator_account_id ?? null,
     executionOwnerId: principals.executionOwnerId,

--- a/apps/api/src/modules/vendor-credentials/application/vendor-credential-test.ts
+++ b/apps/api/src/modules/vendor-credentials/application/vendor-credential-test.ts
@@ -5,6 +5,10 @@ import type {
 import type { RuntimeCatalogVendor } from "@mosoo/runtime-catalog";
 import { VENDOR_OPENAI_COMPATIBLE, getVendor } from "@mosoo/runtime-catalog";
 
+import {
+  captureServerProductEvent,
+  SERVER_PRODUCT_ANALYTICS_EVENTS,
+} from "../../../platform/analytics/product-analytics";
 import { createApiWideEvent, emitApiWideEvent } from "../../../platform/cloudflare/logger";
 import type { ApiBindings } from "../../../platform/cloudflare/worker-types";
 import { ensureAppOwnership } from "../../apps/application/app.service";
@@ -112,17 +116,36 @@ async function ensureCredentialTestAccess(
 export async function testVendorCredential(
   bindings: Pick<
     ApiBindings,
-    "DB" | "MOSOO_PROVIDER_FETCH_PROXY_TOKEN" | "MOSOO_PROVIDER_FETCH_PROXY_URL" | "WEB_ORIGIN"
+    | "DB"
+    | "MOSOO_DEPLOYMENT_MODE"
+    | "MOSOO_ENVIRONMENT"
+    | "MOSOO_PROVIDER_FETCH_PROXY_TOKEN"
+    | "MOSOO_PROVIDER_FETCH_PROXY_URL"
+    | "POSTHOG_API_HOST"
+    | "POSTHOG_PROJECT_KEY"
+    | "WEB_ORIGIN"
   >,
   viewer: AuthenticatedViewer,
   input: TestVendorCredentialInput,
 ): Promise<TestVendorCredentialResult> {
   await ensureCredentialTestAccess(bindings.DB, viewer, input);
 
-  return probeVendorCredential({
+  const result = await probeVendorCredential({
     ...input,
     fetchProxy: resolveProviderFetchProxy(bindings),
   });
+  if (result.ok) {
+    await captureServerProductEvent(bindings, {
+      distinctId: viewer.id,
+      event: SERVER_PRODUCT_ANALYTICS_EVENTS.integrationConnected,
+      properties: {
+        app_id: input.appId,
+        integration_type: "model_provider",
+        vendor_id: input.vendorId,
+      },
+    });
+  }
+  return result;
 }
 
 export async function probeVendorCredential(

--- a/apps/api/src/platform/analytics/product-analytics.ts
+++ b/apps/api/src/platform/analytics/product-analytics.ts
@@ -1,0 +1,87 @@
+export const SERVER_PRODUCT_ANALYTICS_EVENTS = {
+  agentCreated: "agent_created",
+  appCreated: "app_created",
+  taskSucceeded: "task_succeeded",
+  integrationConnected: "integration_connected",
+  onboardingCompleted: "onboarding_completed",
+  signupCompleted: "signup_completed",
+} as const;
+
+export type ServerProductAnalyticsEvent =
+  (typeof SERVER_PRODUCT_ANALYTICS_EVENTS)[keyof typeof SERVER_PRODUCT_ANALYTICS_EVENTS];
+
+export interface ServerProductAnalyticsBindings {
+  MOSOO_DEPLOYMENT_MODE?: string;
+  MOSOO_ENVIRONMENT?: string;
+  POSTHOG_API_HOST?: string;
+  POSTHOG_PROJECT_KEY?: string;
+}
+
+export type ServerProductAnalyticsProperties = Readonly<
+  Record<string, boolean | number | string | null | undefined>
+>;
+
+type ProductAnalyticsTransport = (input: string, init: RequestInit) => Promise<Response>;
+let transportOverride: ProductAnalyticsTransport | null = null;
+
+const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function getProjectKey(bindings: ServerProductAnalyticsBindings): string {
+  return bindings.POSTHOG_PROJECT_KEY?.trim() ?? "";
+}
+
+export function isServerProductAnalyticsConfigured(
+  bindings: ServerProductAnalyticsBindings,
+): boolean {
+  return getProjectKey(bindings).length > 0;
+}
+
+export async function captureServerProductEvent(
+  bindings: ServerProductAnalyticsBindings,
+  input: {
+    distinctId: string;
+    event: ServerProductAnalyticsEvent;
+    properties?: ServerProductAnalyticsProperties;
+  },
+): Promise<void> {
+  const projectKey = getProjectKey(bindings);
+  if (projectKey.length === 0 || input.distinctId.trim().length === 0) {
+    return;
+  }
+
+  const apiHost = trimTrailingSlash(bindings.POSTHOG_API_HOST?.trim() || DEFAULT_POSTHOG_HOST);
+  const properties = Object.fromEntries(
+    Object.entries({
+      deployment_mode: bindings.MOSOO_DEPLOYMENT_MODE?.trim() || "cloud",
+      distinct_id: input.distinctId,
+      environment: bindings.MOSOO_ENVIRONMENT?.trim() || "production",
+      ...input.properties,
+    }).filter(([, value]) => value !== undefined),
+  );
+  const transport = transportOverride ?? globalThis.fetch;
+
+  try {
+    await transport(`${apiHost}/capture/`, {
+      body: JSON.stringify({
+        api_key: projectKey,
+        event: input.event,
+        properties,
+        timestamp: new Date().toISOString(),
+      }),
+      headers: { "Content-Type": "application/json" },
+      method: "POST",
+    });
+  } catch {
+    // Analytics must never break the product's authoritative business path.
+  }
+}
+
+export function setServerProductAnalyticsTransportForTests(
+  transport: ProductAnalyticsTransport | null,
+): void {
+  transportOverride = transport;
+}

--- a/apps/api/src/platform/cloudflare/worker-types.ts
+++ b/apps/api/src/platform/cloudflare/worker-types.ts
@@ -42,6 +42,13 @@ interface OptionalRuntimeBindings {
   MOSOO_RUNTIME_NO_PROXY?: string;
 }
 
+interface OptionalProductAnalyticsBindings {
+  MOSOO_DEPLOYMENT_MODE?: string;
+  MOSOO_ENVIRONMENT?: string;
+  POSTHOG_API_HOST?: string;
+  POSTHOG_PROJECT_KEY?: string;
+}
+
 interface OptionalCostLedgerReconciliationBindings {
   MOSOO_COST_LEDGER_RECONCILIATION_MODE?: string;
 }
@@ -88,6 +95,7 @@ export type ApiBindings = Env &
   OptionalSessionBinding &
   OptionalCostLedgerReconciliationBindings &
   OptionalLocalProviderFetchProxyBindings &
+  OptionalProductAnalyticsBindings &
   OptionalRuntimeBindings &
   OptionalSkillsShBindings &
   OptionalSlackAdapterBindings &

--- a/apps/api/tests/api-driver-boundary-fixtures.ts
+++ b/apps/api/tests/api-driver-boundary-fixtures.ts
@@ -181,6 +181,7 @@ export function createDriverEvent(value: object): DriverEvent {
 export function createRuntimeSessionLink(): RuntimeSessionLink {
   return {
     agentId: API_DRIVER_BOUNDARY_IDS.agent,
+    appId: API_DRIVER_BOUNDARY_IDS.app,
     callerId: API_DRIVER_BOUNDARY_IDS.account,
     creatorId: API_DRIVER_BOUNDARY_IDS.account,
     executionOwnerId: API_DRIVER_BOUNDARY_IDS.account,

--- a/apps/api/tests/app-provisioning.test.ts
+++ b/apps/api/tests/app-provisioning.test.ts
@@ -146,7 +146,10 @@ describe("App provisioning boundary", () => {
     `);
 
     await expect(
-      createApp(database, makeViewer("account-2"), { name: "New App", organizationId: "org-1" }),
+      createApp({ DB: database }, makeViewer("account-2"), {
+        name: "New App",
+        organizationId: "org-1",
+      }),
     ).rejects.toThrow();
 
     const apps = await listOrganizationApps(database, makeViewer("account-1"), "org-1");

--- a/apps/api/tests/driver-session-link.test.ts
+++ b/apps/api/tests/driver-session-link.test.ts
@@ -37,6 +37,7 @@ function createDriverSessionLinkDatabase(): SqliteD1Database {
 
     CREATE TABLE session (
       agent_id text,
+      app_id text,
       creator_account_id text NOT NULL,
       id text PRIMARY KEY NOT NULL
 );

--- a/apps/api/tests/onboarding-bootstrap.test.ts
+++ b/apps/api/tests/onboarding-bootstrap.test.ts
@@ -109,7 +109,7 @@ describe("onboarding bootstrap", () => {
   test("creates an organization and activates it for the viewer", async () => {
     const database = createOnboardingDatabase();
 
-    const status = await bootstrapOnboarding(database, VIEWER, {
+    const status = await bootstrapOnboarding({ DB: database }, VIEWER, {
       name: "Created Org",
     });
 

--- a/apps/api/tests/product-analytics.test.ts
+++ b/apps/api/tests/product-analytics.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import {
+  captureServerProductEvent,
+  isServerProductAnalyticsConfigured,
+  setServerProductAnalyticsTransportForTests,
+} from "../src/platform/analytics/product-analytics";
+
+interface RecordedRequest {
+  body: Record<string, unknown>;
+  url: string;
+}
+
+afterEach(() => {
+  setServerProductAnalyticsTransportForTests(null);
+});
+
+describe("server product analytics", () => {
+  it("is disabled without a project key", async () => {
+    const requests: RecordedRequest[] = [];
+    setServerProductAnalyticsTransportForTests(async (url, init) => {
+      requests.push({ body: JSON.parse(init.body as string) as Record<string, unknown>, url });
+      return new Response(null, { status: 200 });
+    });
+
+    const bindings = {
+      MOSOO_DEPLOYMENT_MODE: "cloud",
+      MOSOO_ENVIRONMENT: "test",
+    };
+    expect(isServerProductAnalyticsConfigured(bindings)).toBe(false);
+    await captureServerProductEvent(bindings, {
+      distinctId: "acct_123",
+      event: "app_created",
+      properties: { app_id: "app_123" },
+    });
+    expect(requests).toHaveLength(0);
+  });
+
+  it("sends an explicit event with common SaaS context", async () => {
+    const requests: RecordedRequest[] = [];
+    setServerProductAnalyticsTransportForTests(async (url, init) => {
+      requests.push({ body: JSON.parse(init.body as string) as Record<string, unknown>, url });
+      return new Response(null, { status: 200 });
+    });
+
+    await captureServerProductEvent(
+      {
+        MOSOO_DEPLOYMENT_MODE: "cloud",
+        MOSOO_ENVIRONMENT: "test",
+        POSTHOG_API_HOST: "https://us.i.posthog.com/",
+        POSTHOG_PROJECT_KEY: "phc_public",
+      },
+      {
+        distinctId: "acct_123",
+        event: "app_created",
+        properties: {
+          app_id: "app_123",
+          organization_id: "org_123",
+        },
+      },
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe("https://us.i.posthog.com/capture/");
+    expect(requests[0]?.body["api_key"]).toBe("phc_public");
+    expect(requests[0]?.body["event"]).toBe("app_created");
+    const properties = requests[0]?.body["properties"] as Record<string, unknown>;
+    expect(properties).toEqual({
+      app_id: "app_123",
+      deployment_mode: "cloud",
+      distinct_id: "acct_123",
+      environment: "test",
+      organization_id: "org_123",
+    });
+  });
+
+  it("never throws when PostHog is unavailable", async () => {
+    setServerProductAnalyticsTransportForTests(async () => {
+      throw new Error("network down");
+    });
+
+    await expect(
+      captureServerProductEvent(
+        { POSTHOG_PROJECT_KEY: "phc_public" },
+        { distinctId: "acct_123", event: "integration_connected" },
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/tests/runtime-session-link.test.ts
+++ b/apps/api/tests/runtime-session-link.test.ts
@@ -25,6 +25,7 @@ function createRuntimeSessionLinkDatabase(): SqliteD1Database {
     CREATE TABLE session (
       id text PRIMARY KEY NOT NULL,
       agent_id text NOT NULL,
+      app_id text,
       creator_account_id text NOT NULL
 );
 

--- a/apps/api/tests/runtime-session-outputs.test.ts
+++ b/apps/api/tests/runtime-session-outputs.test.ts
@@ -137,6 +137,7 @@ async function insertActiveSandboxSession(database: D1Database): Promise<void> {
 function createRuntimeLink(): RuntimeSessionLink {
   return {
     agentId: PUBLIC_API_TEST_IDS.agent,
+    appId: PUBLIC_API_TEST_IDS.app,
     callerId: PUBLIC_API_TEST_IDS.ownerAccount,
     creatorId: PUBLIC_API_TEST_IDS.ownerAccount,
     executionOwnerId: PUBLIC_API_TEST_IDS.ownerAccount,

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -23,6 +23,9 @@ BACKUP_BUCKET_NAME = "mosoo-sandbox-state"
 SANDBOX_STATE_BUCKET_NAME = "mosoo-sandbox-state"
 SANDBOX_FILE_BUCKET_LOCAL = "true"
 MOSOO_APP_DEPLOYMENT_DOMAIN = "apps.localhost"
+MOSOO_DEPLOYMENT_MODE = "cloud"
+MOSOO_ENVIRONMENT = "development"
+POSTHOG_API_HOST = "https://us.i.posthog.com"
 
 [[send_email]]
 name = "AUTH_EMAIL"
@@ -149,6 +152,9 @@ BACKUP_BUCKET_NAME = "mosoo-sandbox-state"
 SANDBOX_STATE_BUCKET_NAME = "mosoo-sandbox-state"
 SANDBOX_FILE_BUCKET_LOCAL = "false"
 MOSOO_APP_DEPLOYMENT_DOMAIN = "apps.mosoo.ai"
+MOSOO_DEPLOYMENT_MODE = "cloud"
+MOSOO_ENVIRONMENT = "production"
+POSTHOG_API_HOST = "https://us.i.posthog.com"
 
 [[env.prod.send_email]]
 name = "AUTH_EMAIL"

--- a/apps/web/src/analytics/product-analytics-provider.tsx
+++ b/apps/web/src/analytics/product-analytics-provider.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from "react";
+import type { ReactNode } from "react";
+import { useLocation } from "react-router-dom";
+
+import { useAppSession } from "@/app/session-provider";
+
+import {
+  captureProductEvent,
+  configureProductAnalytics,
+  identifyProductUser,
+  PRODUCT_ANALYTICS_EVENTS,
+} from "./product-analytics";
+
+configureProductAnalytics({
+  apiHost: import.meta.env.VITE_POSTHOG_API_HOST,
+  deploymentMode: import.meta.env.VITE_MOSOO_DEPLOYMENT_MODE,
+  environment: import.meta.env.VITE_MOSOO_ENVIRONMENT,
+  projectKey: import.meta.env.VITE_POSTHOG_PROJECT_KEY ?? "",
+});
+
+export function ProductAnalyticsProvider({ children }: { children: ReactNode }) {
+  const location = useLocation();
+  const { activeAppId, activeOrganizationId, user } = useAppSession();
+  const lastPageKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (user !== null) {
+      identifyProductUser({ accountId: user.id, name: user.name });
+    }
+  }, [user]);
+
+  useEffect(() => {
+    const pageKey = `${location.pathname}${location.search}`;
+    if (lastPageKeyRef.current === pageKey) {
+      return;
+    }
+    lastPageKeyRef.current = pageKey;
+    captureProductEvent(PRODUCT_ANALYTICS_EVENTS.pageViewed, {
+      app_id: activeAppId,
+      organization_id: activeOrganizationId,
+      route: location.pathname,
+    });
+  }, [activeAppId, activeOrganizationId, location.pathname, location.search]);
+
+  return children;
+}

--- a/apps/web/src/analytics/product-analytics.ts
+++ b/apps/web/src/analytics/product-analytics.ts
@@ -1,0 +1,199 @@
+export const PRODUCT_ANALYTICS_EVENTS = {
+  appCreated: "app_created",
+  integrationConnected: "integration_connected",
+  loginStarted: "login_started",
+  onboardingCompleted: "onboarding_completed",
+  onboardingStarted: "onboarding_started",
+  onboardingStepViewed: "onboarding_step_viewed",
+  pageViewed: "page_viewed",
+  signupCompleted: "signup_completed",
+} as const;
+
+export type ProductAnalyticsEvent =
+  (typeof PRODUCT_ANALYTICS_EVENTS)[keyof typeof PRODUCT_ANALYTICS_EVENTS];
+
+export interface ProductAnalyticsConfig {
+  apiHost?: string | undefined;
+  deploymentMode?: string | undefined;
+  environment?: string | undefined;
+  projectKey: string;
+}
+
+export interface ProductAnalyticsIdentity {
+  accountId: string;
+  name?: string | null;
+}
+
+export type ProductAnalyticsProperties = Readonly<
+  Record<string, boolean | number | string | null | undefined>
+>;
+
+type ProductAnalyticsTransport = (input: string, init: RequestInit) => Promise<Response>;
+
+interface ProductAnalyticsState {
+  apiHost: string;
+  deploymentMode: string;
+  distinctId: string;
+  enabled: boolean;
+  environment: string;
+  identifiedAccountId: string | null;
+  projectKey: string;
+}
+
+const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+const ANONYMOUS_STORAGE_KEY = "mosoo_posthog_anonymous_id";
+let transportOverride: ProductAnalyticsTransport | null = null;
+let state: ProductAnalyticsState = createInitialState();
+
+function createAnonymousId(): string {
+  const cryptoObject = globalThis.crypto;
+  const suffix =
+    typeof cryptoObject?.randomUUID === "function"
+      ? cryptoObject.randomUUID()
+      : `${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
+  return `mosoo_anon_${suffix}`;
+}
+
+function readStoredAnonymousId(): string | null {
+  try {
+    return globalThis.localStorage?.getItem(ANONYMOUS_STORAGE_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function storeAnonymousId(id: string): void {
+  try {
+    globalThis.localStorage?.setItem(ANONYMOUS_STORAGE_KEY, id);
+  } catch {
+    // Browser storage can be unavailable in restricted contexts.
+  }
+}
+
+function getOrCreateAnonymousId(): string {
+  const stored = readStoredAnonymousId();
+  if (stored !== null && stored.startsWith("mosoo_anon_")) {
+    return stored;
+  }
+
+  const id = createAnonymousId();
+  storeAnonymousId(id);
+  return id;
+}
+
+function createInitialState(): ProductAnalyticsState {
+  return {
+    apiHost: DEFAULT_POSTHOG_HOST,
+    deploymentMode: "cloud",
+    distinctId: getOrCreateAnonymousId(),
+    enabled: false,
+    environment: "production",
+    identifiedAccountId: null,
+    projectKey: "",
+  };
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function locationProperties(): ProductAnalyticsProperties {
+  if (typeof window === "undefined") {
+    return {};
+  }
+
+  return {
+    $current_url: window.location.href,
+    $host: window.location.host,
+    $pathname: window.location.pathname,
+    $referrer: typeof document === "undefined" ? "" : document.referrer,
+  };
+}
+
+function sanitizeProperties(properties: ProductAnalyticsProperties): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(properties).filter(([, value]) => value !== undefined));
+}
+
+function postEvent(event: string, properties: Readonly<Record<string, unknown>>): void {
+  if (!state.enabled) {
+    return;
+  }
+
+  const transport = transportOverride ?? globalThis.fetch;
+  if (typeof transport !== "function") {
+    return;
+  }
+
+  const body = JSON.stringify({
+    api_key: state.projectKey,
+    event,
+    properties: sanitizeProperties({
+      ...locationProperties(),
+      deployment_mode: state.deploymentMode,
+      distinct_id: state.distinctId,
+      environment: state.environment,
+      ...properties,
+    }),
+    timestamp: new Date().toISOString(),
+  });
+
+  void transport(`${state.apiHost}/capture/`, {
+    body,
+    headers: { "Content-Type": "application/json" },
+    keepalive: true,
+    method: "POST",
+  }).catch(() => undefined);
+}
+
+export function configureProductAnalytics(config: ProductAnalyticsConfig): void {
+  const projectKey = config.projectKey.trim();
+  state = {
+    ...state,
+    apiHost: trimTrailingSlash(config.apiHost?.trim() || DEFAULT_POSTHOG_HOST),
+    deploymentMode: config.deploymentMode?.trim() || "cloud",
+    enabled: projectKey.length > 0,
+    environment: config.environment?.trim() || "production",
+    projectKey,
+  };
+}
+
+export function captureProductEvent(
+  event: ProductAnalyticsEvent,
+  properties: ProductAnalyticsProperties = {},
+): void {
+  postEvent(event, properties);
+}
+
+export function identifyProductUser(identity: ProductAnalyticsIdentity): void {
+  const accountId = identity.accountId.trim();
+  if (accountId.length === 0 || state.identifiedAccountId === accountId) {
+    return;
+  }
+
+  const anonymousId = state.distinctId;
+  state = { ...state, distinctId: accountId, identifiedAccountId: accountId };
+  postEvent("$identify", {
+    $anon_distinct_id: anonymousId,
+    $set: sanitizeProperties({ name: identity.name ?? undefined }),
+  });
+}
+
+export function resetProductAnalytics(): void {
+  const distinctId = createAnonymousId();
+  storeAnonymousId(distinctId);
+  state = {
+    ...state,
+    distinctId,
+    identifiedAccountId: null,
+  };
+}
+
+export function getProductAnalyticsState(): Readonly<ProductAnalyticsState> {
+  return state;
+}
+
+export function setProductAnalyticsTransportForTests(
+  transport: ProductAnalyticsTransport | null,
+): void {
+  transportOverride = transport;
+}

--- a/apps/web/src/analytics/product-analytics.ts
+++ b/apps/web/src/analytics/product-analytics.ts
@@ -103,10 +103,8 @@ function locationProperties(): ProductAnalyticsProperties {
   }
 
   return {
-    $current_url: window.location.href,
     $host: window.location.host,
     $pathname: window.location.pathname,
-    $referrer: typeof document === "undefined" ? "" : document.referrer,
   };
 }
 

--- a/apps/web/src/app/account-menu.tsx
+++ b/apps/web/src/app/account-menu.tsx
@@ -3,6 +3,7 @@ import Logout01Icon from "@hugeicons/core-free-icons/Logout01Icon";
 import Settings02Icon from "@hugeicons/core-free-icons/Settings02Icon";
 import { Link } from "react-router-dom";
 
+import { resetProductAnalytics } from "@/analytics/product-analytics";
 import { cn } from "@/shared/lib/class-names";
 import { Button } from "@/shared/ui/button";
 import {
@@ -122,6 +123,7 @@ export function AccountMenu({
             onSelect={() => {
               void (async () => {
                 await authClient["signOut"]();
+                resetProductAnalytics();
                 globalThis.location.href = "/login";
               })();
             }}

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -2,6 +2,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { BrowserRouter } from "react-router-dom";
 
+import { ProductAnalyticsProvider } from "@/analytics/product-analytics-provider";
 import { TooltipProvider } from "@/shared/ui/tooltip";
 
 import { appQueryClient } from "./query-client";
@@ -12,7 +13,9 @@ export function AppProviders({ children }: { children: ReactNode }) {
     <QueryClientProvider client={appQueryClient}>
       <TooltipProvider>
         <BrowserRouter>
-          <AppSessionProvider>{children}</AppSessionProvider>
+          <AppSessionProvider>
+            <ProductAnalyticsProvider>{children}</ProductAnalyticsProvider>
+          </AppSessionProvider>
         </BrowserRouter>
       </TooltipProvider>
     </QueryClientProvider>

--- a/apps/web/src/import-meta.d.ts
+++ b/apps/web/src/import-meta.d.ts
@@ -1,6 +1,10 @@
 interface ImportMetaEnv {
   readonly VITE_APP_DEPLOYMENT_LOCAL_PREVIEW_URL?: string;
   readonly VITE_CHANNEL_WEBHOOK_ORIGIN?: string;
+  readonly VITE_MOSOO_DEPLOYMENT_MODE?: string;
+  readonly VITE_MOSOO_ENVIRONMENT?: string;
+  readonly VITE_POSTHOG_API_HOST?: string;
+  readonly VITE_POSTHOG_PROJECT_KEY?: string;
 }
 
 interface ImportMeta {

--- a/apps/web/src/routes/login/use-login.ts
+++ b/apps/web/src/routes/login/use-login.ts
@@ -2,6 +2,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
+import { captureProductEvent, PRODUCT_ANALYTICS_EVENTS } from "@/analytics/product-analytics";
+
 import { authClient } from "../../domains/auth/api/auth-client";
 import {
   shouldUseMosooAiDevelopmentBackdoor,
@@ -107,6 +109,7 @@ export function useLoginFlow(): LoginFlow {
 
   async function handleGoogleLogin(): Promise<void> {
     setError(null);
+    captureProductEvent(PRODUCT_ANALYTICS_EVENTS.loginStarted, { method: "google" });
 
     const result = await authClient["signIn"].social({
       callbackURL: redirectPath,
@@ -129,6 +132,7 @@ export function useLoginFlow(): LoginFlow {
 
     setError(null);
     setOtpSending(true);
+    captureProductEvent(PRODUCT_ANALYTICS_EVENTS.loginStarted, { method: "email_otp" });
 
     try {
       if (shouldUseMosooAiDevelopmentBackdoor(normalizedEmail)) {

--- a/apps/web/src/routes/onboarding/onboarding.route.tsx
+++ b/apps/web/src/routes/onboarding/onboarding.route.tsx
@@ -3,6 +3,7 @@ import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useReducer } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { captureProductEvent, PRODUCT_ANALYTICS_EVENTS } from "../../analytics/product-analytics";
 import { useAppSession } from "../../app/session-provider";
 import { onboardingBootstrap } from "../../domains/onboarding/api/onboarding-client";
 import { isTruthy } from "../../shared/lib/truthiness";
@@ -66,6 +67,7 @@ export function Onboarding() {
   const handleBootstrap = useCallback(
     async (input?: { name?: string }) => {
       dispatch({ type: "bootstrapStarted" });
+      captureProductEvent(PRODUCT_ANALYTICS_EVENTS.onboardingStarted);
       try {
         await onboardingBootstrap(toOnboardingBootstrapInput(input));
         await Promise.all([refreshOrganizations(), sleepPromise(800)]);

--- a/apps/web/tests/product-analytics.test.ts
+++ b/apps/web/tests/product-analytics.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import {
+  captureProductEvent,
+  configureProductAnalytics,
+  getProductAnalyticsState,
+  identifyProductUser,
+  resetProductAnalytics,
+  setProductAnalyticsTransportForTests,
+} from "../src/analytics/product-analytics";
+
+interface RecordedRequest {
+  body: Record<string, unknown>;
+  url: string;
+}
+
+const originalWindow = globalThis.window;
+const originalDocument = globalThis.document;
+
+function installBrowserLocation(pathname = "/apps", search = "?source=test"): void {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: {
+        href: `https://app.mosoo.ai${pathname}${search}`,
+        host: "app.mosoo.ai",
+        pathname,
+        search,
+      },
+    },
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { referrer: "https://mosoo.ai/" },
+  });
+}
+
+afterEach(() => {
+  resetProductAnalytics();
+  setProductAnalyticsTransportForTests(null);
+  Object.defineProperty(globalThis, "window", { configurable: true, value: originalWindow });
+  Object.defineProperty(globalThis, "document", { configurable: true, value: originalDocument });
+});
+
+describe("product analytics", () => {
+  it("is inert without a project key", async () => {
+    const requests: RecordedRequest[] = [];
+    setProductAnalyticsTransportForTests(async (url, init) => {
+      requests.push({ body: JSON.parse(init.body as string) as Record<string, unknown>, url });
+      return new Response(null, { status: 200 });
+    });
+
+    configureProductAnalytics({ apiHost: "https://us.i.posthog.com", projectKey: "" });
+    captureProductEvent("onboarding_started");
+    await Promise.resolve();
+
+    expect(requests).toHaveLength(0);
+    expect(getProductAnalyticsState().enabled).toBe(false);
+  });
+
+  it("captures anonymous events without autocapture or sensitive properties", async () => {
+    installBrowserLocation();
+    const requests: RecordedRequest[] = [];
+    setProductAnalyticsTransportForTests(async (url, init) => {
+      requests.push({ body: JSON.parse(init.body as string) as Record<string, unknown>, url });
+      return new Response(null, { status: 200 });
+    });
+
+    configureProductAnalytics({
+      apiHost: "https://us.i.posthog.com/",
+      deploymentMode: "cloud",
+      environment: "test",
+      projectKey: "phc_public",
+    });
+    captureProductEvent("onboarding_started", { step: "welcome" });
+    await Promise.resolve();
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe("https://us.i.posthog.com/capture/");
+    expect(requests[0]?.body["event"]).toBe("onboarding_started");
+    expect(requests[0]?.body["api_key"]).toBe("phc_public");
+    const properties = requests[0]?.body["properties"] as Record<string, unknown>;
+    expect(properties["distinct_id"]).toMatch(/^mosoo_anon_/);
+    expect(properties["deployment_mode"]).toBe("cloud");
+    expect(properties["environment"]).toBe("test");
+    expect(properties["step"]).toBe("welcome");
+    expect(properties["$current_url"]).toBe("https://app.mosoo.ai/apps?source=test");
+  });
+
+  it("aliases the anonymous identity once, then uses the stable account id", async () => {
+    installBrowserLocation();
+    const requests: RecordedRequest[] = [];
+    setProductAnalyticsTransportForTests(async (url, init) => {
+      requests.push({ body: JSON.parse(init.body as string) as Record<string, unknown>, url });
+      return new Response(null, { status: 200 });
+    });
+    configureProductAnalytics({ projectKey: "phc_public" });
+
+    const anonymousId = getProductAnalyticsState().distinctId;
+    identifyProductUser({ accountId: "acct_123", name: "Rock" });
+    captureProductEvent("page_viewed", { route: "/apps" });
+    await Promise.resolve();
+
+    expect(requests.map((request) => request.body["event"])).toEqual(["$identify", "page_viewed"]);
+    const identifyProperties = requests[0]?.body["properties"] as Record<string, unknown>;
+    expect(identifyProperties["distinct_id"]).toBe("acct_123");
+    expect(identifyProperties["$anon_distinct_id"]).toBe(anonymousId);
+    expect(identifyProperties["$set"]).toEqual({ name: "Rock" });
+    const pageProperties = requests[1]?.body["properties"] as Record<string, unknown>;
+    expect(pageProperties["distinct_id"]).toBe("acct_123");
+  });
+
+  it("resets to a fresh anonymous identity on logout", () => {
+    installBrowserLocation();
+    configureProductAnalytics({ projectKey: "phc_public" });
+    identifyProductUser({ accountId: "acct_123" });
+
+    resetProductAnalytics();
+
+    expect(getProductAnalyticsState().distinctId).toMatch(/^mosoo_anon_/);
+    expect(getProductAnalyticsState().identifiedAccountId).toBe(null);
+  });
+});

--- a/apps/web/tests/product-analytics.test.ts
+++ b/apps/web/tests/product-analytics.test.ts
@@ -31,7 +31,7 @@ function installBrowserLocation(pathname = "/apps", search = "?source=test"): vo
   });
   Object.defineProperty(globalThis, "document", {
     configurable: true,
-    value: { referrer: "https://mosoo.ai/" },
+    value: { referrer: "https://mosoo.ai/?code=referrer-secret" },
   });
 }
 
@@ -84,7 +84,10 @@ describe("product analytics", () => {
     expect(properties["deployment_mode"]).toBe("cloud");
     expect(properties["environment"]).toBe("test");
     expect(properties["step"]).toBe("welcome");
-    expect(properties["$current_url"]).toBe("https://app.mosoo.ai/apps?source=test");
+    expect(properties["$host"]).toBe("app.mosoo.ai");
+    expect(properties["$pathname"]).toBe("/apps");
+    expect(JSON.stringify(requests[0]?.body)).not.toContain("source=test");
+    expect(JSON.stringify(requests[0]?.body)).not.toContain("referrer-secret");
   });
 
   it("aliases the anonymous identity once, then uses the stable account id", async () => {

--- a/docs/product-analytics.md
+++ b/docs/product-analytics.md
@@ -1,0 +1,64 @@
+# Product analytics (PostHog Cloud)
+
+Mosoo sends explicit, low-volume product events to one PostHog Cloud project. Browser events cover intent and navigation; API events cover authoritative business outcomes. Analytics failures never fail the business operation.
+
+## Identity and privacy
+
+- Before login, the web app uses a persistent random `mosoo_anon_*` ID.
+- After login, `$identify` joins that anonymous history to the stable Mosoo account ID.
+- Logout creates a fresh anonymous ID so two accounts on one browser are not mixed.
+- Email addresses, prompts, credentials, task content, and model responses are not sent.
+- PostHog autocapture and session replay are not enabled by this integration.
+
+## Events
+
+Browser intent events:
+
+- `page_viewed`
+- `login_started`
+- `onboarding_started`
+
+Authoritative API events:
+
+- `signup_completed`
+- `onboarding_completed`
+- `app_created`
+- `agent_created`
+- `integration_connected` after a model-provider credential probe succeeds
+- `task_succeeded` after a runtime run first transitions to completed
+
+Common properties include `environment`, `deployment_mode`, and the relevant `organization_id`, `app_id`, `agent_id`, integration type, or runtime identifiers. Person identity is the stable account ID.
+
+## Configuration
+
+Create one PostHog Cloud project and copy its **Project API key** (the public `phc_...` ingestion key) and regional ingestion host.
+
+Configure the GitHub `try` environment secret `POSTHOG_PROJECT_KEY`. The deploy workflow injects it as `VITE_POSTHOG_PROJECT_KEY` while building the web app.
+
+Set the same key on the API Worker:
+
+```bash
+cd apps/api
+../../node_modules/.bin/vp exec wrangler secret put POSTHOG_PROJECT_KEY --env prod
+```
+
+The repository defaults both sides to the US ingestion host, `https://us.i.posthog.com`. If the project is in PostHog EU Cloud, change both `POSTHOG_API_HOST` in `apps/api/wrangler.toml` and `VITE_POSTHOG_API_HOST` in the deploy workflow to `https://eu.i.posthog.com`.
+
+For local analytics, put matching `VITE_POSTHOG_PROJECT_KEY` and `POSTHOG_PROJECT_KEY` values in the normal local environment. Without the project key, analytics is intentionally disabled. This integration does not require a PostHog personal API key.
+
+## Suggested insights
+
+Activation funnel, unique users ordered:
+
+```text
+signup_completed -> onboarding_completed -> app_created -> agent_created -> integration_connected -> task_succeeded
+```
+
+Also create:
+
+- a path insight starting from `page_viewed`;
+- an onboarding funnel `onboarding_started -> onboarding_completed`;
+- a breakdown of `integration_connected` by `vendor_id`;
+- a breakdown of all funnels by `environment` and `deployment_mode`.
+
+Payments and subscriptions are not currently Mosoo product surfaces, so no synthetic payment events are emitted.


### PR DESCRIPTION
## Summary
- add privacy-conscious browser and Cloudflare Worker PostHog event transport
- join anonymous browser activity to stable Mosoo account IDs
- capture authoritative signup, onboarding, app, agent, integration, and successful task events
- wire deployment configuration and document the recommended funnels

## Verification
- 37 targeted tests pass
- web and API TypeScript checks pass
- web production build passes
- focused lint on all analytics-related files passes

## Configuration after merge
- add the PostHog Project API key as the GitHub `try` environment secret `POSTHOG_PROJECT_KEY`
- set the same value as the `POSTHOG_PROJECT_KEY` secret on `mosoo-api-prod`
- US PostHog ingestion is configured by default; see `docs/product-analytics.md` for EU Cloud
