### PR TITLE
perf(runtime): prewarm sessions and raise sandbox capacity

### DIFF
--- a/apps/api/src/modules/public-api/public-thread-create.ts
+++ b/apps/api/src/modules/public-api/public-thread-create.ts
@@ -80,6 +80,7 @@ export async function createPublicThread(
         attributedUserId: admission.attributedUserId,
         metadata: { public_api: metadata },
       },
+      ...(request.input.inputText === undefined ? { requestUrl: request.requestUrl } : {}),
       viewer: admission.creatorViewer,
     });
     const sessionId = session.id;

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -196,7 +196,7 @@ class_name = "Sandbox"
 [[env.prod.containers]]
 class_name = "Sandbox"
 image = "../driver/Containerfile"
-instance_type = "basic"
+instance_type = "standard-2"
 max_instances = 1000
 
 [[env.prod.r2_buckets]]


### PR DESCRIPTION
## Summary

- Start runtime prewarm when the Public API creates an empty Thread, overlapping Sandbox startup with the user's first input.
- Raise the production Sandbox instance type from `basic` to `standard-2` for Codex, Anthropic, OpenCode, and environment build/deploy workloads.
- Keep the two independently promoted performance champions as separate commits.

## Why

- A new user's first Run currently serializes Thread creation, Sandbox startup, runtime CLI/SDK initialization, and provider work.
- Prewarming removes avoidable serialization; additional CPU and memory reduce the remaining runtime startup bottleneck.
- Advances #387 and builds on the performance infrastructure from #451 / #454.

## Verification

- Commands:
  - `just commit-check` — passed for both commits.
  - `TMPDIR=/private/tmp just check` — passed (format, docs, lint, typecheck, 2,000+ regular tests, and GraphQL codegen check).
  - `just tc-package @mosoo/api` — passed.
- Manual steps:
  - Real local Public API OpenAI runtime E2E: 1/1 passed; runtime completed in 23.9s.
  - DeepSeek prewarm staging crossover, 4 pairs: first output median 34.43s → 26.68s; paired improvement 25.4%; 8/8 correctness, identity, trace, and cleanup checks passed.
  - Anthropic `basic` → `standard-2` staging crossover, 4 pairs: first output median 20.75s → 10.63s; paired improvement 46.4%; completion median 34.65s → 24.87s; 8/8 checks passed.
- Not run:
  - A complete Codex staging before/after batch; Codex has local correctness coverage, while the measured machine-size crossover used Anthropic.

## Impact

- User/API/contract changes: Faster first-session startup; no public API or data-contract change.
- Generated files / GraphQL / DB / lockfile: None.
- Env or config changes: All production Sandbox workloads use `standard-2` (`1 vCPU`, `6 GiB` memory, `12 GB` disk).
- Risk and rollback:
  - Current production usage projects approximately $150–255/month additional Containers compute after the global size increase. Revert `e868c9d5fd` to restore `basic`.
  - An abandoned empty Thread may start a billable Sandbox before first input; staging lifecycle evidence showed it returning inactive after about 11.5 minutes. Revert `88fa8606a1` to remove prewarm.

## Review

- Closest review areas: Public Thread creation lifecycle and production Cloudflare Container sizing.
- Known trade-offs: Anthropic marginal inter-chunk P95 increased by 79ms, while first output and completion improved in every paired run; the larger instance applies globally rather than only to one runtime.
