### PR TITLE
fix(runtime): scope HTTPS interception to limited sandboxes

### DIFF
--- a/apps/api/src/adapters/durable-objects/sandbox-https-interception.ts
+++ b/apps/api/src/adapters/durable-objects/sandbox-https-interception.ts
@@ -1,19 +1,25 @@
-interface SandboxHttpsInterception {
+export interface SandboxHttpsInterception {
+  envVars: Record<string, string>;
   interceptHttps: boolean;
 }
 
 /**
- * Pins the HTTPS interception choice instead of inheriting the SDK default.
- * Local Sandbox keeps the existing CA compatibility escape hatch; production
- * must intercept HTTPS or a Limited allowlist would cover only plain HTTP.
+ * Keeps the Cloudflare interception hook and Sandbox control-plane startup
+ * flag aligned. Full network Sandboxes must keep interception off; otherwise
+ * the control plane requires a CA that Cloudflare only injects after an
+ * outbound interception rule is installed.
  */
 export function configureSandboxHttpsInterception(
   sandbox: SandboxHttpsInterception,
-  localBinding: string | undefined,
+  enabled: boolean,
 ): void {
-  // Local workerd can omit the ephemeral CA while HTTPS interception is active,
-  // resetting TLS before the sandbox reaches providers.
-  // With interception off the egress allowlist cannot cover HTTPS, so limited
-  // network policies fail closed while this is in effect (sandbox-network-enforcement.ts).
-  sandbox.interceptHttps = localBinding !== "true";
+  sandbox.interceptHttps = enabled;
+
+  const envVars = { ...sandbox.envVars };
+  if (enabled) {
+    envVars["SANDBOX_INTERCEPT_HTTPS"] = "1";
+  } else {
+    delete envVars["SANDBOX_INTERCEPT_HTTPS"];
+  }
+  sandbox.envVars = envVars;
 }

--- a/apps/api/src/adapters/durable-objects/sandbox-network-enforcement.ts
+++ b/apps/api/src/adapters/durable-objects/sandbox-network-enforcement.ts
@@ -1,13 +1,15 @@
 import type { SandboxNetworkConstraints } from "../../modules/runtime/domain/sandbox-network-constraints";
 import { parseSandboxNetworkConstraints } from "../../modules/runtime/domain/sandbox-network-constraints";
+import type { SandboxHttpsInterception } from "./sandbox-https-interception";
+import { configureSandboxHttpsInterception } from "./sandbox-https-interception";
 
 /**
  * Storage key for the constraints applied to this sandbox. The record must
  * survive container restarts and `destroy()` (which only clears SDK
  * port/tunnel keys), so a rehydrated Durable Object can re-apply
- * `enableInternet` before the next container start: the SDK persists its own
- * allowlist, but `enableInternet` is a plain instance property read at
- * container start time.
+ * `enableInternet` and HTTPS interception before the next container start:
+ * the SDK persists its own allowlist, but those startup settings are plain
+ * instance properties.
  */
 export const SANDBOX_NETWORK_CONSTRAINTS_STORAGE_KEY = "mosooSandboxNetworkConstraints";
 
@@ -17,7 +19,7 @@ export const SANDBOX_NETWORK_CONSTRAINTS_STORAGE_KEY = "mosooSandboxNetworkConst
  * `setAllowedHosts` persists in DO storage and applies live via intercept-all
  * outbound HTTP/HTTPS routing.
  */
-export interface SandboxNetworkDelegate {
+export interface SandboxNetworkDelegate extends SandboxHttpsInterception {
   enableInternet: boolean;
   setAllowedHosts(hosts: string[]): Promise<void>;
 }
@@ -122,6 +124,8 @@ export async function configureSandboxNetworkConstraints(
       await storage.put(SANDBOX_NETWORK_CONSTRAINTS_STORAGE_KEY, constraints);
     }
 
+    configureSandboxHttpsInterception(delegate, true);
+
     // Repeat the SDK call even for an unchanged policy. This is intentionally
     // idempotent and repairs SDK-local interception state after a partial
     // configure, DO wake, or container restart while our fail-closed record
@@ -131,6 +135,7 @@ export async function configureSandboxNetworkConstraints(
     return;
   }
 
+  configureSandboxHttpsInterception(delegate, false);
   delegate.enableInternet = true;
 
   if (previous === null) {
@@ -139,14 +144,14 @@ export async function configureSandboxNetworkConstraints(
 }
 
 /**
- * Re-applies the persisted `enableInternet` decision when the Durable Object
- * wakes, before any container start. The SDK restores its own allowlist and
- * interception state from its storage; only the start-time internet switch
- * needs re-asserting from our record.
+ * Re-applies the persisted network decision when the Durable Object wakes,
+ * before any container start. The SDK restores its allowlist from storage;
+ * Mosoo restores the start-time internet and HTTPS interception settings.
  */
 export async function restoreSandboxNetworkEnforcement(
   storage: SandboxNetworkStorage,
   delegate: SandboxNetworkDelegate,
+  options: { httpsInterceptionDisabled: boolean },
 ): Promise<void> {
   // The persisted policy is the only authority available after a DO wake.
   // Close internet before reading it so storage or validation failures cannot
@@ -154,10 +159,15 @@ export async function restoreSandboxNetworkEnforcement(
   delegate.enableInternet = false;
   const stored = await readStoredSandboxNetworkConstraints(storage);
 
-  if (stored === null) {
-    delegate.enableInternet = true;
+  if (stored?.networkPolicy === "limited") {
+    assertEnforceableSandboxNetworkConstraints(stored, {
+      containerRunning: false,
+      httpsInterceptionDisabled: options.httpsInterceptionDisabled,
+    });
+    configureSandboxHttpsInterception(delegate, true);
     return;
   }
 
-  delegate.enableInternet = stored.networkPolicy !== "limited";
+  configureSandboxHttpsInterception(delegate, false);
+  delegate.enableInternet = true;
 }

--- a/apps/api/src/adapters/durable-objects/sandbox.do.ts
+++ b/apps/api/src/adapters/durable-objects/sandbox.do.ts
@@ -1,7 +1,6 @@
 import { DurableObject } from "cloudflare:workers";
 
 import type { ApiBindings } from "../../platform/cloudflare/worker-types";
-import { configureSandboxHttpsInterception } from "./sandbox-https-interception";
 import {
   configureSandboxNetworkConstraints,
   restoreSandboxNetworkEnforcement,
@@ -34,19 +33,15 @@ export class Sandbox extends DurableObject {
 
     this.#httpsInterceptionDisabled = env.SANDBOX_FILE_BUCKET_LOCAL === "true";
     this.#delegatePromise = import("@cloudflare/sandbox").then(
-      ({ Sandbox: SandboxImplementation }) => {
-        const delegate = new SandboxImplementation(ctx, env);
-
-        configureSandboxHttpsInterception(delegate, env.SANDBOX_FILE_BUCKET_LOCAL);
-
-        return delegate;
-      },
+      ({ Sandbox: SandboxImplementation }) => new SandboxImplementation(ctx, env),
     );
     // Re-assert the persisted internet switch before any container start. A
     // rejected restore blocks every access/start RPC, while teardown remains
     // available so lifecycle repair can remove the untrusted container.
     this.#networkRestorePromise = this.#delegatePromise.then((delegate) =>
-      restoreSandboxNetworkEnforcement(ctx.storage, delegate),
+      restoreSandboxNetworkEnforcement(ctx.storage, delegate, {
+        httpsInterceptionDisabled: this.#httpsInterceptionDisabled,
+      }),
     );
   }
 

--- a/apps/api/tests/sandbox-https-interception.test.ts
+++ b/apps/api/tests/sandbox-https-interception.test.ts
@@ -3,17 +3,18 @@ import { describe, expect, test } from "bun:test";
 import { configureSandboxHttpsInterception } from "../src/adapters/durable-objects/sandbox-https-interception";
 
 describe("Sandbox HTTPS interception", () => {
-  test("pins production on and preserves the explicit local CA escape hatch", () => {
-    const local = { interceptHttps: true };
-    configureSandboxHttpsInterception(local, "true");
-    expect(local.interceptHttps).toBe(false);
+  test("keeps the platform hook and Sandbox startup flag aligned", () => {
+    const sandbox = {
+      envVars: { EXISTING: "kept" },
+      interceptHttps: false,
+    };
 
-    const production = { interceptHttps: false };
-    configureSandboxHttpsInterception(production, "false");
-    expect(production.interceptHttps).toBe(true);
+    configureSandboxHttpsInterception(sandbox, true);
+    expect(sandbox.interceptHttps).toBe(true);
+    expect(sandbox.envVars).toEqual({ EXISTING: "kept", SANDBOX_INTERCEPT_HTTPS: "1" });
 
-    const unset = { interceptHttps: false };
-    configureSandboxHttpsInterception(unset, undefined);
-    expect(unset.interceptHttps).toBe(true);
+    configureSandboxHttpsInterception(sandbox, false);
+    expect(sandbox.interceptHttps).toBe(false);
+    expect(sandbox.envVars).toEqual({ EXISTING: "kept" });
   });
 });

--- a/apps/api/tests/sandbox-network-enforcement.test.ts
+++ b/apps/api/tests/sandbox-network-enforcement.test.ts
@@ -27,6 +27,8 @@ function createDelegate() {
   return {
     allowedHostsCalls,
     enableInternet: true,
+    envVars: {},
+    interceptHttps: false,
     setAllowedHosts: (hosts: string[]) => {
       allowedHostsCalls.push(hosts);
       return Promise.resolve();
@@ -48,6 +50,8 @@ describe("sandbox network enforcement", () => {
     await configureSandboxNetworkConstraints(storage, delegate, constraints, ENFORCEABLE);
 
     expect(delegate.enableInternet).toBe(false);
+    expect(delegate.interceptHttps).toBe(true);
+    expect(delegate.envVars).toEqual({ SANDBOX_INTERCEPT_HTTPS: "1" });
     expect(delegate.allowedHostsCalls).toEqual([["api.anthropic.com", "api.example.com"]]);
     expect(storage.values.get(SANDBOX_NETWORK_CONSTRAINTS_STORAGE_KEY)).toEqual(constraints);
   });
@@ -66,6 +70,8 @@ describe("sandbox network enforcement", () => {
     ).rejects.toThrow("cannot be enforced");
 
     expect(delegate.enableInternet).toBe(true);
+    expect(delegate.interceptHttps).toBe(false);
+    expect(delegate.envVars).toEqual({});
     expect(delegate.allowedHostsCalls).toEqual([]);
     expect(storage.values.has(SANDBOX_NETWORK_CONSTRAINTS_STORAGE_KEY)).toBe(false);
   });
@@ -82,6 +88,8 @@ describe("sandbox network enforcement", () => {
     );
 
     expect(delegate.enableInternet).toBe(true);
+    expect(delegate.interceptHttps).toBe(false);
+    expect(delegate.envVars).toEqual({});
     expect(delegate.allowedHostsCalls).toEqual([]);
   });
 
@@ -102,6 +110,8 @@ describe("sandbox network enforcement", () => {
     let persistedAtSdkCall = false;
     const delegate = {
       enableInternet: true,
+      envVars: {},
+      interceptHttps: false,
       setAllowedHosts: () => {
         persistedAtSdkCall = storage.values.has(SANDBOX_NETWORK_CONSTRAINTS_STORAGE_KEY);
         return Promise.reject(new Error("SDK interception failed"));
@@ -204,16 +214,44 @@ describe("sandbox network enforcement", () => {
         },
       }),
       limited,
+      { httpsInterceptionDisabled: false },
     );
     expect(limited.enableInternet).toBe(false);
+    expect(limited.interceptHttps).toBe(true);
+    expect(limited.envVars).toEqual({ SANDBOX_INTERCEPT_HTTPS: "1" });
     // The SDK restores its own persisted allowlist; restore only re-applies
-    // the start-time internet switch.
+    // the start-time properties.
     expect(limited.allowedHostsCalls).toEqual([]);
 
     const untouched = createDelegate();
 
-    await restoreSandboxNetworkEnforcement(createStorage(), untouched);
+    await restoreSandboxNetworkEnforcement(createStorage(), untouched, {
+      httpsInterceptionDisabled: false,
+    });
     expect(untouched.enableInternet).toBe(true);
+    expect(untouched.interceptHttps).toBe(false);
+    expect(untouched.envVars).toEqual({});
+  });
+
+  test("restore fails closed for persisted Limited policy without HTTPS interception", async () => {
+    const delegate = createDelegate();
+
+    await expect(
+      restoreSandboxNetworkEnforcement(
+        createStorage({
+          [SANDBOX_NETWORK_CONSTRAINTS_STORAGE_KEY]: {
+            allowedHosts: ["api.example.com"],
+            networkPolicy: "limited",
+          },
+        }),
+        delegate,
+        { httpsInterceptionDisabled: true },
+      ),
+    ).rejects.toThrow("cannot be enforced");
+
+    expect(delegate.enableInternet).toBe(false);
+    expect(delegate.interceptHttps).toBe(false);
+    expect(delegate.envVars).toEqual({});
   });
 
   test("restore fails closed on a corrupt persisted record", async () => {
@@ -223,6 +261,7 @@ describe("sandbox network enforcement", () => {
       restoreSandboxNetworkEnforcement(
         createStorage({ [SANDBOX_NETWORK_CONSTRAINTS_STORAGE_KEY]: { networkPolicy: "open" } }),
         delegate,
+        { httpsInterceptionDisabled: false },
       ),
     ).rejects.toThrow("unknown network policy");
     expect(delegate.enableInternet).toBe(false);


### PR DESCRIPTION
## Summary

- Scope Cloudflare Sandbox HTTPS interception to Limited network sessions.
- Restore both the interception hook and its startup flag when a Durable Object wakes.

## Why

- Full network sessions were forced to require HTTPS interception without an outbound interception rule. Cloudflare therefore provided no CA, the Sandbox control plane refused to start, and the agent driver never reached hello/heartbeat.

## Verification

- Commands: `just check`; focused Sandbox tests; API typecheck/format; isolated local D1 migration chain; remote migration ledger; queue inventory; Driver build; API/Web production dry-runs.
- Manual steps: confirmed WH-2099 production has no pending migration and all five required queues.
- Not run: post-deploy OpenAI session canary (runs after merge/deploy).

## Impact

- User/API/contract changes: Full/OpenAI sessions can start again; no public API contract change.
- Generated files / GraphQL / DB / lockfile: none.
- Env or config changes: none.
- Risk and rollback: Limited sessions keep fail-closed enforcement; rollback by reverting this commit.

## Review

- Closest review areas: Sandbox startup settings and persisted network-policy restore.
- Known trade-offs: Full sessions intentionally keep HTTPS interception disabled unless a Limited policy installs the corresponding allowlist rule.