### PR TITLE
fix(web): restore Environment page scrolling

### DIFF
--- a/apps/web/src/routes/environments/environments.route.tsx
+++ b/apps/web/src/routes/environments/environments.route.tsx
@@ -7,9 +7,13 @@ export function EnvironmentsPage() {
   const params = useParams();
   const { environmentId } = params;
 
-  if (isTruthy(environmentId)) {
-    return <EnvironmentDetailPage key={environmentId} environmentId={environmentId} />;
-  }
-
-  return <EnvironmentsListPage />;
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      {isTruthy(environmentId) ? (
+        <EnvironmentDetailPage key={environmentId} environmentId={environmentId} />
+      ) : (
+        <EnvironmentsListPage />
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

- Constrain the Environment route to the App shell's available height.
- Keep the existing list and detail scroll containers working inside that boundary.

## Root cause

The responsive App shell clips route overflow. The Environment route did not establish a full-height flex boundary, so its children stayed content-height; their existing `overflow-y-auto` styles had no constrained height and the lower form content was clipped instead of scrollable.

## User impact

App owners can scroll Environment details to reach environment variables, save controls, and the final status message. The same boundary also keeps long Environment lists scrollable.

## Verification

- `just fmt-check-path apps/web/src/routes/environments/environments.route.tsx` — passed
- `just tc-package @mosoo/web` — passed
- `bun run --filter @mosoo/web build` — passed
- `just test-file apps/web/tests/mobile-responsive-boundary.test.ts` — 10 passed
- Browser smoke at 1280×720 — Environment detail measured `clientHeight=720`, `scrollHeight=1168`, and reached `scrollTop=448`
- `just check` — formatting, docs, lint, and workspace typecheck passed; the parallel test stage hit two unrelated existing isolation/resource failures:
  - `providers-tab-dialog.test.tsx`: 190/191 Web tests passed; the failing test passed 4/4 when run alone
  - Agent Driver tests exited 137 in the parallel gate and passed when run alone

## Change surface

- Generated files: none
- GraphQL/codegen: not applicable; no schema or operation changes
- Database migrations: none
- Lockfile changes: none
