### PR TITLE
fix(analytics): correct activation attribution

### DIFF
--- a/apps/web/src/analytics/product-analytics-provider.tsx
+++ b/apps/web/src/analytics/product-analytics-provider.tsx
@@ -25,7 +25,7 @@ export function ProductAnalyticsProvider({ children }: { children: ReactNode }) 
 
   useEffect(() => {
     if (user !== null) {
-      identifyProductUser({ accountId: user.id, name: user.name });
+      identifyProductUser({ accountId: user.id, email: user.email, name: user.name });
     }
   }, [user]);
 

--- a/apps/web/src/analytics/product-analytics.ts
+++ b/apps/web/src/analytics/product-analytics.ts
@@ -21,6 +21,7 @@ export interface ProductAnalyticsConfig {
 
 export interface ProductAnalyticsIdentity {
   accountId: string;
+  email: string;
   name?: string | null;
 }
 
@@ -169,10 +170,14 @@ export function identifyProductUser(identity: ProductAnalyticsIdentity): void {
   }
 
   const anonymousId = state.distinctId;
+  const internalOrTestUser = identity.email.trim().toLowerCase().endsWith("@dify.ai");
   state = { ...state, distinctId: accountId, identifiedAccountId: accountId };
   postEvent("$identify", {
     $anon_distinct_id: anonymousId,
-    $set: sanitizeProperties({ name: identity.name ?? undefined }),
+    $set: sanitizeProperties({
+      $internal_or_test_user: internalOrTestUser,
+      name: identity.name ?? undefined,
+    }),
   });
 }
 

--- a/apps/web/tests/product-analytics.test.ts
+++ b/apps/web/tests/product-analytics.test.ts
@@ -100,7 +100,7 @@ describe("product analytics", () => {
     configureProductAnalytics({ projectKey: "phc_public" });
 
     const anonymousId = getProductAnalyticsState().distinctId;
-    identifyProductUser({ accountId: "acct_123", name: "Rock" });
+    identifyProductUser({ accountId: "acct_123", email: "rock@dify.ai", name: "Rock" });
     captureProductEvent("page_viewed", { route: "/apps" });
     await Promise.resolve();
 
@@ -108,7 +108,11 @@ describe("product analytics", () => {
     const identifyProperties = requests[0]?.body["properties"] as Record<string, unknown>;
     expect(identifyProperties["distinct_id"]).toBe("acct_123");
     expect(identifyProperties["$anon_distinct_id"]).toBe(anonymousId);
-    expect(identifyProperties["$set"]).toEqual({ name: "Rock" });
+    expect(identifyProperties["$set"]).toEqual({
+      $internal_or_test_user: true,
+      name: "Rock",
+    });
+    expect(JSON.stringify(requests[0]?.body)).not.toContain("rock@dify.ai");
     const pageProperties = requests[1]?.body["properties"] as Record<string, unknown>;
     expect(pageProperties["distinct_id"]).toBe("acct_123");
   });
@@ -116,7 +120,7 @@ describe("product analytics", () => {
   it("resets to a fresh anonymous identity on logout", () => {
     installBrowserLocation();
     configureProductAnalytics({ projectKey: "phc_public" });
-    identifyProductUser({ accountId: "acct_123" });
+    identifyProductUser({ accountId: "acct_123", email: "rock@example.com" });
 
     resetProductAnalytics();
 

--- a/docs/product-analytics.md
+++ b/docs/product-analytics.md
@@ -6,6 +6,7 @@ mosoo sends explicit, low-volume product events to one PostHog Cloud project. Br
 
 - Before login, the web app uses a persistent random `mosoo_anon_*` ID.
 - After login, `$identify` joins that anonymous history to the stable mosoo account ID.
+- `$identify` sets `$internal_or_test_user` for `@dify.ai` accounts so PostHog can exclude internal traffic without receiving the email address.
 - Logout creates a fresh anonymous ID so two accounts on one browser are not mixed.
 - Email addresses, prompts, credentials, task content, and model responses are not sent.
 - PostHog autocapture and session replay are not enabled by this integration.
@@ -21,11 +22,11 @@ Browser intent events:
 Authoritative API events:
 
 - `signup_completed`
-- `onboarding_completed`
-- `app_created`
+- `onboarding_completed` after the account's organization and default App are bootstrapped
+- `app_created` when a user manually creates an additional App
 - `agent_created`
 - `integration_connected` after a model-provider credential probe succeeds
-- `task_succeeded` after a runtime run first transitions to completed
+- `task_succeeded` after a runtime run first transitions to completed; `session_type` identifies `ui`, `preview`, or `api_channel` traffic
 
 Common properties include `environment`, `deployment_mode`, and the relevant `organization_id`, `app_id`, `agent_id`, integration type, or runtime identifiers. Person identity is the stable account ID.
 
@@ -51,13 +52,17 @@ For local analytics, put matching `VITE_POSTHOG_PROJECT_KEY` and `POSTHOG_PROJEC
 Activation funnel, unique users ordered:
 
 ```text
-signup_completed -> onboarding_completed -> app_created -> agent_created -> integration_connected -> task_succeeded
+signup_completed -> agent_created -> task_succeeded
 ```
+
+`onboarding_completed` is an automatic bootstrap milestone, and every new account receives a default App, so neither it nor `app_created` is a required activation step. `integration_connected` is also diagnostic: it can happen before or after Agent creation and is not required by every successful runtime path. Event totals for `task_succeeded` count completed runs; use a unique-user funnel when measuring activation.
 
 Also create:
 
 - a path insight starting from `page_viewed`;
 - an onboarding funnel `onboarding_started -> onboarding_completed`;
+- an external API adoption insight filtered to `task_succeeded` where `session_type = api_channel`; events without `session_type` predate channel attribution and must not be counted as proven API adoption;
+- a manual App-creation insight from `app_created` where `source = manual`;
 - a breakdown of `integration_connected` by `vendor_id`;
 - a breakdown of all funnels by `environment` and `deployment_mode`.
 


### PR DESCRIPTION
## Summary

- set `$internal_or_test_user` during PostHog identification for `@dify.ai` accounts without sending the email address
- document the primary activation funnel as `signup_completed -> agent_created -> task_succeeded`
- separate manual App creation, credential connection, and API-channel adoption into diagnostic insights

## Root cause

The configured PostHog internal-user cohort filtered on `$internal_or_test_user`, but mosoo never set that person property. The documented funnel also treated automatic onboarding, manual additional-App creation, and credential probing as mandatory ordered activation steps even though the product flow does not.

## Impact

After deployment and the next authenticated page load, internal accounts can be excluded reliably. Existing event history is not rewritten. `task_succeeded` remains a completed-Run event; API adoption should filter it with `session_type = api_channel`.

## Verification

- `just test-file apps/web/tests/product-analytics.test.ts` — 4 passed
- `just tc-package @mosoo/web` — passed
- `just docs-check` — passed
- `git diff --check` — passed
- `just commit-check` — passed
- local `just check`: formatting, docs, lint, and typecheck passed; tests reported 1089 passed, 42 live tests skipped, and one unrelated reproducible macOS `/var` vs `/private/var` path failure in `apps/driver/tests/acp-file-system.test.ts`. PR CI will run the canonical Linux gate.

## Change inventory

- Generated files: none
- GraphQL codegen: none
- DB migrations: none
- Lockfile changes: none
