### PR TITLE
fix(web): reduce login load critical path

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -18,19 +18,6 @@
     <meta property="og:site_name" content="mosoo" />
     <meta name="twitter:card" content="summary" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <!-- Preload the primary UI font so it streams in parallel with the CSS/JS
-         instead of being discovered only after the stylesheet parses. Geist is
-         the body + heading face (--font-sans) painted on every page's first
-         view; the file is small (~29 KB) and self-hosted, so this shrinks the
-         font-swap window without competing for bandwidth on the critical path.
-         Only Geist is preloaded — Inter is a fallback and far larger. -->
-    <link
-      rel="preload"
-      href="/fonts/Geist-Variable.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin="anonymous"
-    />
     <title>mosoo</title>
     <!-- Set html lang attribute early based on stored locale preference.
          Falls back to navigator.language. Runs before React mounts so the

--- a/apps/web/src/app/route-guards.tsx
+++ b/apps/web/src/app/route-guards.tsx
@@ -40,11 +40,11 @@ export function AppLoading(): ReactElement {
 export function GuestRoute({ children }: RouteChildrenProps): ReactNode {
   const { onboardingState, user, userLoading } = useAppSession();
 
-  if (userLoading) {
-    return <AppLoading />;
-  }
   if (!user) {
     return children;
+  }
+  if (userLoading) {
+    return <AppLoading />;
   }
   if (onboardingState === "loading" || onboardingState === null) {
     return <AppLoading />;

--- a/apps/web/src/routes/login/login.route.tsx
+++ b/apps/web/src/routes/login/login.route.tsx
@@ -18,7 +18,37 @@ function DeferredLoginDoodles(): ReactElement | null {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    setMounted(true);
+    let idleId: number | null = null;
+    let timeoutId: number | null = null;
+
+    const reveal = () => {
+      if (typeof window.requestIdleCallback === "function") {
+        idleId = window.requestIdleCallback(() => {
+          setMounted(true);
+        });
+        return;
+      }
+
+      timeoutId = window.setTimeout(() => {
+        setMounted(true);
+      }, 250);
+    };
+
+    if (document.readyState === "complete") {
+      timeoutId = window.setTimeout(reveal, 0);
+    } else {
+      window.addEventListener("load", reveal, { once: true });
+    }
+
+    return () => {
+      window.removeEventListener("load", reveal);
+      if (idleId !== null) {
+        window.cancelIdleCallback(idleId);
+      }
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+    };
   }, []);
 
   if (!mounted) {

--- a/apps/web/src/routes/login/use-login.ts
+++ b/apps/web/src/routes/login/use-login.ts
@@ -4,11 +4,6 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { captureProductEvent, PRODUCT_ANALYTICS_EVENTS } from "@/analytics/product-analytics";
 
-import { authClient } from "../../domains/auth/api/auth-client";
-import {
-  shouldUseMosooAiDevelopmentBackdoor,
-  signInWithMosooAiDevelopmentBackdoor,
-} from "../../domains/auth/mosoo-ai-development-backdoor";
 import { userKeys } from "../../domains/user/query/user-queries";
 import {
   decodeAuthError,
@@ -111,6 +106,7 @@ export function useLoginFlow(): LoginFlow {
     setError(null);
     captureProductEvent(PRODUCT_ANALYTICS_EVENTS.loginStarted, { method: "google" });
 
+    const { authClient } = await import("../../domains/auth/api/auth-client");
     const result = await authClient["signIn"].social({
       callbackURL: redirectPath,
       errorCallbackURL: loginErrorCallbackUrl,
@@ -135,12 +131,15 @@ export function useLoginFlow(): LoginFlow {
     captureProductEvent(PRODUCT_ANALYTICS_EVENTS.loginStarted, { method: "email_otp" });
 
     try {
+      const { shouldUseMosooAiDevelopmentBackdoor, signInWithMosooAiDevelopmentBackdoor } =
+        await import("../../domains/auth/mosoo-ai-development-backdoor");
       if (shouldUseMosooAiDevelopmentBackdoor(normalizedEmail)) {
         await signInWithMosooAiDevelopmentBackdoor(normalizedEmail);
         await finishSuccessfulLogin();
         return;
       }
 
+      const { authClient } = await import("../../domains/auth/api/auth-client");
       const result = await authClient["emailOtp"].sendVerificationOtp({
         email: normalizedEmail,
         type: "sign-in",
@@ -173,6 +172,7 @@ export function useLoginFlow(): LoginFlow {
 
     try {
       const normalizedEmail = email.trim();
+      const { authClient } = await import("../../domains/auth/api/auth-client");
       const result = await authClient["signIn"].emailOtp({
         email: normalizedEmail,
         name: deriveNameFromEmail(normalizedEmail),


### PR DESCRIPTION
Closes YEF-952

## Summary

- Defer login doodle artwork until after `window.load` and browser idle time.
- Load the Better Auth client and development backdoor only when a login action is submitted.
- Let the guest login route render while the viewer query is still loading.
- Remove the global Geist font preload from the document load path.

## Why

- `/login` was the only route over the 50 ms load-event target in the initial production-preview pass.
- The login page was downloading decorative/auth-only code before it was needed and blocking logged-out users behind the viewer check.

## Verification

- Commands:
  - `bun run --filter @mosoo/web build`
  - `bun run fmt:check:path apps/web/index.html apps/web/src/app/route-guards.tsx apps/web/src/routes/login/login.route.tsx apps/web/src/routes/login/use-login.ts`
  - `bun run --filter @mosoo/web test`
  - `bun run --filter @mosoo/web tc`
  - `bun run --filter @mosoo/web lint`
- Manual steps:
  - Production preview at `http://127.0.0.1:4173`, Playwright Chrome, fresh browser context per route sample, service workers blocked, `/api/*` fulfilled with deterministic 401.
  - 39 registered routes measured with 3 samples per route; max median `loadEventEnd` was 46.4 ms and no route median was over 50 ms.
- Not run:
  - Chrome DevTools MCP trace because the MCP server could not attach to a running local Chrome instance.

## Impact

- User/API/contract changes:
  - Logged-out visitors can see the login screen while the viewer query resolves; authenticated users still redirect after the viewer state is known.
- Generated files / GraphQL / DB / lockfile:
  - N/A
- Env or config changes:
  - N/A
- Risk and rollback:
  - Low; rollback reverts the commit if login redirect behavior or font loading needs the previous behavior.

## Review

- Closest review areas:
  - `apps/web/src/routes/login/*`
  - `apps/web/src/app/route-guards.tsx`
- Known trade-offs:
  - Removing the font preload can allow a normal `font-display: swap` font swap instead of forcing the font into every page's load event.
