### PR TITLE
fix(web): route root assets through worker

### DIFF
--- a/apps/web/tests/worker-domain-redirect.test.ts
+++ b/apps/web/tests/worker-domain-redirect.test.ts
@@ -1,6 +1,13 @@
 import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 
 import worker from "../src/worker";
+
+test("routes the root asset through the Worker before serving it", () => {
+  const wrangler = readFileSync(new URL("../wrangler.toml", import.meta.url), "utf8");
+
+  expect(wrangler).toContain('run_worker_first = ["/"]');
+});
 
 test("redirects the legacy console host without losing the path or query", async () => {
   let fetchedAsset = false;

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -7,6 +7,7 @@ main = "src/worker.ts"
 [assets]
 directory = "./dist"
 binding = "ASSETS"
+run_worker_first = ["/"]
 # The Worker (src/worker.ts) owns SPA fallback so unknown console paths can be
 # handled by react-router.
 not_found_handling = "none"


### PR DESCRIPTION
## Summary
- route only `/` through the Web Worker before static asset serving
- preserve asset-first behavior for every other path
- lock the routing contract with a regression test

## Why
Production deploy run 30549463021 deployed successfully but failed verification because `http://cloud.mosoo.ai/` returned 200. Cloudflare static assets serve matching assets before Worker code unless `assets.run_worker_first` selects the path.

## Verification
- `vp exec bun test apps/web/tests/worker-domain-redirect.test.ts`
- production Web build
- `wrangler deploy --env prod --dry-run`
- `TMPDIR=/private/tmp just check`