### PR TITLE
fix(runtime): hibernate idle pet subjects

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-conversation-session-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-conversation-session-store.ts
@@ -305,7 +305,12 @@ export async function recordRuntimeConversationSessionActive(
     appDb
       .update(sandboxesTable)
       .set({
-        inactiveDeadlineAt: null,
+        inactiveDeadlineAt: sql`
+          CASE
+            WHEN ${sandboxesTable.kind} = 'pet' THEN ${sandboxesTable.inactiveDeadlineAt}
+            ELSE NULL
+          END
+        `,
         updatedAt: input.now,
       })
       .where(eq(sandboxesTable.id, input.runtimeSubjectId)),

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-run-lease-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-run-lease-store.ts
@@ -515,7 +515,10 @@ export async function recordRuntimeRunLeaseReleasedOutcome(
     .where(
       and(
         eq(sandboxesTable.id, driver.sandboxId),
-        notExists(activeConversationSessionQuery(appDb, driver.sandboxId)),
+        or(
+          eq(sandboxesTable.kind, "pet"),
+          notExists(activeConversationSessionQuery(appDb, driver.sandboxId)),
+        ),
         notExists(runLeaseQuery(appDb, driver.sandboxId)),
       ),
     )

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance-store.ts
@@ -135,7 +135,10 @@ export async function listInactiveRuntimeSubjects(
     .where(
       and(
         eq(sandboxesTable.status, "active"),
-        notExists(activeConversationSessionQueryForListedSubject(appDb)),
+        or(
+          eq(sandboxesTable.kind, "pet"),
+          notExists(activeConversationSessionQueryForListedSubject(appDb)),
+        ),
         notExists(runLeaseQueryForListedSubject(appDb)),
         isNotNull(sandboxesTable.inactiveDeadlineAt),
         lte(sandboxesTable.inactiveDeadlineAt, input.now),
@@ -208,7 +211,10 @@ export async function claimInactiveRuntimeSubject(
         and(
           eq(sandboxesTable.id, input.runtimeSubjectId),
           eq(sandboxesTable.status, "active"),
-          notExists(activeConversationSessionQuery(appDb, input.runtimeSubjectId)),
+          or(
+            eq(sandboxesTable.kind, "pet"),
+            notExists(activeConversationSessionQuery(appDb, input.runtimeSubjectId)),
+          ),
           notExists(runLeaseQuery(appDb, input.runtimeSubjectId)),
           isNotNull(sandboxesTable.inactiveDeadlineAt),
           lte(sandboxesTable.inactiveDeadlineAt, input.now),

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-platform.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-platform.ts
@@ -13,6 +13,7 @@ import { requireCloudflareSandboxBinding } from "../../../../platform/cloudflare
 import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
 import type { RuntimeStateClearRule } from "../../domain/runtime-kind-policy";
 import { withRuntimeProvisionTimeout } from "../runtime-provision-timeout";
+import { decodeSandboxBackupIdForPlatform } from "../sandbox-backup-id";
 import { toSandboxHandle } from "../sandbox-handles";
 import type { SandboxHandle } from "../sandbox-handles";
 import type { ReadyRuntimeSubjectBackupRecord } from "./runtime-subject-store";
@@ -76,7 +77,7 @@ export async function restoreRuntimeSubjectBackup(
     withRuntimeProvisionTimeout(
       subject.restoreBackup({
         dir: input.backup.dir,
-        id: input.backup.id,
+        id: decodeSandboxBackupIdForPlatform(input.backup.id),
       }),
       `Runtime subject restore for ${input.runtimeSubjectId}`,
     ),

--- a/apps/api/src/modules/runtime/infrastructure/sandbox-backup-id.ts
+++ b/apps/api/src/modules/runtime/infrastructure/sandbox-backup-id.ts
@@ -1,0 +1,75 @@
+import { isPlatformId, parsePlatformId } from "@mosoo/id";
+import type { SandboxBackupId } from "@mosoo/id";
+
+const BASE32_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+const UUID_PAYLOAD_BITS = 122n;
+const UUID_PAYLOAD_MASK = (1n << UUID_PAYLOAD_BITS) - 1n;
+const UUID_STORAGE_MARKER = 5n;
+
+// UUID v4 has 122 variable bits. Prefixing those bits with `7` plus a
+// three-bit marker keeps the handle reversible inside the existing ULID-shaped column.
+function encodeBase32(value: bigint): string {
+  let remaining = value;
+  let encoded = "";
+
+  for (let index = 0; index < 25; index += 1) {
+    encoded = BASE32_ALPHABET[Number(remaining & 31n)] + encoded;
+    remaining >>= 5n;
+  }
+
+  return encoded;
+}
+
+function decodeBase32(value: string): bigint {
+  let decoded = 0n;
+
+  for (const character of value) {
+    decoded = decoded * 32n + BigInt(BASE32_ALPHABET.indexOf(character));
+  }
+
+  return decoded;
+}
+
+export function encodeSandboxBackupIdForStorage(value: string): SandboxBackupId {
+  if (isPlatformId(value)) {
+    return value as SandboxBackupId;
+  }
+
+  if (!UUID_V4_PATTERN.test(value)) {
+    throw new TypeError("sandbox backup id must be a Cloudflare UUID v4 or Mosoo ULID.");
+  }
+
+  const uuid = BigInt(`0x${value.replaceAll("-", "")}`);
+  const payload =
+    ((uuid >> 80n) << 74n) | (((uuid >> 64n) & 0xfffn) << 62n) | (uuid & ((1n << 62n) - 1n));
+  const stored = `7${encodeBase32((UUID_STORAGE_MARKER << UUID_PAYLOAD_BITS) | payload)}`;
+
+  return parsePlatformId<SandboxBackupId>(stored, "sandbox backup id");
+}
+
+export function decodeSandboxBackupIdForPlatform(value: string): string {
+  if (!isPlatformId(value) || value[0] !== "7") {
+    return value;
+  }
+
+  const encoded = decodeBase32(value.slice(1));
+
+  if (encoded >> UUID_PAYLOAD_BITS !== UUID_STORAGE_MARKER) {
+    return value;
+  }
+
+  const payload = encoded & UUID_PAYLOAD_MASK;
+  const uuid =
+    ((payload >> 74n) << 80n) |
+    (4n << 76n) |
+    (((payload >> 62n) & 0xfffn) << 64n) |
+    (2n << 62n) |
+    (payload & ((1n << 62n) - 1n));
+  const hex = uuid.toString(16).padStart(32, "0");
+
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(
+    16,
+    20,
+  )}-${hex.slice(20)}`;
+}

--- a/apps/api/src/modules/runtime/infrastructure/sandbox-backup-platform.ts
+++ b/apps/api/src/modules/runtime/infrastructure/sandbox-backup-platform.ts
@@ -3,6 +3,10 @@ import {
   withDisposedRpcResult,
 } from "../../../platform/cloudflare/rpc-disposal";
 import type { ApiBindings } from "../../../platform/cloudflare/worker-types";
+import {
+  decodeSandboxBackupIdForPlatform,
+  encodeSandboxBackupIdForStorage,
+} from "./sandbox-backup-id";
 
 interface SandboxBackupObject {
   readonly dir: string;
@@ -10,7 +14,9 @@ interface SandboxBackupObject {
 }
 
 function getSandboxBackupObjectKeys(backupId: string): string[] {
-  return [`backups/${backupId}/data.sqsh`, `backups/${backupId}/meta.json`];
+  const platformBackupId = decodeSandboxBackupIdForPlatform(backupId);
+
+  return [`backups/${platformBackupId}/data.sqsh`, `backups/${platformBackupId}/meta.json`];
 }
 
 export async function createRuntimeSandboxBackup(
@@ -34,7 +40,7 @@ export async function createRuntimeSandboxBackup(
         }),
         (result) => ({
           dir: result.dir,
-          id: result.id,
+          id: encodeSandboxBackupIdForStorage(result.id),
         }),
       ),
   );

--- a/apps/api/src/modules/runtime/infrastructure/sandbox-session/sandbox-conversation-session-platform.ts
+++ b/apps/api/src/modules/runtime/infrastructure/sandbox-session/sandbox-conversation-session-platform.ts
@@ -4,6 +4,7 @@ import type { SandboxBackupId, SandboxSessionId } from "@mosoo/id";
 import { withDisposedRpcResult } from "../../../../platform/cloudflare/rpc-disposal";
 import { getRuntimeSessionOutputDirectory } from "../driver-instance/runtime-session-outputs";
 import { withRuntimeProvisionTimeout } from "../runtime-provision-timeout";
+import { decodeSandboxBackupIdForPlatform } from "../sandbox-backup-id";
 import type { ExecutionSessionHandle, SandboxHandle } from "../sandbox-handles";
 
 interface SandboxConversationDirectoryBackup {
@@ -50,7 +51,7 @@ export async function restoreSandboxConversationDirectoryBackup(
     withRuntimeProvisionTimeout(
       sandbox.restoreBackup({
         dir: input.backup.dir,
-        id: input.backup.id,
+        id: decodeSandboxBackupIdForPlatform(input.backup.id),
       }),
       `Sandbox session cwd restore for ${input.cwd}`,
     ),

--- a/apps/api/tests/error-log-context.test.ts
+++ b/apps/api/tests/error-log-context.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+
+import { createErrorLogContext, normalizeLogMetadata } from "@mosoo/observability";
+
+import { RuntimeSubjectCheckpointFailedError } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-errors";
+
+describe("error log context", () => {
+  test("records nested checkpoint causes without expanding non-Error objects", () => {
+    const checkpointError = new RuntimeSubjectCheckpointFailedError({
+      cause: new Error("sandbox backup upload failed"),
+      dir: "/workspace/memory",
+      runtimeSubjectId: "01J0000000000000000000000D",
+    });
+
+    expect(normalizeLogMetadata(createErrorLogContext(checkpointError))).toMatchObject({
+      error: {
+        cause: {
+          message: "sandbox backup upload failed",
+          name: "Error",
+        },
+        message:
+          "Runtime subject 01J0000000000000000000000D checkpoint failed for /workspace/memory.",
+        name: "RuntimeSubjectCheckpointFailedError",
+      },
+    });
+
+    const objectCause = new Error("unsafe cause", {
+      cause: { token: "must-not-be-logged" },
+    });
+    const normalized = normalizeLogMetadata(createErrorLogContext(objectCause));
+    expect(normalized).toMatchObject({
+      error: {
+        cause: "[Non-Error cause]",
+      },
+    });
+    expect(JSON.stringify(normalized)).not.toContain("must-not-be-logged");
+
+    const circularCause = new Error("circular cause");
+    Object.defineProperty(circularCause, "cause", { value: circularCause });
+    expect(normalizeLogMetadata(createErrorLogContext(circularCause))).toMatchObject({
+      error: {
+        cause: "[Circular]",
+      },
+    });
+  });
+});

--- a/apps/api/tests/runtime-subject-lifecycle.test.ts
+++ b/apps/api/tests/runtime-subject-lifecycle.test.ts
@@ -8,11 +8,14 @@ import {
   markRuntimeSubjectCold,
   markRuntimeSubjectOperationStarted,
 } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store";
+import { encodeSandboxBackupIdForStorage } from "../src/modules/runtime/infrastructure/sandbox-backup-id";
 import type { SandboxHandle } from "../src/modules/runtime/infrastructure/sandbox-handles";
 import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
 import { SqliteD1Database } from "./helpers/sqlite-d1";
 
 const RUNTIME_SUBJECT_ID = "01J0000000000000000000000D";
+const CLOUDFLARE_BACKUP_ID = "550e8400-e29b-41d4-a716-446655440000";
+const STORED_BACKUP_ID = encodeSandboxBackupIdForStorage(CLOUDFLARE_BACKUP_ID);
 
 function createRuntimeSubjectLifecycleDatabase(): SqliteD1Database {
   const database = new SqliteD1Database();
@@ -157,7 +160,11 @@ async function readRuntimeSubject(database: D1Database): Promise<{
 }
 
 function createSandboxHandle(
-  options: { readonly prepareError?: Error; readonly onDestroy?: () => void } = {},
+  options: {
+    readonly onDestroy?: () => void;
+    readonly onRestore?: (backup: { readonly dir: string; readonly id: string }) => void;
+    readonly prepareError?: Error;
+  } = {},
 ): SandboxHandle {
   const unavailable = async () => {
     throw new Error("Unexpected sandbox test method call.");
@@ -181,7 +188,12 @@ function createSandboxHandle(
     },
     mountBucket: unavailable,
     readFile: unavailable,
-    restoreBackup: unavailable,
+    restoreBackup: options.onRestore
+      ? async (backup) => {
+          options.onRestore?.(backup);
+          return backup;
+        }
+      : unavailable,
     setKeepAlive: async () => {},
     startProcess: unavailable,
     terminal: unavailable,
@@ -193,7 +205,11 @@ function createSandboxHandle(
 
 function createBindings(
   database: D1Database,
-  options: { readonly prepareError?: Error; readonly onDestroy?: () => void } = {},
+  options: {
+    readonly onDestroy?: () => void;
+    readonly onRestore?: (backup: { readonly dir: string; readonly id: string }) => void;
+    readonly prepareError?: Error;
+  } = {},
 ): ApiBindings {
   return {
     DB: database,
@@ -334,6 +350,10 @@ describe("runtime subject lifecycle machine", () => {
     const database = createRuntimeSubjectLifecycleDatabase();
     await insertRuntimeSubject(database, { status: "active" });
     await database
+      .prepare("UPDATE sandbox SET kind = ?, subject_id = ?, subject_kind = ? WHERE id = ?")
+      .bind("pet", "01J00000000000000000000001", "agent", RUNTIME_SUBJECT_ID)
+      .run();
+    await database
       .prepare("UPDATE sandbox SET claim_owner = ?, claim_expires_at = ? WHERE id = ?")
       .bind("scheduled-race", Date.now() + 60_000, RUNTIME_SUBJECT_ID)
       .run();
@@ -352,7 +372,7 @@ describe("runtime subject lifecycle machine", () => {
     await expect(
       recycleRuntimeSubject(createBindings(database), {
         claimOwner: "scheduled-race",
-        kind: "cattle",
+        kind: "pet",
         now: Date.now(),
         reason: "test",
         runtimeSubjectId: RUNTIME_SUBJECT_ID,
@@ -365,6 +385,67 @@ describe("runtime subject lifecycle machine", () => {
         .bind(RUNTIME_SUBJECT_ID)
         .first("claim_owner"),
     ).resolves.toBeNull();
+  });
+
+  test("restores pet memory when the same logical subject activates from cold", async () => {
+    const database = createRuntimeSubjectLifecycleDatabase();
+    await insertRuntimeSubject(database, { status: "cold" });
+    await database
+      .prepare(
+        `
+          INSERT INTO sandbox_backup (
+            created_at,
+            dir,
+            error_message,
+            id,
+            keep,
+            sandbox_id,
+            status,
+            ttl_seconds,
+            updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+      )
+      .bind(
+        1,
+        "/workspace/memory",
+        null,
+        STORED_BACKUP_ID,
+        false,
+        RUNTIME_SUBJECT_ID,
+        "ready",
+        600,
+        1,
+      )
+      .run();
+    await database
+      .prepare("UPDATE sandbox SET kind = ?, last_backup_id = ?, subject_kind = ? WHERE id = ?")
+      .bind("pet", STORED_BACKUP_ID, "agent", RUNTIME_SUBJECT_ID)
+      .run();
+    let restoredBackup: { readonly dir: string; readonly id: string } | null = null;
+
+    const activation = await createRuntimeSubjectLifecycleService(
+      createBindings(database, {
+        onRestore: (backup) => {
+          restoredBackup = backup;
+        },
+      }),
+    ).activate({
+      executionOwnerUserId: "01J00000000000000000000002",
+      kind: "pet",
+      runtimeSubjectId: RUNTIME_SUBJECT_ID,
+      spaceAliases: [],
+      subjectId: "01J00000000000000000000009",
+      subjectKind: "agent",
+    });
+
+    expect(activation.subject).toBeTruthy();
+    expect(restoredBackup).toEqual({
+      dir: "/workspace/memory",
+      id: CLOUDFLARE_BACKUP_ID,
+    });
+    expect((await readRuntimeSubject(database)).status).toBe("active");
   });
 
   test("lets interactive activation retry after a prior activation failure", async () => {

--- a/apps/api/tests/runtime-subject-recycle.test.ts
+++ b/apps/api/tests/runtime-subject-recycle.test.ts
@@ -5,15 +5,26 @@ import type { RuntimeOperationId } from "@mosoo/id";
 import { PLATFORM_ID_FIXTURES } from "@mosoo/id/testing";
 
 import {
+  recycleInactiveRuntimeSubjectNow,
   recycleRuntimeSubject,
   resumeRuntimeSubjectRecycleOperation,
 } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-recycle.service";
-import { listStaleRuntimeSubjectOperations } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store";
+import {
+  listInactiveRuntimeSubjects,
+  listStaleRuntimeSubjectOperations,
+} from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store";
+import { encodeSandboxBackupIdForStorage } from "../src/modules/runtime/infrastructure/sandbox-backup-id";
 import type { SandboxHandle } from "../src/modules/runtime/infrastructure/sandbox-handles";
 import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
 import { SqliteD1Database } from "./helpers/sqlite-d1";
 
-const BACKUP_ID = "01J0000000000000000000000V";
+const CLOUDFLARE_BACKUP_ID = "550e8400-e29b-41d4-a716-446655440000";
+const CLOUDFLARE_BACKUP_IDS = [
+  CLOUDFLARE_BACKUP_ID,
+  "550e8400-e29b-41d4-a716-446655440001",
+  "550e8400-e29b-41d4-a716-446655440002",
+] as const;
+const BACKUP_ID = encodeSandboxBackupIdForStorage(CLOUDFLARE_BACKUP_ID);
 const CLAIM_OWNER = "scheduled-maintenance-owner";
 const OPERATION_ID = "01J0000000000000000000000R";
 const SANDBOX_ID = PLATFORM_ID_FIXTURES.sandbox;
@@ -172,7 +183,7 @@ function createSandboxHandle(): SandboxHandle {
   return {
     createBackup: async (options) => ({
       dir: options.dir,
-      id: BACKUP_ID,
+      id: CLOUDFLARE_BACKUP_ID,
     }),
     createSession: unavailable,
     deleteSession: unavailable,
@@ -226,6 +237,107 @@ describe("runtime subject recycle", () => {
     expect(subject?.last_backup_id).toBe(BACKUP_ID);
     expect(subject?.status_operation_id).not.toBe(CLAIM_OWNER);
     expect(isPlatformId(subject?.status_operation_id)).toBe(true);
+  });
+
+  test("hibernates one idle pet subject across sessions after checkpointing durable state", async () => {
+    const database = createRuntimeSubjectRecycleDatabase();
+    await database
+      .prepare(
+        `
+          UPDATE sandbox
+          SET claim_expires_at = NULL,
+              claim_owner = NULL,
+              inactive_deadline_at = ?,
+              subject_kind = ?
+          WHERE id = ?
+        `,
+      )
+      .bind(10, "agent", SANDBOX_ID)
+      .run();
+    database.execute(`
+      INSERT INTO sandbox_session (cwd, sandbox_id, session_id, status, updated_at)
+      VALUES
+        ('/workspace/se/session-1', '${SANDBOX_ID}', '01J0000000000000000000000S', 'active', 1),
+        ('/workspace/se/session-2', '${SANDBOX_ID}', '01J0000000000000000000000T', 'active', 1),
+        ('/workspace/se/terminated', '${SANDBOX_ID}', '01J0000000000000000000000U', 'active', 1);
+
+      INSERT INTO session (id, last_message_at, status)
+      VALUES
+        ('01J0000000000000000000000S', 1, 'IDLE'),
+        ('01J0000000000000000000000T', 1, 'IDLE'),
+        ('01J0000000000000000000000U', 1, 'TERMINATED');
+    `);
+    const checkpointDirs: string[] = [];
+    const lifecycleCalls: string[] = [];
+    let backupIndex = 0;
+    currentSandbox = {
+      ...createSandboxHandle(),
+      createBackup: async (options) => {
+        checkpointDirs.push(options.dir);
+        const id = CLOUDFLARE_BACKUP_IDS[backupIndex];
+        backupIndex += 1;
+        if (!id) {
+          throw new Error("Unexpected extra checkpoint.");
+        }
+        return { dir: options.dir, id };
+      },
+      destroy: async () => {
+        lifecycleCalls.push("destroy");
+      },
+      setKeepAlive: async (keepAlive) => {
+        lifecycleCalls.push(`keepAlive:${keepAlive}`);
+      },
+    };
+    const bindings = createBindings(database);
+
+    await expect(
+      listInactiveRuntimeSubjects(database, {
+        limit: 10,
+        now: 10,
+      }),
+    ).resolves.toEqual([{ id: SANDBOX_ID, kind: "pet" }]);
+    await expect(
+      recycleInactiveRuntimeSubjectNow(bindings, {
+        kind: "pet",
+        now: 10,
+        reason: "test.pet_idle_hibernate",
+        runtimeSubjectId: SANDBOX_ID,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      recycleInactiveRuntimeSubjectNow(bindings, {
+        kind: "pet",
+        now: 10,
+        reason: "test.pet_idle_hibernate_duplicate",
+        runtimeSubjectId: SANDBOX_ID,
+      }),
+    ).resolves.toBe(false);
+
+    expect(checkpointDirs.toSorted()).toEqual([
+      "/workspace/memory",
+      "/workspace/se/session-1",
+      "/workspace/se/session-2",
+    ]);
+    expect(lifecycleCalls).toEqual(["keepAlive:false", "destroy"]);
+    await expect(readRuntimeSubjectRecycleRow(database)).resolves.toMatchObject({
+      last_error: null,
+      last_error_code: null,
+      status: "cold",
+    });
+    const sessions = await database
+      .prepare("SELECT status FROM sandbox_session ORDER BY session_id")
+      .all<{ status: string }>();
+    expect(sessions.results).toEqual([
+      { status: "closed" },
+      { status: "closed" },
+      { status: "closed" },
+    ]);
+    await expect(
+      listInactiveRuntimeSubjects(database, {
+        limit: 10,
+        now: Number.MAX_SAFE_INTEGER,
+      }),
+    ).resolves.toEqual([]);
   });
 
   test("resumes a stale destroy phase using the recorded operation id", async () => {
@@ -292,6 +404,16 @@ describe("runtime subject recycle", () => {
   test("keeps backup failures as stale repair candidates", async () => {
     const database = createRuntimeSubjectRecycleDatabase();
     let backupAvailable = false;
+    const lifecycleCalls: string[] = [];
+    await database
+      .prepare(
+        `
+          INSERT INTO sandbox_session (cwd, sandbox_id, session_id, status, updated_at)
+          VALUES (?, ?, ?, ?, ?)
+        `,
+      )
+      .bind("/workspace/se/session-1", SANDBOX_ID, "01J0000000000000000000000S", "active", 1)
+      .run();
     currentSandbox = {
       ...createSandboxHandle(),
       createBackup: async (options) => {
@@ -302,8 +424,14 @@ describe("runtime subject recycle", () => {
 
         return {
           dir: options.dir,
-          id: BACKUP_ID,
+          id: CLOUDFLARE_BACKUP_ID,
         };
+      },
+      destroy: async () => {
+        lifecycleCalls.push("destroy");
+      },
+      setKeepAlive: async (keepAlive) => {
+        lifecycleCalls.push(`keepAlive:${keepAlive}`);
       },
     };
 
@@ -327,6 +455,13 @@ describe("runtime subject recycle", () => {
       status_operation_id: operationId,
     });
     expect(failedSubject.last_error).toContain("checkpoint failed");
+    expect(lifecycleCalls).toEqual([]);
+    await expect(
+      database
+        .prepare("SELECT status FROM sandbox_session WHERE session_id = ?")
+        .bind("01J0000000000000000000000S")
+        .first("status"),
+    ).resolves.toBe("active");
     await expect(
       listStaleRuntimeSubjectOperations(database, {
         limit: 10,
@@ -358,6 +493,7 @@ describe("runtime subject recycle", () => {
       status: "cold",
       status_operation_id: operationId,
     });
+    expect(lifecycleCalls).toEqual(["keepAlive:false", "destroy"]);
   });
 
   test("keeps destroy failures as stale repair candidates with the recorded backup", async () => {
@@ -368,7 +504,7 @@ describe("runtime subject recycle", () => {
       createBackup: async (options) => {
         return {
           dir: options.dir,
-          id: BACKUP_ID,
+          id: CLOUDFLARE_BACKUP_ID,
         };
       },
       destroy: async () => {

--- a/apps/api/tests/runtime-subject-run-lease.test.ts
+++ b/apps/api/tests/runtime-subject-run-lease.test.ts
@@ -155,6 +155,30 @@ describe("runtime subject run lease store", () => {
     expect(sandbox?.inactive_deadline_at).toBeNull();
   });
 
+  test("arms the pet idle deadline after the final run while its conversation stays active", async () => {
+    const database = createRuntimeSubjectLeaseDatabase();
+    database.execute(`UPDATE sandbox SET kind = 'pet' WHERE id = '${SANDBOX_ID}'`);
+
+    await recordRuntimeRunLeaseAcquired(database, {
+      ...leaseInput(),
+    });
+    const releasedAfter = Date.now();
+    await expect(
+      recordRuntimeRunLeaseReleased(database, {
+        driverInstanceId: DRIVER_INSTANCE_ID,
+        expectedSessionRunId: SESSION_RUN_ID,
+      }),
+    ).resolves.toBe(true);
+
+    const deadline = await database
+      .prepare("SELECT inactive_deadline_at FROM sandbox WHERE id = ?")
+      .bind(SANDBOX_ID)
+      .first<number>("inactive_deadline_at");
+
+    expect(deadline).toBeGreaterThanOrEqual(releasedAfter + 5 * 60_000);
+    expect(deadline).toBeLessThanOrEqual(Date.now() + 5 * 60_000);
+  });
+
   test("keeps terminal run history after lease release", async () => {
     const database = createRuntimeSubjectLeaseDatabase();
 

--- a/apps/api/tests/sandbox-backup-id.test.ts
+++ b/apps/api/tests/sandbox-backup-id.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { isPlatformId } from "@mosoo/id";
+
+import {
+  decodeSandboxBackupIdForPlatform,
+  encodeSandboxBackupIdForStorage,
+} from "../src/modules/runtime/infrastructure/sandbox-backup-id";
+
+describe("sandbox backup id", () => {
+  test("round-trips Cloudflare UUID v4 handles through the existing D1 id shape", () => {
+    const cloudflareId = "550e8400-e29b-41d4-a716-446655440000";
+    const storedId = encodeSandboxBackupIdForStorage(cloudflareId);
+
+    expect(isPlatformId(storedId)).toBe(true);
+    expect(storedId).toBe("7NAGX100WADHTJE5J4CSAM8000");
+    expect(decodeSandboxBackupIdForPlatform(storedId)).toBe(cloudflareId);
+    expect(decodeSandboxBackupIdForPlatform("01J0000000000000000000000V")).toBe(
+      "01J0000000000000000000000V",
+    );
+  });
+});

--- a/apps/api/tests/sandbox-conversation-session.test.ts
+++ b/apps/api/tests/sandbox-conversation-session.test.ts
@@ -4,6 +4,7 @@ import type { AgentKind } from "@mosoo/contracts/agent";
 import type { SandboxSessionStatus } from "@mosoo/contracts/sandbox";
 import { isPlatformId } from "@mosoo/id";
 
+import { encodeSandboxBackupIdForStorage } from "../src/modules/runtime/infrastructure/sandbox-backup-id";
 import type {
   ExecutionSessionHandle,
   RuntimeCommandResultHandle,
@@ -27,6 +28,8 @@ const ORIGIN = {
   executionOwnerUserId: "01J00000000000000000000001",
   type: "agent",
 } as const;
+const CLOUDFLARE_BACKUP_ID = "550e8400-e29b-41d4-a716-446655440000";
+const STORED_BACKUP_ID = encodeSandboxBackupIdForStorage(CLOUDFLARE_BACKUP_ID);
 
 function commandResult(): RuntimeCommandResultHandle {
   return {
@@ -46,13 +49,14 @@ function failedCommandResult(): RuntimeCommandResultHandle {
   };
 }
 
-function createConversationSessionDatabase(): SqliteD1Database {
+function createConversationSessionDatabase(kind: AgentKind = "pet"): SqliteD1Database {
   const database = new SqliteD1Database();
 
   database.execute(`
     CREATE TABLE sandbox (
       id text PRIMARY KEY NOT NULL,
       inactive_deadline_at integer,
+      kind text NOT NULL,
       status text DEFAULT 'active' NOT NULL,
       status_changed_at integer DEFAULT 0 NOT NULL,
       status_event text DEFAULT 'runtime_subject.active' NOT NULL,
@@ -83,8 +87,8 @@ function createConversationSessionDatabase(): SqliteD1Database {
   `);
 
   database.execute(`
-    INSERT INTO sandbox (id, inactive_deadline_at, updated_at)
-    VALUES ('01J0000000000000000000000D', NULL, 1);
+    INSERT INTO sandbox (id, inactive_deadline_at, kind, updated_at)
+    VALUES ('01J0000000000000000000000D', 123, '${kind}', 1);
   `);
 
   return database;
@@ -139,13 +143,7 @@ async function insertConversationBackup(database: D1Database): Promise<void> {
         VALUES (?, ?, ?, ?, ?)
       `,
     )
-    .bind(
-      1,
-      "/workspace/se/session-1",
-      "01J00000000000000000000002",
-      "01J0000000000000000000000D",
-      "ready",
-    )
+    .bind(1, "/workspace/se/session-1", STORED_BACKUP_ID, "01J0000000000000000000000D", "ready")
     .run();
 }
 
@@ -176,6 +174,13 @@ async function readConversationSession(database: D1Database): Promise<{
   return row;
 }
 
+async function readInactiveDeadline(database: D1Database): Promise<number | null> {
+  return database
+    .prepare("SELECT inactive_deadline_at FROM sandbox WHERE id = ?")
+    .bind("01J0000000000000000000000D")
+    .first<number>("inactive_deadline_at");
+}
+
 function createExecutionSession(options: { cwdHasContent: boolean }): ExecutionSessionHandle {
   return {
     async exec() {
@@ -195,7 +200,12 @@ function createExecutionSession(options: { cwdHasContent: boolean }): ExecutionS
   };
 }
 
-function createSandbox(options: { cwdHasContent?: boolean } = {}): SandboxHandle {
+function createSandbox(
+  options: {
+    cwdHasContent?: boolean;
+    onRestore?: (backup: { readonly dir: string; readonly id: string }) => void;
+  } = {},
+): SandboxHandle {
   const executionSession = createExecutionSession({
     cwdHasContent: options.cwdHasContent ?? true,
   });
@@ -217,6 +227,7 @@ function createSandbox(options: { cwdHasContent?: boolean } = {}): SandboxHandle
     },
     async mountBucket() {},
     async restoreBackup(backup) {
+      options.onRestore?.(backup);
       return backup;
     },
     async setKeepAlive() {},
@@ -261,6 +272,7 @@ describe("ensureSandboxConversationSession", () => {
       cwd: "/workspace/se/session-1",
       status: "active",
     });
+    await expect(readInactiveDeadline(database)).resolves.toBe(123);
   });
 
   test("creates a missing conversation session record", async () => {
@@ -281,7 +293,7 @@ describe("ensureSandboxConversationSession", () => {
   });
 
   test("continues a closed cattle session with a new execution session id", async () => {
-    const database = createConversationSessionDatabase();
+    const database = createConversationSessionDatabase("cattle");
     await insertConversationSession(database, { status: "closed" });
     const sandbox = createSandbox();
 
@@ -297,13 +309,20 @@ describe("ensureSandboxConversationSession", () => {
       cloudflare_session_id: result.sandboxSessionId,
       status: "active",
     });
+    await expect(readInactiveDeadline(database)).resolves.toBeNull();
   });
 
   test("continues a closed pet session through the stable restore path", async () => {
     const database = createConversationSessionDatabase();
     await insertConversationSession(database, { status: "closed" });
     await insertConversationBackup(database);
-    const sandbox = createSandbox({ cwdHasContent: false });
+    let restoredBackup: { readonly dir: string; readonly id: string } | null = null;
+    const sandbox = createSandbox({
+      cwdHasContent: false,
+      onRestore: (backup) => {
+        restoredBackup = backup;
+      },
+    });
 
     const result = await ensureSandboxConversationSession(
       createBindings(database),
@@ -311,6 +330,10 @@ describe("ensureSandboxConversationSession", () => {
     );
 
     expect(result.sandboxSessionId).toBe("01J00000000000000000000001");
+    expect(restoredBackup).toEqual({
+      dir: "/workspace/se/session-1",
+      id: CLOUDFLARE_BACKUP_ID,
+    });
     await expect(readConversationSession(database)).resolves.toMatchObject({
       cloudflare_session_id: "01J00000000000000000000001",
       status: "active",

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -196,7 +196,7 @@ class_name = "Sandbox"
 [[env.prod.containers]]
 class_name = "Sandbox"
 image = "../driver/Containerfile"
-instance_type = "standard-1"
+instance_type = "basic"
 max_instances = 1000
 
 [[env.prod.r2_buckets]]

--- a/pkgs/observability/src/metadata/log-metadata.ts
+++ b/pkgs/observability/src/metadata/log-metadata.ts
@@ -11,7 +11,10 @@ type NormalizedLogArray = readonly NormalizedLogValue[];
 type NormalizedLogValue = NormalizedLogArray | NormalizedLogRecord | PrimitiveLogValue;
 
 const CIRCULAR_REFERENCE_LABEL = "[Circular]";
+const ERROR_CAUSE_DEPTH_LIMIT = 5;
+const ERROR_CAUSE_DEPTH_LIMIT_LABEL = "[Cause depth limit]";
 const FUNCTION_VALUE_LABEL = "[Function]";
+const NON_ERROR_CAUSE_LABEL = "[Non-Error cause]";
 const SERIALIZATION_FAILURE_LABEL = "[Unserializable]";
 
 function formatSymbolValue(value: symbol): string {
@@ -20,6 +23,34 @@ function formatSymbolValue(value: symbol): string {
 
 function formatFunctionName(name: string): string {
   return name.length > 0 ? `[Function ${name}]` : FUNCTION_VALUE_LABEL;
+}
+
+function normalizeError(
+  error: Error,
+  seenObjects: WeakSet<object>,
+  causeDepth: number,
+): NormalizedLogValue {
+  if (seenObjects.has(error)) {
+    return CIRCULAR_REFERENCE_LABEL;
+  }
+
+  seenObjects.add(error);
+  const cause =
+    error.cause === undefined
+      ? undefined
+      : causeDepth >= ERROR_CAUSE_DEPTH_LIMIT
+        ? ERROR_CAUSE_DEPTH_LIMIT_LABEL
+        : error.cause instanceof Error
+          ? normalizeError(error.cause, seenObjects, causeDepth + 1)
+          : NON_ERROR_CAUSE_LABEL;
+  seenObjects.delete(error);
+
+  return {
+    ...(cause === undefined ? {} : { cause }),
+    message: error.message,
+    name: error.name,
+    stack: error.stack ?? null,
+  };
 }
 
 function normalizeValue(
@@ -52,11 +83,7 @@ function normalizeValue(
   }
 
   if (value instanceof Error) {
-    return {
-      message: value.message,
-      name: value.name,
-      stack: value.stack ?? null,
-    };
+    return normalizeError(value, seenObjects, 0);
   }
 
   if (Array.isArray(value)) {


### PR DESCRIPTION
## Summary

- Hibernate idle Pet subjects after the existing five-minute grace instead of keeping their physical Sandbox resident forever.
- Preserve the logical `agent:{agentId}` subject across Sessions: checkpoint memory plus eligible Session workspaces, close runtime conversations/drivers, destroy the Sandbox, mark the subject cold, then restore on the next Run.
- Adapt Cloudflare Sandbox SDK 0.12.3 UUID backup handles to the existing D1 ULID-shaped storage contract, and retain safe nested checkpoint causes in structured logs.
- Keep production Sandbox sizing at the currently deployed `basic` / 0.25 vCPU; this PR intentionally does not deploy the unrelated standard-1 change.

## Why

Pet conversations remain active after a Run, while lease release previously armed `inactive_deadline_at` only when no active conversation existed. The idle conversation sweep intentionally handles Cattle only, and the platform obtains/prepares Sandboxes with keep-alive enabled. The combined result is a normal IDLE Pet conversation with no deadline and a permanently running physical Sandbox.

Production read-only evidence before the fix: 11 running Pet Sandboxes, all with zero active Runs and zero live drivers; six active subjects held 17 active conversations (16 IDLE, one TERMINATED), four subjects were stuck in `backing_up`, and one D1-cold subject still had a running physical instance.

The first isolated staging checkpoint also exposed a second concrete mismatch: SDK 0.12.3 returns UUID backup handles, while the existing D1 backup ID column admits 26-character ULID-shaped values. The reversible boundary adapter fixes that mismatch without a schema change. Checkpoint failure still preserves the container and data for repair; it never force-destroys them.

Refs #387

## Verification

- Commands:
  - `TMPDIR=/private/tmp just check` — pass after rebasing onto current `origin/main`; 1,076 tests, 0 failures, plus formatting, docs, lint, all package typechecks, and GraphQL generated-output guard.
  - `just commit-check` — pass for the single Conventional Commit.
  - Focused runtime/backup/logging suites — 35 tests, 0 failures.
- Manual steps:
  - Unique isolated Cloudflare staging: `phib-20260729115849-d7d39ecd`; no production or shared perf resources.
  - Worker version `56da49e3-380b-4bbc-b2b9-49bcf55aa3b4`; Sandbox app `a0356997-3e28-4735-8612-f8c744337ab2`; `basic`, 0.25 vCPU, 1 GiB RAM, 4 GB disk, Firecracker, SDK/image 0.12.3.
  - First Run `01KYPZ1YNSEBXA5YE55GBJ2K3H`: API enqueue→dispatch 2.3s, ACP capabilities 19.8s, commands 26.8s, driver ready 26.9s, first response 46.9s, terminal event 60.5s.
  - Second Run on the same Thread `01KYPZ40G82JK2CWA58S22B6B5`: API accepted in 731ms and completed about 15.0s later; memory and Session markers remained readable and were extended.
  - After a real five-minute grace plus cron margin: memory and eligible Session workspace backups became ready, subject became cold, conversation closed, and exact Sandbox instance became inactive.
  - Follow-up Run `01KYPZHB2YSMVFE7JF0B8ABYQX` restored both markers and native resume state. A second real grace produced another successful hibernation with no permanent running instance.
- Not run:
  - No GraphQL codegen command was required because there is no GraphQL change; the generated-output guard ran in `just check`.
  - No DB generation or migration was run because there is no schema change.

## Impact

- User/API/contract changes: Pet agents retain logical continuity while releasing physical Sandbox capacity after idle grace. No public API contract change.
- Generated files / GraphQL / DB / lockfile: none.
- Env or config changes: production instance type is explicitly kept at `basic`; no new variables, secrets, dependencies, or image version.
- Risk and rollback: new Run acquisition wins the atomic subject claim and cancels collection. Checkpoint failure keeps keep-alive/data intact and leaves a repairable operation. Roll back the Worker to the pre-deploy version if production verification fails.

## Review

- Closest review areas: Pet lease/deadline claim semantics, checkpoint backup-handle adapter, restore path, nested error redaction.
- Known trade-offs: existing leaked Pet subjects with no deadline require one safe checkpoint/recycle operation after deploy; checkpoint failures must remain preserved for diagnosis rather than force-destroyed.
