### PR TITLE
chore(domain): move console to cloud.mosoo.ai

### DIFF
--- a/.github/workflows/deploy-try.yml
+++ b/.github/workflows/deploy-try.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 60
     environment:
       name: try
-      url: https://try.mosoo.ai
+      url: https://cloud.mosoo.ai
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -101,10 +101,16 @@ jobs:
         run: |
           set -euo pipefail
           curl_args=(--fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 10)
-          curl "${curl_args[@]}" --output /dev/null https://try.mosoo.ai/
-          curl "${curl_args[@]}" https://try.mosoo.ai/api/health \
+          curl "${curl_args[@]}" --output /dev/null https://cloud.mosoo.ai/
+          curl "${curl_args[@]}" https://cloud.mosoo.ai/api/health \
             | jq -e '.name == "mosoo" and .ok == true'
-          curl "${curl_args[@]}" https://try.mosoo.ai/api/graphql \
+          curl "${curl_args[@]}" https://cloud.mosoo.ai/api/graphql \
             -H 'content-type: application/json' \
             --data '{"query":"query { __typename }"}' \
             | jq -e '.data.__typename == "Query"'
+          test "$(curl "${curl_args[@]}" --output /dev/null \
+            --write-out '%{http_code} %{redirect_url}' \
+            'https://try.mosoo.ai/domain-migration-check?source=deploy')" = \
+            '308 https://cloud.mosoo.ai/domain-migration-check?source=deploy'
+          curl "${curl_args[@]}" https://try.mosoo.ai/api/health \
+            | jq -e '.name == "mosoo" and .ok == true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ This repository is a monorepo:
 | Path                   | Description                                                                                                                     |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `apps/api`             | Cloudflare Worker API with GraphQL, auth, sessions, channels, runtime control plane, and D1/R2/DO bindings.                     |
-| `apps/web`             | React console app built with Vite Plus and deployed as Cloudflare Worker assets on `try.mosoo.ai`.                              |
+| `apps/web`             | React console app built with Vite Plus and deployed as Cloudflare Worker assets on `cloud.mosoo.ai`.                              |
 | `apps/driver`          | Agent Driver bundle used by API Worker / Sandbox paths.                                                                         |
 | `pkgs/contracts`       | Cross-boundary TypeScript contracts and parser surfaces; cross app / package DTOs should go here first.                         |
 | `pkgs/db`              | Drizzle schema and its append-only D1 migration chain.                                                                          |
@@ -407,7 +407,7 @@ and `just deploy-web` publish directly. The API deploy applies pending remote D1
 migrations as its first remote action (see
 [Database And Migrations](#database-and-migrations)).
 
-API production config lives in `apps/api/wrangler.toml`; web production config lives in `apps/web/wrangler.toml`. Cloudflare routes send `try.mosoo.ai/api/*` to the API Worker and `try.mosoo.ai/*` to the console Web Worker. The public landing page and blog on `mosoo.ai/*` are owned by `langgenius/mosoo-website`.
+API production config lives in `apps/api/wrangler.toml`; web production config lives in `apps/web/wrangler.toml`. Cloudflare routes send `cloud.mosoo.ai/api/*` to the API Worker and `cloud.mosoo.ai/*` to the console Web Worker. The legacy console host redirects Web traffic to `cloud.mosoo.ai` but keeps `try.mosoo.ai/api/*` as a direct compatibility route. The public landing page and blog on `mosoo.ai/*` are owned by `langgenius/mosoo-website`.
 
 Do not deploy production directly from an unreviewed local branch.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <a href="https://try.mosoo.ai">Try mosoo</a> ·
+  <a href="https://cloud.mosoo.ai">Try mosoo</a> ·
   <a href="https://mosoo.ai">Website</a> ·
   <a href="https://mosoo.ai/docs">API Documentation</a> ·
   <a href="https://github.com/langgenius/mosoo-connector">mosoo Connector</a>
@@ -55,7 +55,7 @@ mosoo is in Alpha. The managed runtime and Agent API surfaces above are shipped 
 
 ## Getting Started
 
-The fastest way to try mosoo is the hosted console at [try.mosoo.ai](https://try.mosoo.ai). To run it yourself, self-host from a clean clone as below.
+The fastest way to try mosoo is the hosted console at [cloud.mosoo.ai](https://cloud.mosoo.ai). To run it yourself, self-host from a clean clone as below.
 
 ### Prerequisites
 

--- a/apps/api/tests/runtime-sandbox-provisioning-paths.test.ts
+++ b/apps/api/tests/runtime-sandbox-provisioning-paths.test.ts
@@ -25,8 +25,8 @@ describe("toContainerReachableOrigin", () => {
   });
 
   test("leaves public origins untouched", () => {
-    expect(toContainerReachableOrigin("https://try.mosoo.ai/api/graphql")).toBe(
-      "https://try.mosoo.ai/api/graphql",
+    expect(toContainerReachableOrigin("https://cloud.mosoo.ai/api/graphql")).toBe(
+      "https://cloud.mosoo.ai/api/graphql",
     );
   });
 

--- a/apps/api/tests/runtime-subject-network.test.ts
+++ b/apps/api/tests/runtime-subject-network.test.ts
@@ -22,7 +22,7 @@ describe("runtime subject network constraints", () => {
           environmentAllowedHosts: ["api.example.com"],
           networkPolicy: "full",
         },
-        requestUrl: "https://try.mosoo.ai/api/session",
+        requestUrl: "https://cloud.mosoo.ai/api/session",
         subjectKind: "agent",
       }),
     ).toEqual({ allowedHosts: [], networkPolicy: "full" });
@@ -34,11 +34,11 @@ describe("runtime subject network constraints", () => {
         envVars: {},
         kind: "cattle",
         network: LIMITED_NETWORK,
-        requestUrl: "https://try.mosoo.ai/api/session",
+        requestUrl: "https://cloud.mosoo.ai/api/session",
         subjectKind: "session",
       }),
     ).toEqual({
-      allowedHosts: ["api.example.com", "mcp.linear.app", "try.mosoo.ai"],
+      allowedHosts: ["api.example.com", "cloud.mosoo.ai", "mcp.linear.app"],
       networkPolicy: "limited",
     });
   });
@@ -54,15 +54,15 @@ describe("runtime subject network constraints", () => {
           envVars: {},
           kind: "cattle",
           network: LIMITED_NETWORK,
-          requestUrl: "https://try.mosoo.ai/api/session",
+          requestUrl: "https://cloud.mosoo.ai/api/session",
           subjectKind: "session",
         },
       ).allowedHosts,
     ).toEqual([
       "abc123.r2.cloudflarestorage.com",
       "api.example.com",
+      "cloud.mosoo.ai",
       "mcp.linear.app",
-      "try.mosoo.ai",
     ]);
   });
 
@@ -78,7 +78,7 @@ describe("runtime subject network constraints", () => {
           envVars: {},
           kind: "cattle",
           network: { ...LIMITED_NETWORK, environmentAllowedHosts: [] },
-          requestUrl: "https://try.mosoo.ai/api/session",
+          requestUrl: "https://cloud.mosoo.ai/api/session",
           subjectKind: "session",
         },
       ).allowedHosts,
@@ -103,7 +103,7 @@ describe("runtime subject network constraints", () => {
         envVars: {},
         kind: "pet",
         network: LIMITED_NETWORK,
-        requestUrl: "https://try.mosoo.ai/api/session",
+        requestUrl: "https://cloud.mosoo.ai/api/session",
         subjectKind: "agent",
       }),
     ).toThrow("only for Task Agents");
@@ -118,7 +118,7 @@ describe("runtime subject network constraints", () => {
         },
         kind: "cattle",
         network: LIMITED_NETWORK,
-        requestUrl: "https://try.mosoo.ai/api/session",
+        requestUrl: "https://cloud.mosoo.ai/api/session",
         subjectKind: "session",
       }),
     ).toThrow("HTTPS_PROXY, http_proxy");

--- a/apps/api/tests/sandbox-network-constraints.test.ts
+++ b/apps/api/tests/sandbox-network-constraints.test.ts
@@ -75,7 +75,7 @@ describe("sandbox network constraints", () => {
   test("system host extraction handles URLs, proxy notation, and IPv6", () => {
     expect(
       toSandboxSystemHostsFromUrls([
-        "https://try.mosoo.ai/api/runtime",
+        "https://cloud.mosoo.ai/api/runtime",
         "http://proxy.internal:3128",
         "proxy-host:8080",
         "https://abc123.r2.cloudflarestorage.com",
@@ -87,7 +87,7 @@ describe("sandbox network constraints", () => {
         "http://[::1]:8080",
       ]),
     ).toEqual([
-      "try.mosoo.ai",
+      "cloud.mosoo.ai",
       "proxy.internal",
       "proxy-host",
       "abc123.r2.cloudflarestorage.com",

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -145,7 +145,7 @@ head_sampling_rate = 0.1
 
 [env.prod.vars]
 APP_NAME = "mosoo"
-WEB_ORIGIN = "https://try.mosoo.ai"
+WEB_ORIGIN = "https://cloud.mosoo.ai"
 AUTH_EMAIL_FROM = "mosoo AUTH <auth@mosoo.ai>"
 FILE_BUCKET_NAME = "mosoo-file"
 BACKUP_BUCKET_NAME = "mosoo-sandbox-state"
@@ -172,6 +172,10 @@ required = [
   "GOOGLE_OAUTH_CLIENT_ID",
   "GOOGLE_OAUTH_CLIENT_SECRET",
 ]
+
+[[env.prod.routes]]
+zone_name = "mosoo.ai"
+pattern = "cloud.mosoo.ai/api/*"
 
 [[env.prod.routes]]
 zone_name = "mosoo.ai"

--- a/apps/web/src/routes/app-overview/app-overview-install.tsx
+++ b/apps/web/src/routes/app-overview/app-overview-install.tsx
@@ -114,7 +114,7 @@ function CodingAgentLane(): ReactElement {
       ) : null}
 
       <p className="text-fg-3 mt-3 max-w-2xl text-[13px] leading-5">
-        One command installs the mosoo CLI and the @mosoo skill, signs in to try.mosoo.ai, and
+        One command installs the mosoo CLI and the @mosoo skill, signs in to cloud.mosoo.ai, and
         checks cloud readiness. Sign-in creates your API token automatically; you will be asked for
         a provider key before sessions can run.
       </p>

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -1,3 +1,5 @@
+import { MOSOO_CONSOLE_HOST, MOSOO_LEGACY_CONSOLE_HOST } from "@mosoo/contracts/origin";
+
 // Locally-typed binding so we don't have to pull `@cloudflare/workers-types`
 // into the SPA build. ASSETS is provided by Workers Assets and only exposes
 // `fetch` at runtime.
@@ -15,6 +17,12 @@ export interface Env {
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
+
+    if (url.hostname === MOSOO_LEGACY_CONSOLE_HOST) {
+      url.protocol = "https:";
+      url.hostname = MOSOO_CONSOLE_HOST;
+      return Response.redirect(url.toString(), 308);
+    }
 
     if (url.pathname === "/api" || url.pathname.startsWith("/api/")) {
       if (env.API === undefined) {

--- a/apps/web/tests/app-overview-boundary.test.ts
+++ b/apps/web/tests/app-overview-boundary.test.ts
@@ -50,7 +50,7 @@ describe("App overview boundary", () => {
     expect(installSource).toContain("installs the mosoo CLI");
     expect(installSource).toContain("@mosoo skill");
     expect(installSource).toContain("checks cloud readiness");
-    expect(installSource).toContain("try.mosoo.ai");
+    expect(installSource).toContain("cloud.mosoo.ai");
     expect(installSource).toContain('"Copy"');
     expect(appIdBadgeSource).toContain("Copy app ID");
 

--- a/apps/web/tests/worker-domain-redirect.test.ts
+++ b/apps/web/tests/worker-domain-redirect.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+
+import worker from "../src/worker";
+
+test("redirects the legacy console host without losing the path or query", async () => {
+  let fetchedAsset = false;
+  const response = await worker.fetch(
+    new Request("http://try.mosoo.ai/apps/demo?source=bookmark"),
+    {
+      ASSETS: {
+        fetch: () => {
+          fetchedAsset = true;
+          return Promise.resolve(new Response(null, { status: 404 }));
+        },
+      },
+    },
+  );
+
+  expect(response.status).toBe(308);
+  expect(response.headers.get("location")).toBe("https://cloud.mosoo.ai/apps/demo?source=bookmark");
+  expect(fetchedAsset).toBe(false);
+});

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -16,6 +16,10 @@ name = "mosoo-web-prod"
 workers_dev = false
 
 [[env.prod.routes]]
+pattern = "cloud.mosoo.ai"
+custom_domain = true
+
+[[env.prod.routes]]
 pattern = "try.mosoo.ai"
 custom_domain = true
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ To support lightweight deployment, fast iteration, and future governance expansi
 
 The architecture is built on the Cloudflare platform and uses a Serverless shape for elastic scaling:
 
-- **Frontend and ingress: Cloudflare Workers**. The Web Worker serves Vite-built console assets. The API Worker handles stateless GraphQL / Web API requests and WebSocket handshakes, then hands upgraded session connections to the corresponding Session Durable Object. `mosoo.ai` is the marketing / landing / blog origin owned by `langgenius/mosoo-website`. Authenticated console traffic uses `try.mosoo.ai`, with Cloudflare routing `try.mosoo.ai/api/*` to the API Worker and console paths to the Web Worker.
+- **Frontend and ingress: Cloudflare Workers**. The Web Worker serves Vite-built console assets. The API Worker handles stateless GraphQL / Web API requests and WebSocket handshakes, then hands upgraded session connections to the corresponding Session Durable Object. `mosoo.ai` is the marketing / landing / blog origin owned by `langgenius/mosoo-website`. Authenticated console traffic uses `cloud.mosoo.ai`, with Cloudflare routing `cloud.mosoo.ai/api/*` to the API Worker and console paths to the Web Worker. During the domain migration, console requests on `try.mosoo.ai` redirect permanently to the new host while `try.mosoo.ai/api/*` remains a direct API route for existing CLI credentials and webhooks.
 - **State and connection management: Cloudflare Durable Objects**. Durable Objects hold upgraded WebSocket connections, high-frequency Session state, and distributed coordination points that need single-instance concurrency.
 - **Primary database: Cloudflare D1**. D1 stores Account records, Organization shell records, App records, core entity configuration, and metadata.
 - **Message queues: Cloudflare Queues**. Queues decouple the control plane from offline tasks. They provide ACK semantics, dead-letter queues, and at-least-once delivery for API commands (including deployment and scheduled maintenance) and Channel final delivery. Cost usage is written from normalized runtime events, not ingested through a queue.
@@ -120,8 +120,8 @@ graph TD
 
 The Web layer provides the interactive client experience.
 
-- It is built with **React / React Router / Vite** and served through Cloudflare Workers Static Assets on `try.mosoo.ai`.
-- Browsers access a same-origin `/api/*` entry point from the console origin. Cloudflare routes `try.mosoo.ai/api/*` to the API Worker and console paths on `try.mosoo.ai` to the Web Worker, preserving independent Web/API deployments while keeping a same-origin product experience. `mosoo.ai` remains the marketing / landing / blog origin in the private website repository and sends login intent to the console origin.
+- It is built with **React / React Router / Vite** and served through Cloudflare Workers Static Assets on `cloud.mosoo.ai`.
+- Browsers access a same-origin `/api/*` entry point from the console origin. Cloudflare routes `cloud.mosoo.ai/api/*` to the API Worker and console paths on `cloud.mosoo.ai` to the Web Worker, preserving independent Web/API deployments while keeping a same-origin product experience. `mosoo.ai` remains the marketing / landing / blog origin in the private website repository and sends login intent to the console origin. The legacy Web host preserves paths and query strings when redirecting; its `/api/*` route does not redirect across hosts because clients may drop authorization headers.
 - WebSocket, using the `AG-UI WebSocket` protocol, carries bidirectional high-frequency streaming events such as text streaming and state synchronization.
 
 ### 4.2 API Layer

--- a/docs/prd/public-thread-api-surface.md
+++ b/docs/prd/public-thread-api-surface.md
@@ -2,7 +2,7 @@
 
 Status: Available for App-owner integrations with a limited identity model. The
 exact HTTP contract is the
-[OpenAPI document](https://try.mosoo.ai/api/v1/openapi.json).
+[OpenAPI document](https://cloud.mosoo.ai/api/v1/openapi.json).
 
 ## Why it exists
 

--- a/docs/production-deploy-verification.md
+++ b/docs/production-deploy-verification.md
@@ -220,6 +220,24 @@ The workflow uses one `production` concurrency group and never cancels an
 in-progress release because D1 migration, queue updates, and Worker publication
 are not transactional.
 
+### First `cloud.mosoo.ai` Release
+
+Complete these one-time prerequisites before releasing the domain migration:
+
+- Attach `cloud.mosoo.ai` as an additional Custom Domain on the
+  `mosoo-web-prod` Worker and wait for its DNS record and certificate to become
+  active. The normal deploy publishes the API Worker first, and its
+  `cloud.mosoo.ai/api/*` route requires that hostname to exist already.
+- Add `https://cloud.mosoo.ai/api/auth/callback/google` to the Google OAuth
+  client. Keep the old callback during the compatibility window.
+- Expect existing browser sessions to sign in again because host-scoped cookies
+  do not move between subdomains.
+
+Keep the `try.mosoo.ai` Web Custom Domain and API route during the compatibility
+window. Web requests redirect to the new host; `/api/*` continues to execute on
+the API Worker so existing CLI credentials and webhook URLs do not cross a
+redirect boundary.
+
 For a manual release, run the real deploy only after all simulation steps above
 pass.
 
@@ -259,11 +277,14 @@ provider failure, repeat Steps 6-7 (build and dry-run) manually, then rerun
 After a real production deploy, verify the public surface:
 
 ```bash
-curl https://try.mosoo.ai/
-curl https://try.mosoo.ai/api/health
-curl https://try.mosoo.ai/api/graphql \
+curl https://cloud.mosoo.ai/
+curl https://cloud.mosoo.ai/api/health
+curl https://cloud.mosoo.ai/api/graphql \
   -H 'content-type: application/json' \
   --data '{"query":"query { __typename }"}'
+curl --head --max-redirs 0 \
+  'https://try.mosoo.ai/domain-migration-check?source=runbook'
+curl https://try.mosoo.ai/api/health
 ```
 
 Acceptance:
@@ -271,6 +292,9 @@ Acceptance:
 - `/` returns HTTP 200.
 - `/api/health` returns HTTP 200 and `{"name":"mosoo","ok":true}`.
 - `/api/graphql` returns HTTP 200 and `{"data":{"__typename":"Query"}}`.
+- The old Web URL returns HTTP 308 with the same path and query on
+  `https://cloud.mosoo.ai`.
+- The old `/api/health` URL returns HTTP 200 without redirecting.
 - If local HTTPS probes resolve through the local TUN/fake-IP path, keep
   `--interface en0` and `--resolve` in the smoke commands.
 

--- a/pkgs/contracts/src/metadata/origin.contract.ts
+++ b/pkgs/contracts/src/metadata/origin.contract.ts
@@ -1,8 +1,11 @@
 export const MOSOO_MARKETING_HOST = "mosoo.ai";
 export const MOSOO_MARKETING_ORIGIN = `https://${MOSOO_MARKETING_HOST}`;
 
-export const MOSOO_CONSOLE_HOST = "try.mosoo.ai";
+export const MOSOO_CONSOLE_HOST = "cloud.mosoo.ai";
 export const MOSOO_CONSOLE_ORIGIN = `https://${MOSOO_CONSOLE_HOST}`;
 
 export const MOSOO_PRODUCTION_API_ROUTE_PATTERN = `${MOSOO_CONSOLE_HOST}/api/*`;
 export const MOSOO_GOOGLE_OAUTH_CALLBACK_URL = `${MOSOO_CONSOLE_ORIGIN}/api/auth/callback/google`;
+
+export const MOSOO_LEGACY_CONSOLE_HOST = "try.mosoo.ai";
+export const MOSOO_LEGACY_PRODUCTION_API_ROUTE_PATTERN = `${MOSOO_LEGACY_CONSOLE_HOST}/api/*`;

--- a/pkgs/contracts/tests/production-origin.test.ts
+++ b/pkgs/contracts/tests/production-origin.test.ts
@@ -5,6 +5,8 @@ import {
   MOSOO_CONSOLE_HOST,
   MOSOO_CONSOLE_ORIGIN,
   MOSOO_GOOGLE_OAUTH_CALLBACK_URL,
+  MOSOO_LEGACY_CONSOLE_HOST,
+  MOSOO_LEGACY_PRODUCTION_API_ROUTE_PATTERN,
   MOSOO_MARKETING_HOST,
   MOSOO_PRODUCTION_API_ROUTE_PATTERN,
 } from "@mosoo/contracts/origin";
@@ -20,9 +22,11 @@ describe("production origins", () => {
 
     expect(apiWrangler).toContain(`WEB_ORIGIN = "${MOSOO_CONSOLE_ORIGIN}"`);
     expect(apiWrangler).toContain(`pattern = "${MOSOO_PRODUCTION_API_ROUTE_PATTERN}"`);
+    expect(apiWrangler).toContain(`pattern = "${MOSOO_LEGACY_PRODUCTION_API_ROUTE_PATTERN}"`);
     expect(apiWrangler).toContain('"GOOGLE_OAUTH_CLIENT_ID"');
     expect(apiWrangler).toContain('"GOOGLE_OAUTH_CLIENT_SECRET"');
     expect(webWrangler).toContain(`pattern = "${MOSOO_CONSOLE_HOST}"`);
+    expect(webWrangler).toContain(`pattern = "${MOSOO_LEGACY_CONSOLE_HOST}"`);
     expect(webWrangler).not.toContain(`pattern = "${MOSOO_MARKETING_HOST}"`);
   });
 


### PR DESCRIPTION
## Summary

- move the authenticated console and primary `/api/*` route from `try.mosoo.ai` to `cloud.mosoo.ai`
- keep `try.mosoo.ai/api/*` as a direct compatibility alias for existing CLI credentials, webhooks, and WebSocket clients
- return HTTP 308 for legacy Web URLs while preserving the path and query string
- update runtime allowlists, deploy smoke checks, docs, and public origin contracts

## First-release prerequisites

Before the first production release:

- attach `cloud.mosoo.ai` to `mosoo-web-prod` and wait for DNS/TLS activation
- add `https://cloud.mosoo.ai/api/auth/callback/google` to the Google OAuth client while retaining the old callback during the compatibility window
- expect existing host-scoped browser sessions to sign in again

No production deployment is included in this PR.

## Verification

- `bun test pkgs/contracts/tests/production-origin.test.ts apps/api/tests/runtime-sandbox-provisioning-paths.test.ts apps/api/tests/runtime-subject-network.test.ts apps/api/tests/sandbox-network-constraints.test.ts apps/web/tests/app-overview-boundary.test.ts apps/web/tests/worker-domain-redirect.test.ts` — 29/29 passed
- `just check` — formatting, docs links, lint, typecheck, and all relevant tests passed; the only failure is the unchanged Driver macOS `/var/...` vs `/private/var/...` baseline in `apps/driver/tests/acp-file-system.test.ts`
- `just commit-check` — passed

Generated files: none. GraphQL codegen: not required. DB migrations: none. Lockfile changes: none.