### PR TITLE
feat(web): pace streamed text with a per-frame grapheme budget

### DIFF
--- a/apps/web/src/domains/runtime/session-stream/session-stream-render-scheduler.ts
+++ b/apps/web/src/domains/runtime/session-stream/session-stream-render-scheduler.ts
@@ -1,13 +1,18 @@
+import { isAgUiSessionRunTerminalEvent } from "@mosoo/ag-ui-session";
 import type { AgUiSessionEvent } from "@mosoo/ag-ui-session";
 
 interface QueuedSessionEvent {
   event: AgUiSessionEvent;
+  // Grapheme clusters of a paceable text delta, precomputed at enqueue time so
+  // per-frame budgeting is O(pending items). Null for events pacing ignores.
+  segments: string[] | null;
   sessionId: string;
 }
 
 export interface SessionStreamRenderSchedulerHost {
   cancelFrame: (handle: number) => void;
   cancelTimeout: (handle: number) => void;
+  now: () => number;
   requestFrame: (callback: () => void) => number;
   requestTimeout: (callback: () => void, delayMs: number) => number;
 }
@@ -17,16 +22,109 @@ export type SessionStreamRenderSchedulerApply = (
   events: AgUiSessionEvent[],
 ) => boolean;
 
-// Flood guard only: bounds a single React commit during pathological event
-// storms. Everything queued for the session is otherwise delivered on the
-// next frame — requestAnimationFrame batching is the smoothing; an artificial
-// per-frame character budget just throttles visible streaming.
+// Flood guard: bounds a single React commit during pathological event storms.
 const MAX_EVENTS_PER_FRAME = 512;
 
 // requestAnimationFrame stops firing when the window is hidden, occluded, or
 // battery-throttled. Without a timer fallback the queue silently starves and
 // the transcript freezes while the socket keeps receiving events.
 const THROTTLED_FRAME_FALLBACK_MS = 50;
+
+// The server coalesces stream deltas into ~150ms batches (apps/api
+// session-viewer-event-delivery-buffer.ts), so one websocket message carries
+// hundreds of characters and rendering it in a single frame shows one visible
+// jump per batch. Pacing spreads queued text across frames instead: each frame
+// emits pending * dt / τ graphemes, an exponential drain with time constant τ.
+// With τ ≈ 250ms a 150ms batch is still draining when the next one lands, so
+// batch jumps fuse into continuous flow while on-screen text lags the socket
+// by at most ~τ.
+const PACING_TIME_CONSTANT_MS = 250;
+
+// Rate clamps: never crawl below 20 graphemes/s on a tiny tail, never animate
+// faster than 800 graphemes/s (beyond that it reads as a jump anyway). Both
+// scale with real elapsed time, so 60Hz and 120Hz displays stream at the same
+// visible speed and the timeout fallback keeps the same pace in hidden tabs.
+const MIN_PACED_GRAPHEMES_PER_SECOND = 20;
+const MAX_PACED_GRAPHEMES_PER_SECOND = 800;
+
+// Backpressure valve: a backlog the max rate cannot drain within ~5s means the
+// producer is far ahead of the animation (very fast model, long throttled
+// pause). Deliver it whole rather than showing seconds-stale text.
+const MAX_PENDING_PACED_GRAPHEMES = 4096;
+
+// Split points must land on grapheme boundaries: slicing UTF-16 text at an
+// arbitrary index can cut a surrogate pair or ZWJ emoji in half and render �.
+// Without Intl.Segmenter, code-point iteration still keeps surrogate pairs
+// intact; only multi-code-point clusters (ZWJ emoji, flags) may split.
+function createGraphemeSegmenter(): (text: string) => string[] {
+  if (typeof Intl !== "undefined" && typeof Intl.Segmenter === "function") {
+    const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+    return (text) => Array.from(segmenter.segment(text), (part) => part.segment);
+  }
+
+  return (text) => Array.from(text);
+}
+
+const segmentGraphemes = createGraphemeSegmenter();
+
+// Only visible streaming text is paced. Tool-call args and lifecycle events
+// pass through so pacing never delays structural updates, and reasoning-chunk /
+// thinking deltas are live-state reducer no-ops not worth throttling.
+function getPaceableTextDelta(event: AgUiSessionEvent): string | null {
+  if (event.type === "REASONING_MESSAGE_CONTENT" || event.type === "TEXT_MESSAGE_CONTENT") {
+    return event.delta.length > 0 ? event.delta : null;
+  }
+
+  if (event.type === "TEXT_MESSAGE_CHUNK") {
+    return typeof event.delta === "string" && event.delta.length > 0 ? event.delta : null;
+  }
+
+  return null;
+}
+
+// Pacing applies only while a stream is visibly in flight. Once the queue
+// holds proof that a stream segment finished — an END event, a run terminal
+// event, or a snapshot that replaces state wholesale (reconnect catch-up) —
+// everything up to that point is delivered unpaced: animating text the server
+// already finished would only delay the settled state, and snapshot replays
+// must never be animated.
+const PACING_BARRIER_EVENT_TYPES = new Set<string>([
+  "MESSAGES_SNAPSHOT",
+  "REASONING_END",
+  "REASONING_MESSAGE_END",
+  "STATE_SNAPSHOT",
+  "TEXT_MESSAGE_END",
+  "THINKING_END",
+  "THINKING_TEXT_MESSAGE_END",
+]);
+
+function isPacingBarrierEvent(event: AgUiSessionEvent): boolean {
+  return PACING_BARRIER_EVENT_TYPES.has(event.type) || isAgUiSessionRunTerminalEvent(event);
+}
+
+function withTextDelta(
+  event: AgUiSessionEvent,
+  delta: string,
+  isRemainder: boolean,
+): AgUiSessionEvent {
+  if (event.type === "REASONING_MESSAGE_CONTENT" || event.type === "TEXT_MESSAGE_CONTENT") {
+    return { ...event, delta };
+  }
+
+  if (event.type === "TEXT_MESSAGE_CHUNK") {
+    if (!isRemainder) {
+      return { ...event, delta };
+    }
+
+    // A chunk carrying a role upserts a blank message before appending (see
+    // live-state.reducer.ts), so the remainder of a split chunk must not
+    // repeat the role or it would wipe the text the head part just delivered.
+    const { name: _name, role: _role, ...rest } = event;
+    return { ...rest, delta };
+  }
+
+  return event;
+}
 
 function createBrowserFrameSchedulerHost(): SessionStreamRenderSchedulerHost {
   return {
@@ -36,6 +134,7 @@ function createBrowserFrameSchedulerHost(): SessionStreamRenderSchedulerHost {
     cancelTimeout: (handle) => {
       globalThis.clearTimeout(handle);
     },
+    now: () => globalThis.performance.now(),
     requestFrame: (callback) => globalThis.requestAnimationFrame(callback),
     requestTimeout: (callback, delayMs) =>
       globalThis.setTimeout(callback, delayMs) as unknown as number,
@@ -46,6 +145,8 @@ export class SessionStreamRenderScheduler {
   readonly #apply: SessionStreamRenderSchedulerApply;
   #frameHandle: number | null = null;
   readonly #host: SessionStreamRenderSchedulerHost;
+  #lastDrainAt: number | null = null;
+  #pacingCarry = 0;
   #queue: QueuedSessionEvent[] = [];
   #queueOffset = 0;
   #timeoutHandle: number | null = null;
@@ -62,6 +163,8 @@ export class SessionStreamRenderScheduler {
     this.#cancelPending();
     this.#queue = [];
     this.#queueOffset = 0;
+    this.#lastDrainAt = null;
+    this.#pacingCarry = 0;
   }
 
   public enqueue(sessionId: string, event: AgUiSessionEvent): void {
@@ -74,10 +177,7 @@ export class SessionStreamRenderScheduler {
     }
 
     for (const event of events) {
-      this.#queue.push({
-        event,
-        sessionId,
-      });
+      this.#queue.push(this.#toQueueItem(sessionId, event));
     }
 
     this.#schedule();
@@ -105,18 +205,20 @@ export class SessionStreamRenderScheduler {
 
     this.#queue = remaining;
     this.#queueOffset = 0;
+    this.#pacingCarry = 0;
 
     if (events.length > 0) {
       if (!this.#apply(sessionId, events)) {
         this.#queue = [
-          ...events.map((event) => ({
-            event,
-            sessionId,
-          })),
+          ...events.map((event) => this.#toQueueItem(sessionId, event)),
           ...this.#queue,
         ];
         this.#queueOffset = 0;
       }
+    }
+
+    if (this.#queue.length === 0) {
+      this.#lastDrainAt = null;
     }
 
     this.#schedule();
@@ -139,6 +241,10 @@ export class SessionStreamRenderScheduler {
       return;
     }
 
+    // Idle → active: baseline pacing time at enqueue so the first frame sees
+    // one frame's worth of elapsed time, not the whole idle gap.
+    this.#lastDrainAt ??= this.#host.now();
+
     const drain = () => {
       this.#cancelPending();
       this.#drainFrame();
@@ -153,13 +259,15 @@ export class SessionStreamRenderScheduler {
 
     if (batch && batch.events.length > 0 && !this.#apply(batch.sessionId, batch.events)) {
       this.#queue = [
-        ...batch.events.map((event) => ({
-          event,
-          sessionId: batch.sessionId,
-        })),
+        ...batch.events.map((event) => this.#toQueueItem(batch.sessionId, event)),
         ...this.#queue.slice(this.#queueOffset),
       ];
       this.#queueOffset = 0;
+    }
+
+    if (this.#queueOffset >= this.#queue.length) {
+      this.#lastDrainAt = null;
+      this.#pacingCarry = 0;
     }
 
     this.#schedule();
@@ -185,6 +293,32 @@ export class SessionStreamRenderScheduler {
     }
   }
 
+  #computePacingBudget(pendingPacedGraphemes: number, elapsedMs: number): number {
+    if (pendingPacedGraphemes === 0) {
+      this.#pacingCarry = 0;
+      return 0;
+    }
+
+    if (pendingPacedGraphemes > MAX_PENDING_PACED_GRAPHEMES) {
+      this.#pacingCarry = 0;
+      return Number.POSITIVE_INFINITY;
+    }
+
+    const elapsedSeconds = elapsedMs / 1000;
+    const proportional = (pendingPacedGraphemes * elapsedMs) / PACING_TIME_CONSTANT_MS;
+    const paced = Math.min(
+      Math.max(proportional, MIN_PACED_GRAPHEMES_PER_SECOND * elapsedSeconds),
+      MAX_PACED_GRAPHEMES_PER_SECOND * elapsedSeconds,
+    );
+    const budget = this.#pacingCarry + paced;
+    const wholeGraphemes = Math.floor(budget);
+
+    // Fractional carry keeps sub-grapheme-per-frame rates moving instead of
+    // rounding to zero forever.
+    this.#pacingCarry = budget - wholeGraphemes;
+    return wholeGraphemes;
+  }
+
   #takeFrameBatch(): {
     events: AgUiSessionEvent[];
     sessionId: string;
@@ -197,23 +331,88 @@ export class SessionStreamRenderScheduler {
     }
 
     const { sessionId } = first;
-    const events: AgUiSessionEvent[] = [];
-    let nextQueueOffset = this.#queueOffset;
+    let runEnd = this.#queueOffset;
+    let pacedFrom = this.#queueOffset;
 
-    while (nextQueueOffset < this.#queue.length && events.length < MAX_EVENTS_PER_FRAME) {
-      const item = this.#queue[nextQueueOffset];
+    while (runEnd < this.#queue.length) {
+      const item = this.#queue[runEnd];
 
       if (!item || item.sessionId !== sessionId) {
         break;
       }
 
-      events.push(item.event);
-      nextQueueOffset += 1;
+      if (isPacingBarrierEvent(item.event)) {
+        pacedFrom = runEnd + 1;
+      }
+
+      runEnd += 1;
+    }
+
+    let pendingPacedGraphemes = 0;
+
+    for (let index = pacedFrom; index < runEnd; index += 1) {
+      pendingPacedGraphemes += this.#queue[index]?.segments?.length ?? 0;
+    }
+
+    const now = this.#host.now();
+    const elapsedMs = Math.max(0, now - (this.#lastDrainAt ?? now));
+    this.#lastDrainAt = now;
+
+    let budget = this.#computePacingBudget(pendingPacedGraphemes, elapsedMs);
+
+    const events: AgUiSessionEvent[] = [];
+    let nextQueueOffset = this.#queueOffset;
+
+    while (nextQueueOffset < runEnd && events.length < MAX_EVENTS_PER_FRAME) {
+      const item = this.#queue[nextQueueOffset];
+
+      if (!item) {
+        break;
+      }
+
+      if (nextQueueOffset < pacedFrom || item.segments === null) {
+        events.push(item.event);
+        nextQueueOffset += 1;
+        continue;
+      }
+
+      if (item.segments.length <= budget) {
+        budget -= item.segments.length;
+        events.push(item.event);
+        nextQueueOffset += 1;
+        continue;
+      }
+
+      if (budget > 0) {
+        const headDelta = item.segments.slice(0, budget).join("");
+        const tailSegments = item.segments.slice(budget);
+
+        events.push(withTextDelta(item.event, headDelta, false));
+        this.#queue[nextQueueOffset] = {
+          event: withTextDelta(item.event, tailSegments.join(""), true),
+          segments: tailSegments,
+          sessionId,
+        };
+      }
+
+      // Budget exhausted at a paced event. Everything behind it stays queued
+      // so no later event can overtake text still being typed out.
+      break;
     }
 
     this.#queueOffset = nextQueueOffset;
     this.#compactConsumedQueue();
 
     return { events, sessionId };
+  }
+
+  #toQueueItem(sessionId: string, event: AgUiSessionEvent): QueuedSessionEvent {
+    const delta = getPaceableTextDelta(event);
+
+    return {
+      event,
+      segments: delta === null ? null : segmentGraphemes(delta),
+      sessionId,
+    };
   }
 }

--- a/apps/web/tests/session-stream-render-scheduler.test.ts
+++ b/apps/web/tests/session-stream-render-scheduler.test.ts
@@ -5,43 +5,88 @@ import type { AgUiSessionEvent } from "@mosoo/ag-ui-session";
 import type { SessionStreamRenderSchedulerHost } from "../src/domains/runtime/session-stream/session-stream-render-scheduler";
 import { SessionStreamRenderScheduler } from "../src/domains/runtime/session-stream/session-stream-render-scheduler";
 
-function createManualHost(): {
-  frameCallbacks: (() => void)[];
+const FRAME_MS = 16;
+
+interface ManualHost {
+  advance: (deltaMs: number) => void;
+  fireFrame: (deltaMs?: number) => boolean;
+  fireTimeout: (deltaMs?: number) => boolean;
   host: SessionStreamRenderSchedulerHost;
-  timeoutCallbacks: (() => void)[];
-} {
-  const frameCallbacks: (() => void)[] = [];
-  const timeoutCallbacks: (() => void)[] = [];
+}
+
+function createManualHost(): ManualHost {
+  let now = 0;
+  let nextHandle = 0;
+  const frames = new Map<number, () => void>();
+  const timeouts = new Map<number, () => void>();
+
+  const fireNext = (callbacks: Map<number, () => void>, deltaMs: number): boolean => {
+    now += deltaMs;
+    const first = callbacks.entries().next();
+
+    if (first.done) {
+      return false;
+    }
+
+    callbacks.delete(first.value[0]);
+    first.value[1]();
+    return true;
+  };
 
   return {
-    frameCallbacks,
+    advance: (deltaMs) => {
+      now += deltaMs;
+    },
+    fireFrame: (deltaMs = FRAME_MS) => fireNext(frames, deltaMs),
+    fireTimeout: (deltaMs = 50) => fireNext(timeouts, deltaMs),
     host: {
-      cancelFrame: () => {},
-      cancelTimeout: () => {},
+      cancelFrame: (handle) => {
+        frames.delete(handle);
+      },
+      cancelTimeout: (handle) => {
+        timeouts.delete(handle);
+      },
+      now: () => now,
       requestFrame: (callback) => {
-        frameCallbacks.push(callback);
-        return frameCallbacks.length;
+        nextHandle += 1;
+        frames.set(nextHandle, callback);
+        return nextHandle;
       },
       requestTimeout: (callback) => {
-        timeoutCallbacks.push(callback);
-        return timeoutCallbacks.length;
+        nextHandle += 1;
+        timeouts.set(nextHandle, callback);
+        return nextHandle;
       },
     },
-    timeoutCallbacks,
   };
 }
 
-function drainFrames(callbacks: (() => void)[]): void {
-  while (callbacks.length > 0) {
-    callbacks.shift()?.();
+function drainFrames(manual: ManualHost, deltaMs = FRAME_MS, limit = 10_000): number {
+  let fired = 0;
+
+  while (manual.fireFrame(deltaMs)) {
+    fired += 1;
+
+    if (fired > limit) {
+      throw new Error("Frame drain did not settle.");
+    }
   }
+
+  return fired;
 }
 
-function textEvent(delta: string): AgUiSessionEvent {
+function textEvent(delta: string, messageId = "message-1"): AgUiSessionEvent {
   return {
     delta,
-    messageId: "message-1",
+    messageId,
     type: "TEXT_MESSAGE_CONTENT",
+  };
+}
+
+function textEndEvent(messageId = "message-1"): AgUiSessionEvent {
+  return {
+    messageId,
+    type: "TEXT_MESSAGE_END",
   };
 }
 
@@ -52,127 +97,419 @@ function stateDeltaEvent(): AgUiSessionEvent {
   };
 }
 
+function eventText(event: AgUiSessionEvent): string {
+  if (event.type === "REASONING_MESSAGE_CONTENT" || event.type === "TEXT_MESSAGE_CONTENT") {
+    return event.delta;
+  }
+
+  if (event.type === "TEXT_MESSAGE_CHUNK") {
+    return event.delta ?? "";
+  }
+
+  return "";
+}
+
+function batchText(events: AgUiSessionEvent[]): string {
+  return events.map(eventText).join("");
+}
+
 describe("session stream render scheduler", () => {
-  test("delivers every queued text chunk unthrottled and in order", () => {
-    const { frameCallbacks, host } = createManualHost();
+  test("paces a mid-stream batch across frames instead of one jump", () => {
+    const manual = createManualHost();
     const batches: AgUiSessionEvent[][] = [];
     const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
       batches.push(events);
       return true;
-    }, host);
+    }, manual.host);
+    const text = "x".repeat(1000);
+
+    scheduler.enqueueMany("session-1", [textEvent(text)]);
+    const frames = drainFrames(manual);
+
+    // 800 graphemes/s at 16ms frames is 12-13 graphemes per frame.
+    expect(frames).toBeGreaterThan(70);
+    expect(batches.every((events) => batchText(events).length <= 13)).toBe(true);
+    expect(batches.map(batchText).join("")).toBe(text);
+  });
+
+  test("delivers a batch that already ends the message without pacing", () => {
+    const manual = createManualHost();
+    const batches: AgUiSessionEvent[][] = [];
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      batches.push(events);
+      return true;
+    }, manual.host);
+    const text = "x".repeat(1000);
+
+    scheduler.enqueueMany("session-1", [textEvent(text), textEndEvent()]);
+    drainFrames(manual);
+
+    expect(batches.length).toBe(1);
+    expect(batches[0]?.length).toBe(2);
+    expect(batchText(batches[0] ?? [])).toBe(text);
+  });
+
+  test("flushes the paced tail as soon as the end event arrives", () => {
+    const manual = createManualHost();
+    const batches: AgUiSessionEvent[][] = [];
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      batches.push(events);
+      return true;
+    }, manual.host);
+    const text = "x".repeat(1000);
+
+    scheduler.enqueueMany("session-1", [textEvent(text)]);
+    manual.fireFrame();
+    manual.fireFrame();
+    expect(batches.map(batchText).join("").length).toBeLessThan(30);
+
+    scheduler.enqueueMany("session-1", [textEndEvent()]);
+    manual.fireFrame();
+
+    expect(batches.length).toBe(3);
+    expect(batches[2]?.at(-1)?.type).toBe("TEXT_MESSAGE_END");
+    expect(batches.map(batchText).join("")).toBe(text);
+  });
+
+  test("run terminal events dump pending text immediately", () => {
+    const manual = createManualHost();
+    const batches: AgUiSessionEvent[][] = [];
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      batches.push(events);
+      return true;
+    }, manual.host);
+    const text = "x".repeat(1000);
+
+    scheduler.enqueueMany("session-1", [textEvent(text), { message: "boom", type: "RUN_ERROR" }]);
+    drainFrames(manual);
+
+    expect(batches.length).toBe(1);
+    expect(batchText(batches[0] ?? [])).toBe(text);
+  });
+
+  test("state snapshots from reconnect catch-up are never animated", () => {
+    const manual = createManualHost();
+    const batches: AgUiSessionEvent[][] = [];
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      batches.push(events);
+      return true;
+    }, manual.host);
+
+    scheduler.enqueueMany("session-1", [
+      textEvent("x".repeat(500)),
+      { snapshot: {}, type: "STATE_SNAPSHOT" },
+    ]);
+    drainFrames(manual);
+
+    expect(batches.length).toBe(1);
+    expect(batches[0]?.length).toBe(2);
+  });
+
+  test("dumps the whole backlog once it outgrows the pacing window", () => {
+    const manual = createManualHost();
+    const batches: AgUiSessionEvent[][] = [];
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      batches.push(events);
+      return true;
+    }, manual.host);
+    const text = "x".repeat(5000);
+
+    scheduler.enqueueMany("session-1", [textEvent(text)]);
+    manual.fireFrame();
+
+    expect(batches.length).toBe(1);
+    expect(batchText(batches[0] ?? [])).toBe(text);
+  });
+
+  test("splits only at grapheme cluster boundaries", () => {
+    const manual = createManualHost();
+    const pieces: string[] = [];
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      pieces.push(batchText(events));
+      return true;
+    }, manual.host);
+    const family = "👨‍👩‍👧‍👦";
+    const text = family.repeat(40);
+
+    scheduler.enqueueMany("session-1", [textEvent(text)]);
+    const frames = drainFrames(manual);
+
+    expect(frames).toBeGreaterThan(5);
+    expect(pieces.join("")).toBe(text);
+
+    for (const piece of pieces) {
+      expect(piece.isWellFormed()).toBe(true);
+      expect(new RegExp(`^(?:${family})*$`, "u").test(piece)).toBe(true);
+    }
+  });
+
+  test("keeps a tiny tail moving through the minimum rate floor", () => {
+    const manual = createManualHost();
+    const batches: AgUiSessionEvent[][] = [];
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      batches.push(events);
+      return true;
+    }, manual.host);
+
+    scheduler.enqueueMany("session-1", [textEvent("abc")]);
+    manual.fireFrame();
+    manual.fireFrame();
+    manual.fireFrame();
+
+    // 20 graphemes/s at 16ms frames stays below one grapheme for three frames.
+    expect(batches.length).toBe(0);
+
+    const frames = drainFrames(manual);
+
+    expect(frames).toBeLessThanOrEqual(12);
+    expect(batches.map(batchText).join("")).toBe("abc");
+  });
+
+  test("streams at the same visible speed on 60Hz and 120Hz displays", () => {
+    const run = (frameMs: number, frameCount: number): number => {
+      const manual = createManualHost();
+      let delivered = "";
+      const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+        delivered += batchText(events);
+        return true;
+      }, manual.host);
+
+      scheduler.enqueueMany("session-1", [textEvent("x".repeat(100))]);
+
+      for (let index = 0; index < frameCount; index += 1) {
+        manual.fireFrame(frameMs);
+      }
+
+      return delivered.length;
+    };
+
+    const at60Hz = run(16, 10);
+    const at120Hz = run(8, 20);
+
+    expect(Math.abs(at60Hz - at120Hz)).toBeLessThanOrEqual(2);
+  });
+
+  test("non-text events pass through but never overtake paced text", () => {
+    const manual = createManualHost();
+    const batches: AgUiSessionEvent[][] = [];
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      batches.push(events);
+      return true;
+    }, manual.host);
+    const text = "x".repeat(200);
+
+    scheduler.enqueueMany("session-1", [stateDeltaEvent(), textEvent(text), stateDeltaEvent()]);
+    drainFrames(manual);
+
+    // The leading state delta rides the first frame; the trailing one may only
+    // arrive after every queued character.
+    expect(batches[0]?.[0]?.type).toBe("STATE_DELTA");
+    const flat = batches.flat();
+    expect(flat.at(-1)?.type).toBe("STATE_DELTA");
+    expect(batchText(flat)).toBe(text);
+  });
+
+  test("split chunk remainders drop the role so replays cannot reset the message", () => {
+    const manual = createManualHost();
+    const chunks: AgUiSessionEvent[] = [];
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      chunks.push(...events);
+      return true;
+    }, manual.host);
+    const text = "x".repeat(600);
+
+    scheduler.enqueueMany("session-1", [
+      { delta: text, messageId: "message-1", role: "assistant", type: "TEXT_MESSAGE_CHUNK" },
+    ]);
+    drainFrames(manual);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks[0]?.type === "TEXT_MESSAGE_CHUNK" && chunks[0].role).toBe("assistant");
+
+    for (const chunk of chunks.slice(1)) {
+      expect(chunk.type === "TEXT_MESSAGE_CHUNK" && "role" in chunk).toBe(false);
+    }
+
+    expect(batchText(chunks)).toBe(text);
+  });
+
+  test("flushNow delivers the paced remainder exactly once", () => {
+    const manual = createManualHost();
+    const batches: AgUiSessionEvent[][] = [];
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      batches.push(events);
+      return true;
+    }, manual.host);
+    const text = "x".repeat(1000);
+
+    scheduler.enqueueMany("session-1", [textEvent(text)]);
+    manual.fireFrame();
+    manual.fireFrame();
+    scheduler.flushNow("session-1");
+
+    expect(batches.map(batchText).join("")).toBe(text);
+    expect(drainFrames(manual)).toBe(0);
+  });
+
+  test("does not burst after an idle gap", () => {
+    const manual = createManualHost();
+    const batches: AgUiSessionEvent[][] = [];
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      batches.push(events);
+      return true;
+    }, manual.host);
+
+    scheduler.enqueueMany("session-1", [textEvent("abc"), textEndEvent()]);
+    drainFrames(manual);
+    expect(batches.length).toBe(1);
+
+    manual.advance(60_000);
+    scheduler.enqueueMany("session-1", [textEvent("x".repeat(1000))]);
+    manual.fireFrame();
+
+    expect(batchText(batches[1] ?? []).length).toBeLessThanOrEqual(13);
+  });
+
+  test("drains through the timeout fallback when frames never fire", () => {
+    const manual = createManualHost();
+    const batches: AgUiSessionEvent[][] = [];
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      batches.push(events);
+      return true;
+    }, manual.host);
+    const text = "x".repeat(200);
+
+    scheduler.enqueueMany("session-1", [textEvent(text)]);
+
+    let ticks = 0;
+
+    while (manual.fireTimeout(50)) {
+      ticks += 1;
+
+      if (ticks > 100) {
+        throw new Error("Timeout drain did not settle.");
+      }
+    }
+
+    expect(ticks).toBeGreaterThan(3);
+    expect(batches.map(batchText).join("")).toBe(text);
+  });
+
+  test("delivers a finished stream through the flood guard in arrival order", () => {
+    const manual = createManualHost();
+    const batches: AgUiSessionEvent[][] = [];
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      batches.push(events);
+      return true;
+    }, manual.host);
     const events = Array.from({ length: 600 }, (_unused, index) => textEvent(`chunk-${index}`));
 
-    scheduler.enqueueMany("session-1", events);
-    drainFrames(frameCallbacks);
+    scheduler.enqueueMany("session-1", [...events, textEndEvent()]);
+    drainFrames(manual);
 
-    // 600 events exceed one frame's flood guard, never more than two frames.
+    // 601 events exceed one frame's flood guard, never more than two frames.
     expect(batches.length).toBe(2);
-    expect(
-      batches.flat().map((event) => (event.type === "TEXT_MESSAGE_CONTENT" ? event.delta : "")),
-    ).toEqual(events.map((event) => (event.type === "TEXT_MESSAGE_CONTENT" ? event.delta : "")));
+    expect(batches.flat().map(eventText).join("")).toBe(events.map(eventText).join(""));
   });
 
   test("keeps another session queued while flushing the first session", () => {
-    const { frameCallbacks, host } = createManualHost();
+    const manual = createManualHost();
     const applied: { events: AgUiSessionEvent[]; sessionId: string }[] = [];
     const scheduler = new SessionStreamRenderScheduler((sessionId, events) => {
       applied.push({ events, sessionId });
       return true;
-    }, host);
+    }, manual.host);
 
     scheduler.enqueueMany("session-1", [textEvent("a"), textEvent("b")]);
     scheduler.enqueueMany("session-2", [textEvent("c")]);
     scheduler.flushNow("session-1");
-    drainFrames(frameCallbacks);
+    drainFrames(manual);
 
     expect(applied.map((batch) => batch.sessionId)).toEqual(["session-1", "session-2"]);
-    expect(
-      applied.map((batch) =>
-        batch.events
-          .map((event) => (event.type === "TEXT_MESSAGE_CONTENT" ? event.delta : ""))
-          .join(""),
-      ),
-    ).toEqual(["ab", "c"]);
+    expect(applied.map((batch) => batchText(batch.events))).toEqual(["ab", "c"]);
   });
 
   test("flushes only undelivered events after a partial frame drain", () => {
-    const { frameCallbacks, host } = createManualHost();
+    const manual = createManualHost();
     const applied: { events: AgUiSessionEvent[]; sessionId: string }[] = [];
     const scheduler = new SessionStreamRenderScheduler((sessionId, events) => {
       applied.push({ events, sessionId });
       return true;
-    }, host);
+    }, manual.host);
     const sessionOneEvents = Array.from({ length: 600 }, (_unused, index) =>
       textEvent(`a-${index}`),
     );
 
-    scheduler.enqueueMany("session-1", sessionOneEvents);
+    scheduler.enqueueMany("session-1", [...sessionOneEvents, textEndEvent()]);
     scheduler.enqueueMany("session-2", [textEvent("b")]);
-    frameCallbacks.shift()?.();
+    manual.fireFrame();
     scheduler.flushNow("session-2");
-    drainFrames(frameCallbacks);
+    drainFrames(manual);
 
     expect(applied.map((batch) => batch.sessionId)).toEqual([
       "session-1",
       "session-2",
       "session-1",
     ]);
-    expect(applied.map((batch) => batch.events.length)).toEqual([512, 1, 88]);
-    expect(
-      applied
-        .flatMap((batch) => batch.events)
-        .map((event) => (event.type === "TEXT_MESSAGE_CONTENT" ? event.delta : "")),
-    ).toEqual([
-      ...sessionOneEvents.slice(0, 512).map((event) => event.delta),
+    expect(applied.map((batch) => batch.events.length)).toEqual([512, 1, 89]);
+    expect(applied.flatMap((batch) => batch.events).map(eventText)).toEqual([
+      ...sessionOneEvents.slice(0, 512).map(eventText),
       "b",
-      ...sessionOneEvents.slice(512).map((event) => event.delta),
+      ...sessionOneEvents.slice(512).map(eventText),
+      "",
     ]);
   });
 
   test("delivers mixed event types in arrival order", () => {
-    const { frameCallbacks, host } = createManualHost();
+    const manual = createManualHost();
     const types: string[] = [];
     const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
       for (const event of events) {
         types.push(event.type);
       }
       return true;
-    }, host);
+    }, manual.host);
 
-    scheduler.enqueueMany("session-1", [textEvent("a"), stateDeltaEvent(), textEvent("b")]);
-    drainFrames(frameCallbacks);
+    scheduler.enqueueMany("session-1", [
+      textEvent("a"),
+      stateDeltaEvent(),
+      textEvent("b"),
+      textEndEvent(),
+    ]);
+    drainFrames(manual);
 
-    expect(types).toEqual(["TEXT_MESSAGE_CONTENT", "STATE_DELTA", "TEXT_MESSAGE_CONTENT"]);
+    expect(types).toEqual([
+      "TEXT_MESSAGE_CONTENT",
+      "STATE_DELTA",
+      "TEXT_MESSAGE_CONTENT",
+      "TEXT_MESSAGE_END",
+    ]);
   });
 
-  test("requeues a rejected batch without losing content", () => {
-    const { frameCallbacks, host } = createManualHost();
-    const appliedDeltas: string[] = [];
+  test("requeues a rejected paced batch without losing content", () => {
+    const manual = createManualHost();
     let rejectNextBatch = true;
+    const batches: AgUiSessionEvent[][] = [];
     const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
       if (rejectNextBatch) {
         rejectNextBatch = false;
         return false;
       }
 
-      for (const event of events) {
-        if (event.type === "TEXT_MESSAGE_CONTENT") {
-          appliedDeltas.push(event.delta);
-        }
-      }
-
+      batches.push(events);
       return true;
-    }, host);
+    }, manual.host);
+    const text = "x".repeat(1300);
 
-    scheduler.enqueueMany("session-1", [textEvent("x".repeat(1300))]);
-    drainFrames(frameCallbacks);
+    scheduler.enqueueMany("session-1", [textEvent(text)]);
+    drainFrames(manual);
 
     expect(rejectNextBatch).toBe(false);
-    expect(appliedDeltas.join("")).toBe("x".repeat(1300));
+    expect(batches.map(batchText).join("")).toBe(text);
   });
 
   test("requeues a rejected batch after compacting consumed events", () => {
-    const { frameCallbacks, host } = createManualHost();
+    const manual = createManualHost();
     const appliedDeltas: string[] = [];
     let applyAttempts = 0;
     const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
@@ -189,32 +526,13 @@ describe("session stream render scheduler", () => {
       }
 
       return true;
-    }, host);
+    }, manual.host);
     const events = Array.from({ length: 3000 }, (_unused, index) => textEvent(`chunk-${index}`));
 
-    scheduler.enqueueMany("session-1", events);
-    drainFrames(frameCallbacks);
+    scheduler.enqueueMany("session-1", [...events, textEndEvent()]);
+    drainFrames(manual);
 
     expect(applyAttempts).toBe(7);
-    expect(appliedDeltas).toEqual(events.map((event) => event.delta));
-  });
-
-  test("drains through the timeout fallback when frames never fire", () => {
-    const { host, timeoutCallbacks } = createManualHost();
-    const appliedDeltas: string[] = [];
-    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
-      for (const event of events) {
-        if (event.type === "TEXT_MESSAGE_CONTENT") {
-          appliedDeltas.push(event.delta);
-        }
-      }
-      return true;
-    }, host);
-
-    scheduler.enqueueMany("session-1", [textEvent("hidden"), textEvent("window")]);
-    // requestAnimationFrame is throttled or paused: only the timer fires.
-    drainFrames(timeoutCallbacks);
-
-    expect(appliedDeltas).toEqual(["hidden", "window"]);
+    expect(appliedDeltas).toEqual(events.map((event) => eventText(event)));
   });
 });


### PR DESCRIPTION
## Summary

- Add per-frame pacing to `SessionStreamRenderScheduler` so server-batched stream deltas render as continuous text instead of one visible jump per ~150ms batch.
- Each frame emits `pending × dt / τ` graphemes (τ = 250ms, an exponential backlog drain), clamped to 20–800 graphemes/s, with fractional carry between frames; elapsed-time scaling keeps 60Hz, 120Hz, and throttled-tab timer cadence at the same visible speed.
- Deltas split only at grapheme cluster boundaries via `Intl.Segmenter` (code-point fallback), so surrogate pairs and ZWJ emoji never tear mid-split.
- Pacing stops the moment a stream is provably over: message/reasoning END events, run terminal events, and state/messages snapshots (reconnect catch-up) flush everything ahead of them unpaced; `flushNow` (socket close / session switch) still dumps synchronously; backlogs over 4096 graphemes are delivered whole rather than showing seconds-stale text.
- Strict FIFO is preserved: a paced text remainder holds back later events so nothing overtakes text still typing out, and split `TEXT_MESSAGE_CHUNK` remainders drop `role` so a replayed role cannot re-upsert a blank message (`live-state.reducer.ts` upsert semantics).

## Why

- The server coalesces session events into 150ms / 4KB / 64-event batches (`apps/api/.../session-viewer-event-delivery-buffer.ts`), so the scheduler's previous "rAF batching is the smoothing" assumption renders each websocket message as one text jump. YEF-941 surveyed the dify / open-webui / NextChat / lobe-chat typewriter implementations and specified this design: rAF pacing with backlog-proportional rate, grapheme-safe splitting, and never animating after stream end.

## Verification

- Commands: `cd apps/web && bun test tests` (210 pass, includes 20 scheduler tests driving a manual clock host), `bun run tc`, `bun run lint`, `bun run fmt:check` — all clean.
- Manual steps: N/A — the change is temporal render cadence with zero layout/pixel diff, so a static screenshot cannot show it; the unit tests assert per-frame emission counts, grapheme-boundary splits, END/terminal/snapshot flush, `flushNow` exactly-once delivery, and FIFO ordering instead.
- Not run: full-stack visual capture of streaming.

## Impact

- User/API/contract changes: none on the wire; purely client-side render scheduling. Internal `SessionStreamRenderSchedulerHost` gains `now()`.
- Generated files / GraphQL / DB / lockfile: N/A.
- Env or config changes: N/A.
- Risk and rollback: contained in one module; revert restores jump-per-batch rendering. Failure modes are bounded by design: ≤4096-grapheme backlog before whole delivery, terminal events always flush, and the 50ms timeout fallback keeps hidden tabs draining.

## Review

- Closest review areas: `#takeFrameBatch` (barrier scan + budget walk + split requeue) in `session-stream-render-scheduler.ts`, and `withTextDelta` role-dropping versus the `TEXT_MESSAGE_CHUNK` upsert in `live-state.reducer.ts`.
- Known trade-offs: pacing is session-FIFO with in-place delta splitting rather than literal per-message queues — the same visible effect for the dominant one-stream-at-a-time case, but reducer event ordering can never be violated; non-text events queued behind actively-typing text wait ≤ ~τ (bounded by the 4096 dump valve). A producer sustained above 800 graphemes/s alternates pace/dump per the issue's spec.
