### PR TITLE
feat(analytics): track sandbox usage metrics

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/event-persistence.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/event-persistence.ts
@@ -91,6 +91,19 @@ function isMatchingStaleTerminalRunTransition(input: {
   return input.transition !== undefined && input.outcome.currentStatus === input.transition.status;
 }
 
+function getRunDurationMs(outcome: SessionRunTransitionOutcome): number | null {
+  if (
+    outcome.kind !== "applied" ||
+    outcome.run.startedAt === null ||
+    outcome.run.completedAt === null
+  ) {
+    return null;
+  }
+
+  const durationMs = Date.parse(outcome.run.completedAt) - Date.parse(outcome.run.startedAt);
+  return Number.isFinite(durationMs) ? Math.max(0, durationMs) : null;
+}
+
 async function autoTitleRuntimeSession(
   database: D1Database,
   link: RuntimeSessionLink,
@@ -360,6 +373,8 @@ export async function persistProjectedRuntimeDriverEvents(
     runTransitionOutcome?.kind === "applied" &&
     link.executionOwnerId !== null
   ) {
+    const runDurationMs = getRunDurationMs(runTransitionOutcome);
+
     await captureServerProductEvent(bindings, {
       distinctId: link.executionOwnerId,
       event: SERVER_PRODUCT_ANALYTICS_EVENTS.taskSucceeded,
@@ -367,7 +382,12 @@ export async function persistProjectedRuntimeDriverEvents(
         agent_id: link.agentId,
         app_id: link.appId,
         run_id: link.sessionRunId,
+        run_duration_ms: runDurationMs,
+        sandbox_id: link.sandboxId,
+        sandbox_kind: link.sandboxKind,
+        sandbox_subject_kind: link.sandboxSubjectKind,
         session_id: link.sessionId,
+        session_type: link.sessionType,
       },
     });
   }

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/event-types.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/event-types.ts
@@ -1,6 +1,7 @@
 import type { SessionUsageSummary } from "@mosoo/ag-ui-session";
 import type { AgentKind } from "@mosoo/contracts/agent";
 import type { SandboxSubjectKind } from "@mosoo/contracts/sandbox";
+import type { SessionType } from "@mosoo/contracts/session";
 import type { SessionRunStatus } from "@mosoo/contracts/session-run";
 import type {
   AccountId,
@@ -31,6 +32,7 @@ export interface RuntimeSessionLink {
   sessionId: SessionId | null;
   sessionRunId: SessionRunId | null;
   sessionRunStatus: SessionRunStatus | null;
+  sessionType: SessionType | null;
   traceId: string | null;
   sandboxSubjectKind: SandboxSubjectKind | null;
 }

--- a/apps/api/src/modules/runtime/infrastructure/driver-instance/session-link.repository.ts
+++ b/apps/api/src/modules/runtime/infrastructure/driver-instance/session-link.repository.ts
@@ -1,5 +1,6 @@
 import type { AgentKind } from "@mosoo/contracts/agent";
 import type { SandboxSubjectKind } from "@mosoo/contracts/sandbox";
+import type { SessionType } from "@mosoo/contracts/session";
 import type { SessionRunStatus } from "@mosoo/contracts/session-run";
 import {
   agentsTable,
@@ -40,6 +41,7 @@ interface RuntimeSessionLinkRow {
   session_id: SessionId | null;
   session_run_id: SessionRunId | null;
   session_run_status: SessionRunStatus | null;
+  session_type: SessionType | null;
   trace_id: string | null;
 }
 
@@ -104,6 +106,7 @@ export async function getRuntimeSessionLink(
         session_id: linkedSessionId.as("session_id"),
         session_run_id: sessionRunsTable.id,
         session_run_status: sessionRunsTable.status,
+        session_type: sessionsTable.type,
         trace_id: sessionRunsTable.traceId,
       })
       .from(driverInstancesTable)
@@ -132,6 +135,7 @@ export async function getRuntimeSessionLink(
     sessionId: row?.session_id ?? null,
     sessionRunId: row?.session_run_id ?? null,
     sessionRunStatus: row?.session_run_status ?? null,
+    sessionType: row?.session_type ?? null,
     traceId: row?.trace_id ?? null,
   };
 }

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-lifecycle.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-lifecycle.service.ts
@@ -16,6 +16,10 @@ import type {
 import { createPlatformId } from "@mosoo/id";
 import { RUNTIME_DIAGNOSTIC_EVENT } from "@mosoo/runtime-events";
 
+import {
+  captureServerProductEvent,
+  SERVER_PRODUCT_ANALYTICS_EVENTS,
+} from "../../../../platform/analytics/product-analytics";
 import { createErrorLogContext, logWarn } from "../../../../platform/cloudflare/logger";
 import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
 import { currentTimestampMs } from "../../../../time";
@@ -257,6 +261,27 @@ export class RuntimeSubjectLifecycleService {
 
       if (!activated) {
         throw new Error("Runtime subject activation claim expired before completion.");
+      }
+
+      if (isCold) {
+        await captureServerProductEvent(this.#bindings, {
+          distinctId: input.executionOwnerUserId,
+          event: SERVER_PRODUCT_ANALYTICS_EVENTS.sandboxCreated,
+          properties: {
+            activation_purpose: purpose,
+            agent_id:
+              input.diagnosticContext?.agentId ??
+              (input.subjectKind === "agent" ? input.subjectId : undefined),
+            execution_owner_id: input.executionOwnerUserId,
+            sandbox_id: input.runtimeSubjectId,
+            sandbox_kind: input.kind,
+            session_id:
+              input.diagnosticContext?.sessionId ??
+              (input.subjectKind === "session" ? input.subjectId : undefined),
+            subject_id: input.subjectId,
+            subject_kind: input.subjectKind,
+          },
+        });
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : "Runtime subject activation failed.";

--- a/apps/api/src/platform/analytics/product-analytics.ts
+++ b/apps/api/src/platform/analytics/product-analytics.ts
@@ -1,6 +1,7 @@
 export const SERVER_PRODUCT_ANALYTICS_EVENTS = {
   agentCreated: "agent_created",
   appCreated: "app_created",
+  sandboxCreated: "sandbox_created",
   taskSucceeded: "task_succeeded",
   integrationConnected: "integration_connected",
   onboardingCompleted: "onboarding_completed",

--- a/apps/api/tests/api-driver-boundary-fixtures.ts
+++ b/apps/api/tests/api-driver-boundary-fixtures.ts
@@ -198,6 +198,7 @@ export function createRuntimeSessionLink(): RuntimeSessionLink {
     sessionId: API_DRIVER_BOUNDARY_IDS.session,
     sessionRunId: API_DRIVER_BOUNDARY_IDS.sessionRun,
     sessionRunStatus: "running",
+    sessionType: "preview",
     traceId: "trace-1",
   };
 }

--- a/apps/api/tests/driver-session-link.test.ts
+++ b/apps/api/tests/driver-session-link.test.ts
@@ -39,8 +39,9 @@ function createDriverSessionLinkDatabase(): SqliteD1Database {
       agent_id text,
       app_id text,
       creator_account_id text NOT NULL,
-      id text PRIMARY KEY NOT NULL
-);
+      id text PRIMARY KEY NOT NULL,
+      type text DEFAULT 'preview' NOT NULL
+    );
 
     CREATE TABLE agent (
       id text PRIMARY KEY NOT NULL,
@@ -109,6 +110,7 @@ describe("driver runtime session link", () => {
         sessionId: SESSION_ID,
         sessionRunId: null,
         sessionRunStatus: null,
+        sessionType: "preview",
         traceId: null,
       }),
     ).toBe(true);

--- a/apps/api/tests/runtime-final-output-ingestion.test.ts
+++ b/apps/api/tests/runtime-final-output-ingestion.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import type { DriverEventEnvelope } from "@mosoo/agent-driver/events";
 import type { DriverEventReceipt } from "@mosoo/agent-driver/orpc";
@@ -27,6 +27,7 @@ import { recordDriverInstanceCompletion } from "../src/modules/runtime/infrastru
 import { loadSessionViewerState } from "../src/modules/sessions/application/session-live-state.service";
 import { createSessionProcessEventsFromSessionEventRows } from "../src/modules/sessions/application/session-process-events.service";
 import type { SessionEventProcessRow } from "../src/modules/sessions/application/session-process-events.service";
+import { setServerProductAnalyticsTransportForTests } from "../src/platform/analytics/product-analytics";
 import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
 import {
   createPublicHttpContractDatabase,
@@ -65,6 +66,10 @@ const PROGRESS_TEXTS = [
   "进度 2：工具调用已经完成。",
   "进度 3：artifact 已创建。",
 ] as const;
+
+afterEach(() => {
+  setServerProductAnalyticsTransportForTests(null);
+});
 
 interface TestDriverState {
   createDriverEventReceipts(events: readonly DriverEventEnvelope[]): DriverEventReceipt[];
@@ -306,7 +311,15 @@ describe("runtime final output ingestion", () => {
     async (_driverBehavior, driverProvidesSnapshot) => {
       const database = await createPublicHttpContractDatabase();
       await insertRuntimeFixture(database);
-      const bindings = createPublicHttpTestBindings(database) as ApiBindings;
+      const capturedEvents: unknown[] = [];
+      setServerProductAnalyticsTransportForTests(async (_input, init) => {
+        capturedEvents.push(JSON.parse(init.body as string) as unknown);
+        return new Response(null, { status: 200 });
+      });
+      const bindings = {
+        ...createPublicHttpTestBindings(database),
+        POSTHOG_PROJECT_KEY: "phc_test",
+      } as ApiBindings;
       const finalText = "The final answer.";
       const fragmentTexts = ["The ", "final ", "answer."];
       const finalMessageId = createPlatformId<SessionMessageId>();
@@ -360,6 +373,18 @@ describe("runtime final output ingestion", () => {
           .map((row) => row.content_text),
       ).toEqual([finalText]);
       expect(assistantMessages.map((event) => event.content)).toEqual([finalText]);
+      expect(capturedEvents).toEqual([
+        expect.objectContaining({
+          event: "task_succeeded",
+          properties: expect.objectContaining({
+            run_duration_ms: expect.any(Number),
+            sandbox_id: PUBLIC_API_TEST_IDS.sandbox,
+            sandbox_kind: "pet",
+            sandbox_subject_kind: "agent",
+            session_type: "api_channel",
+          }),
+        }),
+      ]);
     },
   );
 

--- a/apps/api/tests/runtime-session-link.test.ts
+++ b/apps/api/tests/runtime-session-link.test.ts
@@ -26,7 +26,8 @@ function createRuntimeSessionLinkDatabase(): SqliteD1Database {
       id text PRIMARY KEY NOT NULL,
       agent_id text NOT NULL,
       app_id text,
-      creator_account_id text NOT NULL
+      creator_account_id text NOT NULL,
+      type text DEFAULT 'preview' NOT NULL
 );
 
     CREATE TABLE agent (
@@ -77,6 +78,7 @@ describe("runtime session link", () => {
       sessionId: "session-1",
       sessionRunId: "run-1",
       sessionRunStatus: "running",
+      sessionType: "preview",
     });
   });
 });

--- a/apps/api/tests/runtime-session-outputs.test.ts
+++ b/apps/api/tests/runtime-session-outputs.test.ts
@@ -148,6 +148,7 @@ function createRuntimeLink(): RuntimeSessionLink {
     sessionId: PUBLIC_API_TEST_IDS.ownerSession,
     sessionRunId: PUBLIC_API_TEST_IDS.run,
     sessionRunStatus: "running",
+    sessionType: "ui",
     traceId: "trace-session-outputs",
   };
 }

--- a/apps/api/tests/runtime-subject-lifecycle.test.ts
+++ b/apps/api/tests/runtime-subject-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import { createPlatformId } from "@mosoo/id";
 import type { SandboxId, SessionId } from "@mosoo/id";
@@ -15,6 +15,7 @@ import {
 } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store";
 import { encodeSandboxBackupIdForStorage } from "../src/modules/runtime/infrastructure/sandbox-backup-id";
 import type { SandboxHandle } from "../src/modules/runtime/infrastructure/sandbox-handles";
+import { setServerProductAnalyticsTransportForTests } from "../src/platform/analytics/product-analytics";
 import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
 import { SqliteD1Database } from "./helpers/sqlite-d1";
 
@@ -30,6 +31,10 @@ const RUNTIME_SUBJECT_QUOTA_SCOPE = {
   appId: APP_ID,
   executionOwnerUserId: ACCOUNT_ID,
 } as const;
+
+afterEach(() => {
+  setServerProductAnalyticsTransportForTests(null);
+});
 
 function createRuntimeSubjectLifecycleDatabase(): SqliteD1Database {
   const database = new SqliteD1Database();
@@ -472,6 +477,48 @@ describe("runtime subject lifecycle machine", () => {
       claim_expires_at: null,
       claim_owner: null,
       status: "active",
+    });
+  });
+
+  test("captures one sandbox creation when a cold subject becomes active", async () => {
+    const database = createRuntimeSubjectLifecycleDatabase();
+    await insertRuntimeSubject(database, { status: "cold" });
+    const capturedEvents: unknown[] = [];
+    setServerProductAnalyticsTransportForTests(async (_input, init) => {
+      capturedEvents.push(JSON.parse(init.body as string) as unknown);
+      return new Response(null, { status: 200 });
+    });
+    const bindings = {
+      ...createBindings(database),
+      POSTHOG_PROJECT_KEY: "phc_test",
+    } as ApiBindings;
+    const service = createRuntimeSubjectLifecycleService(bindings);
+    const activation = {
+      executionOwnerUserId: "01J00000000000000000000002",
+      kind: "cattle" as const,
+      networkConstraints: { allowedHosts: [], networkPolicy: "full" as const },
+      runtimeSubjectId: RUNTIME_SUBJECT_ID,
+      spaceAliases: [],
+      subjectId: "01J00000000000000000000009",
+      subjectKind: "session" as const,
+    };
+
+    await service.activate(activation);
+    await service.activate(activation);
+
+    expect(capturedEvents).toHaveLength(1);
+    expect(capturedEvents[0]).toMatchObject({
+      event: "sandbox_created",
+      properties: {
+        activation_purpose: "interactive",
+        distinct_id: activation.executionOwnerUserId,
+        execution_owner_id: activation.executionOwnerUserId,
+        sandbox_id: RUNTIME_SUBJECT_ID,
+        sandbox_kind: "cattle",
+        session_id: activation.subjectId,
+        subject_id: activation.subjectId,
+        subject_kind: "session",
+      },
     });
   });
 


### PR DESCRIPTION
## Summary

- emit `sandbox_created` after a cold sandbox successfully becomes active, without double-counting warm reuse
- enrich `task_succeeded` with `run_duration_ms`, `session_type`, and sandbox dimensions
- cover the PostHog payloads and session-link context with regression tests

## Why

This gives Product a measurable current-state baseline for sandbox adoption and usage while the team decides Mosoo's actual north-star metric.

These are deliberately provisional proxy metrics. The related product discussion must decide whether they represent durable user value before they become targets or incentives.

## Product impact

PostHog can now:

- count `sandbox_created`
- sum `task_succeeded.run_duration_ms`, normally filtering out `session_type = preview`
- break results down by sandbox kind, subject kind, session type, Agent, App, or account

Runtime duration currently means successful Run wall time from `started_at` to `completed_at`. It is not total container uptime and excludes idle keepalive. Data starts after deployment; this PR does not backfill history.

Related to #497.

## Validation

- `just test-package @mosoo/api` — 1191 passed
- `vp run --filter @mosoo/api tc` — passed
- `just lint` — passed
- `just fmt-check` — passed
- `just commit-check` — passed
- `just check` — format, docs, lint, and workspace typecheck passed; the test phase had one failure in the unmodified `apps/driver/tests/acp-file-system.test.ts` on macOS path canonicalization (expected `/var/...`, received `/private/var/...`). A focused rerun reproduced 4 passed / 1 failed.

## Change surface

- Generated files: no
- GraphQL codegen: no
- Database migrations: no
- Lockfile changes: no
- Deployment included: no
