### PR TITLE
fix(runtime): rearm legacy pet idle deadline

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-conversation-session-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-conversation-session-store.ts
@@ -5,6 +5,10 @@ import type { SandboxId, SandboxSessionId, SessionId } from "@mosoo/id";
 import { and, desc, eq, inArray, lte, notExists, sql } from "drizzle-orm";
 
 import { getAppDatabase, runAppDatabaseBatch } from "../../../../platform/db/drizzle";
+import {
+  getRuntimeKindPolicy,
+  getRuntimeSubjectInactiveDeadline,
+} from "../../domain/runtime-kind-policy";
 import { toRuntimeSubjectStatusLifecycleEventName } from "../../domain/runtime-subject-lifecycle.machine";
 import {
   activeConversationSessionQuery,
@@ -280,6 +284,11 @@ export async function recordRuntimeConversationSessionActive(
     readonly sessionId: SessionId;
   },
 ): Promise<void> {
+  const petInactiveDeadlineAt = getRuntimeSubjectInactiveDeadline(
+    getRuntimeKindPolicy("pet"),
+    input.now,
+  );
+
   await runAppDatabaseBatch(database, (appDb) => [
     appDb
       .insert(sandboxSessionsTable)
@@ -307,7 +316,8 @@ export async function recordRuntimeConversationSessionActive(
       .set({
         inactiveDeadlineAt: sql`
           CASE
-            WHEN ${sandboxesTable.kind} = 'pet' THEN ${sandboxesTable.inactiveDeadlineAt}
+            WHEN ${sandboxesTable.kind} = 'pet'
+              THEN COALESCE(${sandboxesTable.inactiveDeadlineAt}, ${petInactiveDeadlineAt})
             ELSE NULL
           END
         `,

--- a/apps/api/tests/sandbox-conversation-session.test.ts
+++ b/apps/api/tests/sandbox-conversation-session.test.ts
@@ -293,6 +293,19 @@ describe("ensureSandboxConversationSession", () => {
     });
   });
 
+  test("arms an idle deadline when a legacy Pet session has none", async () => {
+    const database = createConversationSessionDatabase();
+    database.execute("UPDATE sandbox SET inactive_deadline_at = NULL");
+    const sandbox = createSandbox();
+    const startedAt = Date.now();
+
+    await ensureSandboxConversationSession(createBindings(database), createInput(sandbox));
+
+    const deadline = await readInactiveDeadline(database);
+    expect(deadline).toBeGreaterThanOrEqual(startedAt + 5 * 60_000);
+    expect(deadline).toBeLessThanOrEqual(Date.now() + 5 * 60_000);
+  });
+
   test("continues a closed cattle session with a new execution session id", async () => {
     const database = createConversationSessionDatabase("cattle");
     await insertConversationSession(database, { status: "closed" });


### PR DESCRIPTION
## What changed

- Preserve the Pet lifecycle invariant when a conversation session activates.
- If a legacy Pet sandbox has inactive_deadline_at = NULL, arm the normal five-minute idle deadline.
- Keep existing deadlines unchanged and preserve Cattle behavior.

## Root cause

Older Pet sandboxes could retain a null idle deadline. Session activation preserved that null value, so the normal run-lease and checkpoint/hibernate lifecycle had no deadline to consume. This could leave an otherwise idle container running and accruing provisioned memory/disk charges.

## Impact

Legacy Pet sandboxes now re-enter the existing lifecycle on their next activation: session activation arms the deadline, run lease acquisition clears it while work is active, and release re-arms it for normal checkpoint/hibernate.

## Verification

- just test-file apps/api/tests/sandbox-conversation-session.test.ts
- just test-file apps/api/tests/runtime-subject-run-lease.test.ts
- just test-file apps/api/tests/runtime-subject-lifecycle.test.ts
- just tc-package @mosoo/api
- TMPDIR=/private/tmp just check

No generated files, GraphQL codegen changes, DB migrations, or lockfile changes.