### PR TITLE
fix(web): pin skills catalog count format to en-US

### DIFF
--- a/apps/web/src/routes/integrations/skills/format.ts
+++ b/apps/web/src/routes/integrations/skills/format.ts
@@ -11,3 +11,12 @@ export function formatDate(iso: string): string {
   }
   return DATE_FORMATTER.format(d);
 }
+
+// Pinned to en-US so compact notation stays "2.1M"/"21K" next to the English
+// catalog copy instead of following the browser locale (e.g. zh-CN "万").
+export function formatCatalogCount(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: value >= 1000 ? 1 : 0,
+    notation: value >= 10_000 ? "compact" : "standard",
+  }).format(value);
+}

--- a/apps/web/src/routes/integrations/skills/skills-sh-catalog.tsx
+++ b/apps/web/src/routes/integrations/skills/skills-sh-catalog.tsx
@@ -29,6 +29,7 @@ import { Switch } from "@/shared/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 import { isTruthy } from "../../../shared/lib/truthiness";
+import { formatCatalogCount } from "./format";
 import type { useSkillRegistry } from "./use-skill-registry";
 
 const CATALOG_PER_PAGE = 24;
@@ -517,11 +518,4 @@ function CatalogViewButton({
       {label}
     </button>
   );
-}
-
-function formatCatalogCount(value: number): string {
-  return new Intl.NumberFormat(undefined, {
-    maximumFractionDigits: value >= 1000 ? 1 : 0,
-    notation: value >= 10_000 ? "compact" : "standard",
-  }).format(value);
 }

--- a/apps/web/tests/skills-catalog-format.test.ts
+++ b/apps/web/tests/skills-catalog-format.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatCatalogCount } from "../src/routes/integrations/skills/format";
+
+describe("formatCatalogCount", () => {
+  test("keeps small counts in standard notation", () => {
+    expect(formatCatalogCount(0)).toBe("0");
+    expect(formatCatalogCount(999)).toBe("999");
+    expect(formatCatalogCount(9_999)).toBe("9,999");
+  });
+
+  test("compacts counts from 10k with at most one fraction digit", () => {
+    expect(formatCatalogCount(10_000)).toBe("10K");
+    expect(formatCatalogCount(12_345)).toBe("12.3K");
+    expect(formatCatalogCount(1_234_567)).toBe("1.2M");
+  });
+
+  test("uses en-US units regardless of runtime locale", () => {
+    // Regression: an unpinned locale rendered zh-CN units ("2.1万 installs")
+    // inside the English catalog copy.
+    expect(formatCatalogCount(21_000)).toBe("21K");
+    for (const value of [10_000, 21_000, 123_456, 10_000_000]) {
+      expect(formatCatalogCount(value)).not.toMatch(/[万亿]/);
+    }
+  });
+});


### PR DESCRIPTION
Fill what changed. Use N/A for irrelevant or maintainer-only items. See `CONTRIBUTING.md` for branch, CLA, generated file, and CI rules.

## Summary

- Pin the skills.sh Discover catalog count formatting (install badges and the result total) to `en-US` instead of the browser default locale.
- Move `formatCatalogCount` out of `skills-sh-catalog.tsx` into the route's existing `format.ts` (which already pins `en-US` for dates) and add a regression test.

## Why

- On Chinese-locale browsers, `Intl.NumberFormat(undefined, { notation: "compact" })` rendered CJK units inside the English catalog copy, e.g. `2.2万 installs`. The rest of the app (`routes/cost/cost-model.ts`) already pins `en-US` for compact numbers; this brings the skills catalog in line.

## Verification

- Commands: `bun test tests` in `apps/web` (new `skills-catalog-format.test.ts` passes; 190 pass), `bun run tc`, `bun run lint`, `bun run fmt:check`, `bun run commit:check` — all pass.
- Manual steps: ran the local stack and loaded Config → Skills → Discover in Chromium with `locale: zh-CN`. Before: badges render `2.2万 installs`; after: `21.7K installs` / `19K installs` etc. with live skills.sh data.
- Not run: full `just check` gate passes except two failures that reproduce identically on a clean `origin/main` checkout in this sandbox and are unrelated to this web-only change: `providers-tab-dialog.test.tsx` (readonly `globalThis.window` assignment under bun canary) and one `apps/driver` `acp-file-system` test (pinned submodule, sandbox fs).

## Impact

- User/API/contract changes: visual only — catalog counts always use en-US units (`21.7K`, `1.2M`) regardless of browser locale. No API or contract changes.
- Generated files / GraphQL / DB / lockfile: N/A
- Env or config changes: N/A
- Risk and rollback: low; single formatter used only by the Discover tab. Revert the commit to roll back.

## Review

- Closest review areas: `apps/web/src/routes/integrations/skills/format.ts`, `skills-sh-catalog.tsx`.
- Known trade-offs: counts are intentionally not localized (matches the hard-coded English strings like "installs" on this page).
