### PR TITLE
perf(skills): index GitHub branch ref matching

### DIFF
--- a/apps/api/src/modules/skills/application/skill-package-github.service.ts
+++ b/apps/api/src/modules/skills/application/skill-package-github.service.ts
@@ -781,13 +781,18 @@ async function getDefaultBranch(owner: string, repo: string): Promise<string> {
   return payload["default_branch"];
 }
 
-function longestMatchingRef(segments: string[], candidates: string[]): string | null {
+function longestMatchingRef(
+  segments: readonly string[],
+  candidates: readonly string[],
+): string | null {
+  const candidateRefs = new Set(candidates);
+  let candidate = "";
   let matched: string | null = null;
 
-  for (let index = 1; index <= segments.length; index += 1) {
-    const candidate = segments.slice(0, index).join("/");
+  for (const segment of segments) {
+    candidate = candidate.length === 0 ? segment : `${candidate}/${segment}`;
 
-    if (!candidates.includes(candidate)) {
+    if (!candidateRefs.has(candidate)) {
       continue;
     }
 

--- a/apps/api/tests/skill-package-github-boundary.test.ts
+++ b/apps/api/tests/skill-package-github-boundary.test.ts
@@ -117,6 +117,47 @@ describe("GitHub skill package boundary", () => {
     expect(downloads).toEqual(new Map([...fileBodies.keys()].map((url) => [url, 1] as const)));
   });
 
+  test("resolves tree URLs whose branch names contain slashes", async () => {
+    globalThis.fetch = async (input) => {
+      const url = typeof input === "string" ? input : input.url;
+
+      if (url === "https://api.github.com/repos/acme/repo/branches?per_page=100") {
+        return Response.json([{ name: "main" }, { name: "release/2026" }]);
+      }
+
+      if (url === "https://api.github.com/repos/acme/repo/contents/skills?ref=release%2F2026") {
+        return Response.json([
+          {
+            download_url:
+              "https://raw.githubusercontent.com/acme/repo/release/2026/skills/SKILL.md",
+            path: "skills/SKILL.md",
+            type: "file",
+          },
+        ]);
+      }
+
+      if (url === "https://raw.githubusercontent.com/acme/repo/release/2026/skills/SKILL.md") {
+        return new Response(
+          "---\nname: slash-branch-skill\ndescription: branch ref test\n---\n# Skill\n",
+          {
+            headers: {
+              "content-length": "69",
+            },
+          },
+        );
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    };
+
+    const normalized = await loadSkillPackageFromGithub(
+      "https://github.com/acme/repo/tree/release/2026/skills",
+    );
+
+    expect(normalized.frontmatter.name).toBe("slash-branch-skill");
+    expect(normalized.entries.map((entry) => entry.path)).toEqual(["SKILL.md"]);
+  });
+
   test("resolves a --skill selector to the skills/<name> directory", async () => {
     globalThis.fetch = async (input) => {
       const url = typeof input === "string" ? input : input.url;


### PR DESCRIPTION
## Summary

- Index GitHub branch references once before matching skill paths.
- Preserve slash-delimited branch names while removing repeated branch-array scans.
- Keep the existing matching contract and add regression coverage.

## Verification

- `bun test apps/api/tests/skills-github-boundary.test.ts`
- `just tc-package @mosoo/api`
- API lint and focused formatting checks
- `just commit-check`

## Impact

- No user-facing, API, schema, configuration, or generated-file changes.
- Low-risk lookup optimization; revert the squash merge to roll back.