### PR TITLE
fix(web): align YEF-922 list empty state height

### DIFF
--- a/apps/web/src/shared/ui/empty-state.tsx
+++ b/apps/web/src/shared/ui/empty-state.tsx
@@ -23,7 +23,7 @@ export function EmptyState({
   return (
     <div
       className={cn(
-        "flex h-full min-h-[320px] flex-col items-center justify-center text-center",
+        "flex h-full min-h-[320px] flex-1 flex-col items-center justify-center text-center",
         className,
       )}
     >

--- a/apps/web/src/shared/ui/list-page.tsx
+++ b/apps/web/src/shared/ui/list-page.tsx
@@ -61,6 +61,10 @@ export function ListPageContent({
   className?: string;
 }): ReactElement {
   return (
-    <div className={cn("flex-1 overflow-y-auto px-4 pb-8 sm:px-8", className)}>{children}</div>
+    <div
+      className={cn("flex min-h-0 flex-1 flex-col overflow-y-auto px-4 pb-8 sm:px-8", className)}
+    >
+      {children}
+    </div>
   );
 }

--- a/apps/web/tests/mobile-responsive-boundary.test.ts
+++ b/apps/web/tests/mobile-responsive-boundary.test.ts
@@ -26,6 +26,10 @@ const LIST_PAGE_SOURCE = readFileSync(
   new URL("../src/shared/ui/list-page.tsx", import.meta.url),
   "utf8",
 );
+const EMPTY_STATE_SOURCE = readFileSync(
+  new URL("../src/shared/ui/empty-state.tsx", import.meta.url),
+  "utf8",
+);
 const ACCESS_TOKENS_SOURCE = readFileSync(
   new URL("../src/routes/settings/access-tokens-tab.tsx", import.meta.url),
   "utf8",
@@ -92,6 +96,11 @@ describe("mobile console boundaries", () => {
     expect(LIST_PAGE_SOURCE).toContain("flex-wrap");
     expect(LIST_PAGE_SOURCE).toContain("w-full sm:w-[260px]");
     expect(LIST_PAGE_SOURCE).toContain("px-4 pb-4 sm:px-8");
+  });
+
+  test("shared list empty states fill the remaining page content height", () => {
+    expect(LIST_PAGE_SOURCE).toContain("flex min-h-0 flex-1 flex-col overflow-y-auto");
+    expect(EMPTY_STATE_SOURCE).toContain("min-h-[320px] flex-1");
   });
 
   test("wide data tables switch to mobile cards instead of clipping", () => {


### PR DESCRIPTION
## Summary

- Make shared list content a definite flex column area so main empty states can fill the remaining page height.
- Let `EmptyState` flex to the available list content height and add a boundary test for that contract.

## Why

- The Agents placeholder was centering inside its 320px minimum instead of the fixed remaining viewport area, so it did not align with the Runs empty state.

Closes YEF-922

## Verification

- Commands:
  - `bun test apps/web/tests/mobile-responsive-boundary.test.ts`
  - `bun run fmt:check:path apps/web/src/shared/ui/list-page.tsx apps/web/src/shared/ui/empty-state.tsx apps/web/tests/mobile-responsive-boundary.test.ts`
  - `bun run --filter @mosoo/web tc`
  - `TMPDIR=/private/tmp just check`
- Manual steps:
  - Reviewed the issue screenshot and compared the Agents/Runs shared list empty-state layout.
- Not run:
  - N/A

## Impact

- User/API/contract changes:
  - Web console list empty states now occupy the remaining list page height consistently.
- Generated files / GraphQL / DB / lockfile:
  - N/A
- Env or config changes:
  - N/A
- Risk and rollback:
  - Low risk; affects shared list-page empty-state layout. Roll back by reverting this commit.

## Review

- Closest review areas:
  - `apps/web/src/shared/ui/list-page.tsx`
  - `apps/web/src/shared/ui/empty-state.tsx`
- Known trade-offs:
  - This intentionally applies the layout contract to all shared list pages, not only Agents, to keep empty states consistent.
