### PR TITLE
perf(runtime): reduce ACP cold-start latency

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -196,7 +196,7 @@ class_name = "Sandbox"
 [[env.prod.containers]]
 class_name = "Sandbox"
 image = "../driver/Containerfile"
-instance_type = "basic"
+instance_type = "standard-1"
 max_instances = 1000
 
 [[env.prod.r2_buckets]]


### PR DESCRIPTION
## Summary
- raise production agent containers from basic to standard-1 so OpenCode ACP cold initialization has 0.5 vCPU
- pin Driver PR langgenius/mosoo-agent-driver#88, which injects runtime context through OpenCode native instructions and removes the hidden bootstrap model turn
- preserve the existing bootstrap path for non-OpenCode ACP agents

## Root cause
The reported 73s cold run combined three independent waits: OpenCode/ACP cold initialization on a 0.25 vCPU container, a hidden 15.8s bootstrap model turn, and provider first-token latency. The earlier sub-10s certification measured a warm OpenAI runtime; it was not the same cold OpenCode/DeepSeek path. Production Container App state was read-only verified at 0.25 vCPU / 1 GiB / 4 GB, exactly matching the staging baseline.

## Staging evidence
Exact-shape fixture: pet / acp-fallback / DeepSeek v4 pro / 887-character production profile prompt / one bearer MCP / no skills / matching built-in tools. Test prompts explicitly made no tool or HAP calls.

- basic + candidate Driver: successful cold TTFT median about 43.6s, with repeated ACP initialize 30s timeouts
- standard-1 + candidate Driver: 5/5 cold threads completed; cold TTFT median 32.2s, completion 33.9s; same-thread second-turn TTFT median 8.6s, completion 10.7s
- Chrome: 46.117s browser vs 46.065s backend, about 52ms browser overhead
- standard-2: 5/5 completed and cold TTFT median 25.7s, but rejected as unnecessary cost
- successful runs reused the same Driver on turn two; logs reported nativeInstructions=true and no ACP bootstrap prompt event

## Cost and rollout risk
standard-1 changes each active container from 0.25 to 0.5 vCPU, 1 to 4 GiB memory, and 4 to 8 GB disk. Cloudflare bills active usage, so this is a material production cost increase; it should be watched during rollout. standard-2 was intentionally not selected. No production deployment was performed in this PR.

## Verification
- Driver targeted tests: 17 passed
- Driver typecheck and build passed
- Driver changed-file formatting passed
- production Wrangler dry-run passed
- full Driver suite: 1080 passed, 42 skipped; one pre-existing macOS /var vs /private/var path assertion remains unrelated
- staging fixture, PAT, MCP, and test Threads cleaned up; perf_b Worker rolled back to its pre-test version and original container rollout initiated

GraphQL schema, generated clients, and DB schema/migrations are unchanged; graphql-codegen and DB generation/reset/migrate are not applicable.

Closes the production follow-up in #387.