### PR TITLE
fix(runtime): prepare checkpoint directories before backup

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/sandbox-backup-platform.ts
+++ b/apps/api/src/modules/runtime/infrastructure/sandbox-backup-platform.ts
@@ -32,8 +32,9 @@ export async function createRuntimeSandboxBackup(
 
   return withDisposedRpcResource(
     await getRuntimeSubjectKeepAliveHandle(bindings, input.sandboxId),
-    async (sandbox) =>
-      withDisposedRpcResult(
+    async (sandbox) => {
+      await sandbox.mkdir(input.dir, { recursive: true });
+      return withDisposedRpcResult(
         sandbox.createBackup({
           dir: input.dir,
           ttl: input.ttlSeconds,
@@ -42,7 +43,8 @@ export async function createRuntimeSandboxBackup(
           dir: result.dir,
           id: encodeSandboxBackupIdForStorage(result.id),
         }),
-      ),
+      );
+    },
   );
 }
 

--- a/apps/api/tests/runtime-subject-recycle.test.ts
+++ b/apps/api/tests/runtime-subject-recycle.test.ts
@@ -191,7 +191,7 @@ function createSandboxHandle(): SandboxHandle {
     destroy: async () => {},
     exec: unavailable,
     getSession: unavailable,
-    mkdir: unavailable,
+    mkdir: async () => {},
     mountBucket: unavailable,
     readFile: unavailable,
     restoreBackup: unavailable,
@@ -269,6 +269,7 @@ describe("runtime subject recycle", () => {
         ('01J0000000000000000000000U', 1, 'TERMINATED');
     `);
     const checkpointDirs: string[] = [];
+    const preparedDirs: string[] = [];
     const lifecycleCalls: string[] = [];
     let backupIndex = 0;
     currentSandbox = {
@@ -281,6 +282,9 @@ describe("runtime subject recycle", () => {
           throw new Error("Unexpected extra checkpoint.");
         }
         return { dir: options.dir, id };
+      },
+      mkdir: async (path) => {
+        preparedDirs.push(path);
       },
       destroy: async () => {
         lifecycleCalls.push("destroy");
@@ -319,6 +323,7 @@ describe("runtime subject recycle", () => {
       "/workspace/se/session-1",
       "/workspace/se/session-2",
     ]);
+    expect(preparedDirs.toSorted()).toEqual(checkpointDirs.toSorted());
     expect(lifecycleCalls).toEqual(["keepAlive:false", "destroy"]);
     await expect(readRuntimeSubjectRecycleRow(database)).resolves.toMatchObject({
       last_error: null,


### PR DESCRIPTION
## Summary
- materialize declared checkpoint directories before Cloudflare Sandbox backup
- allow stale/missing pet session workspaces to converge instead of leaving the subject permanently `backing_up`
- assert every checkpoint target is prepared in the recycle test

## Production evidence
A pet subject repeatedly failed maintenance because an old session workspace no longer existed; the operation retried every ten minutes and blocked new runs.

## Verification
- `bun test apps/api/tests/runtime-subject-recycle.test.ts`
- `just tc-package @mosoo/api`
- focused formatting checks
- `git diff --check`