### PR TITLE
fix(runtime): cap free sandbox concurrency

### DIFF
--- a/apps/api/src/modules/runtime/application/execution-plane/execution-plane-adapter.ts
+++ b/apps/api/src/modules/runtime/application/execution-plane/execution-plane-adapter.ts
@@ -44,11 +44,6 @@ export interface DispatchRuntimeTurnInput {
   sessionRunId: SessionRunId;
 }
 
-export interface RuntimeExecutionTerminalOptions {
-  cols?: number;
-  rows?: number;
-}
-
 export interface StopRuntimeSubjectDriversInput {
   operationId?: RuntimeOperationId;
   runtimeSubjectId: SandboxId;
@@ -78,15 +73,6 @@ export interface RuntimeSubjectOperationSessionTarget {
 }
 
 export interface RuntimeExecutionPlaneAdapter {
-  connectTerminal(
-    bindings: ApiBindings,
-    input: {
-      runtimeSubjectId: SandboxId;
-      options?: RuntimeExecutionTerminalOptions;
-      request: Request;
-      terminalSessionId?: string;
-    },
-  ): Promise<Response>;
   dispatchTurn(bindings: ApiBindings, input: DispatchRuntimeTurnInput): Promise<void>;
   materializeActiveSessionResources(
     bindings: ApiBindings,

--- a/apps/api/src/modules/runtime/application/owner-debug-terminal.service.ts
+++ b/apps/api/src/modules/runtime/application/owner-debug-terminal.service.ts
@@ -1,6 +1,6 @@
 import type { PtyOptions } from "@cloudflare/sandbox";
 import { parsePlatformId } from "@mosoo/id";
-import type { AccountId, AgentId, SandboxId } from "@mosoo/id";
+import type { AccountId, AgentId } from "@mosoo/id";
 
 import type { ApiBindings } from "../../../platform/cloudflare/worker-types";
 import { API_ERROR_CODE, ApiError, createApiError } from "../../../platform/errors";
@@ -8,11 +8,11 @@ import { ensureAgentOwner } from "../../agents/application/agent-access.service"
 import type { AuthenticatedViewer } from "../../auth/application/viewer-auth.service";
 import { getRuntimeKindPolicy } from "../domain/runtime-kind-policy";
 import { resolveStableAgentRuntimeSubject } from "../domain/runtime-sandbox-subject";
-import { createSandboxExecutionPlaneAdapter } from "../infrastructure/execution-plane/sandbox-execution-plane-adapter";
+import { connectPreparedSandboxTerminal } from "../infrastructure/execution-plane/sandbox-execution-plane-adapter";
+import { createRuntimeSubjectLifecycleService } from "../infrastructure/runtime-subject-lifecycle/runtime-subject-lifecycle.service";
 import { ensureRuntimeSubjectId } from "../infrastructure/runtime-subject-lifecycle/runtime-subject-store";
 
 const DEFAULT_OWNER_DEBUG_TERMINAL_OPTIONS: PtyOptions = { cols: 120, rows: 32 };
-const executionPlane = createSandboxExecutionPlaneAdapter();
 
 function ensureOwnerDebugTerminalWebSocketRequest(request: Request): void {
   if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
@@ -30,7 +30,7 @@ async function resolveOwnerDebugTerminalTarget(
     agentId: AgentId;
     viewerId: AccountId;
   },
-): Promise<{ runtimeSubjectId: SandboxId; terminalSessionId: string }> {
+) {
   const agent = await ensureAgentOwner(database, input.viewerId, input.agentId);
   const policy = getRuntimeKindPolicy(agent.kind);
 
@@ -47,7 +47,18 @@ async function resolveOwnerDebugTerminalTarget(
   });
 
   return {
-    runtimeSubjectId: await ensureRuntimeSubjectId(database, subject),
+    agentId: agent.id,
+    appId: agent.appId,
+    executionOwnerUserId: agent.ownerId,
+    kind: agent.kind,
+    runtimeSubjectId: await ensureRuntimeSubjectId(database, {
+      ...subject,
+      agentId: agent.id,
+      appId: agent.appId,
+      executionOwnerUserId: agent.ownerId,
+    }),
+    subjectId: subject.subjectId,
+    subjectKind: subject.subjectKind,
     terminalSessionId: getOwnerDebugTerminalSessionId({
       agentId: agent.id,
       viewerId: input.viewerId,
@@ -72,8 +83,12 @@ export async function connectOwnerDebugTerminalWebSocket(
     agentId,
     viewerId: input.viewer.id,
   });
-  return executionPlane.connectTerminal(bindings, {
-    runtimeSubjectId: target.runtimeSubjectId,
+  const activation = await createRuntimeSubjectLifecycleService(bindings).activate({
+    ...target,
+    networkConstraints: { allowedHosts: [], networkPolicy: "full" },
+  });
+
+  return connectPreparedSandboxTerminal(activation.subject, {
     options,
     request: input.request,
     terminalSessionId: target.terminalSessionId,

--- a/apps/api/src/modules/runtime/application/session-definition/hydrate-run-context.service.ts
+++ b/apps/api/src/modules/runtime/application/session-definition/hydrate-run-context.service.ts
@@ -3,7 +3,15 @@ import type { SessionSummary } from "@mosoo/contracts/session";
 import type { UserWarning } from "@mosoo/contracts/session-run";
 import type { ResolvedRunSkill } from "@mosoo/contracts/skill";
 import { createPlatformId } from "@mosoo/id";
-import type { AgentId, PlatformId, AppId, SandboxId, SandboxSessionId, SessionId } from "@mosoo/id";
+import type {
+  AccountId,
+  AgentId,
+  PlatformId,
+  AppId,
+  SandboxId,
+  SandboxSessionId,
+  SessionId,
+} from "@mosoo/id";
 import { getRuntimeCatalogEntry, getRuntimeCatalogVendorForProvider } from "@mosoo/runtime-catalog";
 import { RUNTIME_DIAGNOSTIC_EVENT } from "@mosoo/runtime-events";
 
@@ -61,6 +69,8 @@ async function resolveRuntimeProfileIds(
   bindings: ApiBindings,
   input: {
     agentId: AgentId;
+    appId: AppId;
+    executionOwnerUserId: AccountId;
     kind: DriverProfileConfig["kind"];
     sessionId: SessionId;
   },
@@ -70,7 +80,12 @@ async function resolveRuntimeProfileIds(
 }> {
   const sandboxSubject = resolveAgentRuntimeSandboxSubject(input);
   const [sandboxId, existingConversationSession] = await Promise.all([
-    ensureRuntimeSubjectId(bindings.DB, sandboxSubject),
+    ensureRuntimeSubjectId(bindings.DB, {
+      ...sandboxSubject,
+      agentId: input.agentId,
+      appId: input.appId,
+      executionOwnerUserId: input.executionOwnerUserId,
+    }),
     getRuntimeConversationSession(bindings.DB, input.sessionId),
   ]);
 
@@ -273,6 +288,8 @@ async function hydrateRunContextFromSession(
   let profile: DriverProfileConfig;
   const runtimeProfileIds = await resolveRuntimeProfileIds(bindings, {
     agentId: agent.id,
+    appId: session.appId,
+    executionOwnerUserId: agent.ownerId,
     kind: binding.kind,
     sessionId: session.id,
   });
@@ -427,6 +444,8 @@ async function refreshCachedRunContextVolatileFields(
 
   const runtimeProfileIds = await resolveRuntimeProfileIds(bindings, {
     agentId: agent.id,
+    appId: session.appId,
+    executionOwnerUserId: agent.ownerId,
     kind: binding.kind,
     sessionId: session.id,
   });

--- a/apps/api/src/modules/runtime/application/session-runs/prewarm-agent-session-runtime.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/prewarm-agent-session-runtime.service.ts
@@ -75,6 +75,7 @@ export async function prewarmAgentSessionRuntime(
     const sandboxId = hydrated.value.profile.sandbox.id;
     const { subject: sandbox } = await timing.measure("activateRuntimeSubject", () =>
       createRuntimeSubjectLifecycleService(bindings).activate({
+        agentId: hydrated.value.profile.agentId,
         executionOwnerUserId: hydrated.value.profile.session.origin.executionOwnerUserId,
         kind: hydrated.value.profile.kind,
         networkConstraints: resolveRuntimeSubjectNetworkConstraints(bindings, {
@@ -85,6 +86,7 @@ export async function prewarmAgentSessionRuntime(
           subjectKind: hydrated.value.profile.sandbox.subjectKind,
         }),
         runtimeSubjectId: sandboxId,
+        appId: session.appId,
         purpose: "prewarm",
         subjectId: hydrated.value.profile.sandbox.subjectId,
         subjectKind: hydrated.value.profile.sandbox.subjectKind,

--- a/apps/api/src/modules/runtime/infrastructure/execution-plane/sandbox-execution-plane-adapter.ts
+++ b/apps/api/src/modules/runtime/infrastructure/execution-plane/sandbox-execution-plane-adapter.ts
@@ -1,4 +1,5 @@
-import type { SandboxId, SessionId } from "@mosoo/id";
+import type { PtyOptions } from "@cloudflare/sandbox";
+import type { SessionId } from "@mosoo/id";
 import { RUNTIME_DIAGNOSTIC_EVENT } from "@mosoo/runtime-events";
 
 import {
@@ -10,7 +11,6 @@ import { createStopwatch } from "../../../../time";
 import type {
   DispatchRuntimeTurnInput,
   PrepareRuntimeRunInput,
-  RuntimeExecutionTerminalOptions,
   RuntimeExecutionPlaneAdapter,
   RuntimeExecutionPlaneRunLease,
   RuntimeSubjectOperationInput,
@@ -26,7 +26,6 @@ import { dispatchDriverTurn, ensureDriverSessionReady } from "../driver-session.
 import {
   createRuntimeSubjectLifecycleService,
   getRuntimeSubjectKeepAliveHandle,
-  prepareRuntimeSubjectFilesystem,
 } from "../runtime-subject-lifecycle/runtime-subject-lifecycle.service";
 import { resolveRuntimeSubjectNetworkConstraints } from "../runtime-subject-lifecycle/runtime-subject-network";
 import {
@@ -50,7 +49,7 @@ function releaseRunResources(handles: {
 }
 
 type TerminalSessionHandle = ExecutionSessionHandle & {
-  terminal(request: Request, options?: RuntimeExecutionTerminalOptions): Promise<Response>;
+  terminal(request: Request, options?: PtyOptions): Promise<Response>;
 };
 
 function isSessionAlreadyExistsError(error: unknown): boolean {
@@ -94,32 +93,23 @@ async function ensureTerminalSession(
   }
 }
 
-class SandboxExecutionPlaneAdapter implements RuntimeExecutionPlaneAdapter {
-  async connectTerminal(
-    bindings: ApiBindings,
-    input: {
-      runtimeSubjectId: SandboxId;
-      options?: { cols?: number; rows?: number };
-      request: Request;
-      terminalSessionId?: string;
-    },
-  ): Promise<Response> {
-    const subject = await getRuntimeSubjectKeepAliveHandle(bindings, input.runtimeSubjectId);
-
-    // Owners can open the terminal before any run has executed prepareRun, so the
-    // sandbox container may be live but /workspace/{cache,memory,se} have never
-    // been provisioned — ls would show an empty workspace and look broken.
-    // Re-assert the platform roots before opening the sandbox terminal.
-    await prepareRuntimeSubjectFilesystem(subject);
-
-    if (input.terminalSessionId) {
-      const terminalSession = await ensureTerminalSession(subject, input.terminalSessionId);
-      return terminalSession.terminal(input.request, input.options);
-    }
-
-    return subject.terminal(input.request, input.options);
+export async function connectPreparedSandboxTerminal(
+  subject: SandboxHandle,
+  input: {
+    options?: PtyOptions;
+    request: Request;
+    terminalSessionId?: string;
+  },
+): Promise<Response> {
+  if (input.terminalSessionId) {
+    const terminalSession = await ensureTerminalSession(subject, input.terminalSessionId);
+    return terminalSession.terminal(input.request, input.options);
   }
 
+  return subject.terminal(input.request, input.options);
+}
+
+class SandboxExecutionPlaneAdapter implements RuntimeExecutionPlaneAdapter {
   async prepareRun(
     bindings: ApiBindings,
     requestUrl: string,
@@ -164,6 +154,7 @@ class SandboxExecutionPlaneAdapter implements RuntimeExecutionPlaneAdapter {
       });
       const { subject: sandbox } = await timing.measure("activateRuntimeSubject", () =>
         runtimeSubjectLifecycle.activate({
+          agentId: input.profile.agentId,
           diagnosticContext: {
             agentId: input.profile.configRevision.agentId,
             sessionId: input.sessionId,
@@ -179,6 +170,7 @@ class SandboxExecutionPlaneAdapter implements RuntimeExecutionPlaneAdapter {
             subjectKind: input.profile.sandbox.subjectKind,
           }),
           runtimeSubjectId: sandboxId,
+          appId: input.profile.vendorCredential.appId,
           subjectId: input.profile.sandbox.subjectId,
           subjectKind: input.profile.sandbox.subjectKind,
           timing,

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-lifecycle.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-lifecycle.service.ts
@@ -3,8 +3,10 @@ import type { SandboxSubjectKind } from "@mosoo/contracts/sandbox";
 import type { RuntimeSubjectErrorCode } from "@mosoo/contracts/sandbox";
 import type {
   AccountId,
+  AgentId,
   DriverInstanceId,
   PlatformId,
+  AppId,
   RuntimeOperationId,
   SandboxId,
   SandboxSessionId,
@@ -16,6 +18,7 @@ import { RUNTIME_DIAGNOSTIC_EVENT } from "@mosoo/runtime-events";
 
 import { createErrorLogContext, logWarn } from "../../../../platform/cloudflare/logger";
 import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
+import { validationError } from "../../../../platform/errors";
 import { currentTimestampMs } from "../../../../time";
 import {
   appendRuntimeDiagnosticEvent,
@@ -52,7 +55,8 @@ import {
 } from "./runtime-subject-platform";
 import {
   claimRuntimeSubjectActivation,
-  createClaimedColdRuntimeSubjectRecord,
+  ensureRuntimeSubjectId,
+  FREE_PLAN_CONCURRENT_SANDBOX_LIMITS,
   getRuntimeConversationSessionState,
   getRuntimeSubjectActivationRecord,
   markRuntimeSubjectActivationDestroying,
@@ -78,15 +82,25 @@ const MAINTENANCE_CLAIM_OWNER_PREFIXES = ["scheduled-", "immediate-"] as const;
 export type RuntimeSubjectActivationPurpose = "interactive" | "prewarm";
 
 export interface ActivateRuntimeSubjectInput {
+  readonly agentId: AgentId;
   readonly executionOwnerUserId: AccountId;
   readonly kind: AgentKind;
   readonly diagnosticContext?: RuntimeDiagnosticContext;
   readonly networkConstraints: SandboxNetworkConstraints;
   readonly purpose?: RuntimeSubjectActivationPurpose;
   readonly runtimeSubjectId: SandboxId;
+  readonly appId: AppId;
   readonly subjectId: PlatformId;
   readonly subjectKind: SandboxSubjectKind;
   readonly timing?: RuntimeTimingRecorder;
+}
+
+function freePlanSandboxLimitError() {
+  const limits = FREE_PLAN_CONCURRENT_SANDBOX_LIMITS;
+
+  return validationError(
+    `Free plan concurrent sandbox limit reached (${limits.agent} per Agent, ${limits.app} per App, ${limits.account} per account). Wait for a sandbox to stop before trying again.`,
+  );
 }
 
 export interface ActiveRuntimeSubject {
@@ -403,15 +417,19 @@ export class RuntimeSubjectLifecycleService {
     );
 
     if (!record) {
-      const created = await createClaimedColdRuntimeSubjectRecord(this.#bindings.DB, {
-        ...input,
-        claimExpiresAt,
-        claimOwner,
+      const runtimeSubjectId = await ensureRuntimeSubjectId(this.#bindings.DB, {
+        agentId: input.agentId,
+        appId: input.appId,
+        executionOwnerUserId: input.executionOwnerUserId,
+        kind: input.kind,
         now,
+        runtimeSubjectId: input.runtimeSubjectId,
+        subjectId: input.subjectId,
+        subjectKind: input.subjectKind,
       });
 
-      if (created) {
-        return null;
+      if (runtimeSubjectId !== input.runtimeSubjectId) {
+        throw new Error("Runtime subject activation resolved a different lifecycle record.");
       }
 
       const createdByAnotherActivation = await getRuntimeSubjectActivationRecord(
@@ -523,14 +541,31 @@ export class RuntimeSubjectLifecycleService {
     }
 
     const claimed = await claimRuntimeSubjectActivation(this.#bindings.DB, {
+      agentId: input.activation.agentId,
+      appId: input.activation.appId,
       claimExpiresAt: input.claimExpiresAt,
       claimOwner: input.claimOwner,
+      executionOwnerUserId: input.activation.executionOwnerUserId,
       expectedStatus: record.status,
       now: currentTimestampMs(),
       runtimeSubjectId: input.activation.runtimeSubjectId,
     });
 
     if (!claimed) {
+      if (record.status === "cold") {
+        const refreshed = await getRuntimeSubjectActivationRecord(
+          this.#bindings.DB,
+          input.activation.runtimeSubjectId,
+        );
+
+        if (
+          refreshed?.status === "cold" &&
+          !hasActiveRuntimeSubjectClaim(refreshed, currentTimestampMs())
+        ) {
+          throw freePlanSandboxLimitError();
+        }
+      }
+
       throw new Error("Runtime subject is busy with lifecycle maintenance.");
     }
 

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-record-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-record-store.ts
@@ -2,7 +2,15 @@ import type { AgentKind } from "@mosoo/contracts/agent";
 import type { RuntimeSubjectErrorCode, SandboxSubjectKind } from "@mosoo/contracts/sandbox";
 import { sandboxesTable } from "@mosoo/db";
 import { createPlatformId } from "@mosoo/id";
-import type { PlatformId, RuntimeOperationId, SandboxBackupId, SandboxId } from "@mosoo/id";
+import type {
+  AccountId,
+  AgentId,
+  PlatformId,
+  AppId,
+  RuntimeOperationId,
+  SandboxBackupId,
+  SandboxId,
+} from "@mosoo/id";
 import { and, eq, inArray, isNull, lte, notExists, or, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
@@ -30,6 +38,41 @@ import type {
   RuntimeSubjectRecord,
   RuntimeSubjectStatus,
 } from "./runtime-subject-store.types";
+
+// ponytail: every hosted account is on Free today; replace constants with
+// entitlements only when paid plans actually ship.
+export const FREE_PLAN_CONCURRENT_SANDBOX_LIMITS = {
+  account: 20,
+  agent: 3,
+  app: 10,
+} as const;
+
+interface RuntimeSubjectQuotaScope {
+  readonly agentId: AgentId;
+  readonly appId: AppId;
+  readonly executionOwnerUserId: AccountId;
+}
+
+function runtimeSubjectQuotaCapacityPredicate(
+  input: RuntimeSubjectQuotaScope & { readonly now: number },
+): SQL {
+  const limits = FREE_PLAN_CONCURRENT_SANDBOX_LIMITS;
+
+  // ponytail: the production pool is capped at 50, so one guarded scan is cheaper
+  // than quota counters; add counters only if the pool ceiling grows materially.
+  return sql`(
+    SELECT
+      COALESCE(SUM(CASE WHEN quota_sandbox.agent_id = ${input.agentId} THEN 1 ELSE 0 END), 0) < ${limits.agent}
+      AND COALESCE(SUM(CASE WHEN quota_sandbox.app_id = ${input.appId} THEN 1 ELSE 0 END), 0) < ${limits.app}
+      AND COALESCE(SUM(CASE WHEN quota_sandbox.owner_account_id = ${input.executionOwnerUserId} THEN 1 ELSE 0 END), 0) < ${limits.account}
+    FROM ${sandboxesTable} AS quota_sandbox
+    WHERE quota_sandbox.status <> 'cold'
+      OR (
+        quota_sandbox.claim_owner IS NOT NULL
+        AND quota_sandbox.claim_expires_at > ${input.now}
+      )
+  )`;
+}
 
 function runtimeSubjectStatusPatch(input: {
   readonly now: number;
@@ -108,8 +151,12 @@ export async function getRuntimeSubjectIdByTuple(
 export async function ensureRuntimeSubjectId(
   database: D1Database,
   input: {
+    readonly agentId: AgentId;
+    readonly appId: AppId;
+    readonly executionOwnerUserId: AccountId;
     readonly kind: AgentKind;
     readonly now?: number;
+    readonly runtimeSubjectId?: SandboxId;
     readonly subjectId: PlatformId;
     readonly subjectKind: SandboxSubjectKind;
   },
@@ -121,10 +168,12 @@ export async function ensureRuntimeSubjectId(
   }
 
   const now = input.now ?? currentTimestampMs();
-  const runtimeSubjectId = createPlatformId<SandboxId>(now);
+  const runtimeSubjectId = input.runtimeSubjectId ?? createPlatformId<SandboxId>(now);
   const result = await getAppDatabase(database)
     .insert(sandboxesTable)
     .values({
+      agentId: input.agentId,
+      appId: input.appId,
       bindMountReady: false,
       claimExpiresAt: null,
       claimOwner: null,
@@ -133,6 +182,7 @@ export async function ensureRuntimeSubjectId(
       id: runtimeSubjectId,
       inactiveDeadlineAt: getRuntimeSubjectInactiveDeadline(getRuntimeKindPolicy(input.kind), now),
       kind: input.kind,
+      ownerAccountId: input.executionOwnerUserId,
       status: "cold",
       statusChangedAt: now,
       statusEvent: toRuntimeSubjectStatusLifecycleEventName("cold"),
@@ -223,51 +273,9 @@ export async function getRuntimeSubjectActivationRecord(
   };
 }
 
-export async function createClaimedColdRuntimeSubjectRecord(
-  database: D1Database,
-  input: {
-    readonly claimExpiresAt: number;
-    readonly claimOwner: string;
-    readonly kind: AgentKind;
-    readonly now: number;
-    readonly runtimeSubjectId: SandboxId;
-    readonly subjectId: PlatformId;
-    readonly subjectKind: SandboxSubjectKind;
-  },
-): Promise<boolean> {
-  const result = await getAppDatabase(database)
-    .insert(sandboxesTable)
-    .values({
-      bindMountReady: false,
-      claimExpiresAt: input.claimExpiresAt,
-      claimOwner: input.claimOwner,
-      createdAt: input.now,
-      globalMountsJson: "[]",
-      id: input.runtimeSubjectId,
-      inactiveDeadlineAt: getRuntimeSubjectInactiveDeadline(
-        getRuntimeKindPolicy(input.kind),
-        input.now,
-      ),
-      kind: input.kind,
-      status: "cold",
-      statusChangedAt: input.now,
-      statusEvent: toRuntimeSubjectStatusLifecycleEventName("cold"),
-      statusOperationId: null,
-      statusSeq: 0,
-      statusSource: "api",
-      subjectId: input.subjectId,
-      subjectKind: input.subjectKind,
-      updatedAt: input.now,
-    })
-    .onConflictDoNothing()
-    .run();
-
-  return getD1ChangeCount(result) > 0;
-}
-
 export async function claimRuntimeSubjectActivation(
   database: D1Database,
-  input: {
+  input: RuntimeSubjectQuotaScope & {
     readonly claimExpiresAt: number;
     readonly claimOwner: string;
     readonly expectedStatus: RuntimeSubjectStatus;
@@ -279,8 +287,11 @@ export async function claimRuntimeSubjectActivation(
     (await getAppDatabase(database)
       .update(sandboxesTable)
       .set({
+        agentId: input.agentId,
+        appId: input.appId,
         claimExpiresAt: input.claimExpiresAt,
         claimOwner: input.claimOwner,
+        ownerAccountId: input.executionOwnerUserId,
         updatedAt: input.now,
       })
       .where(
@@ -293,6 +304,7 @@ export async function claimRuntimeSubjectActivation(
             isNull(sandboxesTable.claimExpiresAt),
             lte(sandboxesTable.claimExpiresAt, input.now),
           ),
+          ...(input.expectedStatus === "cold" ? [runtimeSubjectQuotaCapacityPredicate(input)] : []),
         ),
       )
       .returning({ id: sandboxesTable.id })

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store.ts
@@ -19,8 +19,8 @@ export {
 export {
   advanceRuntimeSubjectOperationStatus,
   claimRuntimeSubjectActivation,
-  createClaimedColdRuntimeSubjectRecord,
   ensureRuntimeSubjectId,
+  FREE_PLAN_CONCURRENT_SANDBOX_LIMITS,
   getRuntimeSubject,
   getRuntimeSubjectActivationRecord,
   getRuntimeSubjectIdByTuple,

--- a/apps/api/tests/helpers/public-api-http-core-schema.sql
+++ b/apps/api/tests/helpers/public-api-http-core-schema.sql
@@ -178,6 +178,8 @@ CREATE TABLE vendor_credential (
 
 CREATE TABLE sandbox (
   id text PRIMARY KEY NOT NULL,
+  agent_id text,
+  app_id text,
   kind text NOT NULL,
   subject_kind text NOT NULL,
   subject_id text NOT NULL,
@@ -196,6 +198,7 @@ CREATE TABLE sandbox (
   claim_owner text,
   claim_expires_at integer,
   inactive_deadline_at integer,
+  owner_account_id text,
   created_at integer NOT NULL,
   updated_at integer NOT NULL
 );

--- a/apps/api/tests/owner-debug-terminal.test.ts
+++ b/apps/api/tests/owner-debug-terminal.test.ts
@@ -109,7 +109,7 @@ describe("owner debug terminal", () => {
     });
   });
 
-  test("provisions /workspace skeleton before opening the terminal session", async () => {
+  test("activates the sandbox before opening the terminal session", async () => {
     const database = await createPublicHttpContractDatabase();
     const spy = createTerminalSandboxHandleSpy();
     const bindings = {
@@ -124,6 +124,12 @@ describe("owner debug terminal", () => {
       viewer: OWNER_VIEWER,
     });
 
+    expect(
+      await database
+        .prepare("SELECT status FROM sandbox WHERE subject_id = ?")
+        .bind(PUBLIC_API_TEST_IDS.agent)
+        .first(),
+    ).toEqual({ status: "active" });
     expect(spy.setKeepAliveCalls).toEqual([true]);
     expect(new Set(spy.mkdirCalls)).toEqual(
       new Set([SANDBOX_CACHE_PATH, SANDBOX_MEMORY_PATH, SANDBOX_SESSION_ROOT]),

--- a/apps/api/tests/runtime-subject-lifecycle.test.ts
+++ b/apps/api/tests/runtime-subject-lifecycle.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, test } from "bun:test";
 
+import { createPlatformId } from "@mosoo/id";
+import type { AgentId, AppId, SandboxId, SessionId } from "@mosoo/id";
+
 import { decideRuntimeSubjectTransition } from "../src/modules/runtime/domain/runtime-subject-lifecycle.machine";
 import { createRuntimeSubjectLifecycleService } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-lifecycle.service";
+import type { ActivateRuntimeSubjectInput } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-lifecycle.service";
 import { destroyRuntimeSubjectContainer } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-platform";
 import { recycleRuntimeSubject } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-recycle.service";
 import {
   advanceRuntimeSubjectOperationStatus,
+  FREE_PLAN_CONCURRENT_SANDBOX_LIMITS,
   markRuntimeSubjectCold,
   markRuntimeSubjectOperationStarted,
 } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store";
@@ -15,14 +20,25 @@ import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
 import { SqliteD1Database } from "./helpers/sqlite-d1";
 
 const RUNTIME_SUBJECT_ID = "01J0000000000000000000000D";
+const ACCOUNT_ID = "01J00000000000000000000002";
+const AGENT_ID = "01J00000000000000000000001";
+const APP_ID = "01J00000000000000000000003";
+const SESSION_ID = "01J00000000000000000000009";
 const CLOUDFLARE_BACKUP_ID = "550e8400-e29b-41d4-a716-446655440000";
 const STORED_BACKUP_ID = encodeSandboxBackupIdForStorage(CLOUDFLARE_BACKUP_ID);
+const RUNTIME_SUBJECT_QUOTA_SCOPE = {
+  agentId: AGENT_ID,
+  appId: APP_ID,
+  executionOwnerUserId: ACCOUNT_ID,
+} as const;
 
 function createRuntimeSubjectLifecycleDatabase(): SqliteD1Database {
   const database = new SqliteD1Database();
 
   database.execute(`
     CREATE TABLE sandbox (
+      agent_id text,
+      app_id text,
       bind_mount_ready integer DEFAULT false NOT NULL,
       claim_expires_at integer,
       claim_owner text,
@@ -35,6 +51,7 @@ function createRuntimeSubjectLifecycleDatabase(): SqliteD1Database {
       last_error text,
       last_error_code text,
       last_restore_backup_id text,
+      owner_account_id text,
       status text NOT NULL,
       status_changed_at integer DEFAULT 0 NOT NULL,
       status_event text DEFAULT 'runtime_subject.cold' NOT NULL,
@@ -125,7 +142,7 @@ async function insertRuntimeSubject(
       `runtime_subject.${input.status === "backing_up" ? "back_up" : input.status}`,
       input.statusSeq ?? 0,
       "test",
-      "01J00000000000000000000009",
+      SESSION_ID,
       "session",
       1,
     )
@@ -277,12 +294,12 @@ describe("runtime subject lifecycle machine", () => {
 
     await expect(
       createRuntimeSubjectLifecycleService(createBindings(database)).activate({
-        executionOwnerUserId: "01J00000000000000000000002",
+        ...RUNTIME_SUBJECT_QUOTA_SCOPE,
         kind: "pet",
         networkConstraints: { allowedHosts: ["api.example.com"], networkPolicy: "limited" },
         runtimeSubjectId: RUNTIME_SUBJECT_ID,
         spaceAliases: [],
-        subjectId: "01J00000000000000000000009",
+        subjectId: AGENT_ID,
         subjectKind: "agent",
       }),
     ).rejects.toThrow("only for Task Agents");
@@ -290,6 +307,45 @@ describe("runtime subject lifecycle machine", () => {
     await expect(
       database.prepare("SELECT id FROM sandbox WHERE id = ?").bind(RUNTIME_SUBJECT_ID).first("id"),
     ).resolves.toBeNull();
+  });
+
+  test("atomically caps Free sandboxes per Agent, App, and account", async () => {
+    for (const scope of ["agent", "app", "account"] as const) {
+      const database = createRuntimeSubjectLifecycleDatabase();
+      const inputs: ActivateRuntimeSubjectInput[] = [];
+      const limit = FREE_PLAN_CONCURRENT_SANDBOX_LIMITS[scope];
+
+      for (let index = 0; index <= limit; index += 1) {
+        const agentId = scope === "agent" ? AGENT_ID : createPlatformId<AgentId>();
+        const appId = scope === "account" ? createPlatformId<AppId>() : APP_ID;
+        const sessionId = createPlatformId<SessionId>();
+
+        inputs.push({
+          agentId,
+          appId,
+          executionOwnerUserId: ACCOUNT_ID,
+          kind: "cattle",
+          networkConstraints: { allowedHosts: [], networkPolicy: "full" },
+          runtimeSubjectId: createPlatformId<SandboxId>(),
+          subjectId: sessionId,
+          subjectKind: "session",
+        });
+      }
+
+      const lifecycle = createRuntimeSubjectLifecycleService(createBindings(database));
+      const outcomes = await Promise.allSettled(inputs.map((input) => lifecycle.activate(input)));
+      const rejected = outcomes.filter(
+        (outcome): outcome is PromiseRejectedResult => outcome.status === "rejected",
+      );
+      const active = await database
+        .prepare("SELECT COUNT(*) AS count FROM sandbox WHERE status = 'active'")
+        .first<{ count: number }>();
+
+      expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(limit);
+      expect(rejected).toHaveLength(1);
+      expect(String(rejected[0]?.reason)).toContain("Free plan concurrent sandbox limit reached");
+      expect(active?.count).toBe(limit);
+    }
   });
 
   test("records operation transitions with monotonic status metadata", async () => {
@@ -359,12 +415,12 @@ describe("runtime subject lifecycle machine", () => {
     const activation = await createRuntimeSubjectLifecycleService(
       createBindings(database),
     ).activate({
-      executionOwnerUserId: "01J00000000000000000000002",
+      ...RUNTIME_SUBJECT_QUOTA_SCOPE,
       kind: "cattle",
       networkConstraints: { allowedHosts: [], networkPolicy: "full" },
       runtimeSubjectId: RUNTIME_SUBJECT_ID,
       spaceAliases: [],
-      subjectId: "01J00000000000000000000009",
+      subjectId: SESSION_ID,
       subjectKind: "session",
     });
 
@@ -465,8 +521,10 @@ describe("runtime subject lifecycle machine", () => {
       )
       .run();
     await database
-      .prepare("UPDATE sandbox SET kind = ?, last_backup_id = ?, subject_kind = ? WHERE id = ?")
-      .bind("pet", STORED_BACKUP_ID, "agent", RUNTIME_SUBJECT_ID)
+      .prepare(
+        "UPDATE sandbox SET kind = ?, last_backup_id = ?, subject_id = ?, subject_kind = ? WHERE id = ?",
+      )
+      .bind("pet", STORED_BACKUP_ID, AGENT_ID, "agent", RUNTIME_SUBJECT_ID)
       .run();
     let restoredBackup: { readonly dir: string; readonly id: string } | null = null;
     let configureNetworkCalls = 0;
@@ -481,12 +539,12 @@ describe("runtime subject lifecycle machine", () => {
         },
       }),
     ).activate({
-      executionOwnerUserId: "01J00000000000000000000002",
+      ...RUNTIME_SUBJECT_QUOTA_SCOPE,
       kind: "pet",
       networkConstraints: { allowedHosts: [], networkPolicy: "full" },
       runtimeSubjectId: RUNTIME_SUBJECT_ID,
       spaceAliases: [],
-      subjectId: "01J00000000000000000000009",
+      subjectId: AGENT_ID,
       subjectKind: "agent",
     });
 
@@ -514,12 +572,12 @@ describe("runtime subject lifecycle machine", () => {
     const activation = await createRuntimeSubjectLifecycleService(
       createBindings(database),
     ).activate({
-      executionOwnerUserId: "01J00000000000000000000002",
+      ...RUNTIME_SUBJECT_QUOTA_SCOPE,
       kind: "cattle",
       networkConstraints: { allowedHosts: [], networkPolicy: "full" },
       runtimeSubjectId: RUNTIME_SUBJECT_ID,
       spaceAliases: [],
-      subjectId: "01J00000000000000000000009",
+      subjectId: SESSION_ID,
       subjectKind: "session",
     });
 
@@ -559,12 +617,12 @@ describe("runtime subject lifecycle machine", () => {
 
     await expect(
       createRuntimeSubjectLifecycleService(createBindings(database, { prepareError })).activate({
-        executionOwnerUserId: "01J00000000000000000000002",
+        ...RUNTIME_SUBJECT_QUOTA_SCOPE,
         kind: "cattle",
         networkConstraints: { allowedHosts: [], networkPolicy: "full" },
         runtimeSubjectId: RUNTIME_SUBJECT_ID,
         spaceAliases: [],
-        subjectId: "01J00000000000000000000009",
+        subjectId: SESSION_ID,
         subjectKind: "session",
       }),
     ).rejects.toThrow("Runtime subject filesystem prepare timed out after 15000ms.");
@@ -609,12 +667,12 @@ describe("runtime subject lifecycle machine", () => {
           prepareError,
         }),
       ).activate({
-        executionOwnerUserId: "01J00000000000000000000002",
+        ...RUNTIME_SUBJECT_QUOTA_SCOPE,
         kind: "cattle",
         networkConstraints: { allowedHosts: [], networkPolicy: "full" },
         runtimeSubjectId: RUNTIME_SUBJECT_ID,
         spaceAliases: [],
-        subjectId: "01J00000000000000000000009",
+        subjectId: SESSION_ID,
         subjectKind: "session",
       }),
     ).rejects.toThrow("original activation failure");
@@ -671,12 +729,12 @@ describe("runtime subject lifecycle machine", () => {
           onDestroy: () => (destroyCalls += 1),
         }),
       ).activate({
-        executionOwnerUserId: "01J00000000000000000000002",
+        ...RUNTIME_SUBJECT_QUOTA_SCOPE,
         kind: "cattle",
         networkConstraints: { allowedHosts: [], networkPolicy: "limited" },
         runtimeSubjectId: RUNTIME_SUBJECT_ID,
         spaceAliases: [],
-        subjectId: "01J00000000000000000000009",
+        subjectId: SESSION_ID,
         subjectKind: "session",
       }),
     ).rejects.toThrow("cannot be enforced");
@@ -700,12 +758,12 @@ describe("runtime subject lifecycle machine", () => {
       createRuntimeSubjectLifecycleService(
         createBindings(database, { onDestroy: () => (destroyCalls += 1), prepareError }),
       ).activate({
-        executionOwnerUserId: "01J00000000000000000000002",
+        ...RUNTIME_SUBJECT_QUOTA_SCOPE,
         kind: "cattle",
         networkConstraints: { allowedHosts: [], networkPolicy: "full" },
         runtimeSubjectId: RUNTIME_SUBJECT_ID,
         spaceAliases: [],
-        subjectId: "01J00000000000000000000009",
+        subjectId: SESSION_ID,
         subjectKind: "session",
       }),
     ).rejects.toThrow("filesystem prepare timed out");
@@ -717,12 +775,12 @@ describe("runtime subject lifecycle machine", () => {
     // manual recreate needed.
     const recovered = await createRuntimeSubjectLifecycleService(createBindings(database)).activate(
       {
-        executionOwnerUserId: "01J00000000000000000000002",
+        ...RUNTIME_SUBJECT_QUOTA_SCOPE,
         kind: "cattle",
         networkConstraints: { allowedHosts: [], networkPolicy: "full" },
         runtimeSubjectId: RUNTIME_SUBJECT_ID,
         spaceAliases: [],
-        subjectId: "01J00000000000000000000009",
+        subjectId: SESSION_ID,
         subjectKind: "session",
       },
     );

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -200,8 +200,9 @@ class_name = "Sandbox"
 [[env.prod.containers]]
 class_name = "Sandbox"
 image = "../driver/Containerfile"
+# ponytail: early-stage spend fuse; raise only after sustained demand is measured.
 instance_type = "standard-2"
-max_instances = 500
+max_instances = 50
 
 [[env.prod.r2_buckets]]
 binding = "FILE_BUCKET"

--- a/pkgs/contracts/tests/production-origin.test.ts
+++ b/pkgs/contracts/tests/production-origin.test.ts
@@ -19,7 +19,7 @@ describe("production origins", () => {
   test("pins the production Sandbox capacity accepted by the account quota", () => {
     const apiWrangler = readRepoFile("apps/api/wrangler.toml");
 
-    expect(apiWrangler).toContain('instance_type = "standard-2"\nmax_instances = 500');
+    expect(apiWrangler).toContain('instance_type = "standard-2"\nmax_instances = 50');
   });
 
   test("keeps Cloudflare routes and OAuth origin aligned", () => {

--- a/pkgs/db/drizzle/0006_runtime_subject_quota_scope.sql
+++ b/pkgs/db/drizzle/0006_runtime_subject_quota_scope.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `sandbox` ADD `agent_id` text CHECK ("agent_id" = upper("agent_id") AND length("agent_id") = 26 AND substr("agent_id", 1, 1) GLOB '[0-7]' AND "agent_id" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*');--> statement-breakpoint
+ALTER TABLE `sandbox` ADD `app_id` text CHECK ("app_id" = upper("app_id") AND length("app_id") = 26 AND substr("app_id", 1, 1) GLOB '[0-7]' AND "app_id" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*');--> statement-breakpoint
+ALTER TABLE `sandbox` ADD `owner_account_id` text CHECK ("owner_account_id" = upper("owner_account_id") AND length("owner_account_id") = 26 AND substr("owner_account_id", 1, 1) GLOB '[0-7]' AND "owner_account_id" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*');

--- a/pkgs/db/drizzle/meta/0006_snapshot.json
+++ b/pkgs/db/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,7210 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d241a88f-b60c-4c7e-8173-3b982448c3b0",
+  "prevId": "f0b14693-a232-46e8-be24-3cb0949901f3",
+  "tables": {
+    "agent_deployment_version": {
+      "name": "agent_deployment_version",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text CHECK (\"agent_id\" = upper(\"agent_id\") AND length(\"agent_id\") = 26 AND substr(\"agent_id\", 1, 1) GLOB '[0-7]' AND \"agent_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "text CHECK (\"created_by_account_id\" = upper(\"created_by_account_id\") AND length(\"created_by_account_id\") = 26 AND substr(\"created_by_account_id\", 1, 1) GLOB '[0-7]' AND \"created_by_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text CHECK (\"environment_id\" = upper(\"environment_id\") AND length(\"environment_id\") = 26 AND substr(\"environment_id\", 1, 1) GLOB '[0-7]' AND \"environment_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_bindings_json": {
+          "name": "mcp_bindings_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_id": {
+          "name": "runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skills_json": {
+          "name": "skills_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_deployment_version_agent_number_idx": {
+          "name": "agent_deployment_version_agent_number_idx",
+          "columns": ["agent_id", "version_number"],
+          "isUnique": true
+        },
+        "agent_deployment_version_agent_created_idx": {
+          "name": "agent_deployment_version_agent_created_idx",
+          "columns": ["agent_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_mcp_binding": {
+      "name": "agent_mcp_binding",
+      "columns": {
+        "agent_credential_id": {
+          "name": "agent_credential_id",
+          "type": "text CHECK (\"agent_credential_id\" = upper(\"agent_credential_id\") AND length(\"agent_credential_id\") = 26 AND substr(\"agent_credential_id\", 1, 1) GLOB '[0-7]' AND \"agent_credential_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text CHECK (\"agent_id\" = upper(\"agent_id\") AND length(\"agent_id\") = 26 AND substr(\"agent_id\", 1, 1) GLOB '[0-7]' AND \"agent_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_mode": {
+          "name": "credential_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'runtime_resolved'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text CHECK (\"server_id\" = upper(\"server_id\") AND length(\"server_id\") = 26 AND substr(\"server_id\", 1, 1) GLOB '[0-7]' AND \"server_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_mcp_binding_agent_sort_idx": {
+          "name": "agent_mcp_binding_agent_sort_idx",
+          "columns": ["agent_id", "sort_order"],
+          "isUnique": true
+        },
+        "agent_mcp_binding_server_idx": {
+          "name": "agent_mcp_binding_server_idx",
+          "columns": ["server_id"],
+          "isUnique": false
+        },
+        "agent_mcp_binding_profile_server_idx": {
+          "name": "agent_mcp_binding_profile_server_idx",
+          "columns": ["agent_id", "server_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_mcp_binding_agent_credential_shape_check": {
+          "name": "agent_mcp_binding_agent_credential_shape_check",
+          "value": "\n        (\"agent_mcp_binding\".\"credential_mode\" = 'agent_bound' AND \"agent_mcp_binding\".\"agent_credential_id\" IS NOT NULL)\n        OR (\"agent_mcp_binding\".\"credential_mode\" = 'runtime_resolved' AND \"agent_mcp_binding\".\"agent_credential_id\" IS NULL)\n      "
+        }
+      }
+    },
+    "agent_skill": {
+      "name": "agent_skill",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text CHECK (\"agent_id\" = upper(\"agent_id\") AND length(\"agent_id\") = 26 AND substr(\"agent_id\", 1, 1) GLOB '[0-7]' AND \"agent_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "text CHECK (\"skill_id\" = upper(\"skill_id\") AND length(\"skill_id\") = 26 AND substr(\"skill_id\", 1, 1) GLOB '[0-7]' AND \"skill_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_skill_agent_sort_idx": {
+          "name": "agent_skill_agent_sort_idx",
+          "columns": ["agent_id", "sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_skill_agent_id_skill_id_pk": {
+          "columns": ["agent_id", "skill_id"],
+          "name": "agent_skill_agent_id_skill_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent": {
+      "name": "agent",
+      "columns": {
+        "config_json": {
+          "name": "config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text CHECK (\"environment_id\" = upper(\"environment_id\") AND length(\"environment_id\") = 26 AND substr(\"environment_id\", 1, 1) GLOB '[0-7]' AND \"environment_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pet'"
+        },
+        "live_deployment_version_id": {
+          "name": "live_deployment_version_id",
+          "type": "text CHECK (\"live_deployment_version_id\" = upper(\"live_deployment_version_id\") AND length(\"live_deployment_version_id\") = 26 AND substr(\"live_deployment_version_id\", 1, 1) GLOB '[0-7]' AND \"live_deployment_version_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "text CHECK (\"owner_account_id\" = upper(\"owner_account_id\") AND length(\"owner_account_id\") = 26 AND substr(\"owner_account_id\", 1, 1) GLOB '[0-7]' AND \"owner_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_id": {
+          "name": "runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        }
+      },
+      "indexes": {
+        "agent_app_owner_account_idx": {
+          "name": "agent_app_owner_account_idx",
+          "columns": ["app_id", "owner_account_id"],
+          "isUnique": false
+        },
+        "agent_app_status_idx": {
+          "name": "agent_app_status_idx",
+          "columns": ["app_id", "status"],
+          "isUnique": false
+        },
+        "agent_environment_idx": {
+          "name": "agent_environment_idx",
+          "columns": ["environment_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_published_live_deployment_version_check": {
+          "name": "agent_published_live_deployment_version_check",
+          "value": "\"agent\".\"status\" <> 'published' OR \"agent\".\"live_deployment_version_id\" IS NOT NULL"
+        }
+      }
+    },
+    "api_command": {
+      "name": "api_command",
+      "columns": {
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claim_owner": {
+          "name": "claim_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_command_dedupe_idx": {
+          "name": "api_command_dedupe_idx",
+          "columns": ["dedupe_key"],
+          "isUnique": true
+        },
+        "api_command_status_updated_idx": {
+          "name": "api_command_status_updated_idx",
+          "columns": ["status", "updated_at"],
+          "isUnique": false
+        },
+        "api_command_claim_idx": {
+          "name": "api_command_claim_idx",
+          "columns": ["status", "claim_expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_account": {
+      "name": "auth_account",
+      "columns": {
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text CHECK (\"account_id\" = upper(\"account_id\") AND length(\"account_id\") = 26 AND substr(\"account_id\", 1, 1) GLOB '[0-7]' AND \"account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_account_provider_account_idx": {
+          "name": "auth_account_provider_account_idx",
+          "columns": ["provider_id", "provider_account_id"],
+          "isUnique": true
+        },
+        "auth_account_account_id_idx": {
+          "name": "auth_account_account_id_idx",
+          "columns": ["account_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_session": {
+      "name": "auth_session",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text CHECK (\"account_id\" = upper(\"account_id\") AND length(\"account_id\") = 26 AND substr(\"account_id\", 1, 1) GLOB '[0-7]' AND \"account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_session_expires_at_idx": {
+          "name": "auth_session_expires_at_idx",
+          "columns": ["expires_at"],
+          "isUnique": false
+        },
+        "auth_session_token_idx": {
+          "name": "auth_session_token_idx",
+          "columns": ["token"],
+          "isUnique": true
+        },
+        "auth_session_account_id_idx": {
+          "name": "auth_session_account_id_idx",
+          "columns": ["account_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_verification": {
+      "name": "auth_verification",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_verification_expires_at_idx": {
+          "name": "auth_verification_expires_at_idx",
+          "columns": ["expires_at"],
+          "isUnique": false
+        },
+        "auth_verification_identifier_idx": {
+          "name": "auth_verification_identifier_idx",
+          "columns": ["identifier"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cli_oauth_flow": {
+      "name": "cli_oauth_flow",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text CHECK (\"account_id\" = upper(\"account_id\") AND length(\"account_id\") = 26 AND substr(\"account_id\", 1, 1) GLOB '[0-7]' AND \"account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "authorized_at": {
+          "name": "authorized_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code_hash": {
+          "name": "device_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cli_oauth_flow_status_expires_idx": {
+          "name": "cli_oauth_flow_status_expires_idx",
+          "columns": ["status", "expires_at"],
+          "isUnique": false
+        },
+        "cli_oauth_flow_device_code_hash_idx": {
+          "name": "cli_oauth_flow_device_code_hash_idx",
+          "columns": ["device_code_hash"],
+          "isUnique": true
+        },
+        "cli_oauth_flow_user_code_idx": {
+          "name": "cli_oauth_flow_user_code_idx",
+          "columns": ["user_code"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "personal_access_token": {
+      "name": "personal_access_token",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text CHECK (\"account_id\" = upper(\"account_id\") AND length(\"account_id\") = 26 AND substr(\"account_id\", 1, 1) GLOB '[0-7]' AND \"account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "personal_access_token_account_created_idx": {
+          "name": "personal_access_token_account_created_idx",
+          "columns": ["account_id", "created_at"],
+          "isUnique": false
+        },
+        "personal_access_token_hash_idx": {
+          "name": "personal_access_token_hash_idx",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_channel_binding": {
+      "name": "agent_channel_binding",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text CHECK (\"agent_id\" = upper(\"agent_id\") AND length(\"agent_id\") = 26 AND substr(\"agent_id\", 1, 1) GLOB '[0-7]' AND \"agent_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_metadata_json": {
+          "name": "display_metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "encrypted_creds_secret_id": {
+          "name": "encrypted_creds_secret_id",
+          "type": "text CHECK (\"encrypted_creds_secret_id\" = upper(\"encrypted_creds_secret_id\") AND length(\"encrypted_creds_secret_id\") = 26 AND substr(\"encrypted_creds_secret_id\", 1, 1) GLOB '[0-7]' AND \"encrypted_creds_secret_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_bot_id": {
+          "name": "external_bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_tenant_id": {
+          "name": "external_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_channel_binding_agent_provider_idx": {
+          "name": "agent_channel_binding_agent_provider_idx",
+          "columns": ["agent_id", "provider"],
+          "isUnique": true
+        },
+        "agent_channel_binding_provider_tenant_bot_idx": {
+          "name": "agent_channel_binding_provider_tenant_bot_idx",
+          "columns": ["provider", "external_tenant_id", "external_bot_id"],
+          "isUnique": true
+        },
+        "agent_channel_binding_agent_status_idx": {
+          "name": "agent_channel_binding_agent_status_idx",
+          "columns": ["agent_id", "status"],
+          "isUnique": false
+        },
+        "agent_channel_binding_app_status_idx": {
+          "name": "agent_channel_binding_app_status_idx",
+          "columns": ["app_id", "status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_channel_binding_agent_id_agent_id_fk": {
+          "name": "agent_channel_binding_agent_id_agent_id_fk",
+          "tableFrom": "agent_channel_binding",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_channel_binding_encrypted_creds_secret_id_vault_secret_id_fk": {
+          "name": "agent_channel_binding_encrypted_creds_secret_id_vault_secret_id_fk",
+          "tableFrom": "agent_channel_binding",
+          "tableTo": "vault_secret",
+          "columnsFrom": ["encrypted_creds_secret_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_channel_binding_app_id_app_id_fk": {
+          "name": "agent_channel_binding_app_id_app_id_fk",
+          "tableFrom": "agent_channel_binding",
+          "tableTo": "app",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_runtime_state": {
+      "name": "channel_runtime_state",
+      "columns": {
+        "binding_id": {
+          "name": "binding_id",
+          "type": "text CHECK (\"binding_id\" = upper(\"binding_id\") AND length(\"binding_id\") = 26 AND substr(\"binding_id\", 1, 1) GLOB '[0-7]' AND \"binding_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_inbound_at": {
+          "name": "last_inbound_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_poll_at": {
+          "name": "last_poll_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_owner_id": {
+          "name": "lease_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_account_id": {
+          "name": "runtime_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "runtime_state_json": {
+          "name": "runtime_state_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_runtime_state_provider_binding_account_idx": {
+          "name": "channel_runtime_state_provider_binding_account_idx",
+          "columns": ["provider", "binding_id", "runtime_account_id"],
+          "isUnique": true
+        },
+        "channel_runtime_state_status_lease_idx": {
+          "name": "channel_runtime_state_status_lease_idx",
+          "columns": ["status", "lease_expires_at"],
+          "isUnique": false
+        },
+        "channel_runtime_state_binding_updated_idx": {
+          "name": "channel_runtime_state_binding_updated_idx",
+          "columns": ["binding_id", "updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_runtime_state_binding_id_agent_channel_binding_id_fk": {
+          "name": "channel_runtime_state_binding_id_agent_channel_binding_id_fk",
+          "tableFrom": "channel_runtime_state",
+          "tableTo": "agent_channel_binding",
+          "columnsFrom": ["binding_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_event_receipt": {
+      "name": "channel_event_receipt",
+      "columns": {
+        "binding_id": {
+          "name": "binding_id",
+          "type": "text CHECK (\"binding_id\" = upper(\"binding_id\") AND length(\"binding_id\") = 26 AND substr(\"binding_id\", 1, 1) GLOB '[0-7]' AND \"binding_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_tenant_id": {
+          "name": "external_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text CHECK (\"session_id\" = upper(\"session_id\") AND length(\"session_id\") = 26 AND substr(\"session_id\", 1, 1) GLOB '[0-7]' AND \"session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_event_receipt_provider_tenant_event_idx": {
+          "name": "channel_event_receipt_provider_tenant_event_idx",
+          "columns": ["provider", "external_tenant_id", "external_event_id"],
+          "isUnique": true
+        },
+        "channel_event_receipt_binding_updated_idx": {
+          "name": "channel_event_receipt_binding_updated_idx",
+          "columns": ["binding_id", "updated_at"],
+          "isUnique": false
+        },
+        "channel_event_receipt_expires_idx": {
+          "name": "channel_event_receipt_expires_idx",
+          "columns": ["expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_event_receipt_binding_id_agent_channel_binding_id_fk": {
+          "name": "channel_event_receipt_binding_id_agent_channel_binding_id_fk",
+          "tableFrom": "channel_event_receipt",
+          "tableTo": "agent_channel_binding",
+          "columnsFrom": ["binding_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_final_delivery_job": {
+      "name": "channel_final_delivery_job",
+      "columns": {
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "binding_id": {
+          "name": "binding_id",
+          "type": "text CHECK (\"binding_id\" = upper(\"binding_id\") AND length(\"binding_id\") = 26 AND substr(\"binding_id\", 1, 1) GLOB '[0-7]' AND \"binding_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text CHECK (\"run_id\" = upper(\"run_id\") AND length(\"run_id\") = 26 AND substr(\"run_id\", 1, 1) GLOB '[0-7]' AND \"run_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text CHECK (\"session_id\" = upper(\"session_id\") AND length(\"session_id\") = 26 AND substr(\"session_id\", 1, 1) GLOB '[0-7]' AND \"session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_final_delivery_provider_binding_event_idx": {
+          "name": "channel_final_delivery_provider_binding_event_idx",
+          "columns": ["provider", "binding_id", "external_event_id"],
+          "isUnique": true
+        },
+        "channel_final_delivery_session_idx": {
+          "name": "channel_final_delivery_session_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        },
+        "channel_final_delivery_run_idx": {
+          "name": "channel_final_delivery_run_idx",
+          "columns": ["run_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_final_delivery_job_binding_id_agent_channel_binding_id_fk": {
+          "name": "channel_final_delivery_job_binding_id_agent_channel_binding_id_fk",
+          "tableFrom": "channel_final_delivery_job",
+          "tableTo": "agent_channel_binding",
+          "columnsFrom": ["binding_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_final_delivery_job_run_id_session_run_id_fk": {
+          "name": "channel_final_delivery_job_run_id_session_run_id_fk",
+          "tableFrom": "channel_final_delivery_job",
+          "tableTo": "session_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_final_delivery_job_session_id_session_id_fk": {
+          "name": "channel_final_delivery_job_session_id_session_id_fk",
+          "tableFrom": "channel_final_delivery_job",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_thread_session": {
+      "name": "channel_thread_session",
+      "columns": {
+        "binding_id": {
+          "name": "binding_id",
+          "type": "text CHECK (\"binding_id\" = upper(\"binding_id\") AND length(\"binding_id\") = 26 AND substr(\"binding_id\", 1, 1) GLOB '[0-7]' AND \"binding_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_thread_id": {
+          "name": "external_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text CHECK (\"session_id\" = upper(\"session_id\") AND length(\"session_id\") = 26 AND substr(\"session_id\", 1, 1) GLOB '[0-7]' AND \"session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_thread_session_provider_binding_thread_idx": {
+          "name": "channel_thread_session_provider_binding_thread_idx",
+          "columns": ["provider", "binding_id", "external_thread_id"],
+          "isUnique": true
+        },
+        "channel_thread_session_session_idx": {
+          "name": "channel_thread_session_session_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_thread_session_binding_id_agent_channel_binding_id_fk": {
+          "name": "channel_thread_session_binding_id_agent_channel_binding_id_fk",
+          "tableFrom": "channel_thread_session",
+          "tableTo": "agent_channel_binding",
+          "columnsFrom": ["binding_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_thread_session_session_id_session_id_fk": {
+          "name": "channel_thread_session_session_id_session_id_fk",
+          "tableFrom": "channel_thread_session",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_channel_account": {
+      "name": "wechat_channel_account",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text CHECK (\"agent_id\" = upper(\"agent_id\") AND length(\"agent_id\") = 26 AND substr(\"agent_id\", 1, 1) GLOB '[0-7]' AND \"agent_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_creds_secret_id": {
+          "name": "encrypted_creds_secret_id",
+          "type": "text CHECK (\"encrypted_creds_secret_id\" = upper(\"encrypted_creds_secret_id\") AND length(\"encrypted_creds_secret_id\") = 26 AND substr(\"encrypted_creds_secret_id\", 1, 1) GLOB '[0-7]' AND \"encrypted_creds_secret_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_bot_id": {
+          "name": "external_bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_inbound_at": {
+          "name": "last_inbound_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_poll_at": {
+          "name": "last_poll_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "text CHECK (\"owner_account_id\" = upper(\"owner_account_id\") AND length(\"owner_account_id\") = 26 AND substr(\"owner_account_id\", 1, 1) GLOB '[0-7]' AND \"owner_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_state_json": {
+          "name": "runtime_state_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "wechat_channel_account_agent_idx": {
+          "name": "wechat_channel_account_agent_idx",
+          "columns": ["agent_id"],
+          "isUnique": true
+        },
+        "wechat_channel_account_external_idx": {
+          "name": "wechat_channel_account_external_idx",
+          "columns": ["external_account_id", "external_bot_id"],
+          "isUnique": true
+        },
+        "wechat_channel_account_status_idx": {
+          "name": "wechat_channel_account_status_idx",
+          "columns": ["status", "updated_at"],
+          "isUnique": false
+        },
+        "wechat_channel_account_app_status_idx": {
+          "name": "wechat_channel_account_app_status_idx",
+          "columns": ["app_id", "status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wechat_channel_account_agent_id_agent_id_fk": {
+          "name": "wechat_channel_account_agent_id_agent_id_fk",
+          "tableFrom": "wechat_channel_account",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_channel_account_encrypted_creds_secret_id_vault_secret_id_fk": {
+          "name": "wechat_channel_account_encrypted_creds_secret_id_vault_secret_id_fk",
+          "tableFrom": "wechat_channel_account",
+          "tableTo": "vault_secret",
+          "columnsFrom": ["encrypted_creds_secret_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "wechat_channel_account_owner_account_id_account_id_fk": {
+          "name": "wechat_channel_account_owner_account_id_account_id_fk",
+          "tableFrom": "wechat_channel_account",
+          "tableTo": "account",
+          "columnsFrom": ["owner_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_channel_account_app_id_app_id_fk": {
+          "name": "wechat_channel_account_app_id_app_id_fk",
+          "tableFrom": "wechat_channel_account",
+          "tableTo": "app",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_channel_pairing": {
+      "name": "wechat_channel_pairing",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text CHECK (\"agent_id\" = upper(\"agent_id\") AND length(\"agent_id\") = 26 AND substr(\"agent_id\", 1, 1) GLOB '[0-7]' AND \"agent_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "text CHECK (\"created_by_account_id\" = upper(\"created_by_account_id\") AND length(\"created_by_account_id\") = 26 AND substr(\"created_by_account_id\", 1, 1) GLOB '[0-7]' AND \"created_by_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "qr_token_hash": {
+          "name": "qr_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "wechat_channel_pairing_qr_token_hash_idx": {
+          "name": "wechat_channel_pairing_qr_token_hash_idx",
+          "columns": ["qr_token_hash"],
+          "isUnique": true
+        },
+        "wechat_channel_pairing_agent_creator_idx": {
+          "name": "wechat_channel_pairing_agent_creator_idx",
+          "columns": ["agent_id", "created_by_account_id", "consumed_at"],
+          "isUnique": false
+        },
+        "wechat_channel_pairing_app_creator_idx": {
+          "name": "wechat_channel_pairing_app_creator_idx",
+          "columns": ["app_id", "created_by_account_id", "consumed_at"],
+          "isUnique": false
+        },
+        "wechat_channel_pairing_expires_idx": {
+          "name": "wechat_channel_pairing_expires_idx",
+          "columns": ["expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wechat_channel_pairing_agent_id_agent_id_fk": {
+          "name": "wechat_channel_pairing_agent_id_agent_id_fk",
+          "tableFrom": "wechat_channel_pairing",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_channel_pairing_created_by_account_id_account_id_fk": {
+          "name": "wechat_channel_pairing_created_by_account_id_account_id_fk",
+          "tableFrom": "wechat_channel_pairing",
+          "tableTo": "account",
+          "columnsFrom": ["created_by_account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_channel_pairing_app_id_app_id_fk": {
+          "name": "wechat_channel_pairing_app_id_app_id_fk",
+          "tableFrom": "wechat_channel_pairing",
+          "tableTo": "app",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_context_token": {
+      "name": "wechat_context_token",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text CHECK (\"account_id\" = upper(\"account_id\") AND length(\"account_id\") = 26 AND substr(\"account_id\", 1, 1) GLOB '[0-7]' AND \"account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_token_key": {
+          "name": "context_token_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_context_token_secret_id": {
+          "name": "encrypted_context_token_secret_id",
+          "type": "text CHECK (\"encrypted_context_token_secret_id\" = upper(\"encrypted_context_token_secret_id\") AND length(\"encrypted_context_token_secret_id\") = 26 AND substr(\"encrypted_context_token_secret_id\", 1, 1) GLOB '[0-7]' AND \"encrypted_context_token_secret_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "wechat_context_token_key_idx": {
+          "name": "wechat_context_token_key_idx",
+          "columns": ["context_token_key"],
+          "isUnique": true
+        },
+        "wechat_context_token_account_peer_idx": {
+          "name": "wechat_context_token_account_peer_idx",
+          "columns": ["account_id", "external_account_id", "peer_id"],
+          "isUnique": true
+        },
+        "wechat_context_token_account_updated_idx": {
+          "name": "wechat_context_token_account_updated_idx",
+          "columns": ["account_id", "updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wechat_context_token_account_id_wechat_channel_account_id_fk": {
+          "name": "wechat_context_token_account_id_wechat_channel_account_id_fk",
+          "tableFrom": "wechat_context_token",
+          "tableTo": "wechat_channel_account",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_context_token_encrypted_context_token_secret_id_vault_secret_id_fk": {
+          "name": "wechat_context_token_encrypted_context_token_secret_id_vault_secret_id_fk",
+          "tableFrom": "wechat_context_token",
+          "tableTo": "vault_secret",
+          "columnsFrom": ["encrypted_context_token_secret_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_log": {
+      "name": "email_log",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_domain": {
+          "name": "recipient_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recipient_masked": {
+          "name": "recipient_masked",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "email_log_created_at_idx": {
+          "name": "email_log_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "email_log_type_status_idx": {
+          "name": "email_log_type_status_idx",
+          "columns": ["type", "status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environment_revision": {
+      "name": "environment_revision",
+      "columns": {
+        "allow_mcp_servers": {
+          "name": "allow_mcp_servers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allow_package_managers": {
+          "name": "allow_package_managers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allowed_hosts_json": {
+          "name": "allowed_hosts_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "text CHECK (\"created_by_account_id\" = upper(\"created_by_account_id\") AND length(\"created_by_account_id\") = 26 AND substr(\"created_by_account_id\", 1, 1) GLOB '[0-7]' AND \"created_by_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_vars_json": {
+          "name": "env_vars_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text CHECK (\"environment_id\" = upper(\"environment_id\") AND length(\"environment_id\") = 26 AND substr(\"environment_id\", 1, 1) GLOB '[0-7]' AND \"environment_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "network_policy": {
+          "name": "network_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "packages_json": {
+          "name": "packages_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "setup_script": {
+          "name": "setup_script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "environment_revision_environment_created_at_idx": {
+          "name": "environment_revision_environment_created_at_idx",
+          "columns": ["environment_id", "created_at"],
+          "isUnique": false
+        },
+        "environment_revision_app_created_at_idx": {
+          "name": "environment_revision_app_created_at_idx",
+          "columns": ["app_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "environment_revision_network_policy_check": {
+          "name": "environment_revision_network_policy_check",
+          "value": "\"environment_revision\".\"network_policy\" IN ('full', 'limited')"
+        }
+      }
+    },
+    "environment": {
+      "name": "environment",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_revision_id": {
+          "name": "current_revision_id",
+          "type": "text CHECK (\"current_revision_id\" = upper(\"current_revision_id\") AND length(\"current_revision_id\") = 26 AND substr(\"current_revision_id\", 1, 1) GLOB '[0-7]' AND \"current_revision_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "forked_from_environment_id": {
+          "name": "forked_from_environment_id",
+          "type": "text CHECK (\"forked_from_environment_id\" = upper(\"forked_from_environment_id\") AND length(\"forked_from_environment_id\") = 26 AND substr(\"forked_from_environment_id\", 1, 1) GLOB '[0-7]' AND \"forked_from_environment_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_from_environment_name": {
+          "name": "forked_from_environment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_from_owner_name": {
+          "name": "forked_from_owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "text CHECK (\"owner_account_id\" = upper(\"owner_account_id\") AND length(\"owner_account_id\") = 26 AND substr(\"owner_account_id\", 1, 1) GLOB '[0-7]' AND \"owner_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "environment_app_updated_at_idx": {
+          "name": "environment_app_updated_at_idx",
+          "columns": ["app_id", "updated_at"],
+          "isUnique": false
+        },
+        "environment_owner_updated_at_idx": {
+          "name": "environment_owner_updated_at_idx",
+          "columns": ["owner_account_id", "updated_at"],
+          "isUnique": false
+        },
+        "environment_owner_name_idx": {
+          "name": "environment_owner_name_idx",
+          "columns": ["app_id", "owner_account_id", "name"],
+          "isUnique": true,
+          "where": "\"environment\".\"owner_account_id\" IS NOT NULL"
+        },
+        "environment_system_default_idx": {
+          "name": "environment_system_default_idx",
+          "columns": ["app_id"],
+          "isUnique": true,
+          "where": "\"environment\".\"owner_account_id\" IS NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_record": {
+      "name": "file_record",
+      "columns": {
+        "committed": {
+          "name": "committed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "text CHECK (\"created_by_account_id\" = upper(\"created_by_account_id\") AND length(\"created_by_account_id\") = 26 AND substr(\"created_by_account_id\", 1, 1) GLOB '[0-7]' AND \"created_by_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text CHECK (\"owner_id\" = upper(\"owner_id\") AND length(\"owner_id\") = 26 AND substr(\"owner_id\", 1, 1) GLOB '[0-7]' AND \"owner_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_kind": {
+          "name": "owner_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text CHECK (\"scope_id\" = upper(\"scope_id\") AND length(\"scope_id\") = 26 AND substr(\"scope_id\", 1, 1) GLOB '[0-7]' AND \"scope_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_kind": {
+          "name": "session_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "file_record_object_key_idx": {
+          "name": "file_record_object_key_idx",
+          "columns": ["object_key"],
+          "isUnique": true
+        },
+        "file_record_unscoped_parent_path_name_status_idx": {
+          "name": "file_record_unscoped_parent_path_name_status_idx",
+          "columns": ["scope_kind", "parent_path", "name", "status"],
+          "isUnique": true,
+          "where": "\"file_record\".\"scope_id\" IS NULL"
+        },
+        "file_record_scoped_parent_path_name_status_idx": {
+          "name": "file_record_scoped_parent_path_name_status_idx",
+          "columns": ["scope_kind", "scope_id", "parent_path", "name", "status"],
+          "isUnique": true
+        },
+        "file_record_unscoped_pending_path_idx": {
+          "name": "file_record_unscoped_pending_path_idx",
+          "columns": ["scope_kind", "path"],
+          "isUnique": true,
+          "where": "\"file_record\".\"status\" = 'pending' AND \"file_record\".\"scope_id\" IS NULL"
+        },
+        "file_record_scoped_pending_path_idx": {
+          "name": "file_record_scoped_pending_path_idx",
+          "columns": ["scope_kind", "scope_id", "path"],
+          "isUnique": true,
+          "where": "\"file_record\".\"status\" = 'pending' AND \"file_record\".\"scope_id\" IS NOT NULL"
+        },
+        "file_record_unscoped_ready_path_idx": {
+          "name": "file_record_unscoped_ready_path_idx",
+          "columns": ["scope_kind", "path"],
+          "isUnique": true,
+          "where": "\"file_record\".\"status\" = 'ready' AND \"file_record\".\"scope_id\" IS NULL"
+        },
+        "file_record_scoped_ready_path_idx": {
+          "name": "file_record_scoped_ready_path_idx",
+          "columns": ["scope_kind", "scope_id", "path"],
+          "isUnique": true,
+          "where": "\"file_record\".\"status\" = 'ready' AND \"file_record\".\"scope_id\" IS NOT NULL"
+        },
+        "file_record_governance_idx": {
+          "name": "file_record_governance_idx",
+          "columns": ["purpose", "owner_kind", "owner_id", "status", "expires_at"],
+          "isUnique": false
+        },
+        "file_record_listing_idx": {
+          "name": "file_record_listing_idx",
+          "columns": ["scope_kind", "scope_id", "parent_path", "status", "lower(\"name\")"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_upload": {
+      "name": "file_upload",
+      "columns": {
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "text CHECK (\"created_by_account_id\" = upper(\"created_by_account_id\") AND length(\"created_by_account_id\") = 26 AND substr(\"created_by_account_id\", 1, 1) GLOB '[0-7]' AND \"created_by_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expected_size": {
+          "name": "expected_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text CHECK (\"file_id\" = upper(\"file_id\") AND length(\"file_id\") = 26 AND substr(\"file_id\", 1, 1) GLOB '[0-7]' AND \"file_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "if_match_etag": {
+          "name": "if_match_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "multipart_upload_id": {
+          "name": "multipart_upload_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "part_size": {
+          "name": "part_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text CHECK (\"scope_id\" = upper(\"scope_id\") AND length(\"scope_id\") = 26 AND substr(\"scope_id\", 1, 1) GLOB '[0-7]' AND \"scope_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "file_upload_file_id_idx": {
+          "name": "file_upload_file_id_idx",
+          "columns": ["file_id"],
+          "isUnique": true
+        },
+        "file_upload_status_expires_idx": {
+          "name": "file_upload_status_expires_idx",
+          "columns": ["status", "expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_version": {
+      "name": "file_version",
+      "columns": {
+        "committed": {
+          "name": "committed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "text CHECK (\"created_by_account_id\" = upper(\"created_by_account_id\") AND length(\"created_by_account_id\") = 26 AND substr(\"created_by_account_id\", 1, 1) GLOB '[0-7]' AND \"created_by_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text CHECK (\"file_id\" = upper(\"file_id\") AND length(\"file_id\") = 26 AND substr(\"file_id\", 1, 1) GLOB '[0-7]' AND \"file_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text CHECK (\"scope_id\" = upper(\"scope_id\") AND length(\"scope_id\") = 26 AND substr(\"scope_id\", 1, 1) GLOB '[0-7]' AND \"scope_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_etag": {
+          "name": "source_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_object_key": {
+          "name": "source_object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "file_version_object_key_idx": {
+          "name": "file_version_object_key_idx",
+          "columns": ["object_key"],
+          "isUnique": true
+        },
+        "file_version_scope_path_created_idx": {
+          "name": "file_version_scope_path_created_idx",
+          "columns": ["scope_kind", "scope_id", "path", "created_at"],
+          "isUnique": false
+        },
+        "file_version_file_created_idx": {
+          "name": "file_version_file_created_idx",
+          "columns": ["file_id", "created_at"],
+          "isUnique": false
+        },
+        "file_version_pending_idx": {
+          "name": "file_version_pending_idx",
+          "columns": ["committed", "created_at"],
+          "isUnique": false,
+          "where": "\"file_version\".\"committed\" = 0"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_credential": {
+      "name": "mcp_credential",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text CHECK (\"account_id\" = upper(\"account_id\") AND length(\"account_id\") = 26 AND substr(\"account_id\", 1, 1) GLOB '[0-7]' AND \"account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text CHECK (\"agent_id\" = upper(\"agent_id\") AND length(\"agent_id\") = 26 AND substr(\"agent_id\", 1, 1) GLOB '[0-7]' AND \"agent_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_refreshed_at": {
+          "name": "last_refreshed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret_secret_id": {
+          "name": "oauth_client_secret_secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_secret_id": {
+          "name": "refresh_secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_values_json": {
+          "name": "scope_values_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text CHECK (\"server_id\" = upper(\"server_id\") AND length(\"server_id\") = 26 AND substr(\"server_id\", 1, 1) GLOB '[0-7]' AND \"server_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_label": {
+          "name": "subject_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_credential_server_scope_status_idx": {
+          "name": "mcp_credential_server_scope_status_idx",
+          "columns": ["server_id", "scope", "status"],
+          "isUnique": false
+        },
+        "mcp_credential_app_scope_status_idx": {
+          "name": "mcp_credential_app_scope_status_idx",
+          "columns": ["app_id", "scope", "status"],
+          "isUnique": false
+        },
+        "mcp_credential_app_scope_idx": {
+          "name": "mcp_credential_app_scope_idx",
+          "columns": ["server_id", "scope"],
+          "isUnique": true,
+          "where": "\"mcp_credential\".\"scope\" = 'app'"
+        },
+        "mcp_credential_agent_scope_idx": {
+          "name": "mcp_credential_agent_scope_idx",
+          "columns": ["server_id", "agent_id", "scope"],
+          "isUnique": true,
+          "where": "\"mcp_credential\".\"scope\" = 'agent' AND \"mcp_credential\".\"agent_id\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "mcp_credential_scope_shape_check": {
+          "name": "mcp_credential_scope_shape_check",
+          "value": "\n        (\"mcp_credential\".\"scope\" = 'app' AND \"mcp_credential\".\"account_id\" IS NULL AND \"mcp_credential\".\"agent_id\" IS NULL)\n        OR (\"mcp_credential\".\"scope\" = 'agent' AND \"mcp_credential\".\"account_id\" IS NULL AND \"mcp_credential\".\"agent_id\" IS NOT NULL)\n      "
+        },
+        "mcp_credential_scope_values_json_check": {
+          "name": "mcp_credential_scope_values_json_check",
+          "value": "\n        \"mcp_credential\".\"scope_values_json\" IS NULL\n        OR (json_valid(\"mcp_credential\".\"scope_values_json\") AND json_type(\"mcp_credential\".\"scope_values_json\") = 'array')\n      "
+        },
+        "mcp_credential_bearer_shape_check": {
+          "name": "mcp_credential_bearer_shape_check",
+          "value": "\n      \"mcp_credential\".\"auth_type\" != 'bearer'\n      OR (\n        \"mcp_credential\".\"oauth_client_id\" IS NULL\n        AND \"mcp_credential\".\"oauth_client_secret_secret_id\" IS NULL\n        AND \"mcp_credential\".\"refresh_secret_id\" IS NULL\n      )\n    "
+        }
+      }
+    },
+    "mcp_oauth_flow": {
+      "name": "mcp_oauth_flow",
+      "columns": {
+        "authorization_endpoint": {
+          "name": "authorization_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cleanup_after": {
+          "name": "cleanup_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initiator_account_id": {
+          "name": "initiator_account_id",
+          "type": "text CHECK (\"initiator_account_id\" = upper(\"initiator_account_id\") AND length(\"initiator_account_id\") = 26 AND substr(\"initiator_account_id\", 1, 1) GLOB '[0-7]' AND \"initiator_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oauth_client_secret_secret_id": {
+          "name": "oauth_client_secret_secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registration_endpoint": {
+          "name": "registration_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "return_url": {
+          "name": "return_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_values_json": {
+          "name": "scope_values_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text CHECK (\"server_id\" = upper(\"server_id\") AND length(\"server_id\") = 26 AND substr(\"server_id\", 1, 1) GLOB '[0-7]' AND \"server_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_label": {
+          "name": "subject_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint": {
+          "name": "token_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_oauth_flow_status_cleanup_after_idx": {
+          "name": "mcp_oauth_flow_status_cleanup_after_idx",
+          "columns": ["status", "cleanup_after"],
+          "isUnique": false
+        },
+        "mcp_oauth_flow_expires_at_idx": {
+          "name": "mcp_oauth_flow_expires_at_idx",
+          "columns": ["expires_at"],
+          "isUnique": false
+        },
+        "mcp_oauth_flow_server_account_idx": {
+          "name": "mcp_oauth_flow_server_account_idx",
+          "columns": ["server_id", "initiator_account_id"],
+          "isUnique": false
+        },
+        "mcp_oauth_flow_app_server_account_idx": {
+          "name": "mcp_oauth_flow_app_server_account_idx",
+          "columns": ["app_id", "server_id", "initiator_account_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "mcp_oauth_flow_scope_values_json_check": {
+          "name": "mcp_oauth_flow_scope_values_json_check",
+          "value": "\n        \"mcp_oauth_flow\".\"scope_values_json\" IS NULL\n        OR (json_valid(\"mcp_oauth_flow\".\"scope_values_json\") AND json_type(\"mcp_oauth_flow\".\"scope_values_json\") = 'array')\n      "
+        }
+      }
+    },
+    "mcp_server": {
+      "name": "mcp_server",
+      "columns": {
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "byo_client_id": {
+          "name": "byo_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byo_client_secret_secret_id": {
+          "name": "byo_client_secret_secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_scope": {
+          "name": "credential_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oauth_metadata_json": {
+          "name": "oauth_metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "text CHECK (\"owner_account_id\" = upper(\"owner_account_id\") AND length(\"owner_account_id\") = 26 AND substr(\"owner_account_id\", 1, 1) GLOB '[0-7]' AND \"owner_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_server_app_enabled_idx": {
+          "name": "mcp_server_app_enabled_idx",
+          "columns": ["app_id", "enabled"],
+          "isUnique": false
+        },
+        "mcp_server_owner_app_idx": {
+          "name": "mcp_server_owner_app_idx",
+          "columns": ["owner_account_id", "app_id"],
+          "isUnique": false
+        },
+        "mcp_server_app_url_idx": {
+          "name": "mcp_server_app_url_idx",
+          "columns": ["app_id", "url"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "mcp_server_source_scope_check": {
+          "name": "mcp_server_source_scope_check",
+          "value": "\"mcp_server\".\"source\" = 'app' AND \"mcp_server\".\"credential_scope\" = 'app'"
+        }
+      }
+    },
+    "vault_secret": {
+      "name": "vault_secret",
+      "columns": {
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'AES-GCM'"
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ciphertext_iv": {
+          "name": "ciphertext_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wrapped_dek": {
+          "name": "wrapped_dek",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wrapped_dek_iv": {
+          "name": "wrapped_dek_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "vault_secret_kind_created_at_idx": {
+          "name": "vault_secret_kind_created_at_idx",
+          "columns": ["kind", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_account_id": {
+          "name": "creator_account_id",
+          "type": "text CHECK (\"creator_account_id\" = upper(\"creator_account_id\") AND length(\"creator_account_id\") = 26 AND substr(\"creator_account_id\", 1, 1) GLOB '[0-7]' AND \"creator_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_creator_account_idx": {
+          "name": "organization_creator_account_idx",
+          "columns": ["creator_account_id"],
+          "isUnique": true,
+          "where": "\"organization\".\"creator_account_id\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_deployment_run": {
+      "name": "app_deployment_run",
+      "columns": {
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "text CHECK (\"deployment_id\" = upper(\"deployment_id\") AND length(\"deployment_id\") = 26 AND substr(\"deployment_id\", 1, 1) GLOB '[0-7]' AND \"deployment_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_deployment_id": {
+          "name": "external_deployment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_project_id": {
+          "name": "external_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_version_id": {
+          "name": "external_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generated_wrangler_config_json": {
+          "name": "generated_wrangler_config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mosoo_config_json": {
+          "name": "mosoo_config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_json": {
+          "name": "plan_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_branch": {
+          "name": "source_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_project_name": {
+          "name": "target_project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_script_name": {
+          "name": "target_script_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "app_deployment_run_app_id_idx": {
+          "name": "app_deployment_run_app_id_idx",
+          "columns": ["app_id", "id"],
+          "isUnique": false
+        },
+        "app_deployment_run_deployment_id_idx": {
+          "name": "app_deployment_run_deployment_id_idx",
+          "columns": ["deployment_id", "id"],
+          "isUnique": false
+        },
+        "app_deployment_run_active_app_idx": {
+          "name": "app_deployment_run_active_app_idx",
+          "columns": ["app_id"],
+          "isUnique": true,
+          "where": "\"app_deployment_run\".\"status\" IN ('queued', 'preparing', 'building', 'submitting', 'submitted', 'activating')"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "app_deployment_run_status_check": {
+          "name": "app_deployment_run_status_check",
+          "value": "\"app_deployment_run\".\"status\" IN ('queued', 'preparing', 'building', 'submitting', 'submitted', 'activating', 'success', 'failed')"
+        },
+        "app_deployment_run_target_kind_check": {
+          "name": "app_deployment_run_target_kind_check",
+          "value": "\"app_deployment_run\".\"target_kind\" IS NULL OR \"app_deployment_run\".\"target_kind\" IN ('cloudflare_pages', 'cloudflare_worker')"
+        }
+      }
+    },
+    "app_deployment": {
+      "name": "app_deployment",
+      "columns": {
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_successful_url": {
+          "name": "last_successful_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_run_id": {
+          "name": "latest_run_id",
+          "type": "text CHECK (\"latest_run_id\" = upper(\"latest_run_id\") AND length(\"latest_run_id\") = 26 AND substr(\"latest_run_id\", 1, 1) GLOB '[0-7]' AND \"latest_run_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mosoo_subdomain": {
+          "name": "mosoo_subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "text CHECK (\"owner_account_id\" = upper(\"owner_account_id\") AND length(\"owner_account_id\") = 26 AND substr(\"owner_account_id\", 1, 1) GLOB '[0-7]' AND \"owner_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "app_deployment_active_app_idx": {
+          "name": "app_deployment_active_app_idx",
+          "columns": ["app_id"],
+          "isUnique": true,
+          "where": "\"app_deployment\".\"deleted_at\" IS NULL"
+        },
+        "app_deployment_active_subdomain_idx": {
+          "name": "app_deployment_active_subdomain_idx",
+          "columns": ["mosoo_subdomain"],
+          "isUnique": true,
+          "where": "\"app_deployment\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "app_deployment_source_kind_check": {
+          "name": "app_deployment_source_kind_check",
+          "value": "\"app_deployment\".\"source_kind\" IN ('github_public')"
+        }
+      }
+    },
+    "app": {
+      "name": "app",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_environment_id": {
+          "name": "default_environment_id",
+          "type": "text CHECK (\"default_environment_id\" = upper(\"default_environment_id\") AND length(\"default_environment_id\") = 26 AND substr(\"default_environment_id\", 1, 1) GLOB '[0-7]' AND \"default_environment_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text CHECK (\"organization_id\" = upper(\"organization_id\") AND length(\"organization_id\") = 26 AND substr(\"organization_id\", 1, 1) GLOB '[0-7]' AND \"organization_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "text CHECK (\"owner_account_id\" = upper(\"owner_account_id\") AND length(\"owner_account_id\") = 26 AND substr(\"owner_account_id\", 1, 1) GLOB '[0-7]' AND \"owner_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bound_agent_call_idempotency_key": {
+      "name": "bound_agent_call_idempotency_key",
+      "columns": {
+        "body_hash": {
+          "name": "body_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text CHECK (\"run_id\" = upper(\"run_id\") AND length(\"run_id\") = 26 AND substr(\"run_id\", 1, 1) GLOB '[0-7]' AND \"run_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text CHECK (\"session_id\" = upper(\"session_id\") AND length(\"session_id\") = 26 AND substr(\"session_id\", 1, 1) GLOB '[0-7]' AND \"session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_hash": {
+          "name": "subject_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "bound_agent_call_idempotency_subject_key_idx": {
+          "name": "bound_agent_call_idempotency_subject_key_idx",
+          "columns": ["subject_hash", "idempotency_key"],
+          "isUnique": true
+        },
+        "bound_agent_call_idempotency_updated_idx": {
+          "name": "bound_agent_call_idempotency_updated_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public_api_idempotency_key": {
+      "name": "public_api_idempotency_key",
+      "columns": {
+        "body_hash": {
+          "name": "body_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_json": {
+          "name": "response_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "text CHECK (\"token_id\" = upper(\"token_id\") AND length(\"token_id\") = 26 AND substr(\"token_id\", 1, 1) GLOB '[0-7]' AND \"token_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "public_api_idempotency_token_key_idx": {
+          "name": "public_api_idempotency_token_key_idx",
+          "columns": ["token_id", "idempotency_key"],
+          "isUnique": true
+        },
+        "public_api_idempotency_updated_idx": {
+          "name": "public_api_idempotency_updated_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public_api_rate_limit_window": {
+      "name": "public_api_rate_limit_window",
+      "columns": {
+        "bucket_key": {
+          "name": "bucket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "shard": {
+          "name": "shard",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "public_api_rate_limit_window_updated_idx": {
+          "name": "public_api_rate_limit_window_updated_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "public_api_rate_limit_window_bucket_key_window_start_shard_pk": {
+          "columns": ["bucket_key", "window_start", "shard"],
+          "name": "public_api_rate_limit_window_bucket_key_window_start_shard_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "driver_command": {
+      "name": "driver_command",
+      "columns": {
+        "acked_at": {
+          "name": "acked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_connection_id": {
+          "name": "delivery_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "driver_instance_id": {
+          "name": "driver_instance_id",
+          "type": "text CHECK (\"driver_instance_id\" = upper(\"driver_instance_id\") AND length(\"driver_instance_id\") = 26 AND substr(\"driver_instance_id\", 1, 1) GLOB '[0-7]' AND \"driver_instance_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "driver_command_instance_seq_idx": {
+          "name": "driver_command_instance_seq_idx",
+          "columns": ["driver_instance_id", "seq"],
+          "isUnique": true
+        },
+        "driver_command_instance_status_idx": {
+          "name": "driver_command_instance_status_idx",
+          "columns": ["driver_instance_id", "status", "expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "driver_command_driver_instance_id_driver_instance_id_fk": {
+          "name": "driver_command_driver_instance_id_driver_instance_id_fk",
+          "tableFrom": "driver_command",
+          "tableTo": "driver_instance",
+          "columnsFrom": ["driver_instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "driver_instance_mcp_grant": {
+      "name": "driver_instance_mcp_grant",
+      "columns": {
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorization_state": {
+          "name": "authorization_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "can_invalidate": {
+          "name": "can_invalidate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "can_refresh": {
+          "name": "can_refresh",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text CHECK (\"credential_id\" = upper(\"credential_id\") AND length(\"credential_id\") = 26 AND substr(\"credential_id\", 1, 1) GLOB '[0-7]' AND \"credential_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "driver_instance_id": {
+          "name": "driver_instance_id",
+          "type": "text CHECK (\"driver_instance_id\" = upper(\"driver_instance_id\") AND length(\"driver_instance_id\") = 26 AND substr(\"driver_instance_id\", 1, 1) GLOB '[0-7]' AND \"driver_instance_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text CHECK (\"server_id\" = upper(\"server_id\") AND length(\"server_id\") = 26 AND substr(\"server_id\", 1, 1) GLOB '[0-7]' AND \"server_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "driver_instance_mcp_grant_instance_server_idx": {
+          "name": "driver_instance_mcp_grant_instance_server_idx",
+          "columns": ["driver_instance_id", "server_id"],
+          "isUnique": true
+        },
+        "driver_instance_mcp_grant_instance_credential_idx": {
+          "name": "driver_instance_mcp_grant_instance_credential_idx",
+          "columns": ["driver_instance_id", "credential_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "driver_instance_mcp_grant_driver_instance_id_driver_instance_id_fk": {
+          "name": "driver_instance_mcp_grant_driver_instance_id_driver_instance_id_fk",
+          "tableFrom": "driver_instance_mcp_grant",
+          "tableTo": "driver_instance",
+          "columnsFrom": ["driver_instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "driver_instance": {
+      "name": "driver_instance",
+      "columns": {
+        "boot_token_expires_at": {
+          "name": "boot_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "boot_token_hash": {
+          "name": "boot_token_hash",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "boot_token_used_at": {
+          "name": "boot_token_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_code": {
+          "name": "close_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command_seq_cursor": {
+          "name": "command_seq_cursor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "driver_pid": {
+          "name": "driver_pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "driver_started_at": {
+          "name": "driver_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "driver_version": {
+          "name": "driver_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_count": {
+          "name": "heartbeat_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "process_id": {
+          "name": "process_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "restart_count": {
+          "name": "restart_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text CHECK (\"sandbox_id\" = upper(\"sandbox_id\") AND length(\"sandbox_id\") = 26 AND substr(\"sandbox_id\", 1, 1) GLOB '[0-7]' AND \"sandbox_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sandbox_session_id": {
+          "name": "sandbox_session_id",
+          "type": "text CHECK (\"sandbox_session_id\" = upper(\"sandbox_session_id\") AND length(\"sandbox_session_id\") = 26 AND substr(\"sandbox_session_id\", 1, 1) GLOB '[0-7]' AND \"sandbox_session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status_event": {
+          "name": "status_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'driver.provision'"
+        },
+        "status_operation_id": {
+          "name": "status_operation_id",
+          "type": "text CHECK (\"status_operation_id\" = upper(\"status_operation_id\") AND length(\"status_operation_id\") = 26 AND substr(\"status_operation_id\", 1, 1) GLOB '[0-7]' AND \"status_operation_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_seq": {
+          "name": "status_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status_source": {
+          "name": "status_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "driver_instance_completed_idx": {
+          "name": "driver_instance_completed_idx",
+          "columns": ["expires_at", "status"],
+          "isUnique": false
+        },
+        "driver_instance_connection_idx": {
+          "name": "driver_instance_connection_idx",
+          "columns": ["connection_id"],
+          "isUnique": true,
+          "where": "\"driver_instance\".\"connection_id\" IS NOT NULL"
+        },
+        "driver_instance_boot_token_expiry_idx": {
+          "name": "driver_instance_boot_token_expiry_idx",
+          "columns": ["status", "boot_token_expires_at"],
+          "isUnique": false,
+          "where": "\"driver_instance\".\"boot_token_used_at\" IS NULL"
+        },
+        "driver_instance_boot_token_hash_idx": {
+          "name": "driver_instance_boot_token_hash_idx",
+          "columns": ["boot_token_hash"],
+          "isUnique": true
+        },
+        "driver_instance_sandbox_session_idx": {
+          "name": "driver_instance_sandbox_session_idx",
+          "columns": ["sandbox_id", "sandbox_session_id", "status", "updated_at"],
+          "isUnique": false
+        },
+        "driver_instance_live_sandbox_session_idx": {
+          "name": "driver_instance_live_sandbox_session_idx",
+          "columns": ["sandbox_id", "sandbox_session_id"],
+          "isUnique": true,
+          "where": "\"driver_instance\".\"status\" IN ('provisioning', 'connecting', 'ready', 'stopping')"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "driver_instance_status_check": {
+          "name": "driver_instance_status_check",
+          "value": "\"driver_instance\".\"status\" IN ('provisioning', 'connecting', 'ready', 'stopping', 'stopped', 'failed')"
+        },
+        "driver_instance_status_seq_check": {
+          "name": "driver_instance_status_seq_check",
+          "value": "\"driver_instance\".\"status_seq\" >= 0"
+        }
+      }
+    },
+    "native_resume_ref": {
+      "name": "native_resume_ref",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_driver_instance_id": {
+          "name": "observed_driver_instance_id",
+          "type": "text CHECK (\"observed_driver_instance_id\" = upper(\"observed_driver_instance_id\") AND length(\"observed_driver_instance_id\") = 26 AND substr(\"observed_driver_instance_id\", 1, 1) GLOB '[0-7]' AND \"observed_driver_instance_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "observed_session_run_id": {
+          "name": "observed_session_run_id",
+          "type": "text CHECK (\"observed_session_run_id\" = upper(\"observed_session_run_id\") AND length(\"observed_session_run_id\") = 26 AND substr(\"observed_session_run_id\", 1, 1) GLOB '[0-7]' AND \"observed_session_run_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime_id": {
+          "name": "runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text CHECK (\"session_id\" = upper(\"session_id\") AND length(\"session_id\") = 26 AND substr(\"session_id\", 1, 1) GLOB '[0-7]' AND \"session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "native_resume_ref_runtime_updated_idx": {
+          "name": "native_resume_ref_runtime_updated_idx",
+          "columns": ["runtime_id", "updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "native_resume_ref_session_id_session_id_fk": {
+          "name": "native_resume_ref_session_id_session_id_fk",
+          "tableFrom": "native_resume_ref",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sandbox_backup": {
+      "name": "sandbox_backup",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dir": {
+          "name": "dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keep": {
+          "name": "keep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text CHECK (\"sandbox_id\" = upper(\"sandbox_id\") AND length(\"sandbox_id\") = 26 AND substr(\"sandbox_id\", 1, 1) GLOB '[0-7]' AND \"sandbox_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sandbox_backup_sandbox_status_created_idx": {
+          "name": "sandbox_backup_sandbox_status_created_idx",
+          "columns": ["sandbox_id", "status", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sandbox_session": {
+      "name": "sandbox_session",
+      "columns": {
+        "cloudflare_session_id": {
+          "name": "cloudflare_session_id",
+          "type": "text CHECK (\"cloudflare_session_id\" = upper(\"cloudflare_session_id\") AND length(\"cloudflare_session_id\") = 26 AND substr(\"cloudflare_session_id\", 1, 1) GLOB '[0-7]' AND \"cloudflare_session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_json": {
+          "name": "origin_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text CHECK (\"sandbox_id\" = upper(\"sandbox_id\") AND length(\"sandbox_id\") = 26 AND substr(\"sandbox_id\", 1, 1) GLOB '[0-7]' AND \"sandbox_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text CHECK (\"session_id\" = upper(\"session_id\") AND length(\"session_id\") = 26 AND substr(\"session_id\", 1, 1) GLOB '[0-7]' AND \"session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sandbox_session_sandbox_status_idx": {
+          "name": "sandbox_session_sandbox_status_idx",
+          "columns": ["sandbox_id", "status", "updated_at"],
+          "isUnique": false
+        },
+        "sandbox_session_cloudflare_session_idx": {
+          "name": "sandbox_session_cloudflare_session_idx",
+          "columns": ["cloudflare_session_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sandbox_session_session_id_session_id_fk": {
+          "name": "sandbox_session_session_id_session_id_fk",
+          "tableFrom": "sandbox_session",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sandbox": {
+      "name": "sandbox",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text CHECK (\"agent_id\" = upper(\"agent_id\") AND length(\"agent_id\") = 26 AND substr(\"agent_id\", 1, 1) GLOB '[0-7]' AND \"agent_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bind_mount_ready": {
+          "name": "bind_mount_ready",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claim_owner": {
+          "name": "claim_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "global_mounts_json": {
+          "name": "global_mounts_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inactive_deadline_at": {
+          "name": "inactive_deadline_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_backup_id": {
+          "name": "last_backup_id",
+          "type": "text CHECK (\"last_backup_id\" = upper(\"last_backup_id\") AND length(\"last_backup_id\") = 26 AND substr(\"last_backup_id\", 1, 1) GLOB '[0-7]' AND \"last_backup_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_restore_backup_id": {
+          "name": "last_restore_backup_id",
+          "type": "text CHECK (\"last_restore_backup_id\" = upper(\"last_restore_backup_id\") AND length(\"last_restore_backup_id\") = 26 AND substr(\"last_restore_backup_id\", 1, 1) GLOB '[0-7]' AND \"last_restore_backup_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "text CHECK (\"owner_account_id\" = upper(\"owner_account_id\") AND length(\"owner_account_id\") = 26 AND substr(\"owner_account_id\", 1, 1) GLOB '[0-7]' AND \"owner_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status_event": {
+          "name": "status_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'runtime_subject.cold'"
+        },
+        "status_operation_id": {
+          "name": "status_operation_id",
+          "type": "text CHECK (\"status_operation_id\" = upper(\"status_operation_id\") AND length(\"status_operation_id\") = 26 AND substr(\"status_operation_id\", 1, 1) GLOB '[0-7]' AND \"status_operation_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_seq": {
+          "name": "status_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status_source": {
+          "name": "status_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text CHECK (\"subject_id\" = upper(\"subject_id\") AND length(\"subject_id\") = 26 AND substr(\"subject_id\", 1, 1) GLOB '[0-7]' AND \"subject_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sandbox_subject_idx": {
+          "name": "sandbox_subject_idx",
+          "columns": ["kind", "subject_kind", "subject_id"],
+          "isUnique": true
+        },
+        "sandbox_status_deadline_idx": {
+          "name": "sandbox_status_deadline_idx",
+          "columns": ["status", "inactive_deadline_at", "updated_at"],
+          "isUnique": false
+        },
+        "sandbox_claim_idx": {
+          "name": "sandbox_claim_idx",
+          "columns": ["claim_expires_at", "claim_owner"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "sandbox_status_check": {
+          "name": "sandbox_status_check",
+          "value": "\"sandbox\".\"status\" IN ('cold', 'restoring', 'active', 'backing_up', 'destroying', 'error')"
+        },
+        "sandbox_status_seq_check": {
+          "name": "sandbox_status_seq_check",
+          "value": "\"sandbox\".\"status_seq\" >= 0"
+        }
+      }
+    },
+    "session_message": {
+      "name": "session_message",
+      "columns": {
+        "content_text": {
+          "name": "content_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "text CHECK (\"created_by_account_id\" = upper(\"created_by_account_id\") AND length(\"created_by_account_id\") = 26 AND substr(\"created_by_account_id\", 1, 1) GLOB '[0-7]' AND \"created_by_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_json": {
+          "name": "plan_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "segments_json": {
+          "name": "segments_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text CHECK (\"session_id\" = upper(\"session_id\") AND length(\"session_id\") = 26 AND substr(\"session_id\", 1, 1) GLOB '[0-7]' AND \"session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_run_id": {
+          "name": "session_run_id",
+          "type": "text CHECK (\"session_run_id\" = upper(\"session_run_id\") AND length(\"session_run_id\") = 26 AND substr(\"session_run_id\", 1, 1) GLOB '[0-7]' AND \"session_run_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_message_session_seq_idx": {
+          "name": "session_message_session_seq_idx",
+          "columns": ["session_id", "seq"],
+          "isUnique": true
+        },
+        "session_message_run_idx": {
+          "name": "session_message_run_idx",
+          "columns": ["session_run_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_message_session_id_session_id_fk": {
+          "name": "session_message_session_id_session_id_fk",
+          "tableFrom": "session_message",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text CHECK (\"agent_id\" = upper(\"agent_id\") AND length(\"agent_id\") = 26 AND substr(\"agent_id\", 1, 1) GLOB '[0-7]' AND \"agent_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributed_user_id": {
+          "name": "attributed_user_id",
+          "type": "text CHECK (\"attributed_user_id\" = upper(\"attributed_user_id\") AND length(\"attributed_user_id\") = 26 AND substr(\"attributed_user_id\", 1, 1) GLOB '[0-7]' AND \"attributed_user_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_account_id": {
+          "name": "creator_account_id",
+          "type": "text CHECK (\"creator_account_id\" = upper(\"creator_account_id\") AND length(\"creator_account_id\") = 26 AND substr(\"creator_account_id\", 1, 1) GLOB '[0-7]' AND \"creator_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_version_id": {
+          "name": "deployment_version_id",
+          "type": "text CHECK (\"deployment_version_id\" = upper(\"deployment_version_id\") AND length(\"deployment_version_id\") = 26 AND substr(\"deployment_version_id\", 1, 1) GLOB '[0-7]' AND \"deployment_version_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_version_number": {
+          "name": "deployment_version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "text CHECK (\"last_run_id\" = upper(\"last_run_id\") AND length(\"last_run_id\") = 26 AND substr(\"last_run_id\", 1, 1) GLOB '[0-7]' AND \"last_run_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_seq_cursor": {
+          "name": "message_seq_cursor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "renamed": {
+          "name": "renamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_id": {
+          "name": "runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_operation_id": {
+          "name": "status_operation_id",
+          "type": "text CHECK (\"status_operation_id\" = upper(\"status_operation_id\") AND length(\"status_operation_id\") = 26 AND substr(\"status_operation_id\", 1, 1) GLOB '[0-7]' AND \"status_operation_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_seq": {
+          "name": "status_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "runtime_event_seq_cursor": {
+          "name": "runtime_event_seq_cursor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'preview'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_agent_updated_idx": {
+          "name": "session_agent_updated_idx",
+          "columns": ["agent_id", "updated_at", "id"],
+          "isUnique": false
+        },
+        "session_app_creator_archived_updated_idx": {
+          "name": "session_app_creator_archived_updated_idx",
+          "columns": ["app_id", "creator_account_id", "archived_at", "updated_at", "id"],
+          "isUnique": false
+        },
+        "session_app_attributed_archived_updated_idx": {
+          "name": "session_app_attributed_archived_updated_idx",
+          "columns": ["app_id", "attributed_user_id", "archived_at", "updated_at", "id"],
+          "isUnique": false
+        },
+        "session_app_creator_type_archived_updated_idx": {
+          "name": "session_app_creator_type_archived_updated_idx",
+          "columns": ["app_id", "creator_account_id", "type", "archived_at", "updated_at", "id"],
+          "isUnique": false
+        },
+        "session_app_attributed_type_archived_updated_idx": {
+          "name": "session_app_attributed_type_archived_updated_idx",
+          "columns": ["app_id", "attributed_user_id", "type", "archived_at", "updated_at", "id"],
+          "isUnique": false
+        },
+        "session_status_operation_updated_idx": {
+          "name": "session_status_operation_updated_idx",
+          "columns": ["status", "status_operation_id", "updated_at"],
+          "isUnique": false
+        },
+        "session_status_updated_idx": {
+          "name": "session_status_updated_idx",
+          "columns": ["status", "updated_at", "id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "session_status_check": {
+          "name": "session_status_check",
+          "value": "\"session\".\"status\" IN ('IDLE', 'RUNNING', 'RESCHEDULING', 'TERMINATED')"
+        },
+        "session_status_seq_check": {
+          "name": "session_status_seq_check",
+          "value": "\"session\".\"status_seq\" >= 0"
+        }
+      }
+    },
+    "session_execution_snapshot": {
+      "name": "session_execution_snapshot",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_json": {
+          "name": "plan_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text CHECK (\"session_id\" = upper(\"session_id\") AND length(\"session_id\") = 26 AND substr(\"session_id\", 1, 1) GLOB '[0-7]' AND \"session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_execution_snapshot_session_id_session_id_fk": {
+          "name": "session_execution_snapshot_session_id_session_id_fk",
+          "tableFrom": "session_execution_snapshot",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_run_skill": {
+      "name": "session_run_skill",
+      "columns": {
+        "blob_sha256": {
+          "name": "blob_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "materialization_status": {
+          "name": "materialization_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mount_path": {
+          "name": "mount_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolution_mode": {
+          "name": "resolution_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_run_id": {
+          "name": "session_run_id",
+          "type": "text CHECK (\"session_run_id\" = upper(\"session_run_id\") AND length(\"session_run_id\") = 26 AND substr(\"session_run_id\", 1, 1) GLOB '[0-7]' AND \"session_run_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "text CHECK (\"skill_id\" = upper(\"skill_id\") AND length(\"skill_id\") = 26 AND substr(\"skill_id\", 1, 1) GLOB '[0-7]' AND \"skill_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text CHECK (\"snapshot_id\" = upper(\"snapshot_id\") AND length(\"snapshot_id\") = 26 AND substr(\"snapshot_id\", 1, 1) GLOB '[0-7]' AND \"snapshot_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warning_code": {
+          "name": "warning_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_run_skill_run_resolution_idx": {
+          "name": "session_run_skill_run_resolution_idx",
+          "columns": ["session_run_id", "resolution_mode"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_run_skill_session_run_id_session_run_id_fk": {
+          "name": "session_run_skill_session_run_id_session_run_id_fk",
+          "tableFrom": "session_run_skill",
+          "tableTo": "session_run",
+          "columnsFrom": ["session_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_run_skill_session_run_id_skill_id_pk": {
+          "columns": ["session_run_id", "skill_id"],
+          "name": "session_run_skill_session_run_id_skill_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_run": {
+      "name": "session_run",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text CHECK (\"agent_id\" = upper(\"agent_id\") AND length(\"agent_id\") = 26 AND substr(\"agent_id\", 1, 1) GLOB '[0-7]' AND \"agent_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bound_capability_agent_id": {
+          "name": "bound_capability_agent_id",
+          "type": "text CHECK (\"bound_capability_agent_id\" = upper(\"bound_capability_agent_id\") AND length(\"bound_capability_agent_id\") = 26 AND substr(\"bound_capability_agent_id\", 1, 1) GLOB '[0-7]' AND \"bound_capability_agent_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bound_capability_app_id": {
+          "name": "bound_capability_app_id",
+          "type": "text CHECK (\"bound_capability_app_id\" = upper(\"bound_capability_app_id\") AND length(\"bound_capability_app_id\") = 26 AND substr(\"bound_capability_app_id\", 1, 1) GLOB '[0-7]' AND \"bound_capability_app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bound_capability_binding_env": {
+          "name": "bound_capability_binding_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bound_capability_binding_name": {
+          "name": "bound_capability_binding_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bound_capability_deployment_id": {
+          "name": "bound_capability_deployment_id",
+          "type": "text CHECK (\"bound_capability_deployment_id\" = upper(\"bound_capability_deployment_id\") AND length(\"bound_capability_deployment_id\") = 26 AND substr(\"bound_capability_deployment_id\", 1, 1) GLOB '[0-7]' AND \"bound_capability_deployment_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bound_capability_deployment_run_id": {
+          "name": "bound_capability_deployment_run_id",
+          "type": "text CHECK (\"bound_capability_deployment_run_id\" = upper(\"bound_capability_deployment_run_id\") AND length(\"bound_capability_deployment_run_id\") = 26 AND substr(\"bound_capability_deployment_run_id\", 1, 1) GLOB '[0-7]' AND \"bound_capability_deployment_run_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "text CHECK (\"created_by_account_id\" = upper(\"created_by_account_id\") AND length(\"created_by_account_id\") = 26 AND substr(\"created_by_account_id\", 1, 1) GLOB '[0-7]' AND \"created_by_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_version_id": {
+          "name": "deployment_version_id",
+          "type": "text CHECK (\"deployment_version_id\" = upper(\"deployment_version_id\") AND length(\"deployment_version_id\") = 26 AND substr(\"deployment_version_id\", 1, 1) GLOB '[0-7]' AND \"deployment_version_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_version_number": {
+          "name": "deployment_version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "driver_instance_id": {
+          "name": "driver_instance_id",
+          "type": "text CHECK (\"driver_instance_id\" = upper(\"driver_instance_id\") AND length(\"driver_instance_id\") = 26 AND substr(\"driver_instance_id\", 1, 1) GLOB '[0-7]' AND \"driver_instance_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_details_json": {
+          "name": "error_details_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime_id": {
+          "name": "runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text CHECK (\"session_id\" = upper(\"session_id\") AND length(\"session_id\") = 26 AND substr(\"session_id\", 1, 1) GLOB '[0-7]' AND \"session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status_event": {
+          "name": "status_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'run.queue'"
+        },
+        "status_operation_id": {
+          "name": "status_operation_id",
+          "type": "text CHECK (\"status_operation_id\" = upper(\"status_operation_id\") AND length(\"status_operation_id\") = 26 AND substr(\"status_operation_id\", 1, 1) GLOB '[0-7]' AND \"status_operation_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_seq": {
+          "name": "status_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status_source": {
+          "name": "status_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_run_driver_instance_idx": {
+          "name": "session_run_driver_instance_idx",
+          "columns": ["driver_instance_id", "created_at"],
+          "isUnique": false
+        },
+        "session_run_active_driver_lease_idx": {
+          "name": "session_run_active_driver_lease_idx",
+          "columns": ["driver_instance_id"],
+          "isUnique": true,
+          "where": "\"session_run\".\"driver_instance_id\" IS NOT NULL AND \"session_run\".\"status\" IN ('queued', 'booting', 'running', 'waiting_input')"
+        },
+        "session_run_session_created_at_idx": {
+          "name": "session_run_session_created_at_idx",
+          "columns": ["session_id", "created_at"],
+          "isUnique": false
+        },
+        "session_run_session_status_idx": {
+          "name": "session_run_session_status_idx",
+          "columns": ["session_id", "status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_run_session_id_session_id_fk": {
+          "name": "session_run_session_id_session_id_fk",
+          "tableFrom": "session_run",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "session_run_status_check": {
+          "name": "session_run_status_check",
+          "value": "\"session_run\".\"status\" IN ('queued', 'booting', 'running', 'waiting_input', 'completed', 'failed', 'cancelled', 'expired')"
+        },
+        "session_run_status_seq_check": {
+          "name": "session_run_status_seq_check",
+          "value": "\"session_run\".\"status_seq\" >= 0"
+        }
+      }
+    },
+    "session_event": {
+      "name": "session_event",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text CHECK (\"agent_id\" = upper(\"agent_id\") AND length(\"agent_id\") = 26 AND substr(\"agent_id\", 1, 1) GLOB '[0-7]' AND \"agent_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_text": {
+          "name": "content_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "process_status": {
+          "name": "process_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "process_type": {
+          "name": "process_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text CHECK (\"run_id\" = upper(\"run_id\") AND length(\"run_id\") = 26 AND substr(\"run_id\", 1, 1) GLOB '[0-7]' AND \"run_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text CHECK (\"session_id\" = upper(\"session_id\") AND length(\"session_id\") = 26 AND substr(\"session_id\", 1, 1) GLOB '[0-7]' AND \"session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_event_agent_family_created_idx": {
+          "name": "session_event_agent_family_created_idx",
+          "columns": ["agent_id", "family", "created_at", "id"],
+          "isUnique": false
+        },
+        "session_event_agent_visibility_created_idx": {
+          "name": "session_event_agent_visibility_created_idx",
+          "columns": ["agent_id", "visibility", "created_at", "id"],
+          "isUnique": false
+        },
+        "session_event_agent_created_idx": {
+          "name": "session_event_agent_created_idx",
+          "columns": ["agent_id", "created_at", "id"],
+          "isUnique": false
+        },
+        "session_event_session_visibility_seq_idx": {
+          "name": "session_event_session_visibility_seq_idx",
+          "columns": ["session_id", "visibility", "seq"],
+          "isUnique": false
+        },
+        "session_event_session_seq_idx": {
+          "name": "session_event_session_seq_idx",
+          "columns": ["session_id", "seq"],
+          "isUnique": true
+        },
+        "session_event_session_source_idx": {
+          "name": "session_event_session_source_idx",
+          "columns": ["session_id", "source_event_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_event_session_id_session_id_fk": {
+          "name": "session_event_session_id_session_id_fk",
+          "tableFrom": "session_event",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_model_call": {
+      "name": "session_model_call",
+      "columns": {
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "call_key": {
+          "name": "call_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "driver_instance_id": {
+          "name": "driver_instance_id",
+          "type": "text CHECK (\"driver_instance_id\" = upper(\"driver_instance_id\") AND length(\"driver_instance_id\") = 26 AND substr(\"driver_instance_id\", 1, 1) GLOB '[0-7]' AND \"driver_instance_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "native_call_id": {
+          "name": "native_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text CHECK (\"session_id\" = upper(\"session_id\") AND length(\"session_id\") = 26 AND substr(\"session_id\", 1, 1) GLOB '[0-7]' AND \"session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_run_id": {
+          "name": "session_run_id",
+          "type": "text CHECK (\"session_run_id\" = upper(\"session_run_id\") AND length(\"session_run_id\") = 26 AND substr(\"session_run_id\", 1, 1) GLOB '[0-7]' AND \"session_run_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_cost_usd_micros": {
+          "name": "total_cost_usd_micros",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_model_call_run_created_idx": {
+          "name": "session_model_call_run_created_idx",
+          "columns": ["session_run_id", "created_at"],
+          "isUnique": false
+        },
+        "session_model_call_session_created_idx": {
+          "name": "session_model_call_session_created_idx",
+          "columns": ["session_id", "created_at"],
+          "isUnique": false
+        },
+        "session_model_call_run_key_idx": {
+          "name": "session_model_call_run_key_idx",
+          "columns": ["session_run_id", "call_key"],
+          "isUnique": true
+        },
+        "session_model_call_native_idx": {
+          "name": "session_model_call_native_idx",
+          "columns": ["driver_instance_id", "native_call_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_model_call_session_id_session_id_fk": {
+          "name": "session_model_call_session_id_session_id_fk",
+          "tableFrom": "session_model_call",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_model_call_session_run_id_session_run_id_fk": {
+          "name": "session_model_call_session_run_id_session_run_id_fk",
+          "tableFrom": "session_model_call",
+          "tableTo": "session_run",
+          "columnsFrom": ["session_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_permission_request": {
+      "name": "session_permission_request",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "driver_instance_id": {
+          "name": "driver_instance_id",
+          "type": "text CHECK (\"driver_instance_id\" = upper(\"driver_instance_id\") AND length(\"driver_instance_id\") = 26 AND substr(\"driver_instance_id\", 1, 1) GLOB '[0-7]' AND \"driver_instance_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_input": {
+          "name": "raw_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text CHECK (\"run_id\" = upper(\"run_id\") AND length(\"run_id\") = 26 AND substr(\"run_id\", 1, 1) GLOB '[0-7]' AND \"run_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text CHECK (\"session_id\" = upper(\"session_id\") AND length(\"session_id\") = 26 AND substr(\"session_id\", 1, 1) GLOB '[0-7]' AND \"session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_kind": {
+          "name": "tool_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_permission_request_run_idx": {
+          "name": "session_permission_request_run_idx",
+          "columns": ["session_id", "run_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_permission_request_session_id_session_id_fk": {
+          "name": "session_permission_request_session_id_session_id_fk",
+          "tableFrom": "session_permission_request",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_permission_request_session_id_request_id_pk": {
+          "columns": ["session_id", "request_id"],
+          "name": "session_permission_request_session_id_request_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_readiness_snapshot": {
+      "name": "session_readiness_snapshot",
+      "columns": {
+        "readiness_json": {
+          "name": "readiness_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text CHECK (\"session_id\" = upper(\"session_id\") AND length(\"session_id\") = 26 AND substr(\"session_id\", 1, 1) GLOB '[0-7]' AND \"session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_readiness_snapshot_session_id_session_id_fk": {
+          "name": "session_readiness_snapshot_session_id_session_id_fk",
+          "tableFrom": "session_readiness_snapshot",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill_snapshot_entry": {
+      "name": "skill_snapshot_entry",
+      "columns": {
+        "entry_kind": {
+          "name": "entry_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_executable": {
+          "name": "is_executable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text CHECK (\"snapshot_id\" = upper(\"snapshot_id\") AND length(\"snapshot_id\") = 26 AND substr(\"snapshot_id\", 1, 1) GLOB '[0-7]' AND \"snapshot_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "skill_snapshot_entry_snapshot_id_path_pk": {
+          "columns": ["snapshot_id", "path"],
+          "name": "skill_snapshot_entry_snapshot_id_path_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill_snapshot": {
+      "name": "skill_snapshot",
+      "columns": {
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_key": {
+          "name": "blob_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_sha256": {
+          "name": "blob_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_size": {
+          "name": "blob_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_markdown_path": {
+          "name": "skill_markdown_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uncompressed_size": {
+          "name": "uncompressed_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "skill_snapshot_app_created_at_idx": {
+          "name": "skill_snapshot_app_created_at_idx",
+          "columns": ["app_id", "created_at"],
+          "isUnique": false
+        },
+        "skill_snapshot_blob_sha256_idx": {
+          "name": "skill_snapshot_blob_sha256_idx",
+          "columns": ["app_id", "blob_sha256"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill": {
+      "name": "skill",
+      "columns": {
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_snapshot_id": {
+          "name": "current_snapshot_id",
+          "type": "text CHECK (\"current_snapshot_id\" = upper(\"current_snapshot_id\") AND length(\"current_snapshot_id\") = 26 AND substr(\"current_snapshot_id\", 1, 1) GLOB '[0-7]' AND \"current_snapshot_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "forked_from_owner_name": {
+          "name": "forked_from_owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_from_skill_id": {
+          "name": "forked_from_skill_id",
+          "type": "text CHECK (\"forked_from_skill_id\" = upper(\"forked_from_skill_id\") AND length(\"forked_from_skill_id\") = 26 AND substr(\"forked_from_skill_id\", 1, 1) GLOB '[0-7]' AND \"forked_from_skill_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_from_skill_name": {
+          "name": "forked_from_skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "text CHECK (\"owner_account_id\" = upper(\"owner_account_id\") AND length(\"owner_account_id\") = 26 AND substr(\"owner_account_id\", 1, 1) GLOB '[0-7]' AND \"owner_account_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "skill_app_updated_at_idx": {
+          "name": "skill_app_updated_at_idx",
+          "columns": ["app_id", "updated_at"],
+          "isUnique": false
+        },
+        "skill_owner_account_updated_at_idx": {
+          "name": "skill_owner_account_updated_at_idx",
+          "columns": ["owner_account_id", "updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_active_organization_id": {
+          "name": "last_active_organization_id",
+          "type": "text CHECK (\"last_active_organization_id\" = upper(\"last_active_organization_id\") AND length(\"last_active_organization_id\") = 26 AND substr(\"last_active_organization_id\", 1, 1) GLOB '[0-7]' AND \"last_active_organization_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_agent_model": {
+          "name": "system_agent_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_email_idx": {
+          "name": "account_email_idx",
+          "columns": ["email"],
+          "isUnique": true
+        },
+        "account_last_active_organization_idx": {
+          "name": "account_last_active_organization_idx",
+          "columns": ["last_active_organization_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_daily_rollup": {
+      "name": "usage_daily_rollup",
+      "columns": {
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text CHECK (\"actor_user_id\" = upper(\"actor_user_id\") AND length(\"actor_user_id\") = 26 AND substr(\"actor_user_id\", 1, 1) GLOB '[0-7]' AND \"actor_user_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text CHECK (\"agent_id\" = upper(\"agent_id\") AND length(\"agent_id\") = 26 AND substr(\"agent_id\", 1, 1) GLOB '[0-7]' AND \"agent_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_owner_user_id": {
+          "name": "agent_owner_user_id",
+          "type": "text CHECK (\"agent_owner_user_id\" = upper(\"agent_owner_user_id\") AND length(\"agent_owner_user_id\") = 26 AND substr(\"agent_owner_user_id\", 1, 1) GLOB '[0-7]' AND \"agent_owner_user_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_publication_state_at_run": {
+          "name": "agent_publication_state_at_run",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text CHECK (\"organization_id\" = upper(\"organization_id\") AND length(\"organization_id\") = 26 AND substr(\"organization_id\", 1, 1) GLOB '[0-7]' AND \"organization_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_purpose": {
+          "name": "run_purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_cost_usd_micros": {
+          "name": "total_cost_usd_micros",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unpriced_request_count": {
+          "name": "unpriced_request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "usage_daily_rollup_app_date_idx": {
+          "name": "usage_daily_rollup_app_date_idx",
+          "columns": ["app_id", "date"],
+          "isUnique": false
+        },
+        "usage_daily_rollup_organization_date_idx": {
+          "name": "usage_daily_rollup_organization_date_idx",
+          "columns": ["organization_id", "date"],
+          "isUnique": false
+        },
+        "usage_daily_rollup_agent_date_idx": {
+          "name": "usage_daily_rollup_agent_date_idx",
+          "columns": ["agent_id", "date"],
+          "isUnique": false
+        },
+        "usage_daily_rollup_actor_date_idx": {
+          "name": "usage_daily_rollup_actor_date_idx",
+          "columns": ["actor_user_id", "date"],
+          "isUnique": false
+        },
+        "usage_daily_rollup_owner_date_idx": {
+          "name": "usage_daily_rollup_owner_date_idx",
+          "columns": ["agent_owner_user_id", "date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "usage_daily_rollup_organization_id_app_id_agent_id_actor_user_id_agent_owner_user_id_date_agent_publication_state_at_run_run_purpose_provider_model_pk": {
+          "columns": [
+            "organization_id",
+            "app_id",
+            "agent_id",
+            "actor_user_id",
+            "agent_owner_user_id",
+            "date",
+            "agent_publication_state_at_run",
+            "run_purpose",
+            "provider",
+            "model"
+          ],
+          "name": "usage_daily_rollup_organization_id_app_id_agent_id_actor_user_id_agent_owner_user_id_date_agent_publication_state_at_run_run_purpose_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_event_rollup_receipt": {
+      "name": "usage_event_rollup_receipt",
+      "columns": {
+        "rolled_up_at": {
+          "name": "rolled_up_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "usage_event_rollup_receipt_rolled_up_at_idx": {
+          "name": "usage_event_rollup_receipt_rolled_up_at_idx",
+          "columns": ["rolled_up_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "usage_event_rollup_receipt_source_source_event_id_pk": {
+          "columns": ["source", "source_event_id"],
+          "name": "usage_event_rollup_receipt_source_source_event_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_event": {
+      "name": "usage_event",
+      "columns": {
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text CHECK (\"actor_user_id\" = upper(\"actor_user_id\") AND length(\"actor_user_id\") = 26 AND substr(\"actor_user_id\", 1, 1) GLOB '[0-7]' AND \"actor_user_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text CHECK (\"agent_id\" = upper(\"agent_id\") AND length(\"agent_id\") = 26 AND substr(\"agent_id\", 1, 1) GLOB '[0-7]' AND \"agent_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_owner_user_id": {
+          "name": "agent_owner_user_id",
+          "type": "text CHECK (\"agent_owner_user_id\" = upper(\"agent_owner_user_id\") AND length(\"agent_owner_user_id\") = 26 AND substr(\"agent_owner_user_id\", 1, 1) GLOB '[0-7]' AND \"agent_owner_user_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_publication_state_at_run": {
+          "name": "agent_publication_state_at_run",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_revision_id": {
+          "name": "agent_revision_id",
+          "type": "text CHECK (\"agent_revision_id\" = upper(\"agent_revision_id\") AND length(\"agent_revision_id\") = 26 AND substr(\"agent_revision_id\", 1, 1) GLOB '[0-7]' AND \"agent_revision_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text CHECK (\"organization_id\" = upper(\"organization_id\") AND length(\"organization_id\") = 26 AND substr(\"organization_id\", 1, 1) GLOB '[0-7]' AND \"organization_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_snapshot_json": {
+          "name": "price_snapshot_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_status": {
+          "name": "pricing_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_purpose": {
+          "name": "run_purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_id": {
+          "name": "runtime_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text CHECK (\"session_id\" = upper(\"session_id\") AND length(\"session_id\") = 26 AND substr(\"session_id\", 1, 1) GLOB '[0-7]' AND \"session_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_run_id": {
+          "name": "session_run_id",
+          "type": "text CHECK (\"session_run_id\" = upper(\"session_run_id\") AND length(\"session_run_id\") = 26 AND substr(\"session_run_id\", 1, 1) GLOB '[0-7]' AND \"session_run_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_cost_usd_micros": {
+          "name": "total_cost_usd_micros",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage_contract": {
+          "name": "usage_contract",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "usage_event_app_created_idx": {
+          "name": "usage_event_app_created_idx",
+          "columns": ["app_id", "created_at"],
+          "isUnique": false
+        },
+        "usage_event_organization_created_idx": {
+          "name": "usage_event_organization_created_idx",
+          "columns": ["organization_id", "created_at"],
+          "isUnique": false
+        },
+        "usage_event_agent_created_idx": {
+          "name": "usage_event_agent_created_idx",
+          "columns": ["agent_id", "created_at"],
+          "isUnique": false
+        },
+        "usage_event_actor_created_idx": {
+          "name": "usage_event_actor_created_idx",
+          "columns": ["actor_user_id", "created_at"],
+          "isUnique": false
+        },
+        "usage_event_owner_created_idx": {
+          "name": "usage_event_owner_created_idx",
+          "columns": ["agent_owner_user_id", "created_at"],
+          "isUnique": false
+        },
+        "usage_event_session_run_idx": {
+          "name": "usage_event_session_run_idx",
+          "columns": ["session_run_id"],
+          "isUnique": false
+        },
+        "usage_event_source_event_idx": {
+          "name": "usage_event_source_event_idx",
+          "columns": ["source", "source_event_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vendor_credential": {
+      "name": "vendor_credential",
+      "columns": {
+        "api_base": {
+          "name": "api_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_secret_id": {
+          "name": "api_key_secret_id",
+          "type": "text CHECK (\"api_key_secret_id\" = upper(\"api_key_secret_id\") AND length(\"api_key_secret_id\") = 26 AND substr(\"api_key_secret_id\", 1, 1) GLOB '[0-7]' AND \"api_key_secret_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text CHECK (\"id\" = upper(\"id\") AND length(\"id\") = 26 AND substr(\"id\", 1, 1) GLOB '[0-7]' AND \"id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text CHECK (\"app_id\" = upper(\"app_id\") AND length(\"app_id\") = 26 AND substr(\"app_id\", 1, 1) GLOB '[0-7]' AND \"app_id\" NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "vendor_credential_app_vendor_idx": {
+          "name": "vendor_credential_app_vendor_idx",
+          "columns": ["app_id", "vendor_id"],
+          "isUnique": false
+        },
+        "vendor_credential_app_vendor_name_idx": {
+          "name": "vendor_credential_app_vendor_name_idx",
+          "columns": ["app_id", "vendor_id", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "file_record_listing_idx": {
+        "columns": {
+          "lower(\"name\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/pkgs/db/drizzle/meta/_journal.json
+++ b/pkgs/db/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1785774269305,
       "tag": "0005_public-thread-end-user",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1786028822757,
+      "tag": "0006_runtime_subject_quota_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/pkgs/db/src/schema/runtime.schema.ts
+++ b/pkgs/db/src/schema/runtime.schema.ts
@@ -11,6 +11,8 @@ import type {
   SandboxSubjectKind,
 } from "@mosoo/contracts/sandbox";
 import type {
+  AccountId,
+  AgentId,
   CredentialId,
   DriverCommandId,
   DriverInstanceId,
@@ -41,6 +43,8 @@ import { sessionsTable } from "./session/core.schema";
 export const sandboxesTable = sqliteTable(
   "sandbox",
   {
+    agentId: platformIdColumn<AgentId>("agent_id"),
+    appId: platformIdColumn<AppId>("app_id"),
     bindMountReady: integer("bind_mount_ready", { mode: "boolean" }).notNull().default(false),
     claimExpiresAt: integer("claim_expires_at"),
     claimOwner: text("claim_owner"),
@@ -53,6 +57,7 @@ export const sandboxesTable = sqliteTable(
     lastError: text("last_error"),
     lastErrorCode: text("last_error_code").$type<RuntimeSubjectErrorCode>(),
     lastRestoreBackupId: platformIdColumn<SandboxBackupId>("last_restore_backup_id"),
+    ownerAccountId: platformIdColumn<AccountId>("owner_account_id"),
     status: text("status").$type<SandboxStatus>().notNull(),
     statusChangedAt: integer("status_changed_at").notNull().default(0),
     statusEvent: text("status_event").notNull().default("runtime_subject.cold"),


### PR DESCRIPTION
## What changed

- Atomically cap Free concurrent sandboxes at 3 per Agent, 10 per App, and 20 per account in the shared D1 activation claim.
- Route owner debug terminals through the same lifecycle guard.
- Lower the production Sandbox pool ceiling from 500 to 50 as a cross-account spend fuse.
- Add the append-only `0006_runtime_subject_quota_scope` migration and generated snapshot metadata.

## Why

Addresses the unbounded container-creation and spend risk reported in #503 while keeping the early-stage implementation deliberately small.

## Impact

A new Sandbox activation that exceeds any Free concurrency scope receives an actionable limit error. Existing active Sandbox reuse is unaffected.

## Validation

- `TMPDIR=/private/tmp just check`
- `just commit-check`
- Isolated full D1 migration-chain replay
- Read-only production migration, queue, and Sandbox-state inspection
- Production API and Web Wrangler dry-runs
- `git diff --check`

Generated files: D1 migration snapshot and journal metadata. No GraphQL or lockfile changes.
