### PR TITLE
fix(runtime): use Worker-compatible redirect mode

### DIFF
--- a/apps/api/src/adapters/http/routes/driver-route.ts
+++ b/apps/api/src/adapters/http/routes/driver-route.ts
@@ -383,7 +383,7 @@ async function proxyRuntimeLlmRequest(
   const init: RequestInit = {
     headers: buildLlmProxyUpstreamHeaders(request.headers, target),
     method: request.method,
-    redirect: "error",
+    redirect: "manual",
     signal: request.signal,
   };
 

--- a/apps/api/tests/driver-llm-proxy-route.test.ts
+++ b/apps/api/tests/driver-llm-proxy-route.test.ts
@@ -261,7 +261,7 @@ describe("driver LLM proxy route", () => {
     const upstream = captured[0];
     expect(upstream?.url).toBe("https://api.anthropic.com/v1/messages?beta=true");
     expect(upstream?.method).toBe("POST");
-    expect(upstream?.redirect).toBe("error");
+    expect(upstream?.redirect).toBe("manual");
     expect(upstream?.body).toBe(JSON.stringify({ model: "claude-sonnet-5" }));
     // The grant never leaves the control plane; the vault key does not exist
     // anywhere in the sandbox-visible request.


### PR DESCRIPTION
## Summary
- use Cloudflare Workers-supported `redirect: "manual"` for runtime LLM proxy fetches
- preserve no-follow behavior and lock it with the existing route test

## Root cause
Cloudflare Workers rejects `redirect: "error"` before sending the upstream request, while Bun accepts it.

## Verification
- `bun test apps/api/tests/driver-llm-proxy-route.test.ts`
- `just tc-package @mosoo/api`
- focused formatting checks
- `git diff --check`