### PR TITLE
fix(web): declare PAT scope model

### DIFF
--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -41,6 +41,7 @@ export default {
         resource: url.origin,
         resource_documentation: "https://mosoo.ai/docs/api-reference/",
         resource_name: "Mosoo Public Thread API",
+        scopes_supported: [],
       });
 
       return new Response(request.method === "HEAD" ? null : body, {

--- a/apps/web/tests/worker-domain-redirect.test.ts
+++ b/apps/web/tests/worker-domain-redirect.test.ts
@@ -23,6 +23,7 @@ test("serves OAuth protected resource metadata before assets", async () => {
       resource: origin,
       resource_documentation: "https://mosoo.ai/docs/api-reference/",
       resource_name: "Mosoo Public Thread API",
+      scopes_supported: [],
     });
   }
 


### PR DESCRIPTION
## Summary
- publish an empty scopes_supported array because Mosoo Personal Access Tokens do not expose scopes
- keep the metadata explicit without inventing permissions

## Validation
- just test-package @mosoo/web
- just fmt-check-path apps/web
- just tc-package @mosoo/web