### PR TITLE
fix(deploy): restore production sandbox capacity

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -200,7 +200,7 @@ class_name = "Sandbox"
 [[env.prod.containers]]
 class_name = "Sandbox"
 image = "../driver/Containerfile"
-instance_type = "standard-2"
+instance_type = "basic"
 max_instances = 1000
 
 [[env.prod.r2_buckets]]


### PR DESCRIPTION
## Summary

- restore the production Sandbox instance type from standard-2 to basic
- keep the independently validated empty-thread prewarm behavior
- unblock the reviewed cloud.mosoo.ai redirect-worker deployment

## Evidence

The production deploy failed before publishing the Web Worker because standard-2 at max_instances = 1000 exceeded the Cloudflare account memory quota. The previous production configuration used basic successfully. No D1 migrations were pending or applied.

## Verification

- TMPDIR=/private/tmp just check — passed
- just fmt-check — passed
- API Wrangler production dry-run after Driver build — passed
- just commit-check — passed

## Risk and rollback

This is a one-line rollback to the last deployable production capacity. It gives up the unshipped larger-instance speedup but preserves session prewarming. Revert this commit only after Cloudflare confirms enough account memory quota for standard-2 × 1000.