### PR TITLE
fix(domain): route assets through redirect worker

### DIFF
--- a/.github/workflows/deploy-try.yml
+++ b/.github/workflows/deploy-try.yml
@@ -108,22 +108,30 @@ jobs:
             -H 'content-type: application/json' \
             --data '{"query":"query { __typename }"}' \
             | jq -e '.data.__typename == "Query"'
-          expected_redirect='308 https://cloud.mosoo.ai/domain-migration-check?source=deploy'
-          for attempt in {1..12}; do
-            actual_redirect="$(curl "${curl_args[@]}" --output /dev/null \
-              --write-out '%{http_code} %{redirect_url}' \
-              'https://try.mosoo.ai/domain-migration-check?source=deploy')"
-            [[ "$actual_redirect" == "$expected_redirect" ]] && break
-            printf 'Waiting for redirect propagation (%s/12): %s\n' "$attempt" "$actual_redirect"
-            sleep 10
-          done
-          test "$actual_redirect" = "$expected_redirect"
-          test "$(curl "${curl_args[@]}" --output /dev/null \
-            --write-out '%{http_code} %{redirect_url}' \
-            http://cloud.mosoo.ai/)" = '308 https://cloud.mosoo.ai/'
-          test "$(curl "${curl_args[@]}" --output /dev/null \
-            --write-out '%{http_code} %{redirect_url}' \
-            http://cloud.mosoo.ai/api/health)" = \
+          wait_for_redirect() {
+            local url="$1"
+            local expected="$2"
+            local actual=""
+            for attempt in {1..12}; do
+              actual="$(curl "${curl_args[@]}" --output /dev/null \
+                --write-out '%{http_code} %{redirect_url}' "$url")"
+              [[ "$actual" == "$expected" ]] && return 0
+              printf 'Waiting for redirect propagation (%s/12): %s\n' "$attempt" "$actual"
+              sleep 10
+            done
+            return 1
+          }
+          wait_for_redirect \
+            'https://try.mosoo.ai/domain-migration-check?source=deploy' \
+            '308 https://cloud.mosoo.ai/domain-migration-check?source=deploy'
+          wait_for_redirect \
+            'https://try.mosoo.ai/' \
+            '308 https://cloud.mosoo.ai/'
+          wait_for_redirect \
+            'http://cloud.mosoo.ai/' \
+            '308 https://cloud.mosoo.ai/'
+          wait_for_redirect \
+            'http://cloud.mosoo.ai/api/health' \
             '308 https://cloud.mosoo.ai/api/health'
           curl "${curl_args[@]}" https://try.mosoo.ai/api/health \
             | jq -e '.name == "mosoo" and .ok == true'

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -7,6 +7,8 @@ main = "src/worker.ts"
 [assets]
 directory = "./dist"
 binding = "ASSETS"
+# Domain and HTTPS redirects must run before static asset matches.
+run_worker_first = true
 # The Worker (src/worker.ts) owns SPA fallback so unknown console paths can be
 # handled by react-router.
 not_found_handling = "none"

--- a/pkgs/contracts/tests/production-origin.test.ts
+++ b/pkgs/contracts/tests/production-origin.test.ts
@@ -27,6 +27,7 @@ describe("production origins", () => {
     expect(apiWrangler).toContain('"GOOGLE_OAUTH_CLIENT_SECRET"');
     expect(webWrangler).toContain(`pattern = "${MOSOO_CONSOLE_HOST}"`);
     expect(webWrangler).toContain(`pattern = "${MOSOO_LEGACY_CONSOLE_HOST}"`);
+    expect(webWrangler).toContain("run_worker_first = true");
     expect(webWrangler).not.toContain(`pattern = "${MOSOO_MARKETING_HOST}"`);
   });
 


### PR DESCRIPTION
## Summary

- route static assets through the existing Web Worker so legacy-domain and HTTP redirects also cover `/` and asset-backed SPA paths
- reuse one propagation-aware redirect assertion for legacy deep links, legacy root, canonical HTTP root, and canonical HTTP API
- lock the Worker-first asset setting in the production-origin contract test

## Root cause

Cloudflare Workers Assets serves matching assets before the User Worker by default. That let `https://try.mosoo.ai/` and `http://cloud.mosoo.ai/` return cached HTML 200 while unknown deep links correctly reached the redirect code. `run_worker_first = true` applies the existing redirect policy consistently.

## Verification

- 6 focused API/Web/origin tests passed
- `just fmt-check`
- `git diff --check`
- Web build
- Wrangler production Web dry-run
