### PR TITLE
docs(readme): adopt standard open source section layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,30 @@
   <img src="docs/assets/mosoo-banner.png" alt="mosoo" />
 </p>
 
-# mosoo
+<h1 align="center">mosoo</h1>
 
-**An open-source agent runtime for coding agents.**
+<p align="center">
+  <strong>An open-source agent runtime for coding agents.</strong><br />
+  Run OpenAI Codex, Claude Agent SDK, and OpenCode behind API endpoints in isolated AI agent sandboxes.
+</p>
 
-Run OpenAI Codex, Claude Agent SDK, and OpenCode behind API endpoints in isolated AI agent sandboxes.
+<p align="center">
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/langgenius/mosoo" alt="License" /></a>
+  <a href="#product-status"><img src="https://img.shields.io/badge/status-alpha-orange" alt="Status: Alpha" /></a>
+</p>
+
+<p align="center">
+  <a href="https://try.mosoo.ai">Try mosoo</a> ·
+  <a href="https://mosoo.ai">Website</a> ·
+  <a href="https://mosoo.ai/docs">API Documentation</a> ·
+  <a href="https://github.com/langgenius/mosoo-connector">mosoo Connector</a>
+</p>
 
 mosoo provides a Cloudflare-native control plane to stream tool activity, inspect Run history, and keep Threads and files across executions. It is self-hostable in your own account.
 
 Your application remains yours. Its backend owns product behavior and end-user access. mosoo focuses on Agent execution and lifecycle; App Deployment is a separate Alpha surface, not the core product contract.
+
+## How It Works
 
 ```text
 configure Agent + Skills + MCP + provider
@@ -20,14 +35,9 @@ configure Agent + Skills + MCP + provider
   -> continue a durable Thread across Runs
 ```
 
-<p align="center">
-  <a href="https://try.mosoo.ai">Try mosoo</a> ·
-  <a href="https://mosoo.ai">Website</a> ·
-  <a href="https://mosoo.ai/docs">API Documentation</a> ·
-  <a href="https://github.com/langgenius/mosoo-connector">mosoo Connector</a>
-</p>
+## Features
 
-## Agent Runtime and API: What Works Today
+What works today across the Agent runtime and API:
 
 - **Agent runtime and control plane.** Configure and run OpenAI Codex, Claude Agent SDK, and OpenCode behind one normalized runtime protocol.
 - **Agent API.** Start, follow, continue, stop, archive, and delete Agent work from a trusted backend.
@@ -43,28 +53,17 @@ mosoo is for developers extending Codex, Claude Agent SDK, OpenCode, or another 
 
 mosoo is in Alpha. The managed runtime and Agent API surfaces above are shipped and covered by repository tests, but production reliability and external adoption have not been proven. Public APIs and product behavior may still change.
 
-Product and engineering references:
+## Getting Started
 
-- Canonical product contract: [docs/SPEC.md](./docs/SPEC.md)
-- PRD index and historical implementation contracts: [docs/prd/README.md](./docs/prd/README.md)
-- Current implementation architecture: [docs/architecture.md](./docs/architecture.md)
-- Development and contribution guide: [CONTRIBUTING.md](./CONTRIBUTING.md)
+The fastest way to try mosoo is the hosted console at [try.mosoo.ai](https://try.mosoo.ai). To run it yourself, self-host from a clean clone as below.
 
-## Example: Build a Codex Agent API
-
-[Codex Pet](./examples/use-cases/codex-pet.md) shows a published mosoo Agent integrated into an existing product backend through the Thread API. The same API can expose Agents backed by Claude Agent SDK or OpenCode.
-
-https://github.com/user-attachments/assets/4a4bbaab-c192-4462-99e0-020eab966fff
-
-## Local Development
-
-Prerequisites:
+### Prerequisites
 
 - `bun >= 1.4.0-canary.1`
 - `just >= 1.51`
 - A Docker-compatible daemon for Agent runtime and Sandbox flows
 
-From a clean clone:
+### Run Locally
 
 ```bash
 git clone --recurse-submodules https://github.com/langgenius/mosoo.git
@@ -89,6 +88,34 @@ curl http://localhost:8787/api/health
 
 API health is `/api/health`, not `/health`. The mosoo control-plane development login uses OTP; under local loopback origins, addresses ending with `@mosoo.ai` skip that OTP and log in directly.
 
+### Troubleshooting
+
 If setup fails, start with the focused recipe: submodule issues use `git submodule update --init`, missing local secrets use `just env-init`, and D1 schema errors use `just db-migrate`. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full workflow and verification expectations.
 
+## Example: Build a Codex Agent API
+
+[Codex Pet](./examples/use-cases/codex-pet.md) shows a published mosoo Agent integrated into an existing product backend through the Thread API. The same API can expose Agents backed by Claude Agent SDK or OpenCode.
+
+https://github.com/user-attachments/assets/4a4bbaab-c192-4462-99e0-020eab966fff
+
+## Documentation
+
+- API documentation: [mosoo.ai/docs](https://mosoo.ai/docs)
+- Canonical product contract: [docs/SPEC.md](./docs/SPEC.md)
+- Current implementation architecture: [docs/architecture.md](./docs/architecture.md)
+- PRD index and historical implementation contracts: [docs/prd/README.md](./docs/prd/README.md)
+
 The public landing page and blog live in the private `langgenius/mosoo-website` repository and are deployed separately on `mosoo.ai`.
+
+## Community & Support
+
+- Bug reports and feature requests: [GitHub Issues](https://github.com/langgenius/mosoo/issues)
+- Product updates: [mosoo.ai](https://mosoo.ai)
+
+## Contributing
+
+Contributions are welcome. Read [CONTRIBUTING.md](./CONTRIBUTING.md) for the development workflow, commit policy, and verification expectations. Contributions are covered by the [Contributor License Agreement](./CLA.md); CLA Assistant will prompt you on your first pull request.
+
+## License
+
+mosoo is licensed under the [Apache License 2.0](./LICENSE).


### PR DESCRIPTION
## Summary

- Restructure `README.md` into the standard open source section layout: hero (banner, tagline, badges, quick links) → How It Works → Features → Who It Is For → Product Status → Getting Started → Example → Documentation → Community & Support → Contributing → License.
- Add license and Alpha-status badges to the hero, and move the quick links (Try mosoo · Website · API Documentation · mosoo Connector) up into it.
- Add the previously missing closing sections: Community & Support (GitHub Issues, mosoo.ai), Contributing (CONTRIBUTING.md + CLA), and License (Apache-2.0).
- Consolidate scattered doc references (SPEC, architecture, PRD index, API docs) under a single Documentation section; split local development into Prerequisites / Run Locally / Troubleshooting subsections under Getting Started.
- Existing copy is preserved and regrouped — no sentence-level rewrites of product wording.

## Why

- Aligns the README with the section-layout conventions shared by 150k+ star open source projects (internal layout research, YEF-597): hero with badges and nav first, an early action zone (Getting Started), then docs/community/contributing, with License always last.
- The previous layout had the quick links buried mid-page, doc references inside Product Status, no community/contributing/license sections, and local development at the very bottom.

## Verification

- Commands: audited every relative README link against the working tree (all targets exist); trailing-whitespace and EOF-newline checks pass (prek file-hygiene hooks ran on commit).
- Manual steps: reviewed section ordering and heading depth (≤ H3); confirmed the status badge anchor `#product-status` matches the section heading.
- Not run: `just check` — markdown-only change with no code, generated files, or config touched; relying on the PR CI gate.

## Impact

- User/API/contract changes: none — documentation only.
- Generated files / GraphQL / DB / lockfile: none.
- Env or config changes: none.
- Risk and rollback: low; revert this single README commit.

## Review

- Closest review areas: `README.md` hero HTML block and section ordering.
- Known trade-offs: the "Agent Runtime and API: What Works Today" heading becomes "Features" (its framing is kept as the section lead-in sentence); Product Status sits before Getting Started so the Alpha caveat stays above the action zone.
