### PR TITLE
fix(runtime): batch pet checkpoint metadata

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/sandbox-backup-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/sandbox-backup-store.ts
@@ -9,8 +9,17 @@ import { parsePlatformId } from "@mosoo/id";
 import type { RuntimeOperationId, SandboxBackupId, SandboxId, SessionId } from "@mosoo/id";
 import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
 
-import { getAppDatabase, getD1ChangeCount } from "../../../platform/db/drizzle";
+import type { AppDatabase } from "../../../platform/db/drizzle";
+import {
+  getAppDatabase,
+  getD1ChangeCount,
+  runAppDatabaseBatch,
+} from "../../../platform/db/drizzle";
 import { currentTimestampMs } from "../../../time";
+
+// Each row binds nine values; ten rows stay below D1's per-statement variable limit.
+const SANDBOX_BACKUP_INSERT_BATCH_SIZE = 10;
+type AppDatabaseBatchItem = Parameters<AppDatabase["batch"]>[0][number];
 
 export interface CreatedSandboxBackupRecord {
   readonly dir: string;
@@ -132,30 +141,54 @@ export async function recordCreatedSandboxBackups(
     }
   }
 
+  const results = await runAppDatabaseBatch(database, (appDb) => {
+    const queries: [AppDatabaseBatchItem, ...AppDatabaseBatchItem[]] = [
+      appDb
+        .insert(sandboxBackupsTable)
+        .values(backupRows.slice(0, SANDBOX_BACKUP_INSERT_BATCH_SIZE)),
+    ];
+
+    for (
+      let index = SANDBOX_BACKUP_INSERT_BATCH_SIZE;
+      index < backupRows.length;
+      index += SANDBOX_BACKUP_INSERT_BATCH_SIZE
+    ) {
+      queries.push(
+        appDb
+          .insert(sandboxBackupsTable)
+          .values(backupRows.slice(index, index + SANDBOX_BACKUP_INSERT_BATCH_SIZE)),
+      );
+    }
+
+    if (subjectCheckpointBackup) {
+      queries.push(
+        appDb
+          .update(sandboxesTable)
+          .set({
+            lastBackupId: parsePlatformId<SandboxBackupId>(
+              subjectCheckpointBackup.id,
+              "checkpoint sandbox backup id",
+            ),
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(sandboxesTable.id, sandboxId),
+              inArray(sandboxesTable.status, ["backing_up", "destroying"]),
+              ...sandboxStatusOperationCondition(operationId),
+            ),
+          ),
+      );
+    }
+
+    return queries;
+  });
+
   if (!subjectCheckpointBackup) {
-    await getAppDatabase(database).insert(sandboxBackupsTable).values(backupRows).run();
     return;
   }
 
-  const appDb = getAppDatabase(database);
-  await appDb.insert(sandboxBackupsTable).values(backupRows).run();
-  const updated = await appDb
-    .update(sandboxesTable)
-    .set({
-      lastBackupId: parsePlatformId<SandboxBackupId>(
-        subjectCheckpointBackup.id,
-        "checkpoint sandbox backup id",
-      ),
-      updatedAt: now,
-    })
-    .where(
-      and(
-        eq(sandboxesTable.id, sandboxId),
-        inArray(sandboxesTable.status, ["backing_up", "destroying"]),
-        ...sandboxStatusOperationCondition(operationId),
-      ),
-    )
-    .run();
+  const updated = results.at(-1);
 
   if (getD1ChangeCount(updated) === 0) {
     throw new Error("Runtime subject changed before checkpoint backup was recorded.");

--- a/apps/api/tests/sandbox-backup-pruning.test.ts
+++ b/apps/api/tests/sandbox-backup-pruning.test.ts
@@ -18,8 +18,8 @@ const MEMORY_NEW_BACKUP_ID = "01J000000000000000000000H6";
 const MEMORY_OLD_BACKUP_ID = "01J000000000000000000000H7";
 const SESSION_BACKUP_ID = "01J000000000000000000000H8";
 
-function createSandboxBackupDatabase(): SqliteD1Database {
-  const database = new SqliteD1Database();
+function createSandboxBackupDatabase(input: { maxBoundParams?: number } = {}): SqliteD1Database {
+  const database = new SqliteD1Database(input);
 
   database.execute(`
     CREATE TABLE sandbox (
@@ -182,5 +182,34 @@ describe("sandbox backup pruning", () => {
       status: "backing_up",
       status_seq: 0,
     });
+  });
+
+  test("records more backups than fit in one D1 statement", async () => {
+    const database = createSandboxBackupDatabase({ maxBoundParams: 100 });
+    await insertSandbox(database);
+    const suffixes = [..."123456789ABCDEFG"];
+
+    await recordCreatedSandboxBackups(database, {
+      backups: suffixes.map((suffix, index) => ({
+        backup: {
+          dir: index === suffixes.length - 1 ? "/memory" : `/workspace/${index}`,
+          id: `01J000000000000000000000H${suffix}`,
+        },
+        updateSandboxLastBackup: index === suffixes.length - 1,
+      })),
+      sandboxId: "01J0000000000000000000000D",
+      ttlSeconds: 100,
+    });
+
+    const backupCount = await database
+      .prepare("SELECT COUNT(*) AS count FROM sandbox_backup")
+      .first<{ count: number }>();
+    const sandbox = await database
+      .prepare("SELECT last_backup_id FROM sandbox WHERE id = ?")
+      .bind("01J0000000000000000000000D")
+      .first<{ last_backup_id: string }>();
+
+    expect(backupCount?.count).toBe(16);
+    expect(sandbox?.last_backup_id).toBe("01J000000000000000000000HG");
   });
 });


### PR DESCRIPTION
## Summary
- split sandbox backup metadata inserts into D1-safe ten-row statements
- execute every insert and the subject checkpoint update in one atomic D1 batch
- cover a 16-backup Pet checkpoint under a 100-variable statement limit

## Production evidence
A Pet with 15 session workspaces plus subject memory could not hibernate. The production repair log reported `D1_ERROR: too many SQL variables` while inserting 16 backup rows (144 bound values). Checkpoint objects were then rolled back and the Pet remained running.

## Verification
- `just test-file apps/api/tests/sandbox-backup-pruning.test.ts`
- `just test-file apps/api/tests/runtime-subject-recycle.test.ts`
- `just tc-package @mosoo/api`
- `TMPDIR=/private/tmp just check`