### PR TITLE
fix(agent-package): round-trip MCP sidecars

### DIFF
--- a/pkgs/agent-package/src/archive-mcp-admission.ts
+++ b/pkgs/agent-package/src/archive-mcp-admission.ts
@@ -3,7 +3,7 @@ import type { AgentResolutionIssue } from "@mosoo/contracts/agent-manifest";
 import { createArchiveIssue } from "./archive-issue";
 
 const MCP_REMOTE_TRANSPORT_TYPES = new Set(["http", "sse"]);
-const MCP_REMOTE_SIDECAR_FIELDS = new Set(["description", "iconUrl", "type", "url"]);
+const MCP_REMOTE_SIDECAR_FIELDS = new Set(["authType", "description", "iconUrl", "type", "url"]);
 const MCP_SIDECAR_FORBIDDEN_SECRET_FIELDS = new Set([
   "access_token",
   "accesstoken",
@@ -52,6 +52,7 @@ export function admitMcpSidecarServer(
   server: Record<string, unknown>,
 ): McpSidecarAdmissionResult {
   const type = typeof server["type"] === "string" ? server["type"] : null;
+  const authType = server["authType"] === "bearer" ? "bearer" : "oauth";
   const hasCommand = typeof server["command"] === "string";
 
   if (hasCommand || type === "stdio") {
@@ -114,10 +115,10 @@ export function admitMcpSidecarServer(
 
   return {
     normalizedServer: {
-      authType: "oauth",
-      credentialScope: "user",
+      authType,
+      credentialScope: "app",
       iconUrl: typeof server["iconUrl"] === "string" ? server["iconUrl"] : null,
-      source: "personal",
+      source: "app",
       url,
     },
     ok: true,

--- a/pkgs/agent-package/src/archive.ts
+++ b/pkgs/agent-package/src/archive.ts
@@ -63,6 +63,7 @@ function buildMcpJson(agentPackage: AgentPackage): string {
     agentPackage.manifest.mcpServers.map((server) => [
       server.name,
       {
+        authType: server.authType,
         ...(server.iconUrl === null ? {} : { iconUrl: server.iconUrl }),
         type: server.url.endsWith("/sse") ? "sse" : "http",
         url: server.url,
@@ -150,7 +151,7 @@ export function createAgentPackageArchiveBytes(agentPackage: AgentPackage): Uint
 
   assertArchiveEntriesAdmitted(entries);
 
-  return createZipArchive(entries);
+  return createZipArchive(entries, { pathsAlreadyAdmitted: true });
 }
 
 export function parseAgentPackageArchiveBytes(
@@ -171,7 +172,10 @@ export function parseAgentPackageArchiveBytes(
 
   try {
     entries = toArchiveEntryRecord(
-      extractZipArchive(archiveBytes, AGENT_PACKAGE_ARCHIVE_EXTRACT_OPTIONS),
+      extractZipArchive(archiveBytes, {
+        ...AGENT_PACKAGE_ARCHIVE_EXTRACT_OPTIONS,
+        pathsAlreadyAdmitted: true,
+      }),
     );
   } catch {
     return invalidArchiveResult(

--- a/pkgs/agent-package/tests/archive-entry-admission.test.ts
+++ b/pkgs/agent-package/tests/archive-entry-admission.test.ts
@@ -171,6 +171,30 @@ describe("agent package archive entry admission", () => {
     ]);
   });
 
+  test("round-trips the reserved MCP sidecar", () => {
+    const agentPackage = createAgentPackageFixture({
+      mcpServers: [
+        {
+          authType: "bearer",
+          credentialMode: "runtime_resolved",
+          credentialScope: "app",
+          enabled: true,
+          iconUrl: null,
+          name: "Go Gym Production MCP",
+          serverId: null,
+          source: "app",
+          url: "https://go-gym.example/mcp",
+        },
+      ],
+    });
+
+    const archiveBytes = createAgentPackageArchiveBytes(agentPackage);
+    const parsed = parseAgentPackageArchiveBytes(archiveBytes);
+
+    expect(parsed.package).not.toBeNull();
+    expect(parsed.manifest?.mcpServers).toEqual(agentPackage.manifest.mcpServers);
+  });
+
   test("admits nested package assets under declared skill roots", () => {
     const parsed = parseAgentPackageArchiveBytes(
       createStoredZipArchive([
@@ -243,6 +267,7 @@ function createAgentPackageFixture(
   input: {
     assets?: AgentPackage["assets"];
     avatarAssetKey?: string | null;
+    mcpServers?: AgentPackage["manifest"]["mcpServers"];
     skills?: AgentPackage["manifest"]["skills"];
   } = {},
 ): AgentPackage {
@@ -266,7 +291,7 @@ function createAgentPackageFixture(
       },
       kind: "pet",
       manifestVersion: AGENT_MANIFEST_VERSION,
-      mcpServers: [],
+      mcpServers: input.mcpServers ?? [],
       metadata: {
         description: "Test package",
         name: "Test Agent",

--- a/pkgs/skill-package/src/archive.ts
+++ b/pkgs/skill-package/src/archive.ts
@@ -24,6 +24,11 @@ export interface SkillArchiveExtractOptions {
   maxEntryCount?: number;
   maxFileBytes?: number;
   maxTotalFileBytes?: number;
+  pathsAlreadyAdmitted?: boolean;
+}
+
+export interface SkillArchiveCreateOptions {
+  pathsAlreadyAdmitted?: boolean;
 }
 
 interface ZipArchiveMetadata {
@@ -33,12 +38,17 @@ interface ZipArchiveMetadata {
   uncompressedSize: number;
 }
 
-export function createZipArchive(entries: SkillPackageEntry[]): Uint8Array {
+export function createZipArchive(
+  entries: SkillPackageEntry[],
+  options: SkillArchiveCreateOptions = {},
+): Uint8Array {
   const archive: Zippable = {};
-  const admission = createSkillPackagePathAdmission();
+  const admission = options.pathsAlreadyAdmitted ? null : createSkillPackagePathAdmission();
 
   for (const entry of entries) {
-    const admittedPath = admission.admit(entry.path, entry.entryKind).path;
+    const admittedPath =
+      admission?.admit(entry.path, entry.entryKind).path ??
+      normalizeAdmittedArchivePath(entry.path, entry.entryKind);
     const archivePath = entry.entryKind === "directory" ? `${admittedPath}/` : admittedPath;
 
     archive[archivePath] = [entry.body, createZipEntryOptions(entry)];
@@ -72,7 +82,7 @@ export function extractZipArchive(
       return;
     }
 
-    const admittedEntry = readAdmittedZipArchivePath(file.name);
+    const admittedEntry = readAdmittedZipArchivePath(file.name, options.pathsAlreadyAdmitted);
 
     if (admittedEntry instanceof SkillPackageError) {
       extractionState.error = admittedEntry;
@@ -300,7 +310,7 @@ function listZipArchiveEntries(
   const centralDirectorySize = readUint32LE(bytes, endOfCentralDirectoryOffset + 12);
   const centralDirectoryOffset = readUint32LE(bytes, endOfCentralDirectoryOffset + 16);
   const metadata: ZipArchiveMetadata[] = [];
-  const admission = createSkillPackagePathAdmission();
+  const admission = options.pathsAlreadyAdmitted ? null : createSkillPackagePathAdmission();
   let totalFileBytes = 0;
   let offset = centralDirectoryOffset;
   const endOffset = centralDirectoryOffset + centralDirectorySize;
@@ -342,7 +352,8 @@ function listZipArchiveEntries(
     }
 
     const entryKind = inferZipEntryKind(rawPath);
-    const path = admission.admit(rawPath, entryKind).path;
+    const path =
+      admission?.admit(rawPath, entryKind).path ?? normalizeAdmittedArchivePath(rawPath, entryKind);
 
     if (options.maxEntryCount !== undefined && metadata.length >= options.maxEntryCount) {
       throw new SkillPackageError(
@@ -424,12 +435,28 @@ function findEndOfCentralDirectory(bytes: Uint8Array): number {
   return -1;
 }
 
-function readAdmittedZipArchivePath(path: string): AdmittedSkillPackagePath | SkillPackageError {
+function readAdmittedZipArchivePath(
+  path: string,
+  pathsAlreadyAdmitted = false,
+): AdmittedSkillPackagePath | SkillPackageError {
+  if (pathsAlreadyAdmitted) {
+    const entryKind = inferZipEntryKind(path);
+
+    return {
+      entryKind,
+      path: normalizeAdmittedArchivePath(path, entryKind),
+    };
+  }
+
   try {
     return admitSkillPackagePath(path, inferZipEntryKind(path));
   } catch (error) {
     return toSkillZipError(error, "Skill zip decompression failed.");
   }
+}
+
+function normalizeAdmittedArchivePath(path: string, entryKind: SkillPackagePathKind): string {
+  return entryKind === "directory" && path.endsWith("/") ? path.slice(0, -1) : path;
 }
 
 function inferZipEntryKind(path: string): SkillPackagePathKind {


### PR DESCRIPTION
## Summary

- let Agent packages reuse the ZIP codec after Agent-specific path admission
- preserve MCP auth type and normalize imported MCP bindings to the current app scope
- cover .mcp.json export/import with a regression test

## Root cause

Agent packages admit reserved top-level sidecars such as .mcp.json, then delegated to the Skill package ZIP codec, which repeated Skill-specific path admission and rejected dot-prefixed paths.

## Validation

- just test-file pkgs/agent-package/tests/archive-entry-admission.test.ts
- just test-package @mosoo/skill-package
- just tc-package @mosoo/agent-package
- just tc-package @mosoo/skill-package
- just commit-check

Full just check reached 1083 passing tests and one unrelated existing macOS path-alias failure in apps/driver/tests/acp-file-system.test.ts: the test expects /var while realpath reports /private/var.