### PR TITLE
feat(web): add two-lane App Overview onboarding

### DIFF
--- a/apps/web/src/routes/app-overview/app-overview-install.tsx
+++ b/apps/web/src/routes/app-overview/app-overview-install.tsx
@@ -1,29 +1,64 @@
-import { Check, KeyRound } from "lucide-react";
+import { MousePointerClick, SquareTerminal } from "lucide-react";
 import type { ReactElement } from "react";
 import { useState } from "react";
-import { Link } from "react-router-dom";
 
+import { cn } from "@/shared/lib/class-names";
 import { writeClipboardText } from "@/shared/lib/clipboard";
-import { RuntimeIcon } from "@/shared/ui/brand-icons";
 import { Button } from "@/shared/ui/button";
 import { CopyCheckIcon } from "@/shared/ui/copy-check-icon";
 
-const INSTALL_COMMAND = "curl -fsSL https://install.mosoo.ai/install.sh | bash";
-const API_TOKENS_PATH = "/settings/access-tokens";
-const READY_STEPS = [
-  "Installs mosoo CLI",
-  "Installs the @mosoo skill",
-  "Signs in to cloud and runs doctor",
-] as const;
-const CODING_AGENT_HARNESSES = [
-  { label: "Codex", runtimeId: "codex" },
-  { label: "Claude Code", runtimeId: "claude-code" },
-  { label: "OpenCode", runtimeId: "opencode" },
-  { label: "Cursor", runtimeId: "cursor" },
-  { label: "Cline", runtimeId: "cline" },
-] as const;
+import { INSTALL_COMMAND } from "./onboarding-setup-prompt";
+import { DocsAction, OnboardingActions, OnboardingSteps } from "./onboarding-steps";
 
-export function AppOverviewInstallGuide(): ReactElement {
+type SetupLane = "cli" | "console";
+
+const SETUP_LANE_STORAGE_KEY = "mosoo_overview_setup_lane";
+
+function readStoredSetupLane(): SetupLane | null {
+  try {
+    const value = globalThis.localStorage.getItem(SETUP_LANE_STORAGE_KEY);
+    return value === "cli" || value === "console" ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function storeSetupLane(lane: SetupLane): void {
+  try {
+    globalThis.localStorage.setItem(SETUP_LANE_STORAGE_KEY, lane);
+  } catch {
+    // Storage can be unavailable in restricted browser contexts.
+  }
+}
+
+function SetupLaneTab({
+  active,
+  icon,
+  label,
+  onSelect,
+}: {
+  active: boolean;
+  icon: ReactElement;
+  label: string;
+  onSelect: () => void;
+}): ReactElement {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onSelect}
+      className={cn(
+        "flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold transition-colors",
+        active ? "bg-card text-fg-1 shadow-xs" : "text-fg-3 hover:text-fg-2",
+      )}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function CodingAgentLane(): ReactElement {
   const [copied, setCopied] = useState(false);
   const [copyFailed, setCopyFailed] = useState(false);
 
@@ -44,83 +79,108 @@ export function AppOverviewInstallGuide(): ReactElement {
   }
 
   return (
+    <>
+      <div className="border-border bg-bg-sunken mt-7 flex w-full flex-col items-stretch gap-3 rounded-lg border px-4 py-3 sm:flex-row sm:items-center">
+        <code className="text-fg-1 min-w-0 flex-1 truncate text-left font-mono text-[13px] sm:text-base">
+          <span className="text-fg-3 select-none">$ </span>
+          {INSTALL_COMMAND}
+        </code>
+        <Button
+          onClick={() => {
+            void copyInstallCommand();
+          }}
+          className="w-full bg-[rgb(111_211_4)] text-black hover:bg-[rgb(111_211_4)] sm:w-auto"
+          size="default"
+          variant="accent"
+        >
+          <CopyCheckIcon copied={copied} />
+          {copied ? "Copied" : "Copy"}
+        </Button>
+      </div>
+
+      {copyFailed ? (
+        <div className="mt-2 w-full text-left">
+          <input
+            aria-label="mosoo install command"
+            readOnly
+            value={INSTALL_COMMAND}
+            onFocus={(event) => {
+              event.currentTarget.select();
+            }}
+            className="border-border bg-bg-sunken text-fg-1 w-full rounded-md border px-3 py-2 font-mono text-xs"
+          />
+          <p className="text-fg-3 mt-1 text-xs">Copy failed. Select and copy the command above.</p>
+        </div>
+      ) : null}
+
+      <p className="text-fg-3 mt-3 max-w-2xl text-[13px] leading-5">
+        One command installs the mosoo CLI and the @mosoo skill, signs in to try.mosoo.ai, and
+        checks cloud readiness. Sign-in creates your API token automatically; you will be asked for
+        a provider key before sessions can run.
+      </p>
+
+      <OnboardingActions />
+    </>
+  );
+}
+
+function ConsoleLane(): ReactElement {
+  return (
+    <>
+      <OnboardingSteps />
+      <div className="mt-3 w-full">
+        <DocsAction />
+      </div>
+    </>
+  );
+}
+
+/**
+ * The pre-deploy Overview hero, split into two explicit setup lanes: "In your
+ * coding agent" (install command, auto-minted CLI token, copyable setup
+ * prompt) and "In the console" (the three-step checklist). Both lanes read
+ * the same account state, so progress counts once wherever a step happens.
+ * The last chosen lane is remembered locally; first visits land on the
+ * coding-agent lane.
+ */
+export function AppOverviewInstallGuide(): ReactElement {
+  const [lane, setLane] = useState<SetupLane>(() => readStoredSetupLane() ?? "cli");
+
+  function selectLane(nextLane: SetupLane): void {
+    setLane(nextLane);
+    storeSetupLane(nextLane);
+  }
+
+  return (
     <section className="py-8 sm:py-10">
       <div className="mx-auto flex max-w-3xl flex-col items-center text-center">
         <h2 className="text-foreground text-3xl font-semibold tracking-tight sm:text-4xl">
-          Build agent app with <span className="text-[rgb(111_211_4)]">mosoo</span> in your coding
-          agent
+          Build agent app with <span className="text-[rgb(111_211_4)]">mosoo</span>
         </h2>
         <p className="text-muted-foreground mt-3 max-w-2xl text-base leading-7">
-          One command installs mosoo CLI and the @mosoo skill, signs in to try.mosoo.ai, and checks
-          cloud readiness.
+          Pick how you want to set up. Progress counts the same either way.
         </p>
 
-        <div className="border-border bg-bg-sunken mt-8 flex w-full flex-col items-stretch gap-3 rounded-lg border px-4 py-3 sm:flex-row sm:items-center">
-          <code className="text-fg-1 min-w-0 flex-1 truncate text-left font-mono text-[13px] sm:text-base">
-            <span className="text-fg-3 select-none">$ </span>
-            {INSTALL_COMMAND}
-          </code>
-          <Button
-            onClick={() => {
-              void copyInstallCommand();
+        <div className="border-border bg-bg-sunken mt-7 inline-flex rounded-lg border p-1">
+          <SetupLaneTab
+            active={lane === "cli"}
+            icon={<SquareTerminal className="size-4" />}
+            label="In your coding agent"
+            onSelect={() => {
+              selectLane("cli");
             }}
-            className="w-full bg-[rgb(111_211_4)] text-black hover:bg-[rgb(111_211_4)] sm:w-auto"
-            size="default"
-            variant="accent"
-          >
-            <CopyCheckIcon copied={copied} />
-            {copied ? "Copied" : "Copy"}
-          </Button>
+          />
+          <SetupLaneTab
+            active={lane === "console"}
+            icon={<MousePointerClick className="size-4" />}
+            label="In the console"
+            onSelect={() => {
+              selectLane("console");
+            }}
+          />
         </div>
 
-        {copyFailed ? (
-          <div className="mt-2 w-full text-left">
-            <input
-              aria-label="mosoo install command"
-              readOnly
-              value={INSTALL_COMMAND}
-              onFocus={(event) => {
-                event.currentTarget.select();
-              }}
-              className="border-border bg-bg-sunken text-fg-1 w-full rounded-md border px-3 py-2 font-mono text-xs"
-            />
-            <p className="text-fg-3 mt-1 text-xs">
-              Copy failed. Select and copy the command above.
-            </p>
-          </div>
-        ) : null}
-
-        <div className="text-fg-2 mt-7 grid w-full max-w-3xl grid-cols-1 gap-3 text-sm leading-6 font-medium sm:grid-cols-3 sm:gap-4 sm:text-base">
-          {READY_STEPS.map((label) => (
-            <span className="inline-flex min-w-0 items-center justify-center gap-2" key={label}>
-              <Check className="size-4 shrink-0 text-green-600" />
-              {label}
-            </span>
-          ))}
-        </div>
-
-        <Button asChild className="mt-6" size="default" variant="outline">
-          <Link to={API_TOKENS_PATH}>
-            <KeyRound className="size-4" />
-            Create API token
-          </Link>
-        </Button>
-
-        <div
-          aria-label="Supported coding agent harnesses"
-          className="mt-8 flex w-full max-w-2xl flex-wrap items-center justify-center gap-3"
-        >
-          {CODING_AGENT_HARNESSES.map((harness) => (
-            <span
-              className="border-border bg-card inline-flex size-12 items-center justify-center rounded-md border shadow-xs"
-              key={harness.runtimeId}
-              title={harness.label}
-            >
-              <RuntimeIcon className="size-7" runtimeId={harness.runtimeId} />
-              <span className="sr-only">{harness.label}</span>
-            </span>
-          ))}
-        </div>
+        {lane === "cli" ? <CodingAgentLane /> : <ConsoleLane />}
       </div>
     </section>
   );

--- a/apps/web/src/routes/app-overview/onboarding-setup-prompt.ts
+++ b/apps/web/src/routes/app-overview/onboarding-setup-prompt.ts
@@ -1,0 +1,80 @@
+import { MOSOO_CONSOLE_ORIGIN } from "@mosoo/contracts/origin";
+
+import { HELP_DOCS_BASE_URL } from "@/shared/config/help-docs";
+
+export const INSTALL_COMMAND = "curl -fsSL https://install.mosoo.ai/install.sh | bash";
+
+function currentOrigin(): string {
+  return globalThis.window !== undefined ? globalThis.location.origin : MOSOO_CONSOLE_ORIGIN;
+}
+
+/**
+ * Copy-ready onboarding instruction for any coding agent (Codex, Claude Code,
+ * OpenCode, Cursor, Cline, and others). It mirrors the console checklist on
+ * the App Overview: install and sign in, provider key, API token, first agent
+ * and session. The provider key is the one value an agent cannot mint itself,
+ * so the prompt tells the agent to ask the user for it; CLI sign-in creates
+ * its own token through the browser login callback.
+ */
+export function buildOnboardingSetupPrompt(origin: string = currentOrigin()): string {
+  return `# Set up mosoo
+
+Use this instruction with any coding agent. You are helping the user finish
+onboarding to mosoo, an open-source agent runtime: configure an Agent, publish
+it, and call it through the Thread API. Work through the steps in order and
+skip any step that is already done. Ask the user for values only they know.
+Never print or commit secrets.
+
+## Generated variables
+
+\`\`\`text
+MOSOO_CONSOLE_URL=${origin}
+MOSOO_DOCS_URL=${HELP_DOCS_BASE_URL}
+\`\`\`
+
+## 1. Install the mosoo CLI and sign in
+
+\`\`\`bash
+${INSTALL_COMMAND}
+\`\`\`
+
+The installer adds the mosoo CLI and the @mosoo skill, then opens a browser
+sign-in and checks cloud readiness (doctor). The login callback authorizes the
+CLI and creates a personal API token for it automatically. If no browser can
+open, show the user the sign-in URL printed in the terminal and wait for them
+to finish it.
+
+## 2. Add a provider key (required before runs)
+
+Session runs need a model provider credential, for example OpenAI or
+Anthropic. This is the one step you cannot complete alone: ask the user which
+provider they want and have them add the key at MOSOO_CONSOLE_URL/providers.
+Do not start the first run until a provider key is configured.
+
+## 3. Create an API token (optional)
+
+The CLI sign-in from step 1 already covers CLI usage. If this project calls
+the Thread API from a backend or script, create a token at
+MOSOO_CONSOLE_URL/settings/access-tokens and store it in the project
+environment as MOSOO_API_TOKEN. Keep it out of source control.
+
+## 4. Create an agent and run a session
+
+Create an agent at MOSOO_CONSOLE_URL/agent?create=1, then start a first
+session from the agent page or MOSOO_CONSOLE_URL/threads?compose=1. The API
+flow (create a thread, stream events, continue runs) is documented at
+MOSOO_DOCS_URL/coding-agents and MOSOO_DOCS_URL/api-reference.
+
+## 5. Deploy an App (optional)
+
+The App Overview at MOSOO_CONSOLE_URL/ can deploy an App from a public GitHub
+repo and bind published agents to it.
+
+## Done when
+
+- The CLI is signed in and doctor reports the cloud is reachable.
+- A provider key is configured for the active App.
+- An agent exists and at least one Thread run has started under
+  MOSOO_CONSOLE_URL/threads.
+`;
+}

--- a/apps/web/src/routes/app-overview/onboarding-steps.tsx
+++ b/apps/web/src/routes/app-overview/onboarding-steps.tsx
@@ -1,0 +1,212 @@
+import { ArrowUpRight, Check, ChevronRight } from "lucide-react";
+import type { ReactElement } from "react";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+import { useAppSession } from "@/app/session-provider";
+import { HELP_DOCS_HOME_URL } from "@/shared/config/help-docs";
+import { writeClipboardText } from "@/shared/lib/clipboard";
+import { Badge } from "@/shared/ui/badge";
+import { RuntimeIcon } from "@/shared/ui/brand-icons";
+import { CopyCheckIcon } from "@/shared/ui/copy-check-icon";
+
+import { buildOnboardingSetupPrompt } from "./onboarding-setup-prompt";
+import { useOnboardingProgress } from "./use-onboarding-progress";
+
+const CODING_AGENT_HARNESSES = [
+  { label: "Codex", runtimeId: "codex" },
+  { label: "Claude Code", runtimeId: "claude-code" },
+  { label: "OpenCode", runtimeId: "opencode" },
+  { label: "Cursor", runtimeId: "cursor" },
+  { label: "Cline", runtimeId: "cline" },
+] as const;
+
+interface OnboardingStepView {
+  done: boolean;
+  label: string;
+  number: number;
+  optional: boolean;
+  to: string;
+}
+
+function StepMarker({ done, number }: { done: boolean; number: number }): ReactElement {
+  if (done) {
+    return (
+      <span className="text-on-accent flex size-6 shrink-0 items-center justify-center rounded-full bg-green-500">
+        <Check className="size-3.5" strokeWidth={3} />
+        <span className="sr-only">Done:</span>
+      </span>
+    );
+  }
+
+  return (
+    <span className="border-border-strong bg-bg-sunken text-fg-2 flex size-6 shrink-0 items-center justify-center rounded-full border text-xs font-semibold">
+      {number}
+    </span>
+  );
+}
+
+function StepRow({ step }: { step: OnboardingStepView }): ReactElement {
+  return (
+    <Link
+      className="group hover:bg-paper-100 flex items-center gap-3 px-4 py-3.5 transition-colors"
+      to={step.to}
+    >
+      <StepMarker done={step.done} number={step.number} />
+      <span className="text-fg-1 min-w-0 flex-1 truncate text-left text-sm leading-6 font-medium sm:text-base">
+        {step.label}
+      </span>
+      {step.optional ? <Badge variant="outline">Optional</Badge> : null}
+      <ChevronRight className="text-fg-3 size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
+    </Link>
+  );
+}
+
+/**
+ * The three-step onboarding checklist on the App Overview. Every step opens
+ * the matching console page, and completion is read from account state, so
+ * the same checkmarks light up whether a step was finished here in the
+ * console or by the CLI (browser sign-in mints the CLI token, a coding agent
+ * can do the rest). Step 3 retargets to composing a Thread once an agent
+ * exists.
+ */
+export function OnboardingSteps(): ReactElement {
+  const { activeAppId } = useAppSession();
+  const progress = useOnboardingProgress(activeAppId);
+
+  const steps: OnboardingStepView[] = [
+    {
+      done: progress.hasProviderKey === true,
+      label: "Add a provider key",
+      number: 1,
+      optional: false,
+      to: "/providers",
+    },
+    {
+      done: progress.hasApiToken === true,
+      label: "Create an API token",
+      number: 2,
+      optional: true,
+      to: "/settings/access-tokens",
+    },
+    {
+      done: progress.hasAgent === true && progress.hasRunThread === true,
+      label: "Create an agent and run a session",
+      number: 3,
+      optional: false,
+      to: progress.hasAgent === true ? "/threads?compose=1" : "/agent?create=1",
+    },
+  ];
+
+  return (
+    <nav
+      aria-label="Onboarding steps"
+      className="border-border bg-card divide-border mt-8 w-full divide-y overflow-hidden rounded-lg border text-left shadow-xs"
+    >
+      {steps.map((step) => (
+        <StepRow key={step.number} step={step} />
+      ))}
+    </nav>
+  );
+}
+
+/** Link row into the hosted docs, shared by both setup lanes. */
+export function DocsAction(): ReactElement {
+  return (
+    <a
+      className="group border-border bg-card hover:bg-paper-100 flex w-full items-center gap-4 rounded-lg border px-4 py-3.5 text-left transition-colors"
+      href={HELP_DOCS_HOME_URL}
+      rel="noreferrer"
+      target="_blank"
+    >
+      <div className="min-w-0 flex-1">
+        <span className="text-fg-1 text-sm leading-6 font-semibold sm:text-base">
+          Read the docs
+        </span>
+        <p className="text-fg-3 mt-0.5 text-[13px] leading-5">
+          Quickstart, Thread API, and CLI reference.
+        </p>
+      </div>
+      <ArrowUpRight className="text-fg-2 size-4 shrink-0 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+    </a>
+  );
+}
+
+/**
+ * The follow-up actions of the coding-agent lane: copy a setup prompt that
+ * lets any coding agent finish mosoo setup, or read the docs.
+ */
+export function OnboardingActions(): ReactElement {
+  const [copied, setCopied] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
+
+  async function copySetupPrompt(): Promise<void> {
+    setCopyFailed(false);
+
+    const didCopy = await writeClipboardText(buildOnboardingSetupPrompt());
+
+    if (!didCopy) {
+      setCopyFailed(true);
+      return;
+    }
+
+    setCopied(true);
+    globalThis.setTimeout(() => {
+      setCopied(false);
+    }, 1500);
+  }
+
+  return (
+    <div className="mt-3 flex w-full flex-col gap-3">
+      <button
+        className="group border-border bg-card hover:bg-paper-100 flex w-full items-center gap-4 rounded-lg border px-4 py-3.5 text-left transition-colors"
+        onClick={() => {
+          void copySetupPrompt();
+        }}
+        type="button"
+      >
+        <div className="min-w-0 flex-1">
+          <span className="text-fg-1 text-sm leading-6 font-semibold sm:text-base">
+            {copied ? "Setup prompt copied" : "Set up with your coding agent"}
+          </span>
+          <p className="text-fg-3 mt-0.5 text-[13px] leading-5">
+            Copies a setup prompt that walks any coding agent through the full setup.
+          </p>
+        </div>
+        <span
+          aria-label="Supported coding agent harnesses"
+          className="hidden items-center gap-1.5 sm:flex"
+        >
+          {CODING_AGENT_HARNESSES.map((harness) => (
+            <span
+              className="border-border bg-bg-sunken inline-flex size-7 items-center justify-center rounded-md border"
+              key={harness.runtimeId}
+              title={harness.label}
+            >
+              <RuntimeIcon className="size-4.5" runtimeId={harness.runtimeId} />
+              <span className="sr-only">{harness.label}</span>
+            </span>
+          ))}
+        </span>
+        <CopyCheckIcon className="text-fg-2 size-4 shrink-0" copied={copied} />
+      </button>
+
+      {copyFailed ? (
+        <div className="w-full text-left">
+          <textarea
+            aria-label="mosoo setup prompt"
+            className="border-border bg-bg-sunken text-fg-1 h-28 w-full rounded-md border px-3 py-2 font-mono text-xs"
+            onFocus={(event) => {
+              event.currentTarget.select();
+            }}
+            readOnly
+            value={buildOnboardingSetupPrompt()}
+          />
+          <p className="text-fg-3 mt-1 text-xs">Copy failed. Select and copy the prompt above.</p>
+        </div>
+      ) : null}
+
+      <DocsAction />
+    </div>
+  );
+}

--- a/apps/web/src/routes/app-overview/use-onboarding-progress.ts
+++ b/apps/web/src/routes/app-overview/use-onboarding-progress.ts
@@ -1,0 +1,87 @@
+import type { SessionType } from "@mosoo/contracts/session";
+import { useQuery } from "@tanstack/react-query";
+
+import { useVisibleAgentsQuery } from "@/domains/agent/query/agent-queries";
+import { listPersonalAccessTokens } from "@/domains/auth/api/personal-access-token-client";
+import { threadSessions } from "@/domains/session/api/list";
+import { listVendorCredentials } from "@/domains/vendor-credential/api/vendor-credential-client";
+import { toAppId } from "@/routes/typed-id";
+
+export interface OnboardingProgress {
+  /** At least one provider credential exists on the active App. */
+  hasProviderKey: boolean | null;
+  /** At least one non-revoked personal access token exists. */
+  hasApiToken: boolean | null;
+  /** At least one agent is visible on the active App. */
+  hasAgent: boolean | null;
+  /** At least one UI Thread has started a Run on the active App. */
+  hasRunThread: boolean | null;
+}
+
+interface OnboardingThreadState {
+  session: {
+    lastRun: object | null;
+    type: SessionType;
+  };
+}
+
+export function hasRunUiThread(threads: readonly OnboardingThreadState[]): boolean {
+  return threads.some(({ session }) => session.type === "ui" && session.lastRun !== null);
+}
+
+const onboardingKeys = {
+  providerKeys: (appId: string | null) =>
+    ["onboarding-progress", "provider-keys", appId ?? "missing"] as const,
+  sessions: (appId: string | null) =>
+    ["onboarding-progress", "sessions", appId ?? "missing"] as const,
+  tokens: ["onboarding-progress", "access-tokens"] as const,
+};
+
+/**
+ * Completion state for the Overview onboarding checklist. Each flag is `null`
+ * while unknown (loading or failed) so the checklist renders plain step
+ * numbers instead of wrong checkmarks; a read error here must never surface
+ * as a page banner, the steps stay clickable either way.
+ */
+export function useOnboardingProgress(appId: string | null): OnboardingProgress {
+  const providerKeysQuery = useQuery({
+    enabled: appId !== null,
+    queryFn: async () => {
+      if (appId === null) {
+        throw new Error("App id is required to list provider credentials.");
+      }
+
+      return listVendorCredentials(toAppId(appId));
+    },
+    queryKey: onboardingKeys.providerKeys(appId),
+    retry: 1,
+  });
+  const tokensQuery = useQuery({
+    queryFn: listPersonalAccessTokens,
+    queryKey: onboardingKeys.tokens,
+    retry: 1,
+  });
+  const agentsQuery = useVisibleAgentsQuery(appId);
+  const sessionsQuery = useQuery({
+    enabled: appId !== null,
+    queryFn: async () => {
+      if (appId === null) {
+        throw new Error("App id is required to list Thread sessions.");
+      }
+
+      return threadSessions(toAppId(appId), "ui");
+    },
+    queryKey: onboardingKeys.sessions(appId),
+    retry: 1,
+  });
+
+  return {
+    hasAgent: agentsQuery.data === undefined ? null : agentsQuery.data.length > 0,
+    hasApiToken:
+      tokensQuery.data === undefined
+        ? null
+        : tokensQuery.data.tokens.some((token) => token.revokedAt === null),
+    hasProviderKey: providerKeysQuery.data === undefined ? null : providerKeysQuery.data.length > 0,
+    hasRunThread: sessionsQuery.data === undefined ? null : hasRunUiThread(sessionsQuery.data),
+  };
+}

--- a/apps/web/tests/app-overview-boundary.test.ts
+++ b/apps/web/tests/app-overview-boundary.test.ts
@@ -35,6 +35,7 @@ describe("App overview boundary", () => {
     // verbatim by both "/" and the /v0-deploy-preview acceptance route.
     const surfaceSource = readSource("../src/routes/app-overview/deploy/deploy-surface.tsx");
     const installSource = readSource("../src/routes/app-overview/app-overview-install.tsx");
+    const promptSource = readSource("../src/routes/app-overview/onboarding-setup-prompt.ts");
     const appIdBadgeSource = readSource("../src/shared/ui/app-id-badge.tsx");
     const runtimeIconSource = readSource("../src/shared/ui/brand-icons/runtime-icon-data.ts");
 
@@ -45,27 +46,14 @@ describe("App overview boundary", () => {
     expect(installSource).toContain("text-[rgb(111_211_4)]");
     expect(installSource).toContain("bg-[rgb(111_211_4)]");
     expect(installSource).toContain("hover:bg-[rgb(111_211_4)]");
-    expect(installSource).toContain("curl -fsSL https://install.mosoo.ai/install.sh | bash");
-    expect(installSource).toContain("Installs mosoo CLI");
-    expect(installSource).toContain("Installs the @mosoo skill");
-    expect(installSource).toContain("Signs in to cloud and runs doctor");
-    expect(installSource).toContain("try.mosoo.ai");
+    expect(promptSource).toContain("curl -fsSL https://install.mosoo.ai/install.sh | bash");
+    expect(installSource).toContain("installs the mosoo CLI");
     expect(installSource).toContain("@mosoo skill");
+    expect(installSource).toContain("checks cloud readiness");
+    expect(installSource).toContain("try.mosoo.ai");
     expect(installSource).toContain('"Copy"');
-    expect(installSource).toContain("Create API token");
-    expect(installSource).toContain("/settings/access-tokens");
-    expect(installSource).toContain("CODING_AGENT_HARNESSES");
-    expect(installSource).toContain("Supported coding agent harnesses");
-    expect(installSource).toContain("Codex");
-    expect(installSource).toContain("Claude Code");
-    expect(installSource).toContain("OpenCode");
-    expect(installSource).toContain("Cursor");
-    expect(installSource).toContain("Cline");
-    expect(runtimeIconSource).toContain("codex-color.svg");
-    expect(runtimeIconSource).toContain("claudecode-color.svg");
-    expect(runtimeIconSource).toContain("opencode.svg");
-    expect(runtimeIconSource).toContain("cursor.svg");
-    expect(runtimeIconSource).toContain("cline.svg");
+    expect(appIdBadgeSource).toContain("Copy app ID");
+
     expect(installSource).not.toContain("Codex skill");
     expect(installSource).not.toContain("or updates");
     expect(installSource).not.toContain("Start building");
@@ -73,7 +61,6 @@ describe("App overview boundary", () => {
     expect(installSource).not.toContain("App agent");
     expect(installSource).not.toContain("refreshes");
     expect(installSource).not.toContain("Copy command");
-    expect(appIdBadgeSource).toContain("Copy app ID");
     expect(installSource).not.toContain("createPersonalAccessToken");
     expect(installSource).not.toContain("MASKED_TOKEN");
     expect(installSource).not.toContain("Signs the CLI in");
@@ -87,33 +74,104 @@ describe("App overview boundary", () => {
     expect(installSource).not.toContain("Organization");
     expect(installSource).not.toContain("Members");
     expect(installSource).not.toContain("Invite");
+
+    expect(runtimeIconSource).toContain("codex-color.svg");
+    expect(runtimeIconSource).toContain("claudecode-color.svg");
+    expect(runtimeIconSource).toContain("opencode.svg");
+    expect(runtimeIconSource).toContain("cursor.svg");
+    expect(runtimeIconSource).toContain("cline.svg");
+  });
+
+  test("walks onboarding as three clickable steps with two follow-up actions", () => {
+    const routeSource = readSource("../src/routes/app-overview/app-overview.route.tsx");
+    const installSource = readSource("../src/routes/app-overview/app-overview-install.tsx");
+    const stepsSource = readSource("../src/routes/app-overview/onboarding-steps.tsx");
+    const promptSource = readSource("../src/routes/app-overview/onboarding-setup-prompt.ts");
+
+    // The hero splits into two explicit setup lanes: the coding-agent lane
+    // (install command plus follow-up actions) and the console lane (the
+    // checklist). The last chosen lane is remembered locally.
+    expect(installSource).toContain('label="In your coding agent"');
+    expect(installSource).toContain('label="In the console"');
+    expect(installSource).toContain("aria-pressed");
+    expect(installSource).toContain("Pick how you want to set up");
+    expect(installSource).toContain("mosoo_overview_setup_lane");
+    expect(installSource).toContain("OnboardingSteps");
+    expect(installSource).toContain("OnboardingActions");
+    expect(installSource).toContain("DocsAction");
+
+    // Three steps, each a link into the matching console surface. Provider
+    // credentials are required before a Run; API tokens are optional.
+    expect(stepsSource).toContain("Add a provider key");
+    expect(stepsSource).toContain('to: "/providers"');
+    expect(stepsSource).toContain("Optional");
+    expect(stepsSource).toContain("Create an API token");
+    expect(stepsSource).toContain('to: "/settings/access-tokens"');
+    expect(stepsSource).toContain("Create an agent and run a session");
+    expect(stepsSource).toContain("/agent?create=1");
+    expect(stepsSource).toContain("/threads?compose=1");
+
+    // Progress reads stay below the route so failures degrade inside the
+    // checklist instead of becoming an Overview error banner.
+    expect(routeSource).not.toContain("useOnboardingProgress");
+
+    // Follow-up actions: copy a setup prompt for any coding agent, or read
+    // the docs.
+    expect(stepsSource).toContain("Set up with your coding agent");
+    expect(stepsSource).toContain("buildOnboardingSetupPrompt");
+    expect(stepsSource).toContain("DocsAction");
+    expect(stepsSource).toContain("Read the docs");
+    expect(stepsSource).toContain("HELP_DOCS_HOME_URL");
+    expect(stepsSource).toContain("CODING_AGENT_HARNESSES");
+    expect(stepsSource).toContain("Supported coding agent harnesses");
+    expect(stepsSource).toContain("Codex");
+    expect(stepsSource).toContain("Claude Code");
+    expect(stepsSource).toContain("OpenCode");
+    expect(stepsSource).toContain("Cursor");
+    expect(stepsSource).toContain("Cline");
+
+    // The setup prompt mirrors the checklist and keeps the human-owned
+    // provider key as an ask, not something an agent invents.
+    expect(promptSource).toContain("MOSOO_CONSOLE_URL");
+    expect(promptSource).toContain("/providers");
+    expect(promptSource).toContain("/settings/access-tokens");
+    expect(promptSource).toContain("/agent?create=1");
+    expect(promptSource).toContain("ask the user");
+    expect(promptSource).toContain("Never print or commit secrets");
   });
 
   test("keeps the install guide responsive and accessible", () => {
     const surfaceSource = readSource("../src/routes/app-overview/deploy/deploy-surface.tsx");
     const installSource = readSource("../src/routes/app-overview/app-overview-install.tsx");
+    const stepsSource = readSource("../src/routes/app-overview/onboarding-steps.tsx");
 
     expect(surfaceSource).toContain("max-w-4xl");
     expect(surfaceSource).toContain("lg:flex-row");
     expect(installSource).toContain("max-w-3xl");
     expect(installSource).toContain("sm:flex-row");
-    expect(installSource).toContain("text-sm leading-6");
-    expect(installSource).toContain("sm:text-base");
-    expect(installSource).not.toContain("text-xs font-medium sm:grid-cols-3");
+    expect(stepsSource).toContain("text-sm leading-6");
+    expect(stepsSource).toContain("sm:text-base");
+    expect(stepsSource).toContain('aria-label="Onboarding steps"');
     expect(installSource).not.toContain("aria-expanded");
     expect(installSource).not.toContain("aria-controls");
     expect(installSource).not.toContain("Codex, Cursor, Cline");
     expect(installSource).not.toContain("whitespace-pre-wrap");
     expect(installSource).not.toContain("—");
     expect(installSource).not.toContain(" · ");
+    expect(stepsSource).not.toContain("—");
+    expect(stepsSource).not.toContain(" · ");
   });
 
   test("keeps the App console root free of Chinese copy", () => {
     const routeSource = readSource("../src/routes/app-overview/app-overview.route.tsx");
     const installSource = readSource("../src/routes/app-overview/app-overview-install.tsx");
+    const stepsSource = readSource("../src/routes/app-overview/onboarding-steps.tsx");
+    const promptSource = readSource("../src/routes/app-overview/onboarding-setup-prompt.ts");
 
     const cjk = /[一-鿿]/u;
     expect(cjk.test(routeSource)).toBe(false);
     expect(cjk.test(installSource)).toBe(false);
+    expect(cjk.test(stepsSource)).toBe(false);
+    expect(cjk.test(promptSource)).toBe(false);
   });
 });

--- a/apps/web/tests/onboarding-progress.test.ts
+++ b/apps/web/tests/onboarding-progress.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+
+import { hasRunUiThread } from "../src/routes/app-overview/use-onboarding-progress";
+
+describe("App Overview onboarding progress", () => {
+  test("keeps Preview sessions and unrun UI Threads incomplete", () => {
+    expect(
+      hasRunUiThread([
+        { session: { lastRun: {}, type: "preview" } },
+        { session: { lastRun: null, type: "ui" } },
+      ]),
+    ).toBe(false);
+  });
+
+  test("completes after a UI Thread has a Run", () => {
+    expect(hasRunUiThread([{ session: { lastRun: {}, type: "ui" } }])).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Split the pre-deploy App Overview onboarding into explicit coding-agent and console lanes.
- Make the console path match runtime requirements: a provider credential is required, while an API token is optional for external API use.
- Count the run step only after a UI Thread has an actual Run; Preview and unrun Sessions no longer advance progress.
- Preserve the selected lane locally and keep setup actions linked to their owning console pages.

## Verification

- `just tc-package @mosoo/web`
- `just test-package @mosoo/web` (194/194)
- Focused formatting checks
- React Doctor (100/100)
- `just commit-check`
- Full workspace check reaches an existing macOS `/var` versus `/private/var` Driver fixture failure reproduced on clean `main`.

## Impact

- Web-console onboarding behavior only; no API, schema, generated-file, or environment changes.
- Query failures still degrade to actionable numbered steps instead of blocking the overview.
- Revert the squash merge to roll back.