### PR TITLE
fix(domain): harden console rollout

### DIFF
--- a/.github/workflows/deploy-try.yml
+++ b/.github/workflows/deploy-try.yml
@@ -108,9 +108,15 @@ jobs:
             -H 'content-type: application/json' \
             --data '{"query":"query { __typename }"}' \
             | jq -e '.data.__typename == "Query"'
-          test "$(curl "${curl_args[@]}" --output /dev/null \
-            --write-out '%{http_code} %{redirect_url}' \
-            'https://try.mosoo.ai/domain-migration-check?source=deploy')" = \
-            '308 https://cloud.mosoo.ai/domain-migration-check?source=deploy'
+          expected_redirect='308 https://cloud.mosoo.ai/domain-migration-check?source=deploy'
+          for attempt in {1..12}; do
+            actual_redirect="$(curl "${curl_args[@]}" --output /dev/null \
+              --write-out '%{http_code} %{redirect_url}' \
+              'https://try.mosoo.ai/domain-migration-check?source=deploy')"
+            [[ "$actual_redirect" == "$expected_redirect" ]] && break
+            printf 'Waiting for redirect propagation (%s/12): %s\n' "$attempt" "$actual_redirect"
+            sleep 10
+          done
+          test "$actual_redirect" = "$expected_redirect"
           curl "${curl_args[@]}" https://try.mosoo.ai/api/health \
             | jq -e '.name == "mosoo" and .ok == true'

--- a/.github/workflows/deploy-try.yml
+++ b/.github/workflows/deploy-try.yml
@@ -118,5 +118,12 @@ jobs:
             sleep 10
           done
           test "$actual_redirect" = "$expected_redirect"
+          test "$(curl "${curl_args[@]}" --output /dev/null \
+            --write-out '%{http_code} %{redirect_url}' \
+            http://cloud.mosoo.ai/)" = '308 https://cloud.mosoo.ai/'
+          test "$(curl "${curl_args[@]}" --output /dev/null \
+            --write-out '%{http_code} %{redirect_url}' \
+            http://cloud.mosoo.ai/api/health)" = \
+            '308 https://cloud.mosoo.ai/api/health'
           curl "${curl_args[@]}" https://try.mosoo.ai/api/health \
             | jq -e '.name == "mosoo" and .ok == true'

--- a/apps/api/src/platform/cloudflare/create-api-worker.ts
+++ b/apps/api/src/platform/cloudflare/create-api-worker.ts
@@ -1,3 +1,5 @@
+import { MOSOO_CONSOLE_HOST, MOSOO_LEGACY_CONSOLE_HOST } from "@mosoo/contracts/origin";
+
 import { enqueueScheduledMaintenanceCommand } from "../../modules/api-command/application/api-command-enqueue";
 import { redriveFailedApiCommandEnqueues } from "../../modules/api-command/application/api-command-ledger";
 import type { ApiCommandMessage } from "../../modules/api-command/application/api-command-message";
@@ -25,6 +27,16 @@ function getHttpApp(): Promise<ApiHttpApp> {
 export function createApiWorker(): ExportedHandler<ApiBindings> {
   return {
     async fetch(request: Request, env: ApiBindings, ctx: ExecutionContext): Promise<Response> {
+      const url = new URL(request.url);
+
+      if (
+        url.protocol === "http:" &&
+        (url.hostname === MOSOO_CONSOLE_HOST || url.hostname === MOSOO_LEGACY_CONSOLE_HOST)
+      ) {
+        url.protocol = "https:";
+        return Response.redirect(url.toString(), 308);
+      }
+
       const app = await getHttpApp();
       const response = await app.fetch(request, env, ctx);
 

--- a/apps/api/tests/api-worker-https-redirect.test.ts
+++ b/apps/api/tests/api-worker-https-redirect.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+
+import { createApiWorker } from "../src/platform/cloudflare/create-api-worker";
+import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
+
+test("redirects plaintext requests for both production API hosts", async () => {
+  const fetch = createApiWorker().fetch;
+
+  if (fetch === undefined || typeof fetch !== "function") {
+    throw new Error("API Worker fetch handler is unavailable.");
+  }
+
+  for (const host of ["cloud.mosoo.ai", "try.mosoo.ai"]) {
+    const response = await fetch(
+      new Request(`http://${host}/api/health?source=https-check`),
+      {} as ApiBindings,
+      {} as ExecutionContext,
+    );
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe(`https://${host}/api/health?source=https-check`);
+  }
+});

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -18,7 +18,10 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
 
-    if (url.hostname === MOSOO_LEGACY_CONSOLE_HOST) {
+    if (
+      url.hostname === MOSOO_LEGACY_CONSOLE_HOST ||
+      (url.hostname === MOSOO_CONSOLE_HOST && url.protocol === "http:")
+    ) {
       url.protocol = "https:";
       url.hostname = MOSOO_CONSOLE_HOST;
       return Response.redirect(url.toString(), 308);

--- a/apps/web/tests/worker-domain-redirect.test.ts
+++ b/apps/web/tests/worker-domain-redirect.test.ts
@@ -20,3 +20,14 @@ test("redirects the legacy console host without losing the path or query", async
   expect(response.headers.get("location")).toBe("https://cloud.mosoo.ai/apps/demo?source=bookmark");
   expect(fetchedAsset).toBe(false);
 });
+
+test("redirects plaintext requests for the canonical console host", async () => {
+  const response = await worker.fetch(new Request("http://cloud.mosoo.ai/settings?tab=profile"), {
+    ASSETS: {
+      fetch: () => Promise.resolve(new Response(null, { status: 404 })),
+    },
+  });
+
+  expect(response.status).toBe(308);
+  expect(response.headers.get("location")).toBe("https://cloud.mosoo.ai/settings?tab=profile");
+});


### PR DESCRIPTION
## Summary

- retry the legacy-domain redirect assertion while the Web Worker propagates across edges
- redirect plaintext requests for `cloud.mosoo.ai` to HTTPS
- redirect plaintext requests for both production API hostnames to HTTPS without changing the legacy API hostname
- verify both HTTP upgrade paths in the production workflow

## Evidence

Production run 30547860001 published both Workers successfully, then checked the legacy redirect about three seconds after the Web Worker publish and saw the pre-propagation response. The exact probe returned the expected 308 shortly afterward; new root, health, GraphQL, CORS, Google callback, old deep-link redirect, and old API compatibility all pass.

A follow-up audit found the console and API still served HTTP 200, unlike the installer and main site. This PR closes that target-domain security gap without changing the zone-wide policy or unrelated subdomains.

## Verification

- focused API/Web redirect tests: 3 passed
- `just fmt-check`
- `just lint`
- `just tc-package @mosoo/api`
- `just tc-package @mosoo/web`
- `git diff --check`
