### PR TITLE
fix(runtime): export sandbox container proxy

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import { arktypeWorkerConfigInitialized } from "./platform/arktype-worker-config";
 import { createApiWorker } from "./platform/cloudflare/create-api-worker";
 export { ChannelConnection } from "./adapters/durable-objects/channel-connection.do";
+export { ContainerProxy } from "@cloudflare/sandbox";
 export { DriverConnection } from "./adapters/durable-objects/driver-connection.do";
 export { Sandbox } from "./adapters/durable-objects/sandbox.do";
 export { Session } from "./adapters/durable-objects/session.do";


### PR DESCRIPTION
## Summary

- export the Sandbox SDK `ContainerProxy` from the Worker entrypoint
- restore R2 binding mounts and credential proxy startup on Sandbox SDK 0.12.3

## Evidence

Production Sandbox startup failed with `ctx.exports.ContainerProxy is undefined`.
Cloudflare requires this export for R2 binding mounts.

## Verification

- `just fmt-check-path apps/api/src/index.ts`
- `just lint`
- `just tc-package @mosoo/api`
- production API Worker `wrangler deploy --env prod --minify --dry-run`