### PR TITLE
perf(login): defer decorative doodle assets

### DIFF
--- a/apps/web/src/routes/login/login-doodles-loader.ts
+++ b/apps/web/src/routes/login/login-doodles-loader.ts
@@ -1,0 +1,20 @@
+import type { ReactElement } from "react";
+
+type LoginDoodlesComponent = () => ReactElement | null;
+type LoginDoodlesModule = { LoginDoodles: LoginDoodlesComponent };
+
+function EmptyLoginDoodles(): null {
+  return null;
+}
+
+export async function loadLoginDoodles(
+  load: () => Promise<LoginDoodlesModule> = () => import("./doodles"),
+): Promise<{ default: LoginDoodlesComponent }> {
+  try {
+    const doodles = await load();
+    return { default: doodles.LoginDoodles };
+  } catch {
+    // Decorative art must never take down the login form.
+    return { default: EmptyLoginDoodles };
+  }
+}

--- a/apps/web/src/routes/login/login.route.tsx
+++ b/apps/web/src/routes/login/login.route.tsx
@@ -1,15 +1,36 @@
+import { lazy, Suspense, useEffect, useState } from "react";
 import type { ReactElement } from "react";
 
 import { LoginAuthCard } from "./auth-card";
-import { LoginDoodles } from "./doodles";
+import { loadLoginDoodles } from "./login-doodles-loader";
 import { LoginAuthTopbar } from "./topbar";
 import { useLoginFlow } from "./use-login";
+
+const LoginDoodles = lazy(loadLoginDoodles);
 
 // Warm cream ground so the hand-drawn doodle characters read as paper, not UI.
 const authBackgroundStyle = {
   background:
     "radial-gradient(900px 500px at 85% -10%, rgba(28,32,36,.04), transparent 60%), #FDFBF7",
 } as const;
+
+function DeferredLoginDoodles(): ReactElement | null {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <LoginDoodles />
+    </Suspense>
+  );
+}
 
 export function LoginPage(): ReactElement {
   const login = useLoginFlow();
@@ -28,7 +49,7 @@ export function LoginPage(): ReactElement {
 
   return (
     <div className="fixed inset-0 flex flex-col" style={authBackgroundStyle}>
-      <LoginDoodles />
+      <DeferredLoginDoodles />
       <LoginAuthTopbar />
       <LoginAuthCard
         email={login.email}

--- a/apps/web/tests/login-doodles.test.ts
+++ b/apps/web/tests/login-doodles.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+
+import { loadLoginDoodles } from "../src/routes/login/login-doodles-loader";
+
+describe("login doodles", () => {
+  test("falls back to no artwork when the deferred chunk fails", async () => {
+    const doodles = await loadLoginDoodles(async () => {
+      throw new Error("chunk failed");
+    });
+
+    expect(doodles.default()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Move generated decorative artwork behind a post-mount lazy boundary so the login form remains in the initial route chunk.
- Fail closed to no artwork if the deferred chunk cannot load; the authentication UI remains available.
- Remove the empty CI-only commit and keep one formal performance commit.

## Verification

- Web production build and typecheck
- Full Web test suite
- Focused chunk-failure regression test
- Web lint and formatting checks
- `just commit-check`
- Measured `/login` route chunk: 51.99 kB raw / 21.58 kB gzip → 8.68 kB raw / 3.55 kB gzip; artwork is a deferred 43.90 kB / 17.86 kB gzip chunk.

## Impact

- No API, schema, generated-file, or environment changes.
- Decorative artwork may appear after the auth card; a failed artwork request no longer affects login.
- Revert the squash merge to roll back.