### PR TITLE
fix(deployment): encode worker upload metadata

### DIFF
--- a/apps/api/src/modules/apps/application/app-deployment-cloudflare-client.ts
+++ b/apps/api/src/modules/apps/application/app-deployment-cloudflare-client.ts
@@ -3,6 +3,10 @@ import Cloudflare from "cloudflare";
 import { createErrorLogContext, logError } from "../../../platform/cloudflare/logger";
 import type { ApiBindings } from "../../../platform/cloudflare/worker-types";
 
+type CloudflareWorkerUploadMetadata = Parameters<
+  Cloudflare["workers"]["scripts"]["versions"]["create"]
+>[1]["metadata"];
+
 export interface CloudflarePagesProjectInput {
   branch: string;
   projectName: string;
@@ -324,22 +328,25 @@ function workerRoutePattern(hostname: string): string {
   return `${hostname}/*`;
 }
 
-function createWorkerModuleUpload(input: CloudflareWorkerModuleInput) {
+export function createWorkerModuleUpload(input: CloudflareWorkerModuleInput) {
   const file = new File([input.scriptContent], input.mainModuleName, {
     type: "application/javascript+module",
   });
+  const metadata = {
+    bindings: Object.entries(input.vars).map(([name, text]) => ({
+      name,
+      text,
+      type: "plain_text" as const,
+    })),
+    compatibility_date: input.compatibilityDate,
+    main_module: input.mainModuleName,
+  };
 
   return {
     files: [file],
-    metadata: {
-      bindings: Object.entries(input.vars).map(([name, text]) => ({
-        name,
-        text,
-        type: "plain_text" as const,
-      })),
-      compatibility_date: input.compatibilityDate,
-      main_module: input.mainModuleName,
-    },
+    // The SDK's generic multipart encoder expands objects into metadata[...]
+    // fields, but the Workers upload API requires one JSON `metadata` part.
+    metadata: JSON.stringify(metadata) as unknown as CloudflareWorkerUploadMetadata,
   };
 }
 

--- a/apps/api/tests/app-deployment-cloudflare-client.test.ts
+++ b/apps/api/tests/app-deployment-cloudflare-client.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { createWorkerModuleUpload } from "../src/modules/apps/application/app-deployment-cloudflare-client";
+
+describe("app deployment Cloudflare client", () => {
+  test("encodes Worker metadata as one JSON multipart field", () => {
+    const upload = createWorkerModuleUpload({
+      compatibilityDate: "2026-07-14",
+      mainModuleName: "worker.js",
+      scriptContent: "export default { fetch() {} };",
+      scriptName: "example",
+      vars: { MOSOO_AGENT_URL: "https://example.com/bound/token" },
+    });
+
+    expect(upload.files[0]?.name).toBe("worker.js");
+    expect(upload.metadata).toBe(
+      JSON.stringify({
+        bindings: [
+          {
+            name: "MOSOO_AGENT_URL",
+            text: "https://example.com/bound/token",
+            type: "plain_text",
+          },
+        ],
+        compatibility_date: "2026-07-14",
+        main_module: "worker.js",
+      }),
+    );
+  });
+});

--- a/apps/web/tests/providers-tab-dialog.test.tsx
+++ b/apps/web/tests/providers-tab-dialog.test.tsx
@@ -32,8 +32,16 @@ function installDom(): void {
   });
   const { window } = dom;
 
-  globalThis.window = window as unknown as Window & typeof globalThis;
-  globalThis.document = window.document;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: window,
+    writable: true,
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: window.document,
+    writable: true,
+  });
   globalThis.Element = window.Element;
   globalThis.HTMLElement = window.HTMLElement;
   globalThis.HTMLButtonElement = window.HTMLButtonElement;


### PR DESCRIPTION
## Summary
- encode Worker upload metadata as the single JSON multipart field required by Cloudflare
- add a regression test for the generated upload payload
- keep the provider dialog DOM test globals writable so the full repository gate is deterministic

## Verification
- `just test-file apps/api/tests/app-deployment-cloudflare-client.test.ts`
- `just tc-package @mosoo/api`
- `just test-file apps/web/tests/providers-tab-dialog.test.tsx`
- `TMPDIR=/private/var/folders/6l/lkv7jglj5y13mk6jlklj94nh0000gn/T just check`

Generated files: none. GraphQL codegen: not applicable. DB migrations: none. Lockfile changes: none.