### PR TITLE
fix(web): identify PAT authorization server

### DIFF
--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -36,6 +36,7 @@ export default {
       }
 
       const body = JSON.stringify({
+        authorization_servers: [url.origin],
         bearer_methods_supported: ["header"],
         resource: url.origin,
         resource_documentation: "https://mosoo.ai/docs/api-reference/",

--- a/apps/web/tests/worker-domain-redirect.test.ts
+++ b/apps/web/tests/worker-domain-redirect.test.ts
@@ -18,6 +18,7 @@ test("serves OAuth protected resource metadata before assets", async () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("application/json");
     expect(await response.json()).toEqual({
+      authorization_servers: [origin],
       bearer_methods_supported: ["header"],
       resource: origin,
       resource_documentation: "https://mosoo.ai/docs/api-reference/",


### PR DESCRIPTION
## Summary
- identify cloud.mosoo.ai as the issuer and manager of Mosoo Personal Access Tokens
- keep scopes and OAuth endpoints absent because Mosoo PATs do not expose them

## Validation
- bun test apps/web/tests/worker-domain-redirect.test.ts
- just test-package @mosoo/web
- just fmt-check-path apps/web
- just tc-package @mosoo/web