### PR TITLE
fix(runtime): proxy managed provider credentials outside sandboxes

### DIFF
--- a/apps/api/src/adapters/http/routes/driver-route.ts
+++ b/apps/api/src/adapters/http/routes/driver-route.ts
@@ -1,4 +1,11 @@
-import type { CredentialId, DriverInstanceId, McpServerId, SkillSnapshotId } from "@mosoo/id";
+import type { PresetModelProtocol } from "@mosoo/contracts/models";
+import type {
+  CredentialId,
+  DriverInstanceId,
+  McpServerId,
+  SkillSnapshotId,
+  VendorCredentialId,
+} from "@mosoo/id";
 import type { Context } from "hono";
 import { Hono } from "hono";
 
@@ -12,6 +19,12 @@ import {
   requireRuntimeDriverInstanceGrant,
   verifyRuntimeActionToken,
 } from "../../../modules/runtime/application/runtime-driver-access.service";
+import type { RuntimeLlmProxyTarget } from "../../../modules/runtime/application/runtime-llm-proxy.service";
+import {
+  RuntimeLlmProxyError,
+  requireActiveRuntimeLlmProxyDriver,
+  resolveRuntimeLlmProxyTarget,
+} from "../../../modules/runtime/application/runtime-llm-proxy.service";
 import {
   createRuntimeMcpProxyError,
   runtimeMcpProxyErrorBody,
@@ -39,6 +52,12 @@ const HOP_BY_HOP_HEADERS = new Set([
   "transfer-encoding",
   "upgrade",
 ]);
+
+// Headers LLM SDKs use to carry the proxy grant. They are stripped before the
+// request goes upstream and replaced with the vendor's real credential.
+const LLM_PROXY_GRANT_HEADERS = new Set(["authorization", "x-api-key", "x-goog-api-key"]);
+const LLM_PROXY_PATH_MARKER = "/llm/proxy/";
+const LLM_PROXY_UNSAFE_PATH_ENCODING = /%(?:25|2f|5c)/iu;
 
 async function requireDriverActionGrant(c: Context<ApiGatewayEnvironment>) {
   const grant = c.req.query("grant");
@@ -142,6 +161,245 @@ async function requireSkillSnapshotDownloadGrant(
     }
     throw error;
   }
+}
+
+function readLlmProxyGrantToken(headers: Headers): string | null {
+  const apiKey = headers.get("x-api-key")?.trim();
+
+  if (isTruthy(apiKey)) {
+    return apiKey;
+  }
+
+  const googApiKey = headers.get("x-goog-api-key")?.trim();
+
+  if (isTruthy(googApiKey)) {
+    return googApiKey;
+  }
+
+  const authorization = headers.get("Authorization");
+  const [scheme, grant] = authorization?.split(/\s+/, 2) ?? [];
+
+  if (scheme?.toLowerCase() === "bearer" && isTruthy(grant)) {
+    return grant;
+  }
+
+  return null;
+}
+
+function extractLlmProxySubPath(pathname: string): string | null {
+  const markerIndex = pathname.indexOf(LLM_PROXY_PATH_MARKER);
+
+  if (markerIndex === -1) {
+    return null;
+  }
+
+  const rest = pathname.slice(markerIndex + LLM_PROXY_PATH_MARKER.length);
+  const slashIndex = rest.indexOf("/");
+  const subPath = slashIndex === -1 ? "" : rest.slice(slashIndex);
+
+  if (subPath.includes("\\") || LLM_PROXY_UNSAFE_PATH_ENCODING.test(subPath)) {
+    return null;
+  }
+
+  for (const segment of subPath.split("/")) {
+    let decoded: string;
+
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      return null;
+    }
+
+    if (
+      decoded === "." ||
+      decoded === ".." ||
+      decoded.includes("/") ||
+      decoded.includes("\\") ||
+      decoded.includes("%")
+    ) {
+      return null;
+    }
+  }
+
+  return subPath;
+}
+
+function isLlmProxyCapabilityAllowed(
+  method: string,
+  subPath: string,
+  modelId: string,
+  modelProtocol: PresetModelProtocol,
+): boolean {
+  const decodedPath = decodeURIComponent(subPath);
+
+  if (decodedPath !== subPath) {
+    return false;
+  }
+
+  switch (modelProtocol) {
+    case "anthropic-messages":
+      return (
+        method === "POST" &&
+        ["/messages", "/v1/messages", "/v1/messages/count_tokens"].includes(decodedPath)
+      );
+    case "google-gemini": {
+      const modelPath = modelId.includes("/") ? modelId : `models/${modelId}`;
+      const modelPathIsCanonical = modelPath
+        .split("/")
+        .every(
+          (segment) =>
+            segment !== "" &&
+            segment !== "." &&
+            segment !== ".." &&
+            /^[A-Za-z0-9._-]+$/u.test(segment),
+        );
+
+      return (
+        method === "POST" &&
+        modelPathIsCanonical &&
+        [`/${modelPath}:generateContent`, `/${modelPath}:streamGenerateContent`].includes(
+          decodedPath,
+        )
+      );
+    }
+    case "openai-chat-completions":
+      return method === "POST" && decodedPath === "/chat/completions";
+    case "openai-responses":
+      return method === "POST" && ["/responses", "/responses/compact"].includes(decodedPath);
+  }
+}
+
+function isOpenAiResponsesWebSocketProbe(
+  request: Request,
+  subPath: string,
+  modelProtocol: PresetModelProtocol,
+): boolean {
+  return (
+    modelProtocol === "openai-responses" &&
+    request.method === "GET" &&
+    subPath === "/responses" &&
+    request.headers.get("Upgrade")?.toLowerCase() === "websocket"
+  );
+}
+
+async function readGrantedLlmProxyRequestBody(
+  request: Request,
+  modelId: string,
+  modelProtocol: PresetModelProtocol,
+): Promise<{ body: BodyInit | null } | null> {
+  if (modelProtocol === "google-gemini") {
+    // Gemini binds the model in the exact admitted request path.
+    return { body: request.body };
+  }
+
+  try {
+    const body: unknown = await request.json();
+
+    if (
+      typeof body === "object" &&
+      body !== null &&
+      !Array.isArray(body) &&
+      "model" in body &&
+      body.model === modelId
+    ) {
+      // Re-serialize the parsed body so duplicate JSON keys cannot make the
+      // proxy and the upstream disagree about which model was requested.
+      return { body: JSON.stringify(body) };
+    }
+  } catch {
+    // Invalid JSON is outside the model inference capability.
+  }
+
+  return null;
+}
+
+function toLlmProxyUpstreamUrl(request: Request, upstreamBaseUrl: string, subPath: string): string {
+  const base = new URL(upstreamBaseUrl);
+  const basePath = base.pathname === "/" ? "" : base.pathname.replace(/\/+$/u, "");
+  const expectedPath = `${basePath}${subPath}`;
+
+  if (
+    base.hash !== "" ||
+    basePath.includes("\\") ||
+    LLM_PROXY_UNSAFE_PATH_ENCODING.test(basePath)
+  ) {
+    throw new RuntimeLlmProxyError("LLM proxy upstream base URL is invalid.", 502);
+  }
+
+  const target = new URL(`${base.origin}${expectedPath}`);
+
+  for (const [key, value] of base.searchParams) {
+    target.searchParams.append(key, value);
+  }
+
+  for (const [key, value] of new URL(request.url).searchParams) {
+    target.searchParams.append(key, value);
+  }
+
+  if (target.origin !== base.origin || target.pathname !== expectedPath) {
+    throw new RuntimeLlmProxyError("LLM proxy path is invalid.", 400);
+  }
+
+  return target.toString();
+}
+
+function buildLlmProxyUpstreamHeaders(incoming: Headers, target: RuntimeLlmProxyTarget): Headers {
+  const headers = new Headers();
+
+  for (const [key, value] of incoming) {
+    const lowered = key.toLowerCase();
+
+    if (!HOP_BY_HOP_HEADERS.has(lowered) && !LLM_PROXY_GRANT_HEADERS.has(lowered)) {
+      headers.set(key, value);
+    }
+  }
+
+  const { authHeader } = target.vendor;
+
+  if (authHeader.scheme === "bearer") {
+    headers.set(authHeader.apiKeyHeader, `Bearer ${target.apiKey}`);
+    return headers;
+  }
+
+  for (const [key, value] of Object.entries(authHeader.extraHeaders)) {
+    // Only fill protocol headers the client did not set itself: SDKs pin
+    // e.g. anthropic-version to the wire format they actually speak.
+    if (!headers.has(key)) {
+      headers.set(key, value);
+    }
+  }
+
+  headers.set(authHeader.apiKeyHeader, target.apiKey);
+  return headers;
+}
+
+async function proxyRuntimeLlmRequest(
+  request: Request,
+  subPath: string,
+  target: RuntimeLlmProxyTarget,
+  body: BodyInit | null,
+): Promise<Response> {
+  const init: RequestInit = {
+    headers: buildLlmProxyUpstreamHeaders(request.headers, target),
+    method: request.method,
+    redirect: "error",
+    signal: request.signal,
+  };
+
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    init.body = body;
+  }
+
+  const response = await fetch(
+    toLlmProxyUpstreamUrl(request, target.upstreamBaseUrl, subPath),
+    init,
+  );
+
+  return new Response(response.body, {
+    headers: copyProxyResponseHeaders(response.headers),
+    status: response.status,
+    statusText: response.statusText,
+  });
 }
 
 async function proxyRuntimeMcpRequest(
@@ -339,6 +597,127 @@ export function registerDriverRoute(app: Hono<ApiGatewayEnvironment>) {
         { error: error instanceof Error ? error.message : "Credential invalidate failed." },
         { status: 400 },
       );
+    }
+  });
+
+  driver.all("/llm/proxy/:credentialId/*", async (c) => {
+    const grantToken = readLlmProxyGrantToken(c.req.raw.headers);
+
+    if (grantToken === null) {
+      return Response.json(
+        { error: "LLM proxy authorization grant is required." },
+        { status: 401 },
+      );
+    }
+
+    let grant: RuntimeActionTokenPayload;
+
+    try {
+      grant = await verifyRuntimeActionToken(c.env, grantToken);
+    } catch (error) {
+      return Response.json(
+        { error: error instanceof Error ? error.message : "Unauthorized." },
+        { status: 401 },
+      );
+    }
+
+    if (grant.action !== "llm_proxy") {
+      return Response.json(
+        { error: "Runtime action grant is invalid for LLM proxy." },
+        { status: 403 },
+      );
+    }
+
+    let credentialId: VendorCredentialId;
+
+    try {
+      credentialId = toPlatformId<VendorCredentialId>(
+        c.req.param("credentialId"),
+        "Vendor credential ID",
+      );
+    } catch (error) {
+      const response = driverPlatformIdErrorResponse(error);
+      if (response !== null) {
+        return response;
+      }
+      throw error;
+    }
+
+    if (grant.resourceId !== credentialId) {
+      return Response.json(
+        { error: "Runtime action grant does not match this credential." },
+        { status: 403 },
+      );
+    }
+
+    const subPath = extractLlmProxySubPath(new URL(c.req.url).pathname);
+
+    if (subPath === null) {
+      return Response.json({ error: "LLM proxy path is invalid." }, { status: 400 });
+    }
+
+    try {
+      await requireActiveRuntimeLlmProxyDriver(c.env, {
+        driverGeneration: grant.driverGeneration,
+        driverInstanceId: grant.driverInstanceId,
+      });
+    } catch (error) {
+      if (error instanceof RuntimeLlmProxyError) {
+        return Response.json({ error: error.message }, { status: error.status });
+      }
+      throw error;
+    }
+
+    if (isOpenAiResponsesWebSocketProbe(c.req.raw, subPath, grant.modelProtocol)) {
+      // Codex falls back to HTTP Responses only on 426. Never turn this
+      // WebSocket handshake into a credential-bearing HTTP upstream request.
+      return new Response(null, {
+        headers: { Upgrade: "websocket" },
+        status: 426,
+      });
+    }
+
+    if (!isLlmProxyCapabilityAllowed(c.req.method, subPath, grant.modelId, grant.modelProtocol)) {
+      return Response.json(
+        { error: "LLM proxy request is outside the granted model capability." },
+        { status: 403 },
+      );
+    }
+
+    const grantedRequestBody = await readGrantedLlmProxyRequestBody(
+      c.req.raw,
+      grant.modelId,
+      grant.modelProtocol,
+    );
+
+    if (grantedRequestBody === null) {
+      return Response.json(
+        { error: "LLM proxy request is outside the granted model capability." },
+        { status: 403 },
+      );
+    }
+
+    let target: RuntimeLlmProxyTarget;
+
+    try {
+      target = await resolveRuntimeLlmProxyTarget(c.env, {
+        credentialId,
+        appId: grant.appId,
+      });
+    } catch (error) {
+      if (error instanceof RuntimeLlmProxyError) {
+        return Response.json({ error: error.message }, { status: error.status });
+      }
+      throw error;
+    }
+
+    try {
+      return await proxyRuntimeLlmRequest(c.req.raw, subPath, target, grantedRequestBody.body);
+    } catch (error) {
+      if (error instanceof RuntimeLlmProxyError) {
+        return Response.json({ error: error.message }, { status: error.status });
+      }
+      return Response.json({ error: "LLM proxy upstream request failed." }, { status: 502 });
     }
   });
 

--- a/apps/api/src/modules/runtime/application/agent-runtime-profile.ts
+++ b/apps/api/src/modules/runtime/application/agent-runtime-profile.ts
@@ -8,6 +8,7 @@ import type {
   DriverEnvironmentArtifactProfile,
   DriverPermissionPolicy,
   DriverProfileConfig,
+  DriverVendorCredentialProfile,
 } from "../domain/driver-snapshot";
 import { DEFAULT_DRIVER_PERMISSION_POLICY } from "../domain/driver-snapshot";
 import { getSupportedRuntimeId } from "../domain/runtime-config";
@@ -33,6 +34,7 @@ export function createAgentRuntimeProfile(input: {
   sandboxSessionId: SandboxSessionId;
   sessionId: SessionId;
   setupScript: string;
+  vendorCredential: DriverVendorCredentialProfile;
 }): DriverProfileConfig {
   const runtimeId = getSupportedRuntimeId(input.runtimeId);
 
@@ -75,5 +77,6 @@ export function createAgentRuntimeProfile(input: {
     },
     setupScript: input.setupScript,
     sourceKind: "agent",
+    vendorCredential: input.vendorCredential,
   };
 }

--- a/apps/api/src/modules/runtime/application/runtime-llm-proxy.service.ts
+++ b/apps/api/src/modules/runtime/application/runtime-llm-proxy.service.ts
@@ -1,0 +1,104 @@
+import type { DriverInstanceId, AppId, VendorCredentialId } from "@mosoo/id";
+import { getVendor } from "@mosoo/runtime-catalog";
+import type { RuntimeCatalogVendor } from "@mosoo/runtime-catalog";
+
+import type { ApiBindings } from "../../../platform/cloudflare/worker-types";
+import { isTruthy } from "../../../shared/truthiness";
+import { enforceSafeApiBase } from "../../vendor-credentials/application/vendor-credential-validation";
+import { getAppCredentialRow } from "../../vendor-credentials/application/vendor-credential.repository";
+import { readVendorCredentialSecret } from "../../vendor-credentials/application/vendor-credential.secret-resolution";
+import { enforceCanonicalRuntimeLlmProxyBaseUrl } from "../domain/runtime-llm-proxy-base-url";
+import { isDriverInstanceGenerationActive } from "../infrastructure/driver-instance/driver-instance-record.repository";
+
+/**
+ * Upstream target for one proxied model call. `apiKey` is the raw vendor
+ * secret read from the vault; it exists only inside the Worker for the
+ * lifetime of the forwarded request and never reaches the sandbox.
+ */
+export interface RuntimeLlmProxyTarget {
+  apiKey: string;
+  upstreamBaseUrl: string;
+  vendor: RuntimeCatalogVendor;
+}
+
+export class RuntimeLlmProxyError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "RuntimeLlmProxyError";
+    this.status = status;
+  }
+}
+
+export async function requireActiveRuntimeLlmProxyDriver(
+  bindings: ApiBindings,
+  input: {
+    driverGeneration: number;
+    driverInstanceId: DriverInstanceId;
+  },
+): Promise<void> {
+  const driverIsActive = await isDriverInstanceGenerationActive(bindings.DB, {
+    driverInstanceId: input.driverInstanceId,
+    generation: input.driverGeneration,
+  });
+
+  if (!driverIsActive) {
+    throw new RuntimeLlmProxyError("LLM proxy grant driver instance is not active.", 403);
+  }
+}
+
+export async function resolveRuntimeLlmProxyTarget(
+  bindings: ApiBindings,
+  input: {
+    credentialId: VendorCredentialId;
+    appId: AppId;
+  },
+): Promise<RuntimeLlmProxyTarget> {
+  const credential = await getAppCredentialRow(bindings.DB, input.appId, input.credentialId);
+
+  if (credential === null) {
+    throw new RuntimeLlmProxyError("Vendor credential is unavailable.", 401);
+  }
+
+  const vendor = getVendor(credential.vendorId);
+
+  if (vendor === null) {
+    throw new RuntimeLlmProxyError("Vendor is not available.", 502);
+  }
+
+  const secret = await readVendorCredentialSecret(bindings, {
+    credential,
+    appId: input.appId,
+    providerId: credential.vendorId,
+    purpose: "llm_proxy_api_key",
+  });
+
+  if (secret.status === "denied") {
+    throw new RuntimeLlmProxyError("Vendor credential is unavailable.", 401);
+  }
+
+  const upstreamBaseUrl = isTruthy(credential.apiBase)
+    ? credential.apiBase
+    : (vendor.defaultApiBase ?? null);
+
+  if (!isTruthy(upstreamBaseUrl)) {
+    throw new RuntimeLlmProxyError("Vendor upstream endpoint is not configured.", 502);
+  }
+
+  try {
+    enforceSafeApiBase(upstreamBaseUrl);
+    enforceCanonicalRuntimeLlmProxyBaseUrl(upstreamBaseUrl);
+  } catch (error) {
+    throw new RuntimeLlmProxyError(
+      error instanceof Error ? error.message : "Vendor upstream endpoint is not allowed.",
+      502,
+    );
+  }
+
+  return {
+    apiKey: secret.apiKey,
+    upstreamBaseUrl,
+    vendor,
+  };
+}

--- a/apps/api/src/modules/runtime/application/session-definition/hydrate-run-context.service.ts
+++ b/apps/api/src/modules/runtime/application/session-definition/hydrate-run-context.service.ts
@@ -5,7 +5,6 @@ import type { ResolvedRunSkill } from "@mosoo/contracts/skill";
 import { createPlatformId } from "@mosoo/id";
 import type { AgentId, PlatformId, AppId, SandboxId, SandboxSessionId, SessionId } from "@mosoo/id";
 import { getRuntimeCatalogEntry, getRuntimeCatalogVendorForProvider } from "@mosoo/runtime-catalog";
-import type { RuntimeCatalogVendor } from "@mosoo/runtime-catalog";
 import { RUNTIME_DIAGNOSTIC_EVENT } from "@mosoo/runtime-events";
 
 import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
@@ -26,14 +25,8 @@ import {
 import { resolveReadyEnvironmentPackageArtifact } from "../../../environments/application/environment-package-artifact.service";
 import { resolveEnvironmentSetupScriptForExecution } from "../../../environments/application/environment-runtime-snapshot";
 import { resolveRuntimeMcpServersForSnapshot } from "../../../mcp/application/mcp-runtime.service";
-import { enforceSafeApiBase } from "../../../vendor-credentials/application/vendor-credential-validation";
-import { resolveVendorApiKey } from "../../../vendor-credentials/application/vendor-credential.service";
-import type { ResolvedVendorCredential } from "../../../vendor-credentials/application/vendor-credential.types";
-import type {
-  DriverProfileConfig,
-  DriverRuntime,
-  DriverSkillCatalogEntry,
-} from "../../domain/driver-snapshot";
+import { resolveVendorCredentialRef } from "../../../vendor-credentials/application/vendor-credential.service";
+import type { DriverProfileConfig, DriverSkillCatalogEntry } from "../../domain/driver-snapshot";
 import { getSupportedRuntimeId } from "../../domain/runtime-config";
 import { resolveAgentRuntimeSandboxSubject } from "../../domain/runtime-sandbox-subject";
 import {
@@ -49,33 +42,15 @@ import {
 import { getSessionExecutionPlan } from "./session-execution.repository";
 import type { HydratedSessionRunContext } from "./session-execution.types";
 import { resolveSessionSkillReferences } from "./session-skill-reference-resolution.service";
-import {
-  buildSnapshotAgentEnvironment,
-  mergeSessionSnapshotEnvVars,
-} from "./session-snapshot-hydration";
+import { buildSnapshotAgentEnvironment } from "./session-snapshot-hydration";
 
 interface HydratedRunContextCacheEntry {
   expiresAtMs: number;
   value: HydratedSessionRunContext;
 }
 
-interface RuntimeVendorEnvironmentInput {
-  credential: ResolvedVendorCredential;
-  model: DriverProfileConfig["model"];
-  runtimeId: DriverRuntime;
-  vendor: RuntimeCatalogVendor;
-}
-
-const OPENCODE_CONFIG_CONTENT_ENV = "OPENCODE_CONFIG_CONTENT";
 const HYDRATED_RUN_CONTEXT_CACHE_TTL_MS = 20_000;
 const hydratedRunContextCache = new Map<string, HydratedRunContextCacheEntry>();
-
-interface OpenCodeProviderConfig {
-  readonly models?: Record<string, { name: string }>;
-  readonly name?: string;
-  readonly npm?: string;
-  readonly options: Record<string, string>;
-}
 
 async function resolveRuntimeProfileIds(
   bindings: ApiBindings,
@@ -150,107 +125,6 @@ function sanitizeHydratedRunContextForCache(
       envVars: {},
     },
   };
-}
-
-export function buildRuntimeVendorEnvVars(
-  input: RuntimeVendorEnvironmentInput,
-): Record<string, string> {
-  const envVars: Record<string, string> = {
-    [input.vendor.apiKeyEnvVar]: input.credential.apiKey,
-  };
-
-  if (isTruthy(input.credential.apiBase)) {
-    if (!isTruthy(input.vendor.apiBaseEnvVar)) {
-      throw new Error(
-        `${input.vendor.label} does not support a custom API base URL for the configured runtime. Remove the apiBase override from the credential or pick a vendor that supports it.`,
-      );
-    }
-
-    enforceSafeApiBase(input.credential.apiBase);
-    envVars[input.vendor.apiBaseEnvVar] = input.credential.apiBase;
-  }
-
-  if (input.runtimeId === "acp-fallback") {
-    envVars[OPENCODE_CONFIG_CONTENT_ENV] = buildOpenCodeConfig(input);
-  }
-
-  return envVars;
-}
-
-function buildOpenCodeConfig(input: RuntimeVendorEnvironmentInput): string {
-  const openCodeProviderId = resolveOpenCodeProviderId(input.vendor);
-  const model = resolveOpenCodeModelId(input.vendor, input.model);
-  const providerConfig = buildOpenCodeProviderConfig(input);
-
-  return JSON.stringify({
-    $schema: "https://opencode.ai/config.json",
-    enabled_providers: [openCodeProviderId],
-    model,
-    provider: {
-      [openCodeProviderId]: providerConfig,
-    },
-    small_model: model,
-  });
-}
-
-function resolveOpenCodeProviderId(vendor: RuntimeCatalogVendor): string {
-  return vendor.openCodeProvider?.providerId ?? vendor.vendorId;
-}
-
-function resolveOpenCodeModelId(vendor: RuntimeCatalogVendor, model: string): string {
-  const openCodeProviderId = resolveOpenCodeProviderId(vendor);
-
-  if (!model.includes("/")) {
-    return `${openCodeProviderId}/${model}`;
-  }
-
-  const vendorPrefix = `${vendor.vendorId}/`;
-
-  if (openCodeProviderId !== vendor.vendorId && model.startsWith(vendorPrefix)) {
-    return `${openCodeProviderId}/${model.slice(vendorPrefix.length)}`;
-  }
-
-  return model;
-}
-
-function buildOpenCodeProviderConfig(input: RuntimeVendorEnvironmentInput): OpenCodeProviderConfig {
-  const options: Record<string, string> = {
-    apiKey: `{env:${input.vendor.apiKeyEnvVar}}`,
-  };
-  const models =
-    input.credential.models === null
-      ? undefined
-      : Object.fromEntries(input.credential.models.map((modelId) => [modelId, { name: modelId }]));
-  const provider = input.vendor.openCodeProvider;
-
-  if (provider === undefined) {
-    return {
-      ...(models === undefined ? {} : { models }),
-      options,
-    };
-  }
-
-  if (provider.apiBaseOption !== undefined) {
-    options[provider.apiBaseOption] = resolveOpenCodeProviderApiBase(input);
-  }
-
-  return {
-    ...(models === undefined ? {} : { models }),
-    name: provider.name,
-    npm: provider.npmPackage,
-    options,
-  };
-}
-
-function resolveOpenCodeProviderApiBase(input: RuntimeVendorEnvironmentInput): string {
-  const apiBase = input.credential.apiBase ?? input.vendor.defaultApiBase ?? null;
-
-  if (!isTruthy(apiBase)) {
-    throw new Error(`${input.vendor.label} requires a Base URL before it can be used by OpenCode.`);
-  }
-
-  enforceSafeApiBase(apiBase);
-  return apiBase;
 }
 
 async function hydrateRunContextFromSession(
@@ -345,8 +219,8 @@ async function hydrateRunContextFromSession(
     throw new Error(`Runtime ${binding.runtimeId} does not declare vendor ${binding.provider}.`);
   }
 
-  const [credential, snapshotEnvVars, environmentArtifact, setupScript] = await Promise.all([
-    resolveVendorApiKey({
+  const [vendorCredential, envVars, environmentArtifact, setupScript] = await Promise.all([
+    resolveVendorCredentialRef({
       bindings,
       executionOwnerUserId: agent.ownerId,
       options: { modelId: binding.model },
@@ -365,7 +239,7 @@ async function hydrateRunContextFromSession(
     resolveEnvironmentSetupScriptForExecution(bindings.DB, environmentSnapshot),
   ]);
 
-  if (!credential) {
+  if (!vendorCredential) {
     await appendRuntimeDiagnosticEvent(bindings, {
       eventName: RUNTIME_DIAGNOSTIC_EVENT.configCredentialMissing.name,
       sessionId: session.id,
@@ -381,17 +255,6 @@ async function hydrateRunContextFromSession(
     throw new Error(`No credential available for ${vendor.label}. Configure in Providers.`);
   }
 
-  const vendorEnvVars = buildRuntimeVendorEnvVars({
-    credential,
-    model: binding.model,
-    runtimeId,
-    vendor,
-  });
-
-  const envVars = mergeSessionSnapshotEnvVars({
-    snapshotEnvVars,
-    vendorEnvVars,
-  });
   let profile: DriverProfileConfig;
   const runtimeProfileIds = await resolveRuntimeProfileIds(bindings, {
     agentId: agent.id,
@@ -426,6 +289,7 @@ async function hydrateRunContextFromSession(
       sandboxId: runtimeProfileIds.sandboxId,
       sessionId: session.id,
       setupScript,
+      vendorCredential,
     });
   } catch (error) {
     await appendRuntimeDiagnosticEvent(bindings, {
@@ -511,8 +375,8 @@ async function refreshCachedRunContextVolatileFields(
   const toolReferences = executionPlan.tools.toSorted(
     (left, right) => left.sortOrder - right.sortOrder,
   );
-  const [credential, snapshotEnvVars, mcpServers] = await Promise.all([
-    resolveVendorApiKey({
+  const [vendorCredential, envVars, mcpServers] = await Promise.all([
+    resolveVendorCredentialRef({
       bindings,
       executionOwnerUserId: agent.ownerId,
       options: { modelId: binding.model },
@@ -539,19 +403,10 @@ async function refreshCachedRunContextVolatileFields(
       : Promise.resolve([]),
   ]);
 
-  if (!credential) {
+  if (!vendorCredential) {
     throw new Error(`No credential available for ${vendor.label}. Configure in Providers.`);
   }
 
-  const envVars = mergeSessionSnapshotEnvVars({
-    snapshotEnvVars,
-    vendorEnvVars: buildRuntimeVendorEnvVars({
-      credential,
-      model: binding.model,
-      runtimeId,
-      vendor,
-    }),
-  });
   const runtimeProfileIds = await resolveRuntimeProfileIds(bindings, {
     agentId: agent.id,
     kind: binding.kind,
@@ -583,6 +438,7 @@ async function refreshCachedRunContextVolatileFields(
     sandboxId: runtimeProfileIds.sandboxId,
     sessionId: session.id,
     setupScript: environmentSnapshot.setupScript,
+    vendorCredential,
   });
 
   return {

--- a/apps/api/src/modules/runtime/application/session-definition/session-snapshot-hydration.ts
+++ b/apps/api/src/modules/runtime/application/session-definition/session-snapshot-hydration.ts
@@ -7,13 +7,3 @@ export function buildSnapshotAgentEnvironment(
     environmentId: input.environmentId,
   };
 }
-
-export function mergeSessionSnapshotEnvVars(input: {
-  snapshotEnvVars: Record<string, string>;
-  vendorEnvVars: Record<string, string>;
-}): Record<string, string> {
-  return {
-    ...input.vendorEnvVars,
-    ...input.snapshotEnvVars,
-  };
-}

--- a/apps/api/src/modules/runtime/domain/driver-snapshot.ts
+++ b/apps/api/src/modules/runtime/domain/driver-snapshot.ts
@@ -28,6 +28,7 @@ import type {
   SessionRunId,
   SkillId,
   SkillSnapshotId,
+  VendorCredentialId,
 } from "@mosoo/id";
 
 export type { DriverRuntime };
@@ -74,6 +75,20 @@ export type DriverPermissionPolicy = "full_access" | "supervised";
 
 export const DEFAULT_DRIVER_PERMISSION_POLICY = "full_access" satisfies DriverPermissionPolicy;
 
+/**
+ * Reference to the app-scoped vendor credential that powers the runtime.
+ * Deliberately excludes the API key itself: raw provider secrets stay in the
+ * Worker control plane and reach the upstream vendor only through the
+ * driver-bound LLM proxy route, never through sandbox env vars or files.
+ */
+export interface DriverVendorCredentialProfile {
+  readonly apiBase: string | null;
+  readonly appId: AppId;
+  readonly credentialId: VendorCredentialId;
+  readonly models: readonly string[] | null;
+  readonly vendorId: string;
+}
+
 export interface DriverProfileConfig {
   readonly agentId: AgentId;
   readonly configRevision: DriverConfigRevision;
@@ -92,6 +107,7 @@ export interface DriverProfileConfig {
   readonly session: DriverSessionContext;
   readonly setupScript: string;
   readonly sourceKind: "agent";
+  readonly vendorCredential: DriverVendorCredentialProfile;
 }
 
 export interface DriverEnvironmentArtifactProfile {

--- a/apps/api/src/modules/runtime/domain/runtime-driver-routes.ts
+++ b/apps/api/src/modules/runtime/domain/runtime-driver-routes.ts
@@ -1,10 +1,14 @@
 import { PUBLIC_API_PREFIX } from "@mosoo/contracts/public-api";
-import type { McpServerId, SkillSnapshotId } from "@mosoo/id";
+import type { McpServerId, SkillSnapshotId, VendorCredentialId } from "@mosoo/id";
 
 const RUNTIME_DRIVER_ROUTE_PREFIX = `${PUBLIC_API_PREFIX}/driver`;
 
 export function getRuntimeDriverRoutePrefix(): string {
   return RUNTIME_DRIVER_ROUTE_PREFIX;
+}
+
+export function getRuntimeDriverLlmProxyPath(credentialId: VendorCredentialId): string {
+  return `${RUNTIME_DRIVER_ROUTE_PREFIX}/llm/proxy/${encodeURIComponent(credentialId)}`;
 }
 
 export function getRuntimeDriverSkillPackagePath(snapshotId: SkillSnapshotId): string {

--- a/apps/api/src/modules/runtime/domain/runtime-llm-proxy-base-url.ts
+++ b/apps/api/src/modules/runtime/domain/runtime-llm-proxy-base-url.ts
@@ -1,0 +1,41 @@
+const UNSAFE_RUNTIME_LLM_PROXY_PATH_ENCODING = /%(?:25|2e|2f|5c)/iu;
+const RUNTIME_LLM_PROXY_DOT_SEGMENT = /(?:^|\/)\.{1,2}(?:\/|$)/u;
+
+function readRawUrlPath(value: string): string {
+  const schemeEnd = value.indexOf("://");
+
+  if (schemeEnd === -1) {
+    return "";
+  }
+
+  const authorityStart = schemeEnd + 3;
+  const authorityEndOffset = value.slice(authorityStart).search(/[/?#]/u);
+
+  if (authorityEndOffset === -1 || value[authorityStart + authorityEndOffset] !== "/") {
+    return "";
+  }
+
+  const pathStart = authorityStart + authorityEndOffset;
+  const queryStart = value.indexOf("?", pathStart);
+  const fragmentStart = value.indexOf("#", pathStart);
+  const pathEnd = [queryStart, fragmentStart]
+    .filter((index) => index !== -1)
+    .reduce((earliest, index) => Math.min(earliest, index), value.length);
+
+  return value.slice(pathStart, pathEnd);
+}
+
+export function enforceCanonicalRuntimeLlmProxyBaseUrl(baseUrl: string): void {
+  const parsed = new URL(baseUrl);
+  const rawPath = readRawUrlPath(baseUrl);
+
+  if (
+    parsed.hash !== "" ||
+    baseUrl.includes("\\") ||
+    rawPath.includes("//") ||
+    UNSAFE_RUNTIME_LLM_PROXY_PATH_ENCODING.test(rawPath) ||
+    RUNTIME_LLM_PROXY_DOT_SEGMENT.test(rawPath)
+  ) {
+    throw new Error("Custom endpoint path is not canonical for runtime proxying.");
+  }
+}

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/driver-instance-record.repository.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/driver-instance-record.repository.ts
@@ -2,7 +2,7 @@ import { DRIVER_PROTOCOL_VERSION } from "@mosoo/agent-driver/boot";
 import type { DriverRuntime } from "@mosoo/agent-driver/runtime";
 import { driverCommandsTable, driverInstanceMcpGrantsTable, driverInstancesTable } from "@mosoo/db";
 import type { DriverInstanceId, SandboxId, SessionId } from "@mosoo/id";
-import { and, desc, eq, inArray, notInArray, sql } from "drizzle-orm";
+import { and, desc, eq, gt, inArray, isNotNull, notInArray, or, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
 import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
@@ -13,7 +13,11 @@ import {
   LIVE_DRIVER_INSTANCE_STATUSES,
   toDriverInstanceStatusLifecycleEventName,
 } from "../../domain/driver-instance-lifecycle.machine";
-import { DRIVER_BOOT_TOKEN_TTL_MS } from "../../domain/runtime-config";
+import {
+  DRIVER_BOOT_TOKEN_TTL_MS,
+  DRIVER_COLD_READY_TIMEOUT_MS,
+  RUNTIME_SOCKET_TIMEOUT_MS,
+} from "../../domain/runtime-config";
 import type { DriverInstanceMcpGrantRecord } from "./mcp-grants.repository";
 import { driverInstanceExpiresAt } from "./status";
 import type { DriverInstanceStatus } from "./status";
@@ -246,6 +250,53 @@ export async function getDriverInstanceRecord(
   }
 
   return row;
+}
+
+export async function isDriverInstanceGenerationActive(
+  database: D1Database,
+  input: {
+    driverInstanceId: DriverInstanceId;
+    generation: number;
+  },
+): Promise<boolean> {
+  const now = currentTimestampMs();
+  const row =
+    (await getAppDatabase(database)
+      .select({ id: driverInstancesTable.id })
+      .from(driverInstancesTable)
+      .where(
+        and(
+          eq(driverInstancesTable.id, input.driverInstanceId),
+          eq(driverInstancesTable.generation, input.generation),
+          or(
+            and(
+              eq(driverInstancesTable.status, "provisioning"),
+              or(
+                isNotNull(driverInstancesTable.bootTokenUsedAt),
+                gt(driverInstancesTable.bootTokenExpiresAt, now),
+              ),
+            ),
+            and(
+              eq(driverInstancesTable.status, "connecting"),
+              gt(
+                sql<number>`COALESCE(${driverInstancesTable.lastHeartbeatAt}, ${driverInstancesTable.updatedAt})`,
+                now - DRIVER_COLD_READY_TIMEOUT_MS,
+              ),
+            ),
+            and(
+              eq(driverInstancesTable.status, "ready"),
+              gt(
+                sql<number>`COALESCE(${driverInstancesTable.lastHeartbeatAt}, ${driverInstancesTable.updatedAt})`,
+                now - RUNTIME_SOCKET_TIMEOUT_MS,
+              ),
+            ),
+          ),
+        ),
+      )
+      .limit(1)
+      .get()) ?? null;
+
+  return row !== null;
 }
 
 export async function getReusableDriverInstanceRecord(

--- a/apps/api/src/modules/runtime/infrastructure/runtime-boot-token.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-boot-token.ts
@@ -4,13 +4,16 @@ import type {
   DriverRuntimeTransport,
 } from "@mosoo/agent-driver/boot";
 import { DRIVER_PROTOCOL_VERSION, parseDriverBootPayload } from "@mosoo/agent-driver/boot";
+import type { PresetModelProtocol } from "@mosoo/contracts/models";
 import { parsePlatformId } from "@mosoo/id";
 import type {
   CredentialId,
   DriverInstanceId,
   McpServerId,
+  AppId,
   SandboxId,
   SkillSnapshotId,
+  VendorCredentialId,
 } from "@mosoo/id";
 
 import { fromBase64Url, toArrayBuffer, toBase64Url } from "../../../shared/bytes";
@@ -32,6 +35,7 @@ export interface CreateBootPayloadInput {
 export type RuntimeActionTokenAction =
   | "credential_invalidate"
   | "credential_refresh"
+  | "llm_proxy"
   | "mcp_proxy"
   | "skill_snapshot";
 
@@ -46,6 +50,14 @@ export type RuntimeActionTokenPayload =
       resourceId: CredentialId;
     })
   | (RuntimeActionTokenPayloadBase & {
+      action: "llm_proxy";
+      appId: AppId;
+      driverGeneration: number;
+      modelId: string;
+      modelProtocol: PresetModelProtocol;
+      resourceId: VendorCredentialId;
+    })
+  | (RuntimeActionTokenPayloadBase & {
       action: "mcp_proxy";
       resourceId: McpServerId;
     })
@@ -57,6 +69,8 @@ export type RuntimeActionTokenPayload =
 export interface RuntimeActionTokenBindings {
   readonly RUNTIME_ACTION_TOKEN_SECRET: string;
 }
+
+export const RUNTIME_LLM_PROXY_MODEL_ID_MAX_LENGTH = 512;
 
 function toUtf8Bytes(value: string): Uint8Array {
   return new TextEncoder().encode(value);
@@ -132,6 +146,7 @@ function isRuntimeActionTokenAction(value: unknown): value is RuntimeActionToken
   return (
     value === "credential_invalidate" ||
     value === "credential_refresh" ||
+    value === "llm_proxy" ||
     value === "mcp_proxy" ||
     value === "skill_snapshot"
   );
@@ -139,6 +154,15 @@ function isRuntimeActionTokenAction(value: unknown): value is RuntimeActionToken
 
 function isRuntimeActionTokenPayloadRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPresetModelProtocol(value: unknown): value is PresetModelProtocol {
+  return (
+    value === "anthropic-messages" ||
+    value === "google-gemini" ||
+    value === "openai-chat-completions" ||
+    value === "openai-responses"
+  );
 }
 
 function parseRuntimeActionTokenPayload(encodedPayload: string): RuntimeActionTokenPayload {
@@ -166,6 +190,38 @@ function parseRuntimeActionTokenPayload(encodedPayload: string): RuntimeActionTo
     driverInstanceId,
     "Runtime action token driver instance ID",
   );
+
+  if (action === "llm_proxy") {
+    const { appId, driverGeneration, modelId, modelProtocol } = parsed;
+
+    if (
+      typeof appId !== "string" ||
+      appId === "" ||
+      typeof driverGeneration !== "number" ||
+      !Number.isSafeInteger(driverGeneration) ||
+      driverGeneration < 0 ||
+      typeof modelId !== "string" ||
+      modelId === "" ||
+      modelId.length > RUNTIME_LLM_PROXY_MODEL_ID_MAX_LENGTH ||
+      !isPresetModelProtocol(modelProtocol)
+    ) {
+      throw new Error("Runtime action token payload is invalid.");
+    }
+
+    return {
+      action,
+      appId: parsePlatformId<AppId>(appId, "Runtime action token app ID"),
+      driverGeneration,
+      driverInstanceId: parsedDriverInstanceId,
+      expiresAt,
+      modelId,
+      modelProtocol,
+      resourceId: parsePlatformId<VendorCredentialId>(
+        resourceId,
+        "Runtime action token vendor credential ID",
+      ),
+    };
+  }
 
   if (action === "mcp_proxy") {
     return {

--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-execution-spec.builder.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-execution-spec.builder.ts
@@ -30,6 +30,8 @@ import {
   getOrganizationPath,
   listAdditionalDirectories,
 } from "./runtime-sandbox-provisioning.paths";
+import { sanitizeRuntimeVendorEnvVars } from "./runtime-vendor-env-policy";
+import { buildVendorProxyEnvVars } from "./runtime-vendor-proxy-env.builder";
 
 interface RuntimeActionUrlContext {
   bindings: RuntimeExecutionSpecBindings;
@@ -151,6 +153,7 @@ export async function buildExecutionSpec(
   bindings: RuntimeExecutionSpecBindings,
   input: {
     builtInTools: DriverExecutionSpec["builtInTools"];
+    driverGeneration: number;
     driverInstanceId: DriverInstanceId;
     profile: DriverProfileConfig;
     requestUrl: string;
@@ -168,13 +171,20 @@ export async function buildExecutionSpec(
     driverInstanceId: input.driverInstanceId,
     requestUrl: input.requestUrl,
   };
-  const [mcpServers, skills] = await Promise.all([
+  const [mcpServers, skills, vendorProxyEnvVars] = await Promise.all([
     Promise.all(
       input.resolvedMcpServers.map(async (server) => withRuntimeMcpProxy(actionUrlContext, server)),
     ),
     Promise.all(
       input.resolvedSkills.map(async (skill) => toRuntimeResolvedSkill(actionUrlContext, skill)),
     ),
+    buildVendorProxyEnvVars({
+      bindings,
+      driverGeneration: input.driverGeneration,
+      driverInstanceId: input.driverInstanceId,
+      profile: input.profile,
+      requestUrl: input.requestUrl,
+    }),
   ]);
 
   return {
@@ -189,7 +199,10 @@ export async function buildExecutionSpec(
         node: [],
         python: [],
       },
-      variables: { ...input.profile.envVars },
+      variables: {
+        ...sanitizeRuntimeVendorEnvVars(input.profile.envVars),
+        ...vendorProxyEnvVars,
+      },
     },
     model: input.profile.model,
     permissionPolicy: input.profile.permissionPolicy,

--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-files.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-files.service.ts
@@ -8,6 +8,7 @@ import {
   getParentDirectory,
   listAdditionalDirectories,
 } from "./runtime-sandbox-provisioning.paths";
+import { sanitizeRuntimeVendorEnvVars } from "./runtime-vendor-env-policy";
 
 interface RuntimeMemoryMount {
   sourcePath: string;
@@ -205,7 +206,7 @@ export async function runSetupScript(
   const process = await session.startProcess(`sh -e ${quoteShellArg(setupScriptPath)}`, {
     autoCleanup: true,
     cwd: organizationPath,
-    env: profile.envVars,
+    env: sanitizeRuntimeVendorEnvVars(profile.envVars),
   });
   try {
     const exit = await process.waitForExit();

--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-provisioning.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-provisioning.service.ts
@@ -59,6 +59,7 @@ import type {
   ProvisionDriverInput,
   RuntimeSmokeProvision,
 } from "./runtime-sandbox-provisioning.types";
+import { sanitizeRuntimeVendorEnvVars } from "./runtime-vendor-env-policy";
 
 export { DriverPrewarmProvisionSkippedError } from "./runtime-driver-prewarm-ownership";
 
@@ -153,7 +154,13 @@ async function provisionDriver(
     throw new Error(`Unsupported runtime: ${input.runtime}.`);
   }
 
-  const organizationPath = getOrganizationPath(input.profile);
+  const runtimeEnvVars = sanitizeRuntimeVendorEnvVars(input.profile.envVars);
+  const runtimeProfile = {
+    ...input.profile,
+    envVarNames: input.profile.envVarNames.filter((name) => Object.hasOwn(runtimeEnvVars, name)),
+    envVars: runtimeEnvVars,
+  };
+  const organizationPath = getOrganizationPath(runtimeProfile);
   const driverControlPort = getDriverControlPort(driverInstanceId);
   const bootToken = await timing.measure("createBootToken", () => createOpaqueBootToken());
   const insertOnlyDriverRecord = usesInsertOnlyDriverRecord(input);
@@ -213,7 +220,7 @@ async function provisionDriver(
     await installRuntimeEnvironment(env, {
       cloudflareSession: input.cloudflareSession,
       environmentRevisionId,
-      profile: input.profile,
+      profile: runtimeProfile,
       runtimeBase,
       sandbox: input.sandbox,
       sessionId: input.sandboxSessionId,
@@ -254,9 +261,10 @@ async function provisionDriver(
     const execution = await timing.measure("buildExecutionSpec", () =>
       buildExecutionSpec(env, {
         builtInTools: input.builtInTools,
+        driverGeneration: activeDriverGeneration,
         driverInstanceId,
         nativeResumeRef,
-        profile: input.profile,
+        profile: runtimeProfile,
         recoveryMessages,
         requestUrl: containerRequestUrl,
         resolvedMcpServers: input.resolvedMcpServers,

--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-vendor-env-policy.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-vendor-env-policy.ts
@@ -1,0 +1,19 @@
+import { ALL_VENDORS } from "@mosoo/runtime-catalog";
+
+export const OPENCODE_CONFIG_CONTENT_ENV = "OPENCODE_CONFIG_CONTENT";
+
+const RUNTIME_MANAGED_VENDOR_ENV_NAMES = new Set<string>([
+  OPENCODE_CONFIG_CONTENT_ENV,
+  ...ALL_VENDORS.map((vendor) => vendor.apiKeyEnvVar),
+  ...ALL_VENDORS.flatMap((vendor) =>
+    vendor.apiBaseEnvVar === undefined ? [] : [vendor.apiBaseEnvVar],
+  ),
+]);
+
+export function sanitizeRuntimeVendorEnvVars(
+  envVars: Readonly<Record<string, string>>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(envVars).filter(([name]) => !RUNTIME_MANAGED_VENDOR_ENV_NAMES.has(name)),
+  );
+}

--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-vendor-proxy-env.builder.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-vendor-proxy-env.builder.ts
@@ -1,0 +1,249 @@
+import type { PresetModelProtocol } from "@mosoo/contracts/models";
+import type { DriverInstanceId, VendorCredentialId } from "@mosoo/id";
+import { getPresetModel, getVendor } from "@mosoo/runtime-catalog";
+import type { RuntimeCatalogVendor } from "@mosoo/runtime-catalog";
+
+import { isTruthy } from "../../../../shared/truthiness";
+import { enforceSafeApiBase } from "../../../vendor-credentials/application/vendor-credential-validation";
+import type {
+  DriverProfileConfig,
+  DriverVendorCredentialProfile,
+} from "../../domain/driver-snapshot";
+import { RUNTIME_RUN_RETENTION_MS } from "../../domain/runtime-config";
+import { getRuntimeDriverLlmProxyPath } from "../../domain/runtime-driver-routes";
+import { enforceCanonicalRuntimeLlmProxyBaseUrl } from "../../domain/runtime-llm-proxy-base-url";
+import {
+  RUNTIME_LLM_PROXY_MODEL_ID_MAX_LENGTH,
+  createRuntimeActionToken,
+} from "../runtime-boot-token";
+import type { RuntimeActionTokenBindings } from "../runtime-boot-token";
+import { OPENCODE_CONFIG_CONTENT_ENV } from "./runtime-vendor-env-policy";
+
+export interface VendorProxyEnvironmentInput {
+  bindings: RuntimeActionTokenBindings;
+  driverGeneration: number;
+  driverInstanceId: DriverInstanceId;
+  profile: Pick<DriverProfileConfig, "model" | "runtimeId" | "vendorCredential">;
+  requestUrl: string;
+}
+
+interface OpenCodeProviderConfigInput {
+  credential: DriverVendorCredentialProfile;
+  model: string;
+  proxyUrl: string;
+  vendor: RuntimeCatalogVendor;
+}
+
+interface OpenCodeProviderConfig {
+  readonly models?: Record<string, { name: string }>;
+  readonly name?: string;
+  readonly npm?: string;
+  readonly options: Record<string, string>;
+}
+
+function getRuntimeLlmProxyUrl(requestUrl: string, credentialId: VendorCredentialId): string {
+  const url = new URL(requestUrl);
+  url.pathname = getRuntimeDriverLlmProxyPath(credentialId);
+  url.search = "";
+  return url.toString();
+}
+
+function resolveVendorModelId(vendorId: string, model: string): string {
+  const vendorPrefix = `${vendorId}/`;
+  return model.startsWith(vendorPrefix) ? model.slice(vendorPrefix.length) : model;
+}
+
+function resolveLlmProxyModelBinding(
+  profile: VendorProxyEnvironmentInput["profile"],
+  vendor: RuntimeCatalogVendor,
+): {
+  modelId: string;
+  modelProtocol: PresetModelProtocol;
+} {
+  const modelId = resolveVendorModelId(vendor.vendorId, profile.model);
+
+  if (modelId.length === 0 || modelId.length > RUNTIME_LLM_PROXY_MODEL_ID_MAX_LENGTH) {
+    throw new Error(`Model ${profile.model} cannot be bound to an LLM proxy grant.`);
+  }
+
+  const preset = getPresetModel({
+    modelId,
+    vendorId: vendor.vendorId,
+  });
+
+  if (profile.runtimeId === "claude-agent-sdk") {
+    return { modelId, modelProtocol: "anthropic-messages" };
+  }
+
+  if (profile.runtimeId === "openai-runtime") {
+    return { modelId, modelProtocol: "openai-responses" };
+  }
+
+  if (
+    vendor.vendorId === "anthropic" ||
+    vendor.openCodeProvider?.npmPackage === "@ai-sdk/anthropic"
+  ) {
+    return { modelId, modelProtocol: "anthropic-messages" };
+  }
+
+  if (vendor.openCodeProvider?.npmPackage === "@ai-sdk/openai-compatible") {
+    return { modelId, modelProtocol: "openai-chat-completions" };
+  }
+
+  if (preset !== null) {
+    return { modelId, modelProtocol: preset.protocol };
+  }
+
+  if (vendor.vendorId === "opencode") {
+    throw new Error(
+      `OpenCode Zen model ${profile.model} has no catalog protocol for LLM proxy admission.`,
+    );
+  }
+
+  return { modelId, modelProtocol: "openai-chat-completions" };
+}
+
+/**
+ * Builds the vendor env vars a runtime boots with. The raw provider API key
+ * never appears here: runtimes receive a driver-bound `llm_proxy` action grant
+ * in the key env var and the Worker LLM proxy URL in the base-URL env var, so
+ * every model call authenticates against the control plane, which injects the
+ * real upstream credential per request. Anything read out of the sandbox
+ * (process env, /proc, boot payload file) only ever exposes the revocable,
+ * driver-generation-bound grant.
+ */
+export async function buildVendorProxyEnvVars(
+  input: VendorProxyEnvironmentInput,
+): Promise<Record<string, string>> {
+  const credential = input.profile.vendorCredential;
+  const vendor = getVendor(credential.vendorId);
+
+  if (vendor === null) {
+    throw new Error(`Unknown vendor: ${credential.vendorId}.`);
+  }
+
+  if (isTruthy(credential.apiBase)) {
+    // Fail fast at provisioning time; the proxy enforces this again on every
+    // forwarded request in case the credential changes mid-session.
+    enforceSafeApiBase(credential.apiBase);
+    enforceCanonicalRuntimeLlmProxyBaseUrl(credential.apiBase);
+  }
+
+  const modelBinding = resolveLlmProxyModelBinding(input.profile, vendor);
+  const proxyGrant = await createRuntimeActionToken(input.bindings, {
+    action: "llm_proxy",
+    appId: credential.appId,
+    driverGeneration: input.driverGeneration,
+    driverInstanceId: input.driverInstanceId,
+    expiresAt: Date.now() + RUNTIME_RUN_RETENTION_MS,
+    ...modelBinding,
+    resourceId: credential.credentialId,
+  });
+  const proxyUrl = getRuntimeLlmProxyUrl(input.requestUrl, credential.credentialId);
+  const envVars: Record<string, string> = {
+    [vendor.apiKeyEnvVar]: proxyGrant,
+  };
+
+  if (isTruthy(vendor.apiBaseEnvVar)) {
+    envVars[vendor.apiBaseEnvVar] = proxyUrl;
+  } else if (input.profile.runtimeId !== "acp-fallback") {
+    // Without a base-URL env var the runtime would send the grant straight to
+    // the vendor, where it is not a valid key. acp-fallback is exempt because
+    // OpenCode receives the proxy endpoint through its rendered config below.
+    throw new Error(
+      `${vendor.label} does not support endpoint redirection for runtime ${input.profile.runtimeId}; the credential cannot be routed through the control-plane LLM proxy.`,
+    );
+  }
+
+  if (input.profile.runtimeId === "acp-fallback") {
+    envVars[OPENCODE_CONFIG_CONTENT_ENV] = buildOpenCodeConfig({
+      credential,
+      model: input.profile.model,
+      proxyUrl,
+      vendor,
+    });
+  }
+
+  return envVars;
+}
+
+function buildOpenCodeConfig(input: OpenCodeProviderConfigInput): string {
+  const openCodeProviderId = resolveOpenCodeProviderId(input.vendor);
+  const model = resolveOpenCodeModelId(input.vendor, input.model);
+  const providerConfig = buildOpenCodeProviderConfig(input);
+
+  return JSON.stringify({
+    $schema: "https://opencode.ai/config.json",
+    enabled_providers: [openCodeProviderId],
+    model,
+    provider: {
+      [openCodeProviderId]: providerConfig,
+    },
+    small_model: model,
+  });
+}
+
+function resolveOpenCodeProviderId(vendor: RuntimeCatalogVendor): string {
+  return vendor.openCodeProvider?.providerId ?? vendor.vendorId;
+}
+
+function resolveOpenCodeModelId(vendor: RuntimeCatalogVendor, model: string): string {
+  const openCodeProviderId = resolveOpenCodeProviderId(vendor);
+
+  if (!model.includes("/")) {
+    return `${openCodeProviderId}/${model}`;
+  }
+
+  const vendorPrefix = `${vendor.vendorId}/`;
+
+  if (openCodeProviderId !== vendor.vendorId && model.startsWith(vendorPrefix)) {
+    return `${openCodeProviderId}/${model.slice(vendorPrefix.length)}`;
+  }
+
+  return model;
+}
+
+function resolveOpenCodeProxyBaseUrl(vendor: RuntimeCatalogVendor, proxyUrl: string): string {
+  // OpenCode's native providers resolve request paths against a base that
+  // already contains the SDK path prefix. @ai-sdk/anthropic defaults to
+  // https://api.anthropic.com/v1 while the anthropic upstream base mirrored by
+  // the proxy is https://api.anthropic.com, so its proxied base keeps the /v1
+  // segment on the client side.
+  if (vendor.openCodeProvider === undefined && vendor.vendorId === "anthropic") {
+    return `${proxyUrl}/v1`;
+  }
+
+  return proxyUrl;
+}
+
+function buildOpenCodeProviderConfig(input: OpenCodeProviderConfigInput): OpenCodeProviderConfig {
+  const options: Record<string, string> = {
+    apiKey: `{env:${input.vendor.apiKeyEnvVar}}`,
+  };
+  const models =
+    input.credential.models === null
+      ? undefined
+      : Object.fromEntries(input.credential.models.map((modelId) => [modelId, { name: modelId }]));
+  const provider = input.vendor.openCodeProvider;
+
+  if (provider === undefined) {
+    options["baseURL"] = resolveOpenCodeProxyBaseUrl(input.vendor, input.proxyUrl);
+
+    return {
+      ...(models === undefined ? {} : { models }),
+      options,
+    };
+  }
+
+  options[provider.apiBaseOption ?? "baseURL"] = resolveOpenCodeProxyBaseUrl(
+    input.vendor,
+    input.proxyUrl,
+  );
+
+  return {
+    ...(models === undefined ? {} : { models }),
+    name: provider.name,
+    npm: provider.npmPackage,
+    options,
+  };
+}

--- a/apps/api/src/modules/vendor-credentials/application/vendor-credential.secret-resolution.ts
+++ b/apps/api/src/modules/vendor-credentials/application/vendor-credential.secret-resolution.ts
@@ -18,7 +18,11 @@ import {
   getAppVendorCredentialRow,
   listAppCustomCredentialRows,
 } from "./vendor-credential.repository";
-import type { ResolvedVendorCredential, VendorCredentialRow } from "./vendor-credential.types";
+import type {
+  ResolvedVendorCredential,
+  ResolvedVendorCredentialRef,
+  VendorCredentialRow,
+} from "./vendor-credential.types";
 
 export interface ResolveVendorApiKeyOptions {
   modelId?: string;
@@ -35,6 +39,7 @@ export interface ResolveVendorApiKeyRequest {
 export type VendorCredentialSecretReadPurpose =
   | "credential_display_api_key"
   | "custom_model_runtime_api_key"
+  | "llm_proxy_api_key"
   | "runtime_api_key";
 
 export type VendorCredentialSecretWritePurpose =
@@ -263,13 +268,16 @@ async function canResolveRuntimeCredentialForExecutionOwner(input: {
   }
 }
 
-export async function resolveVendorApiKey({
+async function resolveRuntimeVendorCredentialRow({
   bindings,
   executionOwnerUserId,
   options = {},
   appId,
   vendorId,
-}: ResolveVendorApiKeyRequest): Promise<ResolvedVendorCredential | null> {
+}: ResolveVendorApiKeyRequest): Promise<{
+  purpose: VendorCredentialSecretReadPurpose;
+  row: VendorCredentialRow;
+} | null> {
   const modelId = options.modelId;
   const canResolveCredential = await canResolveRuntimeCredentialForExecutionOwner({
     bindings,
@@ -289,12 +297,7 @@ export async function resolveVendorApiKey({
       return null;
     }
 
-    return resolveCredentialFromRow(bindings, {
-      credential: row,
-      appId,
-      providerId: vendorId,
-      purpose: "custom_model_runtime_api_key",
-    });
+    return { purpose: "custom_model_runtime_api_key", row };
   }
 
   const row = await getAppVendorCredentialRow(bindings.DB, appId, vendorId);
@@ -303,10 +306,45 @@ export async function resolveVendorApiKey({
     return null;
   }
 
-  return resolveCredentialFromRow(bindings, {
-    credential: row,
-    appId,
-    providerId: vendorId,
-    purpose: "runtime_api_key",
+  return { purpose: "runtime_api_key", row };
+}
+
+export async function resolveVendorApiKey(
+  request: ResolveVendorApiKeyRequest,
+): Promise<ResolvedVendorCredential | null> {
+  const resolved = await resolveRuntimeVendorCredentialRow(request);
+
+  if (!resolved) {
+    return null;
+  }
+
+  return resolveCredentialFromRow(request.bindings, {
+    credential: resolved.row,
+    appId: request.appId,
+    providerId: request.vendorId,
+    purpose: resolved.purpose,
   });
+}
+
+/**
+ * Resolves the credential a runtime session should use without touching the
+ * vault: no secret read happens here. The returned reference is safe to embed
+ * in driver profiles; the LLM proxy reads the key back at request time.
+ */
+export async function resolveVendorCredentialRef(
+  request: ResolveVendorApiKeyRequest,
+): Promise<ResolvedVendorCredentialRef | null> {
+  const resolved = await resolveRuntimeVendorCredentialRow(request);
+
+  if (!resolved) {
+    return null;
+  }
+
+  return {
+    apiBase: resolved.row.apiBase,
+    appId: resolved.row.appId,
+    credentialId: resolved.row.id,
+    models: parseCredentialModels(resolved.row.modelsJson),
+    vendorId: resolved.row.vendorId,
+  };
 }

--- a/apps/api/src/modules/vendor-credentials/application/vendor-credential.service.ts
+++ b/apps/api/src/modules/vendor-credentials/application/vendor-credential.service.ts
@@ -13,4 +13,7 @@ export { resolveProviderFetchProxy } from "./provider-fetch-proxy";
 
 export { probeVendorCredential, testVendorCredential } from "./vendor-credential-test";
 
-export { resolveVendorApiKey } from "./vendor-credential.secret-resolution";
+export {
+  resolveVendorApiKey,
+  resolveVendorCredentialRef,
+} from "./vendor-credential.secret-resolution";

--- a/apps/api/src/modules/vendor-credentials/application/vendor-credential.types.ts
+++ b/apps/api/src/modules/vendor-credentials/application/vendor-credential.types.ts
@@ -17,3 +17,17 @@ export interface ResolvedVendorCredential {
   credentialId: VendorCredentialId;
   models: string[] | null;
 }
+
+/**
+ * Secret-free view of a runtime vendor credential. Run hydration resolves this
+ * instead of {@link ResolvedVendorCredential} so the raw API key never enters
+ * driver profiles, boot payloads, or sandbox environments; the key itself is
+ * only read back inside the Worker when the LLM proxy forwards a request.
+ */
+export interface ResolvedVendorCredentialRef {
+  apiBase: string | null;
+  appId: AppId;
+  credentialId: VendorCredentialId;
+  models: string[] | null;
+  vendorId: string;
+}

--- a/apps/api/tests/api-driver-boundary-fixtures.ts
+++ b/apps/api/tests/api-driver-boundary-fixtures.ts
@@ -86,6 +86,13 @@ export function createDriverProfile(): DriverProfileConfig {
     },
     setupScript: "",
     sourceKind: "agent",
+    vendorCredential: {
+      apiBase: null,
+      appId: API_DRIVER_BOUNDARY_IDS.app,
+      credentialId: PLATFORM_ID_FIXTURES.vendorCredential,
+      models: null,
+      vendorId: "openai",
+    },
   };
 }
 

--- a/apps/api/tests/api-driver-boundary.test.ts
+++ b/apps/api/tests/api-driver-boundary.test.ts
@@ -9,6 +9,7 @@ import {
   parseDriverBootPayloadJson,
 } from "@mosoo/agent-driver/boot";
 import { createDefaultAgentBuiltInTools } from "@mosoo/contracts/agent";
+import { PLATFORM_ID_FIXTURES } from "@mosoo/id/testing";
 import { RUNTIME_EVENT_SCHEMA_VERSION, createRuntimeEvent } from "@mosoo/runtime-events";
 
 import { getDriverControlPort } from "../src/modules/runtime/domain/sandbox-layout";
@@ -31,6 +32,8 @@ import {
 import { AGENT_DRIVER_PROCESS_COMMAND } from "../src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-artifact";
 import { buildExecutionSpec } from "../src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-execution-spec.builder";
 import type { RuntimeExecutionSpecBindings } from "../src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-execution-spec.builder";
+import { runSetupScript } from "../src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-driver-files.service";
+import type { ExecutionSessionHandle } from "../src/modules/runtime/infrastructure/sandbox-handles";
 import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
 import {
   API_DRIVER_BOUNDARY_IDS,
@@ -270,6 +273,7 @@ describe("API to driver boundary", () => {
         { enabled: true, name: "web_fetch" },
         { enabled: true, name: "web_search" },
       ],
+      driverGeneration: 7,
       driverInstanceId: API_DRIVER_BOUNDARY_IDS.driverInstance,
       nativeResumeRef: {
         kind: "openai_thread_id",
@@ -278,6 +282,18 @@ describe("API to driver boundary", () => {
       },
       profile: {
         ...createDriverProfile(),
+        envVarNames: [
+          "EXISTING_ENV",
+          "OPENAI_API_KEY",
+          "OPENAI_BASE_URL",
+          "OPENCODE_CONFIG_CONTENT",
+        ],
+        envVars: {
+          EXISTING_ENV: "kept",
+          OPENAI_API_KEY: "raw-environment-key",
+          OPENAI_BASE_URL: "https://attacker.example.com/v1",
+          OPENCODE_CONFIG_CONTENT: '{"provider":{"openai":{"options":{"apiKey":"raw"}}}}',
+        },
         environmentArtifact: {
           backupDir: "/workspace/.mosoo/environment-artifacts/artifact",
           backupId: "11111111-1111-4111-8111-111111111111",
@@ -297,8 +313,24 @@ describe("API to driver boundary", () => {
     expect(execution.profilePrompt).toContain("only user-downloadable session output directory");
     expect(execution.profilePrompt).toContain("even if the user does not explicitly ask");
     expect(execution.profilePrompt).toContain("Files written anywhere else are scratch");
+    const llmProxyGrant = execution.environment.variables["OPENAI_API_KEY"];
+    if (llmProxyGrant === undefined) {
+      throw new Error("Expected an LLM proxy grant env var.");
+    }
+
     expect(execution.environment.variables).toEqual({
       EXISTING_ENV: "kept",
+      OPENAI_API_KEY: llmProxyGrant,
+      OPENAI_BASE_URL: `http://localhost:8787/api/driver/llm/proxy/${PLATFORM_ID_FIXTURES.vendorCredential}`,
+    });
+    await expect(verifyRuntimeActionToken(bindings, llmProxyGrant)).resolves.toMatchObject({
+      action: "llm_proxy",
+      appId: API_DRIVER_BOUNDARY_IDS.app,
+      driverGeneration: 7,
+      driverInstanceId: API_DRIVER_BOUNDARY_IDS.driverInstance,
+      modelId: "gpt-5.1",
+      modelProtocol: "openai-responses",
+      resourceId: PLATFORM_ID_FIXTURES.vendorCredential,
     });
     expect(execution.environment.paths).toEqual(artifactPaths);
 
@@ -340,9 +372,46 @@ describe("API to driver boundary", () => {
     ).toBe("https://invalid.local/tombstone.skill");
   });
 
+  test("removes runtime-managed provider values from the setup process", async () => {
+    let setupEnv: Record<string, string | undefined> | undefined;
+    const session: ExecutionSessionHandle = {
+      exec: async () => ({ exitCode: 0, stderr: "", stdout: "missing", success: true }),
+      mkdir: async () => undefined,
+      readFile: async () => ({ content: "", encoding: "utf8" }),
+      startProcess: async (_command, options) => {
+        setupEnv = options.env;
+        return {
+          getLogs: async () => "",
+          getStatus: async () => "completed",
+          id: "setup",
+          kill: async () => undefined,
+          pid: 1,
+          waitForExit: async () => ({ exitCode: 0 }),
+          waitForPort: async () => undefined,
+        };
+      },
+      watch: async () => new ReadableStream<Uint8Array>(),
+      writeFile: async () => undefined,
+    };
+
+    await runSetupScript(session, {
+      ...createDriverProfile(),
+      envVarNames: ["EXISTING_ENV", "OPENAI_API_KEY", "OPENAI_BASE_URL"],
+      envVars: {
+        EXISTING_ENV: "kept",
+        OPENAI_API_KEY: "raw-environment-key",
+        OPENAI_BASE_URL: "https://attacker.example.com/v1",
+      },
+      setupScript: "echo setup",
+    });
+
+    expect(setupEnv).toEqual({ EXISTING_ENV: "kept" });
+  });
+
   test("emits a boot payload that the driver protocol parser accepts", async () => {
     const execution = await buildExecutionSpec(bindings, {
       builtInTools: createDefaultAgentBuiltInTools(),
+      driverGeneration: 0,
       driverInstanceId: API_DRIVER_BOUNDARY_IDS.driverInstance,
       profile: createDriverProfile(),
       requestUrl: "https://api.example.com/api/driver/connect",

--- a/apps/api/tests/driver-llm-proxy-route.test.ts
+++ b/apps/api/tests/driver-llm-proxy-route.test.ts
@@ -1,0 +1,783 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { driverInstancesTable, vendorCredentialsTable } from "@mosoo/db";
+import { parsePlatformId } from "@mosoo/id";
+import type { DriverInstanceId, AppId, VendorCredentialId } from "@mosoo/id";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+
+import { registerDriverRoute } from "../src/adapters/http/routes/driver-route";
+import { getRuntimeDriverLlmProxyPath } from "../src/modules/runtime/domain/runtime-driver-routes";
+import { createRuntimeActionToken } from "../src/modules/runtime/infrastructure/runtime-boot-token";
+import type { RuntimeActionTokenPayload } from "../src/modules/runtime/infrastructure/runtime-boot-token";
+import { storeVendorCredentialSecret } from "../src/modules/vendor-credentials/application/vendor-credential.secret-resolution";
+import type { ApiBindings, ApiGatewayEnvironment } from "../src/platform/cloudflare/worker-types";
+import {
+  PUBLIC_API_TEST_IDS,
+  createPublicHttpContractDatabase,
+  createPublicHttpTestBindings,
+  createTestExecutionContext,
+} from "./helpers/public-api-http-test-fixture";
+
+const CREDENTIAL_ID = parsePlatformId<VendorCredentialId>(
+  "01J0000000000000000000000B",
+  "credential ID",
+);
+const OTHER_CREDENTIAL_ID = parsePlatformId<VendorCredentialId>(
+  "01J0000000000000000000000E",
+  "other credential ID",
+);
+const APP_ID = PUBLIC_API_TEST_IDS.app as AppId;
+const DRIVER_INSTANCE_ID = PUBLIC_API_TEST_IDS.driverOwner as DriverInstanceId;
+const OTHER_DRIVER_INSTANCE_ID = parsePlatformId<DriverInstanceId>(
+  "01J0000000000000000000000G",
+  "other driver instance ID",
+);
+const UPSTREAM_API_KEY = "sk-real-upstream-key";
+
+type ContractDatabase = Awaited<ReturnType<typeof createPublicHttpContractDatabase>>;
+
+interface CapturedUpstreamRequest {
+  body: string | null;
+  headers: Headers;
+  method: string;
+  redirect: RequestRedirect;
+  signal: AbortSignal;
+  url: string;
+}
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function createDriverRouteTestApp(): Hono<ApiGatewayEnvironment> {
+  const app = new Hono<ApiGatewayEnvironment>();
+  registerDriverRoute(app);
+  return app;
+}
+
+function captureUpstreamFetch(response?: () => Response): CapturedUpstreamRequest[] {
+  const captured: CapturedUpstreamRequest[] = [];
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init);
+    captured.push({
+      body: request.method === "GET" || request.method === "HEAD" ? null : await request.text(),
+      headers: request.headers,
+      method: request.method,
+      redirect: request.redirect,
+      signal: request.signal,
+      url: request.url,
+    });
+
+    return (
+      response?.() ??
+      new Response('{"ok":true}', {
+        headers: {
+          "content-type": "application/json",
+          "transfer-encoding": "chunked",
+          "x-upstream-marker": "1",
+        },
+        status: 200,
+      })
+    );
+  }) as typeof fetch;
+
+  return captured;
+}
+
+async function insertDriverInstance(
+  database: ContractDatabase,
+  status: "provisioning" | "connecting" | "ready" | "failed",
+  input: {
+    bootTokenExpiresAt?: number;
+    driverInstanceId?: DriverInstanceId;
+    generation?: number;
+    lastHeartbeatAt?: number | null;
+    updatedAt?: number;
+  } = {},
+) {
+  const nowMs = input.updatedAt ?? Date.now();
+  await database
+    .app()
+    .insert(driverInstancesTable)
+    .values({
+      bootTokenExpiresAt: input.bootTokenExpiresAt ?? nowMs + 60_000,
+      bootTokenHash: new Uint8Array([1, 2, 3]),
+      bootTokenUsedAt: null,
+      closeCode: null,
+      closeReason: null,
+      connectionId: null,
+      createdAt: nowMs,
+      driverPid: null,
+      driverStartedAt: null,
+      driverVersion: null,
+      errorMessage: null,
+      expiresAt: nowMs + 60_000,
+      generation: input.generation ?? 0,
+      heartbeatCount: 0,
+      id: input.driverInstanceId ?? DRIVER_INSTANCE_ID,
+      lastHeartbeatAt: input.lastHeartbeatAt ?? null,
+      processId: null,
+      protocol: "orpc-ws",
+      protocolVersion: 1,
+      runtime: "claude-agent-sdk",
+      sandboxId: PUBLIC_API_TEST_IDS.sandbox,
+      sandboxSessionId: PUBLIC_API_TEST_IDS.ownerSession,
+      status,
+      statusChangedAt: nowMs,
+      statusSource: "api",
+      updatedAt: nowMs,
+    })
+    .run();
+}
+
+async function insertVendorCredential(
+  database: ContractDatabase,
+  bindings: ApiBindings,
+  input: {
+    apiBase?: string | null;
+    credentialId?: VendorCredentialId;
+    vendorId: string;
+  },
+) {
+  const credentialId = input.credentialId ?? CREDENTIAL_ID;
+  const secretId = await storeVendorCredentialSecret(bindings, {
+    apiKey: UPSTREAM_API_KEY,
+    credentialId,
+    appId: APP_ID,
+    providerId: input.vendorId,
+    purpose: "credential_create_api_key",
+  });
+  const nowMs = Date.now();
+
+  await database
+    .app()
+    .insert(vendorCredentialsTable)
+    .values({
+      apiBase: input.apiBase ?? null,
+      apiKeySecretId: secretId,
+      createdAt: nowMs,
+      id: credentialId,
+      isDefault: true,
+      models: null,
+      name: `${input.vendorId} credential`,
+      appId: APP_ID,
+      updatedAt: nowMs,
+      vendorId: input.vendorId,
+    })
+    .run();
+}
+
+async function createLlmProxyGrant(
+  bindings: ApiBindings,
+  overrides: Partial<Extract<RuntimeActionTokenPayload, { action: "llm_proxy" }>> = {},
+): Promise<string> {
+  return createRuntimeActionToken(bindings, {
+    action: "llm_proxy",
+    appId: APP_ID,
+    driverGeneration: 0,
+    driverInstanceId: DRIVER_INSTANCE_ID,
+    expiresAt: Date.now() + 60_000,
+    modelId: "claude-sonnet-5",
+    modelProtocol: "anthropic-messages",
+    resourceId: CREDENTIAL_ID,
+    ...overrides,
+  });
+}
+
+function llmProxyRequest(
+  subPath: string,
+  init: RequestInit & { credentialId?: VendorCredentialId } = {},
+): Request {
+  const { credentialId, ...requestInit } = init;
+  return new Request(
+    `https://api.example.com${getRuntimeDriverLlmProxyPath(credentialId ?? CREDENTIAL_ID)}${subPath}`,
+    requestInit,
+  );
+}
+
+async function setupFixture(input?: {
+  apiBase?: string | null;
+  driverGeneration?: number;
+  driverStatus?: "provisioning" | "connecting" | "ready" | "failed" | "absent";
+  driverUpdatedAt?: number;
+  vendorId?: string;
+}) {
+  const database = await createPublicHttpContractDatabase();
+  const bindings = createPublicHttpTestBindings(database) as ApiBindings;
+
+  if (input?.driverStatus !== "absent") {
+    await insertDriverInstance(database, input?.driverStatus ?? "ready", {
+      generation: input?.driverGeneration,
+      updatedAt: input?.driverUpdatedAt,
+    });
+  }
+
+  await insertVendorCredential(database, bindings, {
+    apiBase: input?.apiBase ?? null,
+    vendorId: input?.vendorId ?? "anthropic",
+  });
+
+  return { bindings, database };
+}
+
+async function dispatch(bindings: ApiBindings, request: Request): Promise<Response> {
+  return createDriverRouteTestApp().request(
+    request,
+    undefined,
+    bindings,
+    createTestExecutionContext(),
+  );
+}
+
+describe("driver LLM proxy route", () => {
+  test("forwards api-key style requests with the vault credential injected", async () => {
+    const { bindings } = await setupFixture();
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings);
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/messages?beta=true", {
+        body: JSON.stringify({ model: "claude-sonnet-5" }),
+        headers: {
+          "anthropic-version": "2024-10-22",
+          "content-type": "application/json",
+          "x-api-key": grant,
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(response.headers.get("x-upstream-marker")).toBe("1");
+    expect(response.headers.get("transfer-encoding")).toBeNull();
+
+    expect(captured).toHaveLength(1);
+    const upstream = captured[0];
+    expect(upstream?.url).toBe("https://api.anthropic.com/v1/messages?beta=true");
+    expect(upstream?.method).toBe("POST");
+    expect(upstream?.redirect).toBe("error");
+    expect(upstream?.body).toBe(JSON.stringify({ model: "claude-sonnet-5" }));
+    // The grant never leaves the control plane; the vault key does not exist
+    // anywhere in the sandbox-visible request.
+    expect(upstream?.headers.get("x-api-key")).toBe(UPSTREAM_API_KEY);
+    expect(upstream?.headers.get("authorization")).toBeNull();
+    // Client-pinned protocol headers win over catalog defaults.
+    expect(upstream?.headers.get("anthropic-version")).toBe("2024-10-22");
+  });
+
+  test("fills catalog protocol headers when the client omits them", async () => {
+    const { bindings } = await setupFixture();
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings);
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/messages", {
+        body: JSON.stringify({ model: "claude-sonnet-5" }),
+        headers: { "x-api-key": grant },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(captured[0]?.headers.get("anthropic-version")).toBe("2023-06-01");
+  });
+
+  test("forwards bearer style requests to a custom endpoint", async () => {
+    const { bindings } = await setupFixture({
+      apiBase: "https://gateway.example.com/v1?api-version=2026-07-01",
+      vendorId: "openai",
+    });
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings, {
+      modelId: "gpt-5.4",
+      modelProtocol: "openai-responses",
+    });
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/responses?stream=true", {
+        body: JSON.stringify({ model: "gpt-5.4" }),
+        headers: { Authorization: `Bearer ${grant}` },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(captured[0]?.url).toBe(
+      "https://gateway.example.com/v1/responses?api-version=2026-07-01&stream=true",
+    );
+    expect(captured[0]?.headers.get("authorization")).toBe(`Bearer ${UPSTREAM_API_KEY}`);
+    expect(captured[0]?.headers.get("x-api-key")).toBeNull();
+  });
+
+  test("binds native Gemini endpoints to the granted model", async () => {
+    const { bindings } = await setupFixture({ vendorId: "opencode" });
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings, {
+      modelId: "gemini-3.5-flash",
+      modelProtocol: "google-gemini",
+    });
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/models/gemini-3.5-flash:streamGenerateContent?alt=sse", {
+        body: "{}",
+        headers: { "x-goog-api-key": grant },
+        method: "POST",
+      }),
+    );
+    const otherModelResponse = await dispatch(
+      bindings,
+      llmProxyRequest("/models/gemini-3.5-pro:streamGenerateContent?alt=sse", {
+        body: "{}",
+        headers: { "x-goog-api-key": grant },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(captured[0]?.url).toBe(
+      "https://opencode.ai/zen/v1/models/gemini-3.5-flash:streamGenerateContent?alt=sse",
+    );
+    expect(captured[0]?.headers.get("authorization")).toBe(`Bearer ${UPSTREAM_API_KEY}`);
+    expect(captured[0]?.headers.get("x-goog-api-key")).toBeNull();
+    expect(otherModelResponse.status).toBe(403);
+    expect(captured).toHaveLength(1);
+  });
+
+  test("returns 426 locally for the Codex Responses WebSocket probe", async () => {
+    const { bindings } = await setupFixture({ vendorId: "openai" });
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings, {
+      modelId: "gpt-5.4",
+      modelProtocol: "openai-responses",
+    });
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/responses", {
+        headers: {
+          Authorization: `Bearer ${grant}`,
+          Upgrade: "websocket",
+        },
+        method: "GET",
+      }),
+    );
+
+    expect(response.status).toBe(426);
+    expect(response.headers.get("upgrade")).toBe("websocket");
+    expect(captured).toHaveLength(0);
+  });
+
+  test("rejects OpenAI endpoints outside the runtime capability", async () => {
+    const { bindings } = await setupFixture({ vendorId: "openai" });
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings, {
+      modelId: "gpt-5.4",
+      modelProtocol: "openai-responses",
+    });
+
+    const modelListResponse = await dispatch(
+      bindings,
+      llmProxyRequest("/models", {
+        headers: { Authorization: `Bearer ${grant}` },
+        method: "GET",
+      }),
+    );
+    const inputTokensResponse = await dispatch(
+      bindings,
+      llmProxyRequest("/responses/input_tokens", {
+        headers: { Authorization: `Bearer ${grant}` },
+        method: "POST",
+      }),
+    );
+
+    expect(modelListResponse.status).toBe(403);
+    expect(inputTokensResponse.status).toBe(403);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("rejects a body model outside the granted capability", async () => {
+    const { bindings } = await setupFixture({ vendorId: "openai" });
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings, {
+      modelId: "gpt-5.4",
+      modelProtocol: "openai-responses",
+    });
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/responses", {
+        body: JSON.stringify({ model: "gpt-5.5" }),
+        headers: { Authorization: `Bearer ${grant}` },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("canonicalizes an admitted JSON body before forwarding it", async () => {
+    const { bindings } = await setupFixture({ vendorId: "openai" });
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings, {
+      modelId: "gpt-5.4",
+      modelProtocol: "openai-responses",
+    });
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/responses", {
+        body: '{"model":"gpt-5.5","model":"gpt-5.4","input":"hello"}',
+        headers: { Authorization: `Bearer ${grant}` },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(captured[0]?.body).toBe('{"model":"gpt-5.4","input":"hello"}');
+  });
+
+  test("requires a canonical JSON body model for non-Gemini requests", async () => {
+    const { bindings } = await setupFixture();
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings);
+
+    const missingModelResponse = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/messages", {
+        body: "{}",
+        headers: { "x-api-key": grant },
+        method: "POST",
+      }),
+    );
+    const malformedBodyResponse = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/messages", {
+        body: "not-json",
+        headers: { "x-api-key": grant },
+        method: "POST",
+      }),
+    );
+
+    expect(missingModelResponse.status).toBe(403);
+    expect(malformedBodyResponse.status).toBe(403);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("rejects requests without a grant", async () => {
+    const { bindings } = await setupFixture();
+    const captured = captureUpstreamFetch();
+
+    const response = await dispatch(bindings, llmProxyRequest("/v1/messages", { method: "POST" }));
+
+    expect(response.status).toBe(401);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("does not run global driver maintenance before authenticating the request", async () => {
+    const { bindings, database } = await setupFixture();
+    await insertDriverInstance(database, "provisioning", {
+      bootTokenExpiresAt: Date.now() - 1,
+      driverInstanceId: OTHER_DRIVER_INSTANCE_ID,
+    });
+
+    const response = await dispatch(bindings, llmProxyRequest("/v1/messages", { method: "POST" }));
+    const unrelatedDriver = await database
+      .app()
+      .select({ status: driverInstancesTable.status })
+      .from(driverInstancesTable)
+      .where(eq(driverInstancesTable.id, OTHER_DRIVER_INSTANCE_ID))
+      .get();
+
+    expect(response.status).toBe(401);
+    expect(unrelatedDriver?.status).toBe("provisioning");
+  });
+
+  test("rejects malformed grants", async () => {
+    const { bindings } = await setupFixture();
+    const captured = captureUpstreamFetch();
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/messages", {
+        headers: { "x-api-key": "not-a-real-grant" },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("rejects grants minted for another action", async () => {
+    const { bindings } = await setupFixture();
+    const captured = captureUpstreamFetch();
+    const grant = await createRuntimeActionToken(bindings, {
+      action: "mcp_proxy",
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      expiresAt: Date.now() + 60_000,
+      resourceId: parsePlatformId("01J0000000000000000000000G", "server id"),
+    });
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/messages", {
+        body: JSON.stringify({ model: "claude-sonnet-5" }),
+        headers: { "x-api-key": grant },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("rejects grants for a different credential", async () => {
+    const { bindings } = await setupFixture();
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings, { resourceId: OTHER_CREDENTIAL_ID });
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/messages", {
+        body: JSON.stringify({ model: "claude-sonnet-5" }),
+        headers: { "x-api-key": grant },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("rejects grants once the driver instance is gone", async () => {
+    const { bindings } = await setupFixture({ driverStatus: "absent" });
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings);
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/messages", {
+        headers: { "x-api-key": grant },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("rejects grants for failed driver instances", async () => {
+    const { bindings } = await setupFixture({ driverStatus: "failed" });
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings);
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/messages", {
+        headers: { "x-api-key": grant },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("rejects grants once the scoped driver heartbeat is stale", async () => {
+    const { bindings } = await setupFixture({
+      driverUpdatedAt: Date.now() - 60_000,
+    });
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings);
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/messages", {
+        headers: { "x-api-key": grant },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("rejects grants minted for a stale driver generation", async () => {
+    const { bindings } = await setupFixture({ driverGeneration: 2 });
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings, { driverGeneration: 1 });
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/messages", {
+        headers: { "x-api-key": grant },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("rejects grants whose app does not own the credential", async () => {
+    const { bindings } = await setupFixture();
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings, {
+      appId: parsePlatformId<AppId>("01J0000000000000000000000Z", "other app id"),
+    });
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/messages", {
+        body: JSON.stringify({ model: "claude-sonnet-5" }),
+        headers: { "x-api-key": grant },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("rejects a path normalized across the provider endpoint boundary", async () => {
+    const { bindings } = await setupFixture();
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings);
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/%2e%2e/internal", {
+        headers: { "x-api-key": grant },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(captured).toHaveLength(0);
+  });
+
+  test.each(["/v1/%2e%2e%2finternal", "/v1/%2e%2e%5cinternal", "/v1/%252e%252e%252finternal"])(
+    "rejects encoded path separators and double encoding: %s",
+    async (subPath) => {
+      const { bindings } = await setupFixture();
+      const captured = captureUpstreamFetch();
+      const grant = await createLlmProxyGrant(bindings);
+
+      const response = await dispatch(
+        bindings,
+        llmProxyRequest(subPath, {
+          headers: { "x-api-key": grant },
+          method: "POST",
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      expect(captured).toHaveLength(0);
+    },
+  );
+
+  test.each(["/v1/messages/", "/v1//messages", "/v1/messages/admin", "//messages"])(
+    "rejects non-exact provider endpoint paths: %s",
+    async (subPath) => {
+      const { bindings } = await setupFixture();
+      const captured = captureUpstreamFetch();
+      const grant = await createLlmProxyGrant(bindings);
+
+      const response = await dispatch(
+        bindings,
+        llmProxyRequest(subPath, {
+          headers: { "x-api-key": grant },
+          method: "POST",
+        }),
+      );
+
+      expect(response.status).toBe(403);
+      expect(captured).toHaveLength(0);
+    },
+  );
+
+  test("rejects methods outside the model inference capability", async () => {
+    const { bindings } = await setupFixture();
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings);
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/messages", {
+        headers: { "x-api-key": grant },
+        method: "DELETE",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("propagates the sandbox request cancellation signal upstream", async () => {
+    const { bindings } = await setupFixture();
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings);
+    const controller = new AbortController();
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/messages", {
+        body: JSON.stringify({ model: "claude-sonnet-5" }),
+        headers: { "x-api-key": grant },
+        method: "POST",
+        signal: controller.signal,
+      }),
+    );
+    controller.abort();
+
+    expect(response.status).toBe(200);
+    expect(captured[0]?.signal.aborted).toBe(true);
+  });
+
+  test("rejects proxied paths with malformed percent encoding", async () => {
+    const { bindings } = await setupFixture();
+    const captured = captureUpstreamFetch();
+    const grant = await createLlmProxyGrant(bindings);
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/%zz/messages", {
+        headers: { "x-api-key": grant },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("maps upstream failures to 502", async () => {
+    const { bindings } = await setupFixture();
+    globalThis.fetch = (async () => {
+      throw new Error("boom");
+    }) as typeof fetch;
+    const grant = await createLlmProxyGrant(bindings);
+
+    const response = await dispatch(
+      bindings,
+      llmProxyRequest("/v1/messages", {
+        body: JSON.stringify({ model: "claude-sonnet-5" }),
+        headers: { "x-api-key": grant },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({ error: "LLM proxy upstream request failed." });
+  });
+});

--- a/apps/api/tests/public-thread-api.e2e.test.ts
+++ b/apps/api/tests/public-thread-api.e2e.test.ts
@@ -584,6 +584,14 @@ describe("Public Thread API e2e", () => {
         .update(sessionRunsTable)
         .set({
           completedAt: 1_150,
+          // The background inline dispatch always fails in this environment
+          // (the sandbox module cannot load under bun) and may finalize the
+          // run with a provisioning error before this simulated completion
+          // runs. Clear the error fields so the simulated outcome is
+          // authoritative regardless of that ordering.
+          errorCode: null,
+          errorDetailsJson: null,
+          errorMessage: null,
           status: "completed",
           updatedAt: 1_150,
         })

--- a/apps/api/tests/runtime-vendor-env-vars.test.ts
+++ b/apps/api/tests/runtime-vendor-env-vars.test.ts
@@ -1,93 +1,259 @@
 import { describe, expect, test } from "bun:test";
 
+import { parsePlatformId } from "@mosoo/id";
+import type { DriverInstanceId, AppId, VendorCredentialId } from "@mosoo/id";
 import {
-  VENDOR_DEEPSEEK,
+  VENDOR_ANTHROPIC,
   VENDOR_GEMINI,
   VENDOR_KIMI,
   VENDOR_MINIMAX,
-  VENDOR_OPENAI,
-  VENDOR_OPENAI_COMPATIBLE,
-  VENDOR_OPENCODE,
   VENDOR_QWEN,
   VENDOR_ZHIPU,
 } from "@mosoo/runtime-catalog";
 import type { RuntimeCatalogVendor } from "@mosoo/runtime-catalog";
 
-import { buildRuntimeVendorEnvVars } from "../src/modules/runtime/application/session-definition/hydrate-run-context.service";
+import type { DriverVendorCredentialProfile } from "../src/modules/runtime/domain/driver-snapshot";
+import { verifyRuntimeActionToken } from "../src/modules/runtime/infrastructure/runtime-boot-token";
+import { sanitizeRuntimeVendorEnvVars } from "../src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-vendor-env-policy";
+import { buildVendorProxyEnvVars } from "../src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-vendor-proxy-env.builder";
 
-describe("runtime vendor env vars", () => {
-  test("injects a custom Responses provider for OpenAI runtime", () => {
-    const envVars = buildRuntimeVendorEnvVars({
-      credential: {
-        apiBase: "https://gateway.example.com/v1",
-        apiKey: "sk-custom-responses",
-        credentialId: "01J000000000000000000000C9",
-        models: ["gpt-custom"],
+const BINDINGS = { RUNTIME_ACTION_TOKEN_SECRET: "test-runtime-action-token" };
+const DRIVER_GENERATION = 3;
+const DRIVER_INSTANCE_ID = parsePlatformId<DriverInstanceId>(
+  "01J0000000000000000000000F",
+  "driver instance ID",
+);
+const APP_ID = parsePlatformId<AppId>("01J0000000000000000000000Q", "app ID");
+const CREDENTIAL_ID = parsePlatformId<VendorCredentialId>(
+  "01J0000000000000000000000B",
+  "credential ID",
+);
+const REQUEST_URL = "https://api.example.com/api/agents/run?probe=1";
+const PROXY_URL = `https://api.example.com/api/driver/llm/proxy/${CREDENTIAL_ID}`;
+
+function vendorCredential(
+  overrides: Partial<DriverVendorCredentialProfile> & { vendorId: string },
+): DriverVendorCredentialProfile {
+  return {
+    apiBase: null,
+    appId: APP_ID,
+    credentialId: CREDENTIAL_ID,
+    models: null,
+    ...overrides,
+  };
+}
+
+async function expectLlmProxyGrant(
+  grant: string | undefined,
+  modelBinding: {
+    modelId: string;
+    modelProtocol:
+      | "anthropic-messages"
+      | "google-gemini"
+      | "openai-responses"
+      | "openai-chat-completions";
+  },
+): Promise<void> {
+  expect(grant).toBeDefined();
+  const payload = await verifyRuntimeActionToken(BINDINGS, grant ?? "");
+  expect(payload).toMatchObject({
+    action: "llm_proxy",
+    appId: APP_ID,
+    driverGeneration: DRIVER_GENERATION,
+    driverInstanceId: DRIVER_INSTANCE_ID,
+    ...modelBinding,
+    resourceId: CREDENTIAL_ID,
+  });
+}
+
+function parseOpenCodeConfig(envVars: Record<string, string>): Record<string, unknown> {
+  return JSON.parse(envVars["OPENCODE_CONFIG_CONTENT"] ?? "{}") as Record<string, unknown>;
+}
+
+describe("runtime vendor proxy env vars", () => {
+  test("removes every runtime-managed provider variable before sandbox setup", () => {
+    expect(
+      sanitizeRuntimeVendorEnvVars({
+        ANTHROPIC_API_KEY: "raw-anthropic-key",
+        EXISTING_ENV: "kept",
+        OPENAI_BASE_URL: "https://attacker.example.com/v1",
+        OPENCODE_CONFIG_CONTENT: '{"provider":{"openai":{"options":{"apiKey":"raw"}}}}',
+      }),
+    ).toEqual({ EXISTING_ENV: "kept" });
+  });
+
+  test("injects a driver-bound proxy grant instead of the Anthropic API key", async () => {
+    const envVars = await buildVendorProxyEnvVars({
+      bindings: BINDINGS,
+      driverGeneration: DRIVER_GENERATION,
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      profile: {
+        model: "claude-sonnet-5",
+        runtimeId: "claude-agent-sdk",
+        vendorCredential: vendorCredential({ vendorId: "anthropic" }),
       },
-      model: "gpt-custom",
-      runtimeId: "openai-runtime",
-      vendor: VENDOR_OPENAI_COMPATIBLE,
+      requestUrl: REQUEST_URL,
     });
 
-    expect(envVars).toEqual({
-      OPENAI_COMPATIBLE_API_KEY: "sk-custom-responses",
-      OPENAI_COMPATIBLE_BASE_URL: "https://gateway.example.com/v1",
+    expect(envVars["ANTHROPIC_BASE_URL"]).toBe(PROXY_URL);
+    await expectLlmProxyGrant(envVars["ANTHROPIC_API_KEY"], {
+      modelId: "claude-sonnet-5",
+      modelProtocol: "anthropic-messages",
     });
   });
 
-  test("fails closed before injecting credentials for unsafe stored API bases", () => {
-    expect(() =>
-      buildRuntimeVendorEnvVars({
-        credential: {
-          apiBase: "http://api.example.com/v1",
-          apiKey: "sk-runtime",
-          credentialId: "01J000000000000000000000C3",
-          models: null,
-        },
-        model: "gpt-5.4",
+  test("keeps a custom Responses endpoint on the control plane for OpenAI runtime", async () => {
+    const envVars = await buildVendorProxyEnvVars({
+      bindings: BINDINGS,
+      driverGeneration: DRIVER_GENERATION,
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      profile: {
+        model: "gpt-custom",
         runtimeId: "openai-runtime",
-        vendor: VENDOR_OPENAI,
-      }),
-    ).toThrow("Custom endpoint must use HTTPS.");
+        vendorCredential: vendorCredential({
+          apiBase: "https://gateway.example.com/v1",
+          models: ["gpt-custom"],
+          vendorId: "openai-compatible",
+        }),
+      },
+      requestUrl: REQUEST_URL,
+    });
+
+    // The stored custom endpoint stays behind the proxy; the sandbox only
+    // ever sees the control-plane URL and the revocable grant.
+    expect(envVars["OPENAI_COMPATIBLE_BASE_URL"]).toBe(PROXY_URL);
+    await expectLlmProxyGrant(envVars["OPENAI_COMPATIBLE_API_KEY"], {
+      modelId: "gpt-custom",
+      modelProtocol: "openai-responses",
+    });
   });
 
-  test("fails closed before injecting credentials for trailing-dot localhost API bases", () => {
-    expect(() =>
-      buildRuntimeVendorEnvVars({
-        credential: {
-          apiBase: "https://localhost./v1",
-          apiKey: "sk-runtime",
-          credentialId: "01J000000000000000000000C4",
-          models: null,
+  test("fails closed before minting grants for unsafe stored API bases", async () => {
+    await expect(
+      buildVendorProxyEnvVars({
+        bindings: BINDINGS,
+        driverGeneration: DRIVER_GENERATION,
+        driverInstanceId: DRIVER_INSTANCE_ID,
+        profile: {
+          model: "gpt-5.4",
+          runtimeId: "openai-runtime",
+          vendorCredential: vendorCredential({
+            apiBase: "http://api.example.com/v1",
+            vendorId: "openai",
+          }),
         },
-        model: "gpt-5.4",
-        runtimeId: "openai-runtime",
-        vendor: VENDOR_OPENAI,
+        requestUrl: REQUEST_URL,
       }),
-    ).toThrow(
+    ).rejects.toThrow("Custom endpoint must use HTTPS.");
+  });
+
+  test("fails closed before minting grants for trailing-dot localhost API bases", async () => {
+    await expect(
+      buildVendorProxyEnvVars({
+        bindings: BINDINGS,
+        driverGeneration: DRIVER_GENERATION,
+        driverInstanceId: DRIVER_INSTANCE_ID,
+        profile: {
+          model: "gpt-5.4",
+          runtimeId: "openai-runtime",
+          vendorCredential: vendorCredential({
+            apiBase: "https://localhost./v1",
+            vendorId: "openai",
+          }),
+        },
+        requestUrl: REQUEST_URL,
+      }),
+    ).rejects.toThrow(
       "Custom endpoint cannot target local, private, metadata, or credential-bearing URLs.",
     );
   });
 
-  test("generates OpenCode config for ACP fallback runtime", () => {
-    const envVars = buildRuntimeVendorEnvVars({
-      credential: {
-        apiBase: null,
-        apiKey: "sk-opencode",
-        credentialId: "01J000000000000000000000C5",
-        models: null,
+  test("accepts custom API base query semantics for control-plane forwarding", async () => {
+    const envVars = await buildVendorProxyEnvVars({
+      bindings: BINDINGS,
+      driverGeneration: DRIVER_GENERATION,
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      profile: {
+        model: "gpt-custom",
+        runtimeId: "openai-runtime",
+        vendorCredential: vendorCredential({
+          apiBase: "https://gateway.example.com/v1?api-version=2026-07-01",
+          models: ["gpt-custom"],
+          vendorId: "openai-compatible",
+        }),
       },
-      model: "qwen3.6-plus",
-      runtimeId: "acp-fallback",
-      vendor: VENDOR_OPENCODE,
+      requestUrl: REQUEST_URL,
     });
-    const config = JSON.parse(envVars["OPENCODE_CONFIG_CONTENT"] ?? "{}") as Record<
-      string,
-      unknown
-    >;
 
-    expect(envVars["OPENCODE_API_KEY"]).toBe("sk-opencode");
-    expect(config).toMatchObject({
+    await expectLlmProxyGrant(envVars["OPENAI_COMPATIBLE_API_KEY"], {
+      modelId: "gpt-custom",
+      modelProtocol: "openai-responses",
+    });
+  });
+
+  test.each([
+    "https://gateway.example.com/v1#responses",
+    "https://gateway.example.com/v1/../admin",
+    "https://gateway.example.com/v1/%2e%2e/admin",
+    "https://gateway.example.com/v1//admin",
+    "https://gateway.example.com/v1%2fadmin",
+    "https://gateway.example.com/v1%5cadmin",
+    "https://gateway.example.com/v1%252fadmin",
+    "https://gateway.example.com/v1\\admin",
+  ])("rejects non-canonical proxy base paths: %s", async (apiBase) => {
+    await expect(
+      buildVendorProxyEnvVars({
+        bindings: BINDINGS,
+        driverGeneration: DRIVER_GENERATION,
+        driverInstanceId: DRIVER_INSTANCE_ID,
+        profile: {
+          model: "gpt-custom",
+          runtimeId: "openai-runtime",
+          vendorCredential: vendorCredential({
+            apiBase,
+            models: ["gpt-custom"],
+            vendorId: "openai-compatible",
+          }),
+        },
+        requestUrl: REQUEST_URL,
+      }),
+    ).rejects.toThrow("Custom endpoint path is not canonical for runtime proxying.");
+  });
+
+  test("fails closed when a runtime has no env var to reach the proxy", async () => {
+    await expect(
+      buildVendorProxyEnvVars({
+        bindings: BINDINGS,
+        driverGeneration: DRIVER_GENERATION,
+        driverInstanceId: DRIVER_INSTANCE_ID,
+        profile: {
+          model: "deepseek-v4-pro",
+          runtimeId: "claude-agent-sdk",
+          vendorCredential: vendorCredential({ vendorId: "opencode" }),
+        },
+        requestUrl: REQUEST_URL,
+      }),
+    ).rejects.toThrow("cannot be routed through the control-plane LLM proxy");
+  });
+
+  test("routes OpenCode Zen through the proxy for ACP fallback runtime", async () => {
+    const envVars = await buildVendorProxyEnvVars({
+      bindings: BINDINGS,
+      driverGeneration: DRIVER_GENERATION,
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      profile: {
+        model: "qwen3.6-plus",
+        runtimeId: "acp-fallback",
+        vendorCredential: vendorCredential({ vendorId: "opencode" }),
+      },
+      requestUrl: REQUEST_URL,
+    });
+
+    await expectLlmProxyGrant(envVars["OPENCODE_API_KEY"], {
+      modelId: "qwen3.6-plus",
+      modelProtocol: "anthropic-messages",
+    });
+    expect(parseOpenCodeConfig(envVars)).toMatchObject({
       enabled_providers: ["opencode"],
       model: "opencode/qwen3.6-plus",
       small_model: "opencode/qwen3.6-plus",
@@ -95,31 +261,51 @@ describe("runtime vendor env vars", () => {
         opencode: {
           options: {
             apiKey: "{env:OPENCODE_API_KEY}",
+            baseURL: PROXY_URL,
           },
         },
       },
     });
   });
 
-  test("generates OpenCode native provider config for DeepSeek official API keys", () => {
-    const envVars = buildRuntimeVendorEnvVars({
-      credential: {
-        apiBase: null,
-        apiKey: "sk-deepseek",
-        credentialId: "01J000000000000000000000C6",
-        models: null,
+  test("binds OpenCode Zen Gemini to its native Google protocol", async () => {
+    const envVars = await buildVendorProxyEnvVars({
+      bindings: BINDINGS,
+      driverGeneration: DRIVER_GENERATION,
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      profile: {
+        model: "gemini-3.5-flash",
+        runtimeId: "acp-fallback",
+        vendorCredential: vendorCredential({ vendorId: "opencode" }),
       },
-      model: "deepseek-v4-pro",
-      runtimeId: "acp-fallback",
-      vendor: VENDOR_DEEPSEEK,
+      requestUrl: REQUEST_URL,
     });
-    const config = JSON.parse(envVars["OPENCODE_CONFIG_CONTENT"] ?? "{}") as Record<
-      string,
-      unknown
-    >;
 
-    expect(envVars["DEEPSEEK_API_KEY"]).toBe("sk-deepseek");
-    expect(config).toMatchObject({
+    await expectLlmProxyGrant(envVars["OPENCODE_API_KEY"], {
+      modelId: "gemini-3.5-flash",
+      modelProtocol: "google-gemini",
+    });
+  });
+
+  test("routes the OpenCode native DeepSeek provider through the proxy", async () => {
+    const envVars = await buildVendorProxyEnvVars({
+      bindings: BINDINGS,
+      driverGeneration: DRIVER_GENERATION,
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      profile: {
+        model: "deepseek-v4-pro",
+        runtimeId: "acp-fallback",
+        vendorCredential: vendorCredential({ vendorId: "deepseek" }),
+      },
+      requestUrl: REQUEST_URL,
+    });
+
+    await expectLlmProxyGrant(envVars["DEEPSEEK_API_KEY"], {
+      modelId: "deepseek-v4-pro",
+      modelProtocol: "openai-chat-completions",
+    });
+    expect(envVars["DEEPSEEK_BASE_URL"]).toBe(PROXY_URL);
+    expect(parseOpenCodeConfig(envVars)).toMatchObject({
       enabled_providers: ["deepseek"],
       model: "deepseek/deepseek-v4-pro",
       small_model: "deepseek/deepseek-v4-pro",
@@ -127,6 +313,32 @@ describe("runtime vendor env vars", () => {
         deepseek: {
           options: {
             apiKey: "{env:DEEPSEEK_API_KEY}",
+            baseURL: PROXY_URL,
+          },
+        },
+      },
+    });
+  });
+
+  test("keeps the /v1 client segment for the OpenCode native Anthropic provider", async () => {
+    const envVars = await buildVendorProxyEnvVars({
+      bindings: BINDINGS,
+      driverGeneration: DRIVER_GENERATION,
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      profile: {
+        model: "claude-sonnet-5",
+        runtimeId: "acp-fallback",
+        vendorCredential: vendorCredential({ vendorId: VENDOR_ANTHROPIC.vendorId }),
+      },
+      requestUrl: REQUEST_URL,
+    });
+
+    expect(parseOpenCodeConfig(envVars)).toMatchObject({
+      provider: {
+        anthropic: {
+          options: {
+            apiKey: "{env:ANTHROPIC_API_KEY}",
+            baseURL: `${PROXY_URL}/v1`,
           },
         },
       },
@@ -135,64 +347,63 @@ describe("runtime vendor env vars", () => {
 
   test.each([
     {
-      baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
       model: "gemini-3.5-flash",
+      modelProtocol: "openai-chat-completions",
       name: "Gemini",
       npm: "@ai-sdk/openai-compatible",
       vendor: VENDOR_GEMINI,
     },
     {
-      baseURL: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
       model: "qwen3.7-plus",
+      modelProtocol: "openai-chat-completions",
       name: "Qwen",
       npm: "@ai-sdk/openai-compatible",
       vendor: VENDOR_QWEN,
     },
     {
-      baseURL: "https://api.moonshot.ai/v1",
       model: "kimi-k2.6",
+      modelProtocol: "openai-chat-completions",
       name: "Kimi",
       npm: "@ai-sdk/openai-compatible",
       vendor: VENDOR_KIMI,
     },
     {
-      baseURL: "https://api.z.ai/api/paas/v4",
       openCodeProviderId: "zai",
       model: "glm-4.7",
+      modelProtocol: "openai-chat-completions",
       name: "Zhipu",
       npm: "@ai-sdk/openai-compatible",
       vendor: VENDOR_ZHIPU,
     },
     {
-      baseURL: "https://api.minimax.io/anthropic/v1",
       model: "MiniMax-M3",
+      modelProtocol: "anthropic-messages",
       name: "MiniMax",
       npm: "@ai-sdk/anthropic",
       vendor: VENDOR_MINIMAX,
     },
   ])(
-    "generates OpenCode adapter provider config for $name official API keys",
-    ({ baseURL, model, name, npm, openCodeProviderId, vendor }) => {
+    "routes the OpenCode adapter provider for $name through the proxy",
+    async ({ model, modelProtocol, name, npm, openCodeProviderId, vendor }) => {
       const typedVendor: RuntimeCatalogVendor = vendor;
       const providerId = openCodeProviderId ?? typedVendor.vendorId;
-      const envVars = buildRuntimeVendorEnvVars({
-        credential: {
-          apiBase: null,
-          apiKey: "sk-provider",
-          credentialId: "01J000000000000000000000C7",
-          models: null,
+      const envVars = await buildVendorProxyEnvVars({
+        bindings: BINDINGS,
+        driverGeneration: DRIVER_GENERATION,
+        driverInstanceId: DRIVER_INSTANCE_ID,
+        profile: {
+          model,
+          runtimeId: "acp-fallback",
+          vendorCredential: vendorCredential({ vendorId: typedVendor.vendorId }),
         },
-        model,
-        runtimeId: "acp-fallback",
-        vendor: typedVendor,
+        requestUrl: REQUEST_URL,
       });
-      const config = JSON.parse(envVars["OPENCODE_CONFIG_CONTENT"] ?? "{}") as Record<
-        string,
-        unknown
-      >;
 
-      expect(envVars[typedVendor.apiKeyEnvVar]).toBe("sk-provider");
-      expect(config).toMatchObject({
+      await expectLlmProxyGrant(envVars[typedVendor.apiKeyEnvVar], {
+        modelId: model,
+        modelProtocol,
+      });
+      expect(parseOpenCodeConfig(envVars)).toMatchObject({
         enabled_providers: [providerId],
         model: `${providerId}/${model}`,
         small_model: `${providerId}/${model}`,
@@ -202,7 +413,7 @@ describe("runtime vendor env vars", () => {
             npm,
             options: {
               apiKey: `{env:${typedVendor.apiKeyEnvVar}}`,
-              baseURL,
+              baseURL: PROXY_URL,
             },
           },
         },
@@ -210,31 +421,27 @@ describe("runtime vendor env vars", () => {
     },
   );
 
-  test("rewrites mosoo Zhipu model prefix to OpenCode's Z.ai provider id", () => {
-    const envVars = buildRuntimeVendorEnvVars({
-      credential: {
-        apiBase: null,
-        apiKey: "sk-zhipu",
-        credentialId: "01J000000000000000000000C9",
-        models: null,
+  test("rewrites mosoo Zhipu model prefix to OpenCode's Z.ai provider id", async () => {
+    const envVars = await buildVendorProxyEnvVars({
+      bindings: BINDINGS,
+      driverGeneration: DRIVER_GENERATION,
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      profile: {
+        model: "zhipu/glm-4.6",
+        runtimeId: "acp-fallback",
+        vendorCredential: vendorCredential({ vendorId: "zhipu" }),
       },
-      model: "zhipu/glm-4.6",
-      runtimeId: "acp-fallback",
-      vendor: VENDOR_ZHIPU,
+      requestUrl: REQUEST_URL,
     });
-    const config = JSON.parse(envVars["OPENCODE_CONFIG_CONTENT"] ?? "{}") as Record<
-      string,
-      unknown
-    >;
 
-    expect(config).toMatchObject({
+    expect(parseOpenCodeConfig(envVars)).toMatchObject({
       enabled_providers: ["zai"],
       model: "zai/glm-4.6",
       provider: {
         zai: {
           options: {
             apiKey: "{env:ZHIPU_API_KEY}",
-            baseURL: "https://api.z.ai/api/paas/v4",
+            baseURL: PROXY_URL,
           },
         },
       },
@@ -242,26 +449,25 @@ describe("runtime vendor env vars", () => {
     });
   });
 
-  test("generates OpenCode custom provider config for a DeepSeek-backed OpenAI-compatible model", () => {
-    const envVars = buildRuntimeVendorEnvVars({
-      credential: {
-        apiBase: "https://api.deepseek.com",
-        apiKey: "sk-custom",
-        credentialId: "01J000000000000000000000C8",
-        models: ["deepseek-v4-flash"],
+  test("routes an OpenCode custom provider through the proxy with declared models", async () => {
+    const envVars = await buildVendorProxyEnvVars({
+      bindings: BINDINGS,
+      driverGeneration: DRIVER_GENERATION,
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      profile: {
+        model: "deepseek-v4-flash",
+        runtimeId: "acp-fallback",
+        vendorCredential: vendorCredential({
+          apiBase: "https://api.deepseek.com",
+          models: ["deepseek-v4-flash"],
+          vendorId: "openai-compatible",
+        }),
       },
-      model: "deepseek-v4-flash",
-      runtimeId: "acp-fallback",
-      vendor: VENDOR_OPENAI_COMPATIBLE,
+      requestUrl: REQUEST_URL,
     });
-    const config = JSON.parse(envVars["OPENCODE_CONFIG_CONTENT"] ?? "{}") as Record<
-      string,
-      unknown
-    >;
 
-    expect(envVars["OPENAI_COMPATIBLE_API_KEY"]).toBe("sk-custom");
-    expect(envVars["OPENAI_COMPATIBLE_BASE_URL"]).toBe("https://api.deepseek.com");
-    expect(config).toMatchObject({
+    expect(envVars["OPENAI_COMPATIBLE_BASE_URL"]).toBe(PROXY_URL);
+    expect(parseOpenCodeConfig(envVars)).toMatchObject({
       enabled_providers: ["openai-compatible"],
       model: "openai-compatible/deepseek-v4-flash",
       small_model: "openai-compatible/deepseek-v4-flash",
@@ -276,7 +482,7 @@ describe("runtime vendor env vars", () => {
           npm: "@ai-sdk/openai-compatible",
           options: {
             apiKey: "{env:OPENAI_COMPATIBLE_API_KEY}",
-            baseURL: "https://api.deepseek.com",
+            baseURL: PROXY_URL,
           },
         },
       },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -186,6 +186,7 @@ Except for runtime boundaries such as Session Durable Objects and Sandbox instan
 9. **Credential / Secret Vault Service**
    - Provider keys, API keys, and MCP credentials are App-scoped for current App work. Runtime resolves the active key by `(execution_actor, app, provider)` and fails closed when the App-scoped credential cannot be proven. In Agent execution, the execution actor is the Agent owner; the caller is used only for ingress context.
    - API keys, provider keys, and MCP access credentials are encrypted at rest with envelope encryption. Plaintext exists only briefly in runtime memory. Profiles store provider and credential references, never plaintext secrets.
+   - Provider model calls authenticate through the Worker-side LLM proxy (`/api/driver/llm/proxy/:credentialId/*`). The Sandbox receives only an expiring, driver-generation- and model-bound `llm_proxy` grant in the vendor key env var and the proxy endpoint in the vendor base-URL env var (or rendered OpenCode config); the Worker verifies the active driver generation, admits only the model protocol's required endpoints, reads the vault secret per forwarded request, and injects the vendor auth header upstream. Raw provider keys never enter the Sandbox boot payload, process environment, or setup script environment.
    - Credential CRUD, active key switching, and Agent / MCP binding changes are control-plane changes. High-frequency `resolveCredential()` calls are runtime reads and remain outside mutation workflows.
 
 10. **Cost / Billing Service**


### PR DESCRIPTION
## Summary

- Keep managed provider secrets in the Worker control plane; sandbox hydration carries only a credential reference.
- Replace provider key/base/config variables after Environment merge and scrub those runtime-managed names from install, setup, and boot inputs. User variables unrelated to the managed provider remain unchanged.
- Mint an HMAC grant bound to app, credential, driver id, driver generation, model, protocol, and expiry. Proxy authorization performs one driver-scoped liveness query instead of global maintenance writes.
- Restrict forwarding to the exact provider methods and paths used by shipped runtimes. Requests must match the granted model (JSON body for OpenAI/Anthropic, path for Gemini); traversal, encoded separators, repeated encoding, and automatic redirects fail closed. Client cancellation propagates upstream.
- Resolve and decrypt the raw provider key only after authorization, then stream the provider response without exposing the key to the sandbox.

## Verification

- 78/78 focused grant, route, path, model-binding, redirect, cancellation, and environment-boundary tests
- API lint and typecheck
- `TMPDIR=/private/tmp just check` (1122/1122, including format, docs, lint, typecheck, and codegen)
- `just commit-check` and pre-push hooks
- GitHub Repository check, CodeQL, title/commit policy, ship policy, and CLA
- Not run: credentialed live sessions against real Anthropic, OpenAI-compatible, and Gemini providers. A provider smoke remains required before production rollout.

## Impact

- Driver-facing LLM calls gain one Worker hop, one driver-primary-key/generation liveness read, then credential and vault reads per request. Global cleanup mutations are not on this hot path.
- Setup scripts and runtime processes no longer receive managed raw provider keys. The expiring, liveness-bound sandbox grant is unusable after driver generation changes or liveness expires.
- Adds the authenticated `/api/driver/llm/proxy/:credentialId/*` route and `llm_proxy` action token; no database migration or Driver repository change.
- Failure is closed: invalid grant, stale driver, wrong model/path/method, redirect, or missing credential never falls back to a raw key. Revert the squash merge to roll back.