### PR TITLE
fix(runtime): deliver complete message streams

### DIFF
--- a/apps/api/src/modules/sessions/infrastructure/session-runtime-event-store.repository.ts
+++ b/apps/api/src/modules/sessions/infrastructure/session-runtime-event-store.repository.ts
@@ -35,6 +35,8 @@ export type {
 } from "./session-runtime-event-store.types";
 
 const MAX_SESSION_RUNTIME_EVENT_INSERT_ATTEMPTS = 5;
+// D1 accepts at most 100 bound parameters; each session_event row binds 18.
+const MAX_SESSION_EVENT_ROWS_PER_INSERT = 5;
 const WRITABLE_SESSION_STATUSES = ["IDLE", "RUNNING", "RESCHEDULING"] as const;
 const TERMINAL_LIFECYCLE_WRITABLE_SESSION_STATUSES = [
   ...WRITABLE_SESSION_STATUSES,
@@ -419,17 +421,34 @@ async function insertSessionEventRows(
     };
   }
 
-  const insertedRows = await getAppDatabase(database)
-    .insert(sessionEventsTable)
-    .values([...values])
-    .onConflictDoNothing({
-      target: [sessionEventsTable.sessionId, sessionEventsTable.sourceEventId],
-    })
-    .returning({
-      sessionId: sessionEventsTable.sessionId,
-      sourceEventId: sessionEventsTable.sourceEventId,
-    })
-    .all();
+  const appDatabase = getAppDatabase(database);
+  const statements: D1PreparedStatement[] = [];
+
+  for (let index = 0; index < values.length; index += MAX_SESSION_EVENT_ROWS_PER_INSERT) {
+    const query = appDatabase
+      .insert(sessionEventsTable)
+      .values(values.slice(index, index + MAX_SESSION_EVENT_ROWS_PER_INSERT))
+      .onConflictDoNothing({
+        target: [sessionEventsTable.sessionId, sessionEventsTable.sourceEventId],
+      })
+      .returning({
+        sessionId: sessionEventsTable.sessionId,
+        sourceEventId: sessionEventsTable.sourceEventId,
+      })
+      .toSQL();
+
+    statements.push(database.prepare(query.sql).bind(...query.params));
+  }
+
+  const results = await database.batch<{ session_id: SessionId; source_event_id: string }>(
+    statements,
+  );
+  const insertedRows = results.flatMap((result) =>
+    result.results.map((row) => ({
+      sessionId: row.session_id,
+      sourceEventId: row.source_event_id,
+    })),
+  );
 
   return {
     insertedCount: insertedRows.length,

--- a/apps/api/tests/helpers/sqlite-d1.ts
+++ b/apps/api/tests/helpers/sqlite-d1.ts
@@ -5,10 +5,14 @@ import { getAppDatabase } from "../../src/platform/db/drizzle";
 
 type RawOptions = { columnNames?: boolean } | undefined;
 
+const statementQueries = new WeakMap<D1PreparedStatement, string>();
+
 export class SqliteD1Database implements D1Database {
   readonly #database = new Database(":memory:");
+  readonly #maxBoundParams: number | undefined;
 
-  constructor(input: { foreignKeys?: boolean } = {}) {
+  constructor(input: { foreignKeys?: boolean; maxBoundParams?: number } = {}) {
+    this.#maxBoundParams = input.maxBoundParams;
     this.#database.run(`PRAGMA foreign_keys = ${input.foreignKeys === false ? "OFF" : "ON"}`);
   }
 
@@ -17,7 +21,7 @@ export class SqliteD1Database implements D1Database {
   }
 
   prepare(query: string): D1PreparedStatement {
-    return createSqliteD1Statement(this.#database, query);
+    return createSqliteD1Statement(this.#database, query, [], this.#maxBoundParams);
   }
 
   app(): AppDatabase {
@@ -30,7 +34,11 @@ export class SqliteD1Database implements D1Database {
 
     try {
       for (const statement of statements) {
-        results.push((await statement.run<T>()) as D1Result<T>);
+        const query = statementQueries.get(statement) ?? "";
+        const returnsRows = /^\s*(select|with)\b/i.test(query) || /\breturning\b/i.test(query);
+        results.push(
+          returnsRows ? await statement.all<T>() : ((await statement.run<T>()) as D1Result<T>),
+        );
       }
       this.#database.run("COMMIT");
       return results;
@@ -62,13 +70,20 @@ function createSqliteD1Statement(
   database: Database,
   query: string,
   values: readonly unknown[] = [],
+  maxBoundParams?: number,
 ): D1PreparedStatement {
-  return {
+  const statement: D1PreparedStatement = {
     all: async <T = unknown>() => {
       const results = database.query(query).all(...values) as T[];
       return { meta: createD1Meta(), results, success: true };
     },
-    bind: (...nextValues: unknown[]) => createSqliteD1Statement(database, query, nextValues),
+    bind: (...nextValues: unknown[]) => {
+      if (maxBoundParams !== undefined && nextValues.length > maxBoundParams) {
+        throw new Error(`too many SQL variables: ${nextValues.length} > ${maxBoundParams}`);
+      }
+
+      return createSqliteD1Statement(database, query, nextValues, maxBoundParams);
+    },
     first: async <T = unknown>(colName?: string) => {
       const row = (database.query(query).get(...values) as Record<string, unknown> | null) ?? null;
 
@@ -83,11 +98,11 @@ function createSqliteD1Statement(
       return row as T;
     },
     raw: async <T = unknown[]>(options?: RawOptions) => {
-      const statement = database.query(query);
-      const rows = statement.values(...values) as T[];
+      const sqliteStatement = database.query(query);
+      const rows = sqliteStatement.values(...values) as T[];
 
       if (options?.columnNames === true) {
-        return [statement.columnNames as T, ...rows];
+        return [sqliteStatement.columnNames as T, ...rows];
       }
 
       return rows;
@@ -101,6 +116,9 @@ function createSqliteD1Statement(
       };
     },
   };
+
+  statementQueries.set(statement, query);
+  return statement;
 }
 
 function createD1Meta(overrides: Partial<D1Meta> = {}): D1Meta {

--- a/apps/api/tests/runtime-final-output-ingestion.test.ts
+++ b/apps/api/tests/runtime-final-output-ingestion.test.ts
@@ -227,18 +227,21 @@ async function insertRuntimeFixture(database: SqliteD1Database): Promise<void> {
   `);
 }
 
-function failSecondSessionEventInsert(database: D1Database): D1Database {
-  let sessionEventInsertCount = 0;
-
+function failTerminalSessionEventInsert(database: D1Database): D1Database {
   function wrapStatement(
     statement: D1PreparedStatement,
     isSessionEventInsert: boolean,
+    shouldFail: boolean,
   ): D1PreparedStatement {
     return new Proxy(statement, {
       get(target, property) {
         if (property === "bind") {
           return (...values: unknown[]) =>
-            wrapStatement(target.bind(...values), isSessionEventInsert);
+            wrapStatement(
+              target.bind(...values),
+              isSessionEventInsert,
+              isSessionEventInsert && values.includes(TERMINAL_SOURCE_EVENT_ID),
+            );
         }
 
         const value = Reflect.get(target, property);
@@ -248,12 +251,8 @@ function failSecondSessionEventInsert(database: D1Database): D1Database {
           (property === "all" || property === "first" || property === "raw" || property === "run")
         ) {
           return (...arguments_: unknown[]) => {
-            if (isSessionEventInsert) {
-              sessionEventInsertCount += 1;
-
-              if (sessionEventInsertCount === 2) {
-                throw new Error("injected terminal session_event persistence failure");
-              }
+            if (shouldFail) {
+              throw new Error("injected terminal session_event persistence failure");
             }
 
             return Reflect.apply(value, target, arguments_);
@@ -272,6 +271,7 @@ function failSecondSessionEventInsert(database: D1Database): D1Database {
           wrapStatement(
             target.prepare(query),
             /insert\s+into\s+["`]session_event["`]/iu.test(query),
+            false,
           );
       }
 
@@ -456,7 +456,7 @@ describe("runtime final output ingestion", () => {
     ];
     const failingBindings = {
       ...bindings,
-      DB: failSecondSessionEventInsert(database),
+      DB: failTerminalSessionEventInsert(database),
     } as ApiBindings;
 
     await expect(pushFreshController(failingBindings, terminalBatch)).rejects.toBeInstanceOf(Error);
@@ -663,7 +663,7 @@ describe("runtime final output ingestion", () => {
     ];
     const failingBindings = {
       ...bindings,
-      DB: failSecondSessionEventInsert(database),
+      DB: failTerminalSessionEventInsert(database),
     } as ApiBindings;
 
     await expect(pushFreshController(failingBindings, terminalBatch)).rejects.toBeInstanceOf(Error);

--- a/apps/api/tests/session-runtime-event-store.test.ts
+++ b/apps/api/tests/session-runtime-event-store.test.ts
@@ -39,8 +39,13 @@ function runtimeEvent(input: {
   });
 }
 
-function createRuntimeEventStoreDatabase(): SqliteD1Database {
-  const database = new SqliteD1Database({ foreignKeys: false });
+function createRuntimeEventStoreDatabase(
+  input: { maxBoundParams?: number } = {},
+): SqliteD1Database {
+  const database = new SqliteD1Database({
+    foreignKeys: false,
+    maxBoundParams: input.maxBoundParams,
+  });
 
   database.execute(`
     CREATE TABLE session (
@@ -115,6 +120,67 @@ function createRuntimeEventStoreDatabase(): SqliteD1Database {
 }
 
 describe("session runtime event store", () => {
+  test("keeps runtime event inserts within D1's bound parameter limit", async () => {
+    const database = createRuntimeEventStoreDatabase({ maxBoundParams: 100 });
+    const records = Array.from({ length: 6 }, (_, index) => {
+      const eventId = `event-${index + 1}`;
+
+      return {
+        event: runtimeEvent({
+          id: eventId,
+          kind: "message.delta",
+          occurredAtMs: 1_000 + index,
+          payload: {
+            contentDelta: `${index}`,
+            messageId: "message-1",
+          },
+          runId: "run-1",
+        }),
+        occurredAt: 1_000 + index,
+        sourceEventId: eventId,
+      };
+    });
+
+    const result = await persistSessionRuntimeEvents(database, {
+      records,
+      sessionId: "session-1",
+    });
+    const rows = await database
+      .prepare("SELECT seq, source_event_id FROM session_event ORDER BY seq")
+      .all<{ seq: number; source_event_id: string }>();
+
+    expect(result.persistedCount).toBe(6);
+    expect(rows.results).toEqual(
+      records.map((record, index) => ({
+        seq: index + 1,
+        source_event_id: record.sourceEventId,
+      })),
+    );
+
+    const failingDatabase = createRuntimeEventStoreDatabase({ maxBoundParams: 100 });
+    failingDatabase.execute(`
+      CREATE TRIGGER reject_last_event
+      BEFORE INSERT ON session_event
+      WHEN NEW.source_event_id = 'event-6'
+      BEGIN
+        SELECT RAISE(ABORT, 'forced event insert failure');
+      END;
+    `);
+
+    await expect(
+      persistSessionRuntimeEvents(failingDatabase, {
+        records,
+        sessionId: "session-1",
+      }),
+    ).rejects.toThrow("forced event insert failure");
+
+    const count = await failingDatabase
+      .prepare("SELECT COUNT(*) AS count FROM session_event")
+      .first<{ count: number }>();
+
+    expect(count?.count).toBe(0);
+  });
+
   test("persists mixed source ids and skips source replays before allocating sequence", async () => {
     const database = createRuntimeEventStoreDatabase();
 

--- a/apps/web/src/domains/runtime/session-stream/session-stream-render-scheduler.ts
+++ b/apps/web/src/domains/runtime/session-stream/session-stream-render-scheduler.ts
@@ -76,6 +76,10 @@ function getPaceableTextDelta(event: AgUiSessionEvent): string | null {
   }
 
   if (event.type === "TEXT_MESSAGE_CHUNK") {
+    if (event.role === "user") {
+      return null;
+    }
+
     return typeof event.delta === "string" && event.delta.length > 0 ? event.delta : null;
   }
 

--- a/apps/web/tests/session-stream-render-scheduler.test.ts
+++ b/apps/web/tests/session-stream-render-scheduler.test.ts
@@ -333,6 +333,27 @@ describe("session stream render scheduler", () => {
     expect(batchText(chunks)).toBe(text);
   });
 
+  test("delivers user chunks atomically instead of pacing the server echo", () => {
+    const manual = createManualHost();
+    const batches: AgUiSessionEvent[][] = [];
+    const scheduler = new SessionStreamRenderScheduler((_sessionId, events) => {
+      batches.push(events);
+      return true;
+    }, manual.host);
+    const event = {
+      delta: "用户发送的内容",
+      messageId: "message-user",
+      role: "user",
+      type: "TEXT_MESSAGE_CHUNK",
+    } as const satisfies AgUiSessionEvent;
+
+    scheduler.enqueue("session-1", event);
+    manual.fireFrame();
+
+    expect(batches).toEqual([[event]]);
+    expect(drainFrames(manual)).toBe(0);
+  });
+
   test("flushNow delivers the paced remainder exactly once", () => {
     const manual = createManualHost();
     const batches: AgUiSessionEvent[][] = [];


### PR DESCRIPTION
## Summary

- Split `session_event` inserts into five-row D1 statements while keeping the logical write atomic through `D1Database.batch()`.
- Deliver `role: user` `TEXT_MESSAGE_CHUNK` events atomically instead of pacing the server echo through the assistant typewriter scheduler.
- Add regressions for D1's 100-bound-parameter limit, batch rollback, terminal replay injection, and fixed user-message rendering.

## Root cause

A `session_event` row binds 18 parameters, but the API inserted a whole streamed delta batch in one statement. Six or more rows exceed D1's 100-parameter limit. The sequence allocator had already reserved the batch range before each failed attempt, which matches the large sequence gaps observed in production. The first small delta survived; later batched deltas were rejected; the lossless final snapshot then appeared all at once.

Separately, #450 paced every `TEXT_MESSAGE_CHUNK`, including the server echo of an already-rendered optimistic user message. That made the same user text visibly stream above the fixed bubble until echo reconciliation completed.

## Impact

Assistant output now receives every persisted delta for smooth pacing, process logs retain the complete stream plus the final lossless snapshot, and sent user messages remain fixed with an atomic echo replacement.

## Validation

- `just test-package @mosoo/api` — 1169 passed
- `just test-package @mosoo/web` — 214 passed
- `just tc-package @mosoo/api`
- `just tc-package @mosoo/web`
- `bun run --filter @mosoo/web build`
- changed-file lint, format, and commit/push hooks passed

`just check` reached the full test phase but exits on the unchanged driver test `ACP file system bridge > writes allowed text files...`: macOS resolves the expected `/var/...` path to `/private/var/...`. The focused failure reproduces on the exact driver submodule SHA pinned by `main`; it is unrelated to this diff.
