### PR TITLE
fix(deployment): name worker multipart module

### DIFF
--- a/apps/api/src/modules/apps/application/app-deployment-cloudflare-client.ts
+++ b/apps/api/src/modules/apps/application/app-deployment-cloudflare-client.ts
@@ -328,7 +328,9 @@ function workerRoutePattern(hostname: string): string {
   return `${hostname}/*`;
 }
 
-export function createWorkerModuleUpload(input: CloudflareWorkerModuleInput) {
+export function createWorkerModuleUpload(
+  input: CloudflareWorkerModuleInput,
+): Pick<Parameters<Cloudflare["workers"]["scripts"]["versions"]["create"]>[1], "metadata"> {
   const file = new File([input.scriptContent], input.mainModuleName, {
     type: "application/javascript+module",
   });
@@ -343,7 +345,9 @@ export function createWorkerModuleUpload(input: CloudflareWorkerModuleInput) {
   };
 
   return {
-    files: [file],
+    // `main_module` identifies a multipart part name. The SDK's `files` array
+    // becomes `files[]`, so put the module at its real part name instead.
+    [input.mainModuleName]: file,
     // The SDK's generic multipart encoder expands objects into metadata[...]
     // fields, but the Workers upload API requires one JSON `metadata` part.
     metadata: JSON.stringify(metadata) as unknown as CloudflareWorkerUploadMetadata,

--- a/apps/api/tests/app-deployment-cloudflare-client.test.ts
+++ b/apps/api/tests/app-deployment-cloudflare-client.test.ts
@@ -3,16 +3,23 @@ import { describe, expect, test } from "bun:test";
 import { createWorkerModuleUpload } from "../src/modules/apps/application/app-deployment-cloudflare-client";
 
 describe("app deployment Cloudflare client", () => {
-  test("encodes Worker metadata as one JSON multipart field", () => {
+  test("uses the module name and metadata as multipart part names", async () => {
+    const scriptContent = "export default { fetch() {} };";
     const upload = createWorkerModuleUpload({
       compatibilityDate: "2026-07-14",
       mainModuleName: "worker.js",
-      scriptContent: "export default { fetch() {} };",
+      scriptContent,
       scriptName: "example",
       vars: { MOSOO_AGENT_URL: "https://example.com/bound/token" },
     });
 
-    expect(upload.files[0]?.name).toBe("worker.js");
+    const modulePart = Reflect.get(upload, "worker.js");
+
+    expect(modulePart).toBeInstanceOf(File);
+    expect((modulePart as File).name).toBe("worker.js");
+    expect((modulePart as File).type).toBe("application/javascript+module");
+    expect(await (modulePart as File).text()).toBe(scriptContent);
+    expect(Reflect.get(upload, "files")).toBeUndefined();
     expect(upload.metadata).toBe(
       JSON.stringify({
         bindings: [


### PR DESCRIPTION
## Summary

- encode the Worker module under its actual multipart part name
- keep metadata as one JSON part
- cover the final module filename, MIME type, and bytes

## Evidence

Cloudflare rejected the previous upload at `worker.js:1:2` because the generated SDK encoded the file array as `files[]`. The Workers API defines `metadata.main_module` as the multipart part name.

## Verification

- `just test-file apps/api/tests/app-deployment-cloudflare-client.test.ts`
- `just tc-package @mosoo/api`
- focused formatting checks
- captured the SDK final FormData: `worker.js` and `metadata`
- production API Worker `wrangler deploy --env prod --minify --dry-run`