### PR TITLE
fix(web): complete PAT agent auth method

### DIFF
--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -50,15 +50,15 @@ export default {
             }
           : {
               agent_auth: {
-                identity_types_supported: ["user_authorization"],
-                register_uri: `${url.origin}/settings/access-tokens`,
-                skill: "https://mosoo.ai/auth.md",
-                user_authorization: {
-                  authorization_uri: `${url.origin}/login`,
+                anonymous: {
+                  claim_uri: `${url.origin}/settings/access-tokens`,
                   credential_types_supported: ["mosoo_personal_access_token"],
-                  provisioning_endpoint: `${url.origin}/settings/access-tokens`,
-                  revocation_uri: `${url.origin}/settings/access-tokens`,
                 },
+                claim_uri: `${url.origin}/settings/access-tokens`,
+                identity_types_supported: ["anonymous"],
+                register_uri: `${url.origin}/settings/access-tokens`,
+                revocation_uri: `${url.origin}/settings/access-tokens`,
+                skill: "https://mosoo.ai/auth.md",
               },
               issuer: url.origin,
               scopes_supported: ["full_account_access"],

--- a/apps/web/tests/worker-domain-redirect.test.ts
+++ b/apps/web/tests/worker-domain-redirect.test.ts
@@ -34,15 +34,15 @@ test("serves agent authentication metadata before assets", async () => {
     expect(authorizationResponse.status).toBe(200);
     expect(await authorizationResponse.json()).toEqual({
       agent_auth: {
-        identity_types_supported: ["user_authorization"],
-        register_uri: `${origin}/settings/access-tokens`,
-        skill: "https://mosoo.ai/auth.md",
-        user_authorization: {
-          authorization_uri: `${origin}/login`,
+        anonymous: {
+          claim_uri: `${origin}/settings/access-tokens`,
           credential_types_supported: ["mosoo_personal_access_token"],
-          provisioning_endpoint: `${origin}/settings/access-tokens`,
-          revocation_uri: `${origin}/settings/access-tokens`,
         },
+        claim_uri: `${origin}/settings/access-tokens`,
+        identity_types_supported: ["anonymous"],
+        register_uri: `${origin}/settings/access-tokens`,
+        revocation_uri: `${origin}/settings/access-tokens`,
+        skill: "https://mosoo.ai/auth.md",
       },
       issuer: origin,
       scopes_supported: ["full_account_access"],


### PR DESCRIPTION
## Summary
- model an unregistered agent as anonymous until the Mosoo App owner claims the integration by provisioning a PAT
- publish the existing settings page as claim, registration, and revocation URI
- keep Personal Access Token as the only advertised credential type

## Validation
- just test-package @mosoo/web
- just fmt-check-path apps/web
- just tc-package @mosoo/web