### PR TITLE
fix(runtime): acknowledge terminal commands before cleanup

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/do.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/do.ts
@@ -92,6 +92,7 @@ export class DriverInstance extends DurableObject implements DriverInstanceHttpH
       state: this.#state,
       viewCache: this.#viewCache,
       viewerEventDelivery: this.#viewerEventDelivery,
+      waitUntil: (task) => this.ctx.waitUntil(task),
       withRuntimeLogContext: (fn) => this.#withRuntimeLogContext(fn),
     });
     void this.ctx.blockConcurrencyWhile(async () => this.#state.load());

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/rpc-command-controller.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/rpc-command-controller.ts
@@ -9,6 +9,7 @@ import { parseSchemaValue } from "@mosoo/contracts/validation";
 import { parsePlatformId } from "@mosoo/id";
 import type { DriverCommandId } from "@mosoo/id";
 
+import { createErrorLogContext, logError } from "../../../../platform/cloudflare/logger";
 import {
   claimNextQueuedRuntimeCommandRecord,
   createRuntimeCommandRecord,
@@ -93,7 +94,17 @@ export class DriverInstanceRpcCommandController {
         input.status === "cancelled" ||
         input.status === "expired")
     ) {
-      await releaseLinkedTerminalDriverInstanceSessionRun(env, driverInstanceId);
+      const release = releaseLinkedTerminalDriverInstanceSessionRun(env, driverInstanceId).catch(
+        (error: unknown) => {
+          this.#dependencies.withRuntimeLogContext(() => {
+            logError("runtime.terminal.lease_release.failed", {
+              ...createErrorLogContext(error),
+              driverInstanceId,
+            });
+          });
+        },
+      );
+      this.#dependencies.waitUntil(release);
     }
 
     return { ok: true };

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/rpc-controller-dependencies.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/rpc-controller-dependencies.ts
@@ -11,5 +11,6 @@ export interface DriverInstanceRpcControllerDependencies {
   state: DriverInstanceRuntimeState;
   viewCache: RuntimeSessionViewCache;
   viewerEventDelivery: SessionViewerEventDeliveryBuffer;
+  waitUntil: (task: Promise<unknown>) => void;
   withRuntimeLogContext: <T>(fn: () => T) => T;
 }

--- a/apps/api/tests/driver-command-terminal-ack.test.ts
+++ b/apps/api/tests/driver-command-terminal-ack.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+
+import type { DriverCommandId, DriverInstanceId, SessionRunId } from "@mosoo/id";
+import { parsePlatformId } from "@mosoo/id";
+
+import { DriverInstanceRpcCommandController } from "../src/modules/runtime/infrastructure/driver-instance/rpc-command-controller";
+import { getRuntimeCommandRecord } from "../src/modules/runtime/infrastructure/session-runs/runtime-command-store.repository";
+import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
+import { SqliteD1Database } from "./helpers/sqlite-d1";
+
+const DRIVER_INSTANCE_ID = parsePlatformId<DriverInstanceId>("01J00000000000000000000001");
+const COMMAND_ID = parsePlatformId<DriverCommandId>("01J00000000000000000000002");
+const SESSION_RUN_ID = parsePlatformId<SessionRunId>("01J00000000000000000000003");
+
+interface Deferred {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+function createDeferred(): Deferred {
+  let resolve = () => {};
+  const promise = new Promise<void>((next) => {
+    resolve = next;
+  });
+
+  return { promise, resolve };
+}
+
+type RawOptions = { columnNames?: boolean } | undefined;
+
+function gateStatement(statement: D1PreparedStatement, started: Deferred, gate: Deferred) {
+  const waitForGate = async () => {
+    started.resolve();
+    await gate.promise;
+  };
+
+  return {
+    all: async <T = unknown>() => {
+      await waitForGate();
+      return statement.all<T>();
+    },
+    bind: (...values: unknown[]) => gateStatement(statement.bind(...values), started, gate),
+    first: async <T = unknown>(column?: string) => {
+      await waitForGate();
+      return statement.first<T>(column);
+    },
+    raw: async <T = unknown[]>(options?: RawOptions) => {
+      await waitForGate();
+      return statement.raw<T>(options);
+    },
+    run: async <T = unknown>() => {
+      await waitForGate();
+      return statement.run<T>();
+    },
+  } satisfies D1PreparedStatement;
+}
+
+class GatedTerminalLookupDatabase extends SqliteD1Database {
+  readonly cleanupGate = createDeferred();
+  readonly cleanupStarted = createDeferred();
+
+  override prepare(query: string): D1PreparedStatement {
+    const statement = super.prepare(query);
+
+    return query.includes('"session_run"')
+      ? gateStatement(statement, this.cleanupStarted, this.cleanupGate)
+      : statement;
+  }
+}
+
+function createDatabase(): GatedTerminalLookupDatabase {
+  const database = new GatedTerminalLookupDatabase({ foreignKeys: false });
+  const payload = JSON.stringify({
+    commandId: COMMAND_ID,
+    input: { text: "hello" },
+    kind: "input.start",
+    requestId: "request-1",
+    runId: SESSION_RUN_ID,
+  });
+
+  database.execute(`
+    CREATE TABLE driver_command (
+      acked_at integer,
+      completed_at integer,
+      delivery_connection_id text,
+      driver_instance_id text NOT NULL,
+      error_json text,
+      expires_at integer,
+      id text PRIMARY KEY NOT NULL,
+      issued_at integer NOT NULL,
+      kind text NOT NULL,
+      payload_json text NOT NULL,
+      result_json text,
+      seq integer NOT NULL,
+      status text NOT NULL
+    );
+
+    CREATE TABLE session_run (
+      driver_instance_id text,
+      id text PRIMARY KEY NOT NULL,
+      status text NOT NULL
+    );
+
+    INSERT INTO driver_command (
+      delivery_connection_id,
+      driver_instance_id,
+      id,
+      issued_at,
+      kind,
+      payload_json,
+      seq,
+      status
+    ) VALUES (
+      'connection-1',
+      '${DRIVER_INSTANCE_ID}',
+      '${COMMAND_ID}',
+      0,
+      'input.start',
+      '${payload}',
+      1,
+      'delivered'
+    );
+  `);
+
+  return database;
+}
+
+describe("terminal runtime command acknowledgement", () => {
+  test("returns before linked run cleanup finishes", async () => {
+    const database = createDatabase();
+    const backgroundTasks: Promise<unknown>[] = [];
+    const controller = new DriverInstanceRpcCommandController({
+      env: { DB: database } as ApiBindings,
+      state: {
+        requireDriverInstanceId: () => DRIVER_INSTANCE_ID,
+      },
+      waitUntil: (task: Promise<unknown>) => {
+        backgroundTasks.push(task);
+      },
+      withRuntimeLogContext: (fn: () => unknown) => fn(),
+    } as never);
+
+    const update = controller.handleCommandUpdate(
+      {
+        commandId: COMMAND_ID,
+        driverInstanceId: DRIVER_INSTANCE_ID,
+        status: "completed",
+      },
+      {
+        assertActiveConnection: () => undefined,
+        connectionId: "connection-1",
+      },
+    );
+
+    await database.cleanupStarted.promise;
+    const acknowledgedBeforeCleanup = await Promise.race([
+      update.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 20)),
+    ]);
+
+    expect(backgroundTasks).toHaveLength(1);
+    database.cleanupGate.resolve();
+    const result = await update;
+    await Promise.all(backgroundTasks);
+
+    expect(acknowledgedBeforeCleanup).toBeTrue();
+    expect(result).toEqual({ ok: true });
+    await expect(
+      getRuntimeCommandRecord(database, DRIVER_INSTANCE_ID, COMMAND_ID),
+    ).resolves.toMatchObject({ status: "completed" });
+  });
+});


### PR DESCRIPTION
## Summary

- Return the Driver's terminal command acknowledgement immediately after the command transition is durably stored.
- Keep linked run/lease cleanup alive with Durable Object `waitUntil` and log cleanup failures independently.
- Add a regression test that blocks the terminal `session_run` lookup and proves the acknowledgement is no longer hostage to cleanup latency.

## Root cause

Production runs `01KYNP1C4XG9KC16SX8RP2843K` and `01KYNP5RKZW1NSYJ9G3WDBVWD9` completed successfully, but each Driver failed 3–5 seconds later with `terminal status could not be delivered`. Production D1 takes roughly 41–62 ms per round trip. The command-update handler persisted the terminal command, then synchronously ran the linked run/lease cleanup before returning. That cleanup pushed the response past the Driver's 250 ms per-attempt deadline. The Driver retried, then self-failed, so the next message created/resumed another runtime and erased the warm-retention benefit from #400.

The Chrome reproduction on the same production Worker confirmed the mechanism: 11.96 s then 10.90 s to reply, but the two runs used different Driver IDs and both Drivers subsequently failed with the same delivery error.

## Verification

- Red/green regression: `just test-file apps/api/tests/driver-command-terminal-ack.test.ts`
- API typecheck: `vp run --filter @mosoo/api tc`
- Related runtime/terminal suite: 33 passed
- Full API suite: 1,063 passed
- `just commit-check`
- `just check`: format, docs, lint, and workspace typecheck passed; tests reached 1,078 passed / 42 skipped / 1 unrelated existing failure in the pinned Driver submodule (`acp-file-system.test.ts` compares macOS `/var/...` with canonical `/private/var/...`). The exact Driver test fails the same way when rerun alone.

## Generated and persistence surfaces

- Generated files: none
- GraphQL codegen: N/A
- DB schema or migrations: none
- Lockfile changes: none

Refs #387.
