### PR TITLE
fix(web): integrate deployment failure details into activity rows

### DIFF
--- a/apps/web/src/routes/app-overview/deploy/components/deployments-history.tsx
+++ b/apps/web/src/routes/app-overview/deploy/components/deployments-history.tsx
@@ -136,7 +136,7 @@ export function DeploymentsHistory({ runs }: { runs: DeploymentRunVM[] }) {
                   {expanded ? (
                     <div className="grid grid-rows-[1fr] transition-[grid-template-rows] duration-200 ease-out starting:grid-rows-[0fr]">
                       <div className="overflow-hidden">
-                        <div className="border-border bg-bg-sunken/40 mt-1 rounded-md border px-3.5 py-2.5 text-[13px]">
+                        <div className="mt-1 text-[13px]">
                           <div className="text-fg-3 mb-1 text-[11.5px] font-medium">
                             Failure details
                           </div>
@@ -173,7 +173,7 @@ export function DeploymentsHistory({ runs }: { runs: DeploymentRunVM[] }) {
               const expanded = expandedRunIds.has(run.id);
               return (
                 <Fragment key={run.id}>
-                  <TableRow>
+                  <TableRow className={cn(failedError !== null && expanded && "border-b-0")}>
                     <TableCell className="py-4 pl-5">
                       <div className="flex items-center gap-3">
                         <span className="bg-bg-sunken text-fg-3 flex size-8 shrink-0 items-center justify-center rounded-full">
@@ -230,11 +230,11 @@ export function DeploymentsHistory({ runs }: { runs: DeploymentRunVM[] }) {
                     </TableCell>
                   </TableRow>
                   {failedError === null || !expanded ? null : (
-                    <TableRow className="hover:bg-transparent">
+                    <TableRow className="bg-muted/50">
                       <TableCell colSpan={3} className="px-5 pt-0 pb-4">
                         <div className="grid grid-rows-[1fr] transition-[grid-template-rows] duration-200 ease-out starting:grid-rows-[0fr]">
                           <div className="overflow-hidden">
-                            <div className="border-border bg-bg-sunken/40 rounded-md border px-3.5 py-2.5 text-[13px]">
+                            <div className="text-[13px]">
                               <div className="text-fg-3 mb-1 text-[11.5px] font-medium">
                                 Failure details
                               </div>


### PR DESCRIPTION
## Summary

- Remove the nested bordered card around "Failure details" in the deploy Activity list; the expanded error now renders flat inside the run's own region.
- Suppress the run row's bottom border while its details are expanded and give the details row the same muted background, so the expansion reads as one continuous block in both the desktop table and the mobile card list.

## Why

- Expanding Details on a failed run showed a divider line plus a rounded bordered box nested inside the row.

## Verification

- Commands: `bun run lint`, `bun run tc`, `bun run test` in `apps/web` (190/191 pass; the single failure is `providers-tab-dialog.test.tsx`, pre-existing on `main` when running the full suite and unrelated to this change — it passes in isolation).
- Manual steps: on `/v0-deploy-preview`, simulated a failed deploy and expanded Details at desktop (1280px) and mobile (390px) widths; the failure details render flat with no divider and no nested card.
- Not run: full workspace `bun run check`.

## Impact

- User/API/contract changes: visual-only change to the deploy Activity failure-details expansion.
- Generated files / GraphQL / DB / lockfile: N/A
- Env or config changes: N/A
- Risk and rollback: low; revert this single commit.

## Review

- Closest review areas: `apps/web/src/routes/app-overview/deploy/components/deployments-history.tsx`
- Known trade-offs: the expanded row and its details row share `bg-muted/50`, so hover no longer visually separates the details row — intentional, the expansion should read as one region.

