### PR TITLE
fix(api): skip sorted process event projection work

### DIFF
--- a/apps/api/src/modules/sessions/application/session-process-events.service.ts
+++ b/apps/api/src/modules/sessions/application/session-process-events.service.ts
@@ -57,9 +57,7 @@ function normalizeProcessEventLimit(limit: number | null | undefined): number {
 function finalizeProcessEventDurations(
   projections: ProcessEventProjection[],
 ): SessionProcessEvent[] {
-  const sortedProjections = projections.toSorted(
-    (a, b) => a.startMs - b.startMs || a.order - b.order,
-  );
+  const sortedProjections = readChronologicalProcessEventProjections(projections);
 
   return sortedProjections.map((projection, index) => {
     const next = sortedProjections[index + 1] ?? null;
@@ -80,6 +78,32 @@ function finalizeProcessEventDurations(
       type: projection.event.type,
     };
   });
+}
+
+function compareProcessEventProjections(
+  left: ProcessEventProjection,
+  right: ProcessEventProjection,
+): number {
+  return left.startMs - right.startMs || left.order - right.order;
+}
+
+function readChronologicalProcessEventProjections(
+  projections: ProcessEventProjection[],
+): ProcessEventProjection[] {
+  for (let index = 1; index < projections.length; index += 1) {
+    const previous = projections[index - 1];
+    const current = projections[index];
+
+    if (
+      previous !== undefined &&
+      current !== undefined &&
+      compareProcessEventProjections(previous, current) > 0
+    ) {
+      return projections.toSorted(compareProcessEventProjections);
+    }
+  }
+
+  return projections;
 }
 
 function toProcessEventProjectionFromSessionEventRow(

--- a/apps/api/tests/session-process-events.test.ts
+++ b/apps/api/tests/session-process-events.test.ts
@@ -10,9 +10,14 @@ import type {
   SessionRuntimeEventVisibility,
 } from "@mosoo/contracts/session";
 import { parsePlatformId } from "@mosoo/id";
+import type { RuntimeEventId, SessionRunId } from "@mosoo/id";
 
 import type { AuthenticatedViewer } from "../src/modules/auth/application/viewer-auth.service";
-import { getThreadSessionProcessEvents } from "../src/modules/sessions/application/session-process-events.service";
+import {
+  createSessionProcessEventsFromSessionEventRows,
+  getThreadSessionProcessEvents,
+} from "../src/modules/sessions/application/session-process-events.service";
+import type { SessionEventProcessRow } from "../src/modules/sessions/application/session-process-events.service";
 import { SqliteD1Database } from "./helpers/sqlite-d1";
 
 const ORGANIZATION_ID = "01J00000000000000000000006";
@@ -243,6 +248,29 @@ async function insertSessionProcessEvent(
     .run();
 }
 
+function sessionProcessRow(input: {
+  content: string;
+  eventType?: string;
+  id: string;
+  occurredAt: number;
+  processType: SessionProcessEventType;
+  runId?: string | null;
+  seq: number;
+}): SessionEventProcessRow {
+  return {
+    content_text: input.content,
+    ended_at: input.occurredAt,
+    event_type: input.eventType ?? input.processType,
+    id: input.id as RuntimeEventId,
+    occurred_at: input.occurredAt,
+    process_status: "available",
+    process_type: input.processType,
+    run_id: (input.runId ?? null) as SessionRunId | null,
+    seq: input.seq,
+    tokens: null,
+  };
+}
+
 describe("session process event projection", () => {
   test("rejects invalid process event limits", async () => {
     await expect(
@@ -282,6 +310,31 @@ describe("session process event projection", () => {
     );
 
     expect(events.map((event) => event.type)).toEqual(["run.started"]);
+  });
+
+  test("keeps defensive chronological projection for unsorted rows", () => {
+    const events = createSessionProcessEventsFromSessionEventRows(
+      [
+        sessionProcessRow({
+          content: "second",
+          id: "event-2",
+          occurredAt: 2000,
+          processType: "run.completed",
+          seq: 2,
+        }),
+        sessionProcessRow({
+          content: "first",
+          id: "event-1",
+          occurredAt: 1000,
+          processType: "run.started",
+          seq: 1,
+        }),
+      ],
+      { foldStreamedRows: false },
+    );
+
+    expect(events.map((event) => event.id)).toEqual(["event-1", "event-2"]);
+    expect(events.map((event) => event.durationMs)).toEqual([1000, 0]);
   });
 
   test("folds persisted assistant message fragments into one process event", async () => {


### PR DESCRIPTION
## Summary

- Avoid sorting session process event projections when rows are already chronological.
- Keep the previous defensive sort fallback for unsorted callers and cover it with a regression test.

## Why

- The complexity scan found event projection as a production read path used by session timelines and public thread event windows.
- Those callers already pass sequence-ordered rows, so always sorting added O(n log n) work to the common path.

## Verification

- Commands:
  - `just fmt-check-path apps/api/src/modules/sessions/application/session-process-events.service.ts`
  - `just fmt-check-path apps/api/tests/session-process-events.test.ts`
  - `just test-file apps/api/tests/session-process-events.test.ts`
  - `just test-file apps/api/tests/runtime-final-output-ingestion.test.ts`
  - `just test-file apps/api/tests/public-thread-api.e2e.test.ts`
  - `just tc-package @mosoo/api`
- Manual steps: N/A
- Not run: full `just check`

## Impact

- User/API/contract changes: none; projected ordering and durations are preserved.
- Generated files / GraphQL / DB / lockfile: none.
- Env or config changes: none.
- Risk and rollback: Low; rollback reverts the projection helper optimization and test.

## Review

- Closest review areas: session process event projection and public thread event windows.
- Known trade-offs: Unsorted inputs still pay the old sort cost.
