### PR TITLE
fix(runtime): remove sandbox quota hard rejection

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-lifecycle.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-lifecycle.service.ts
@@ -18,7 +18,6 @@ import { RUNTIME_DIAGNOSTIC_EVENT } from "@mosoo/runtime-events";
 
 import { createErrorLogContext, logWarn } from "../../../../platform/cloudflare/logger";
 import type { ApiBindings } from "../../../../platform/cloudflare/worker-types";
-import { validationError } from "../../../../platform/errors";
 import { currentTimestampMs } from "../../../../time";
 import {
   appendRuntimeDiagnosticEvent,
@@ -56,7 +55,6 @@ import {
 import {
   claimRuntimeSubjectActivation,
   ensureRuntimeSubjectId,
-  FREE_PLAN_CONCURRENT_SANDBOX_LIMITS,
   getRuntimeConversationSessionState,
   getRuntimeSubjectActivationRecord,
   markRuntimeSubjectActivationDestroying,
@@ -93,14 +91,6 @@ export interface ActivateRuntimeSubjectInput {
   readonly subjectId: PlatformId;
   readonly subjectKind: SandboxSubjectKind;
   readonly timing?: RuntimeTimingRecorder;
-}
-
-function freePlanSandboxLimitError() {
-  const limits = FREE_PLAN_CONCURRENT_SANDBOX_LIMITS;
-
-  return validationError(
-    `Free plan concurrent sandbox limit reached (${limits.agent} per Agent, ${limits.app} per App, ${limits.account} per account). Wait for a sandbox to stop before trying again.`,
-  );
 }
 
 export interface ActiveRuntimeSubject {
@@ -552,20 +542,6 @@ export class RuntimeSubjectLifecycleService {
     });
 
     if (!claimed) {
-      if (record.status === "cold") {
-        const refreshed = await getRuntimeSubjectActivationRecord(
-          this.#bindings.DB,
-          input.activation.runtimeSubjectId,
-        );
-
-        if (
-          refreshed?.status === "cold" &&
-          !hasActiveRuntimeSubjectClaim(refreshed, currentTimestampMs())
-        ) {
-          throw freePlanSandboxLimitError();
-        }
-      }
-
       throw new Error("Runtime subject is busy with lifecycle maintenance.");
     }
 

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-record-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-record-store.ts
@@ -39,39 +39,10 @@ import type {
   RuntimeSubjectStatus,
 } from "./runtime-subject-store.types";
 
-// ponytail: every hosted account is on Free today; replace constants with
-// entitlements only when paid plans actually ship.
-export const FREE_PLAN_CONCURRENT_SANDBOX_LIMITS = {
-  account: 20,
-  agent: 3,
-  app: 10,
-} as const;
-
 interface RuntimeSubjectQuotaScope {
   readonly agentId: AgentId;
   readonly appId: AppId;
   readonly executionOwnerUserId: AccountId;
-}
-
-function runtimeSubjectQuotaCapacityPredicate(
-  input: RuntimeSubjectQuotaScope & { readonly now: number },
-): SQL {
-  const limits = FREE_PLAN_CONCURRENT_SANDBOX_LIMITS;
-
-  // ponytail: the production pool is capped at 50, so one guarded scan is cheaper
-  // than quota counters; add counters only if the pool ceiling grows materially.
-  return sql`(
-    SELECT
-      COALESCE(SUM(CASE WHEN quota_sandbox.agent_id = ${input.agentId} THEN 1 ELSE 0 END), 0) < ${limits.agent}
-      AND COALESCE(SUM(CASE WHEN quota_sandbox.app_id = ${input.appId} THEN 1 ELSE 0 END), 0) < ${limits.app}
-      AND COALESCE(SUM(CASE WHEN quota_sandbox.owner_account_id = ${input.executionOwnerUserId} THEN 1 ELSE 0 END), 0) < ${limits.account}
-    FROM ${sandboxesTable} AS quota_sandbox
-    WHERE quota_sandbox.status <> 'cold'
-      OR (
-        quota_sandbox.claim_owner IS NOT NULL
-        AND quota_sandbox.claim_expires_at > ${input.now}
-      )
-  )`;
 }
 
 function runtimeSubjectStatusPatch(input: {
@@ -304,7 +275,6 @@ export async function claimRuntimeSubjectActivation(
             isNull(sandboxesTable.claimExpiresAt),
             lte(sandboxesTable.claimExpiresAt, input.now),
           ),
-          ...(input.expectedStatus === "cold" ? [runtimeSubjectQuotaCapacityPredicate(input)] : []),
         ),
       )
       .returning({ id: sandboxesTable.id })

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store.ts
@@ -20,7 +20,6 @@ export {
   advanceRuntimeSubjectOperationStatus,
   claimRuntimeSubjectActivation,
   ensureRuntimeSubjectId,
-  FREE_PLAN_CONCURRENT_SANDBOX_LIMITS,
   getRuntimeSubject,
   getRuntimeSubjectActivationRecord,
   getRuntimeSubjectIdByTuple,

--- a/apps/api/tests/runtime-subject-lifecycle.test.ts
+++ b/apps/api/tests/runtime-subject-lifecycle.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { createPlatformId } from "@mosoo/id";
-import type { AgentId, AppId, SandboxId, SessionId } from "@mosoo/id";
+import type { SandboxId, SessionId } from "@mosoo/id";
 
 import { decideRuntimeSubjectTransition } from "../src/modules/runtime/domain/runtime-subject-lifecycle.machine";
 import { createRuntimeSubjectLifecycleService } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-lifecycle.service";
@@ -10,7 +10,6 @@ import { destroyRuntimeSubjectContainer } from "../src/modules/runtime/infrastru
 import { recycleRuntimeSubject } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-recycle.service";
 import {
   advanceRuntimeSubjectOperationStatus,
-  FREE_PLAN_CONCURRENT_SANDBOX_LIMITS,
   markRuntimeSubjectCold,
   markRuntimeSubjectOperationStarted,
 } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store";
@@ -309,43 +308,33 @@ describe("runtime subject lifecycle machine", () => {
     ).resolves.toBeNull();
   });
 
-  test("atomically caps Free sandboxes per Agent, App, and account", async () => {
-    for (const scope of ["agent", "app", "account"] as const) {
-      const database = createRuntimeSubjectLifecycleDatabase();
-      const inputs: ActivateRuntimeSubjectInput[] = [];
-      const limit = FREE_PLAN_CONCURRENT_SANDBOX_LIMITS[scope];
+  test("allows more than three concurrent sandboxes for one Agent", async () => {
+    const database = createRuntimeSubjectLifecycleDatabase();
+    const inputs: ActivateRuntimeSubjectInput[] = Array.from({ length: 4 }, () => {
+      const sessionId = createPlatformId<SessionId>();
 
-      for (let index = 0; index <= limit; index += 1) {
-        const agentId = scope === "agent" ? AGENT_ID : createPlatformId<AgentId>();
-        const appId = scope === "account" ? createPlatformId<AppId>() : APP_ID;
-        const sessionId = createPlatformId<SessionId>();
+      return {
+        agentId: AGENT_ID,
+        appId: APP_ID,
+        executionOwnerUserId: ACCOUNT_ID,
+        kind: "cattle",
+        networkConstraints: { allowedHosts: [], networkPolicy: "full" },
+        runtimeSubjectId: createPlatformId<SandboxId>(),
+        subjectId: sessionId,
+        subjectKind: "session",
+      };
+    });
 
-        inputs.push({
-          agentId,
-          appId,
-          executionOwnerUserId: ACCOUNT_ID,
-          kind: "cattle",
-          networkConstraints: { allowedHosts: [], networkPolicy: "full" },
-          runtimeSubjectId: createPlatformId<SandboxId>(),
-          subjectId: sessionId,
-          subjectKind: "session",
-        });
-      }
+    const lifecycle = createRuntimeSubjectLifecycleService(createBindings(database));
 
-      const lifecycle = createRuntimeSubjectLifecycleService(createBindings(database));
-      const outcomes = await Promise.allSettled(inputs.map((input) => lifecycle.activate(input)));
-      const rejected = outcomes.filter(
-        (outcome): outcome is PromiseRejectedResult => outcome.status === "rejected",
-      );
-      const active = await database
+    await expect(
+      Promise.all(inputs.map((input) => lifecycle.activate(input))),
+    ).resolves.toHaveLength(inputs.length);
+    await expect(
+      database
         .prepare("SELECT COUNT(*) AS count FROM sandbox WHERE status = 'active'")
-        .first<{ count: number }>();
-
-      expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(limit);
-      expect(rejected).toHaveLength(1);
-      expect(String(rejected[0]?.reason)).toContain("Free plan concurrent sandbox limit reached");
-      expect(active?.count).toBe(limit);
-    }
+        .first<{ count: number }>(),
+    ).resolves.toEqual({ count: inputs.length });
   });
 
   test("records operation transitions with monotonic status metadata", async () => {


### PR DESCRIPTION
## What changed

- remove the Free 3-per-Agent, 10-per-App, and 20-per-account hard rejection from the shared Sandbox activation claim
- retain Sandbox ownership metadata, the append-only D1 migration, and the production-wide `max_instances = 50` spend fuse
- replace the quota rejection test with a regression proving four concurrent Cattle Sandboxes for one Agent are admitted

## Why

The quota shipped in #507 rejects overflow Runs instead of waiting. Public API and channel Sessions also attribute every End User Sandbox to the Agent owner, so the fourth concurrent End User can fail despite being a different `(App, userId)`. Until durable waiting admission and correct End User accounting exist, the hard rejection breaks the published integration behavior.

This is a production stopgap for #503, not the complete capacity design. Deployment/build Sandbox paths and the durable waiting/DLQ follow-up remain separate work.

## Impact

Preview, Public Thread API, channel, and owner-debug activation no longer fail because of the removed 3/10/20 thresholds. The global 50-instance Cloudflare cap still bounds spend.

## Verification

- `just test-file apps/api/tests/runtime-subject-lifecycle.test.ts` — 14 passed
- `TMPDIR=/private/tmp just check` — passed
- plain `just check` initially exposed an existing macOS `/var` vs `/private/var` temp-path alias in `apps/driver/tests/acp-file-system.test.ts`; the isolated test passed 5/5 with canonical `TMPDIR=/private/tmp`

Generated files: none. GraphQL codegen changes: none. DB migrations: none. Lockfile changes: none.
