### PR TITLE
fix(app-overview): remove public repo deploy entry

### DIFF
--- a/apps/web/src/routes/app-overview/deploy/deploy-surface.tsx
+++ b/apps/web/src/routes/app-overview/deploy/deploy-surface.tsx
@@ -7,7 +7,6 @@ import { Badge } from "@/shared/ui/badge";
 
 import { DeployActions } from "./components/deploy-actions";
 import { DeployOverview } from "./components/deploy-overview";
-import { DeployRepoCard } from "./components/deploy-repo-card";
 import { ActivitySection } from "./components/deployments-history";
 import type { DeployConsoleState } from "./deploy-console-data";
 import type { ProductionEnvironmentStatus } from "./deployment-status";
@@ -180,12 +179,6 @@ export function DeploySurface({
           <div className="mx-auto flex max-w-4xl flex-col gap-8">
             {loadError === null ? null : <LoadErrorBanner message={loadError} />}
             {emptyHero}
-            <DeployRepoCard
-              appId={appId}
-              deploying={deploy.deploying}
-              serverError={deployError}
-              onDeploy={deploy.deployRepo}
-            />
             <ActivitySection preDeploy runs={[]} error={runsError} />
           </div>
         ) : (


### PR DESCRIPTION
## Summary
- remove the public GitHub repository deploy card from the empty App Overview state
- preserve the existing deployment console, repo change flow, and Production Activity section

## Validation
- `just fmt-check-path apps/web/src/routes/app-overview/deploy/deploy-surface.tsx`
- `just test-file apps/web/tests/mobile-responsive-boundary.test.ts` (10 passed)
- commit/push hook could not run because this fresh worktree has no installed `prek` binary

No generated files, GraphQL codegen, or DB baseline changes.