### PR TITLE
fix(runtime): cap production sandbox capacity

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -201,7 +201,7 @@ class_name = "Sandbox"
 class_name = "Sandbox"
 image = "../driver/Containerfile"
 instance_type = "standard-2"
-max_instances = 1000
+max_instances = 500
 
 [[env.prod.r2_buckets]]
 binding = "FILE_BUCKET"

--- a/pkgs/contracts/tests/production-origin.test.ts
+++ b/pkgs/contracts/tests/production-origin.test.ts
@@ -16,6 +16,12 @@ function readRepoFile(path: string): string {
 }
 
 describe("production origins", () => {
+  test("pins the production Sandbox capacity accepted by the account quota", () => {
+    const apiWrangler = readRepoFile("apps/api/wrangler.toml");
+
+    expect(apiWrangler).toContain('instance_type = "standard-2"\nmax_instances = 500');
+  });
+
   test("keeps Cloudflare routes and OAuth origin aligned", () => {
     const apiWrangler = readRepoFile("apps/api/wrangler.toml");
     const webWrangler = readRepoFile("apps/web/wrangler.toml");


### PR DESCRIPTION
## Summary
- reduce production sandbox `max_instances` from 1000 to 500
- keep `standard-2` unchanged
- lock the production capacity pair in the existing contract test

## Why
The previous 1000 × 6 GiB request exceeded the account-wide container memory quota once the other applications were included. A 500-instance ceiling requests 3000 GiB for Mosoo and keeps the estimated account total at 5200 GiB, leaving 944 GiB below the 6144 GiB limit.

At inspection time production had 78 instance identities and roughly one running instance, so the new ceiling still leaves substantial operating headroom.

## Validation
- `TMPDIR=/private/tmp just check` (1170 tests, 0 failures)
- targeted production-origin contract tests (4 passed)
- production API Wrangler dry-run, including container image build
- `git diff --check`