### PR TITLE
feat(web): publish PAT agent auth metadata

### DIFF
--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -27,7 +27,10 @@ export default {
       return Response.redirect(url.toString(), 308);
     }
 
-    if (url.pathname === "/.well-known/oauth-protected-resource") {
+    if (
+      url.pathname === "/.well-known/oauth-protected-resource" ||
+      url.pathname === "/.well-known/oauth-authorization-server"
+    ) {
       if (request.method !== "GET" && request.method !== "HEAD") {
         return new Response(null, {
           headers: { allow: "GET, HEAD" },
@@ -35,14 +38,32 @@ export default {
         });
       }
 
-      const body = JSON.stringify({
-        authorization_servers: [url.origin],
-        bearer_methods_supported: ["header"],
-        resource: url.origin,
-        resource_documentation: "https://mosoo.ai/docs/api-reference/",
-        resource_name: "Mosoo Public Thread API",
-        scopes_supported: [],
-      });
+      const metadata =
+        url.pathname === "/.well-known/oauth-protected-resource"
+          ? {
+              authorization_servers: [url.origin],
+              bearer_methods_supported: ["header"],
+              resource: url.origin,
+              resource_documentation: "https://mosoo.ai/docs/api-reference/",
+              resource_name: "Mosoo Public Thread API",
+              scopes_supported: ["full_account_access"],
+            }
+          : {
+              agent_auth: {
+                identity_types_supported: ["user_authorization"],
+                register_uri: `${url.origin}/settings/access-tokens`,
+                skill: "https://mosoo.ai/auth.md",
+                user_authorization: {
+                  authorization_uri: `${url.origin}/login`,
+                  credential_types_supported: ["mosoo_personal_access_token"],
+                  provisioning_endpoint: `${url.origin}/settings/access-tokens`,
+                  revocation_uri: `${url.origin}/settings/access-tokens`,
+                },
+              },
+              issuer: url.origin,
+              scopes_supported: ["full_account_access"],
+            };
+      const body = JSON.stringify(metadata);
 
       return new Response(request.method === "HEAD" ? null : body, {
         headers: { "content-type": "application/json" },

--- a/apps/web/tests/worker-domain-redirect.test.ts
+++ b/apps/web/tests/worker-domain-redirect.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 
 import worker from "../src/worker";
 
-test("serves OAuth protected resource metadata before assets", async () => {
+test("serves agent authentication metadata before assets", async () => {
   const env = {
     ASSETS: {
       fetch: () => Promise.reject(new Error("metadata must not reach the asset fallback")),
@@ -23,7 +23,29 @@ test("serves OAuth protected resource metadata before assets", async () => {
       resource: origin,
       resource_documentation: "https://mosoo.ai/docs/api-reference/",
       resource_name: "Mosoo Public Thread API",
-      scopes_supported: [],
+      scopes_supported: ["full_account_access"],
+    });
+
+    const authorizationResponse = await worker.fetch(
+      new Request(`${origin}/.well-known/oauth-authorization-server`),
+      env,
+    );
+
+    expect(authorizationResponse.status).toBe(200);
+    expect(await authorizationResponse.json()).toEqual({
+      agent_auth: {
+        identity_types_supported: ["user_authorization"],
+        register_uri: `${origin}/settings/access-tokens`,
+        skill: "https://mosoo.ai/auth.md",
+        user_authorization: {
+          authorization_uri: `${origin}/login`,
+          credential_types_supported: ["mosoo_personal_access_token"],
+          provisioning_endpoint: `${origin}/settings/access-tokens`,
+          revocation_uri: `${origin}/settings/access-tokens`,
+        },
+      },
+      issuer: origin,
+      scopes_supported: ["full_account_access"],
     });
   }
 


### PR DESCRIPTION
## Summary
- publish authorization-server discovery for Mosoo's existing human-authorized PAT flow
- expose the real login, token provisioning, and revocation pages without adding a token or registration API
- describe PAT effective access as full_account_access because callers cannot select narrower scopes

## Validation
- just test-package @mosoo/web
- just fmt-check-path apps/web
- just tc-package @mosoo/web