### PR TITLE
fix(web): render New Agent runtime cards without waiting for credentials

### DIFF
--- a/apps/web/src/routes/agent/components/create-agent-launcher.tsx
+++ b/apps/web/src/routes/agent/components/create-agent-launcher.tsx
@@ -60,19 +60,19 @@ function CreateAgentLauncherBody({
   const [name, setName] = useState("");
   const [selectedRuntimeId, setSelectedRuntimeId] = useState<string | null>(null);
 
+  // The runtime catalog is static, so the cards render immediately. Credentials
+  // only refine which runtime is preselected once they arrive.
+  const runtimeOptions = useMemo(
+    () => listRuntimeOptions().filter((runtime) => isRuntimeSelectable(runtime.id)),
+    [],
+  );
   const defaultRuntime = useMemo(
     () => (credentialsLoading ? null : resolveDefaultAgentRuntime(credentials)),
     [credentials, credentialsLoading],
   );
-  const runtimeOptions = useMemo(
-    () =>
-      listRuntimeOptions(defaultRuntime?.runtimeId).filter((runtime) =>
-        isRuntimeSelectable(runtime.id),
-      ),
-    [defaultRuntime],
-  );
 
-  const activeRuntimeId = selectedRuntimeId ?? defaultRuntime?.runtimeId ?? null;
+  const activeRuntimeId =
+    selectedRuntimeId ?? defaultRuntime?.runtimeId ?? runtimeOptions[0]?.id ?? null;
 
   const createAgentMutation = useMutation({
     mutationFn: createAgent,
@@ -149,12 +149,7 @@ function CreateAgentLauncherBody({
 
         <div className="space-y-2">
           <Label className="text-muted-foreground text-[12px]">Runtime</Label>
-          {credentialsLoading ? (
-            <div className="text-muted-foreground flex items-center gap-2 py-2 text-[13px]">
-              <Loader2 className="size-4 animate-spin" />
-              Loading runtimes…
-            </div>
-          ) : runtimeOptions.length === 0 ? (
+          {runtimeOptions.length === 0 ? (
             <div className="text-muted-foreground text-[13px]">No runtimes available.</div>
           ) : (
             <div className="grid grid-cols-2 gap-3">


### PR DESCRIPTION
## Summary

- Render the New Agent dialog's runtime cards immediately from the static runtime catalog instead of gating the whole Runtime section behind the vendor-credentials query.
- The credentials query now only settles which runtime is preselected; the first catalog entry serves as the interim default, an explicit user click always wins, and Create stays disabled until credentials resolve so custom-provider model wiring stays correct.

## Why

- Opening New Agent showed a "Loading runtimes…" spinner even though the three runtime options are a compile-time constant (`PUBLIC_RUNTIME_CATALOG`); only the default preselection depends on the vendor-credentials request.

## Verification

- Commands: `bun run fmt:check:path -- apps/web/.../create-agent-launcher.tsx`; `bun run lint`, `bun run tc`, `bun run test` in `apps/web` (187/188 pass; the single failure is `providers-tab-dialog.test.tsx`, which fails identically on clean `main` in full-suite runs and passes in isolation — pre-existing ordering flake, unrelated to this change).
- Manual steps: ran the local dev stack, logged in via the development backdoor, and opened New Agent with the `VendorCredentialList` GraphQL response delayed by 5s. Cards now render immediately with the first runtime preselected while credentials load, and the selection settles to the credential-derived default afterwards. Before/after states were reviewed during manual verification.
- Not run: e2e suite.

## Impact

- User/API/contract changes: UI-only — the Runtime section no longer shows a loading spinner; Create remains disabled until credentials resolve.
- Generated files / GraphQL / DB / lockfile: N/A
- Env or config changes: N/A
- Risk and rollback: low; single-component change, revert to roll back.

## Review

- Closest review areas: default-selection fallback and submit gating in `create-agent-launcher.tsx`.
- Known trade-offs: when the credential-derived default differs from the first catalog entry, the preselected card switches once credentials arrive (unless the user already clicked a card).