### PR TITLE
fix(runtime): reclaim cattle sessions after remote cleanup errors

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance-store.ts
@@ -8,13 +8,18 @@ import {
 import type { DriverInstanceId, SandboxId, SessionId } from "@mosoo/id";
 import { and, asc, eq, exists, inArray, isNotNull, isNull, lte, notExists, or } from "drizzle-orm";
 
-import { getAppDatabase, runAppDatabaseBatch } from "../../../../platform/db/drizzle";
+import {
+  getAppDatabase,
+  getD1ChangeCount,
+  runAppDatabaseBatch,
+} from "../../../../platform/db/drizzle";
 import { currentTimestampMs } from "../../../../time";
 import { RUNTIME_SUBJECT_OPERATION_STATUSES } from "../../domain/runtime-subject-lifecycle.machine";
 import { ACTIVE_SESSION_RUN_STATUSES } from "../../domain/session-run-lifecycle.machine";
 import {
   activeConversationSessionQuery,
   activeConversationSessionQueryForListedSubject,
+  getRuntimeSubjectInactiveDeadlineSql,
   LIVE_DRIVER_STATUSES,
   runLeaseQuery,
   runLeaseQueryForListedSubject,
@@ -147,6 +152,31 @@ export async function listInactiveRuntimeSubjects(
     .orderBy(asc(sandboxesTable.inactiveDeadlineAt))
     .limit(input.limit)
     .all();
+}
+
+export async function repairStrandedCattleRuntimeSubjectDeadlines(
+  database: D1Database,
+  input: { readonly now: number },
+): Promise<number> {
+  const appDb = getAppDatabase(database);
+  const result = await appDb
+    .update(sandboxesTable)
+    .set({
+      inactiveDeadlineAt: getRuntimeSubjectInactiveDeadlineSql(input.now),
+      updatedAt: input.now,
+    })
+    .where(
+      and(
+        eq(sandboxesTable.status, "active"),
+        eq(sandboxesTable.kind, "cattle"),
+        isNull(sandboxesTable.inactiveDeadlineAt),
+        notExists(activeConversationSessionQueryForListedSubject(appDb)),
+        notExists(runLeaseQueryForListedSubject(appDb)),
+      ),
+    )
+    .run();
+
+  return getD1ChangeCount(result);
 }
 
 export async function listStaleRuntimeSubjectOperations(

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service.ts
@@ -21,6 +21,7 @@ import { createSessionStatusTransitionPatch } from "../session-runs/session-life
 import { setSessionRunStatus } from "../session-runs/session-run-store.repository";
 import type { SessionRunTransitionOutcome } from "../session-runs/session-run-store.repository";
 import { listIdleSessionScopedConversationSessions } from "./runtime-conversation-session-store";
+import { repairStrandedCattleRuntimeSubjectDeadlines } from "./runtime-subject-maintenance-store";
 import {
   claimInactiveRuntimeSubject,
   listInactiveRuntimeSubjects,
@@ -312,6 +313,11 @@ export async function runSandboxMaintenance(bindings: ApiBindings): Promise<void
     staleUpdatedAtLte: now - MAINTENANCE_OPERATION_REPAIR_AFTER_MS,
   });
   await closeIdleSessionScopedConversationSessions(bindings, now);
+  const repairedDeadlines = await repairStrandedCattleRuntimeSubjectDeadlines(bindings.DB, { now });
+
+  if (repairedDeadlines > 0) {
+    logWarn("runtime.subject.inactive_deadline_repaired", { count: repairedDeadlines });
+  }
 
   const [candidates, repairCandidates] = await Promise.all([
     listInactiveRuntimeSubjects(bindings.DB, {

--- a/apps/api/src/modules/runtime/infrastructure/sandbox-session/sandbox-conversation-session.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/sandbox-session/sandbox-conversation-session.service.ts
@@ -317,33 +317,36 @@ async function finalizeSandboxConversationClose(
   const { deleteActiveSandboxConversationSession } =
     await import("./sandbox-conversation-session-delete");
 
-  await deleteActiveSandboxConversationSession(bindings, {
-    sandboxSessionId: input.state.sandboxSessionId,
-    sandboxId: input.sandboxId,
-  });
+  try {
+    await deleteActiveSandboxConversationSession(bindings, {
+      sandboxSessionId: input.state.sandboxSessionId,
+      sandboxId: input.sandboxId,
+    });
 
-  if (input.state.agentId) {
-    await appendRuntimeDiagnosticEvent(bindings, {
-      eventName: RUNTIME_DIAGNOSTIC_EVENT.sandboxSessionDestroyed.name,
+    if (input.state.agentId) {
+      await appendRuntimeDiagnosticEvent(bindings, {
+        eventName: RUNTIME_DIAGNOSTIC_EVENT.sandboxSessionDestroyed.name,
+        sessionId: input.sessionId,
+        value: {
+          ...toRuntimeDiagnosticBaseValue({
+            agentId: input.state.agentId,
+            sessionId: input.sessionId,
+          }),
+          reason: "runtime_subject_session_closed",
+          sandboxId: input.sandboxId,
+        },
+      });
+    }
+  } finally {
+    // Remote cleanup must not strand the local subject outside reclamation.
+    await recordRuntimeConversationSessionClosed(bindings.DB, {
+      inactiveDeadlineAt: getRuntimeSubjectInactiveDeadline(
+        getRuntimeKindPolicy(input.state.kind),
+        now,
+      ),
+      now,
+      runtimeSubjectId: input.sandboxId,
       sessionId: input.sessionId,
-      value: {
-        ...toRuntimeDiagnosticBaseValue({
-          agentId: input.state.agentId,
-          sessionId: input.sessionId,
-        }),
-        reason: "runtime_subject_session_closed",
-        sandboxId: input.sandboxId,
-      },
     });
   }
-
-  await recordRuntimeConversationSessionClosed(bindings.DB, {
-    inactiveDeadlineAt: getRuntimeSubjectInactiveDeadline(
-      getRuntimeKindPolicy(input.state.kind),
-      now,
-    ),
-    now,
-    runtimeSubjectId: input.sandboxId,
-    sessionId: input.sessionId,
-  });
 }

--- a/apps/api/tests/runtime-subject-recycle.test.ts
+++ b/apps/api/tests/runtime-subject-recycle.test.ts
@@ -4,6 +4,7 @@ import { isPlatformId, parsePlatformId } from "@mosoo/id";
 import type { RuntimeOperationId } from "@mosoo/id";
 import { PLATFORM_ID_FIXTURES } from "@mosoo/id/testing";
 
+import { repairStrandedCattleRuntimeSubjectDeadlines } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance-store";
 import {
   recycleInactiveRuntimeSubjectNow,
   recycleRuntimeSubject,
@@ -205,6 +206,40 @@ function createSandboxHandle(): SandboxHandle {
 }
 
 describe("runtime subject recycle", () => {
+  test("repairs stranded cattle subjects without touching active conversations", async () => {
+    const database = createRuntimeSubjectRecycleDatabase();
+    database.execute(`
+      UPDATE sandbox
+      SET claim_expires_at = NULL,
+          claim_owner = NULL,
+          inactive_deadline_at = NULL,
+          kind = 'cattle'
+      WHERE id = '${SANDBOX_ID}';
+
+      INSERT INTO sandbox_session (cwd, sandbox_id, session_id, status, updated_at)
+      VALUES ('/workspace', '${SANDBOX_ID}', 'session-1', 'closed', 1);
+    `);
+
+    await expect(repairStrandedCattleRuntimeSubjectDeadlines(database, { now: 10 })).resolves.toBe(
+      1,
+    );
+    await expect(
+      listInactiveRuntimeSubjects(database, { limit: 10, now: 300_009 }),
+    ).resolves.toEqual([]);
+    await expect(
+      listInactiveRuntimeSubjects(database, { limit: 10, now: 300_010 }),
+    ).resolves.toEqual([{ id: SANDBOX_ID, kind: "cattle" }]);
+
+    database.execute(`
+      UPDATE sandbox SET inactive_deadline_at = NULL WHERE id = '${SANDBOX_ID}';
+      UPDATE sandbox_session SET status = 'active' WHERE session_id = 'session-1';
+    `);
+
+    await expect(repairStrandedCattleRuntimeSubjectDeadlines(database, { now: 20 })).resolves.toBe(
+      0,
+    );
+  });
+
   test("uses a generated operation id instead of the maintenance claim owner", async () => {
     const database = createRuntimeSubjectRecycleDatabase();
     currentSandbox = createSandboxHandle();

--- a/apps/api/tests/sandbox-conversation-session.test.ts
+++ b/apps/api/tests/sandbox-conversation-session.test.ts
@@ -19,7 +19,7 @@ mock.module("@cloudflare/sandbox", () => ({
   },
 }));
 
-const { ensureSandboxConversationSession } =
+const { closeIdleCattleConversationSession, ensureSandboxConversationSession } =
   await import("../src/modules/runtime/infrastructure/sandbox-session/sandbox-conversation-session.service");
 
 const ORIGIN = {
@@ -84,6 +84,22 @@ function createConversationSessionDatabase(kind: AgentKind = "pet"): SqliteD1Dat
       sandbox_id text NOT NULL,
       status text NOT NULL
     );
+
+    CREATE TABLE session (
+      agent_id text,
+      id text PRIMARY KEY NOT NULL
+    );
+
+    CREATE TABLE driver_instance (
+      id text PRIMARY KEY NOT NULL,
+      sandbox_id text NOT NULL
+    );
+
+    CREATE TABLE session_run (
+      driver_instance_id text,
+      id text PRIMARY KEY NOT NULL,
+      status text NOT NULL
+    );
   `);
 
   database.execute(`
@@ -100,6 +116,10 @@ async function insertConversationSession(
     readonly status: SandboxSessionStatus;
   },
 ): Promise<void> {
+  await database
+    .prepare("INSERT INTO session (agent_id, id) VALUES (?, ?) ON CONFLICT (id) DO NOTHING")
+    .bind(null, "session-1")
+    .run();
   await database
     .prepare(
       `
@@ -203,6 +223,7 @@ function createExecutionSession(options: { cwdHasContent: boolean }): ExecutionS
 function createSandbox(
   options: {
     cwdHasContent?: boolean;
+    deleteSessionError?: Error;
     onRestore?: (backup: { readonly dir: string; readonly id: string }) => void;
   } = {},
 ): SandboxHandle {
@@ -219,8 +240,12 @@ function createSandbox(
     async createSession() {
       return executionSession;
     },
-    async deleteSession() {
-      return { sessionId: "session-1", success: true, timestamp: new Date(0).toISOString() };
+    async deleteSession(sessionId) {
+      if (options.deleteSessionError) {
+        throw options.deleteSessionError;
+      }
+
+      return { sessionId, success: true, timestamp: new Date(0).toISOString() };
     },
     async destroy() {},
     async getSession() {
@@ -241,8 +266,11 @@ function createSandbox(
   };
 }
 
-function createBindings(database: D1Database): ApiBindings {
-  return { DB: database } as ApiBindings;
+function createBindings(database: D1Database, sandbox?: SandboxHandle): ApiBindings {
+  return {
+    DB: database,
+    ...(sandbox ? { runtimeSubjectHandleFactory: () => sandbox } : {}),
+  } as ApiBindings;
 }
 
 function createInput(sandbox: SandboxHandle, kind: AgentKind = "pet") {
@@ -352,5 +380,31 @@ describe("ensureSandboxConversationSession", () => {
       cloudflare_session_id: "01J00000000000000000000001",
       status: "active",
     });
+  });
+});
+
+describe("closeIdleCattleConversationSession", () => {
+  test("arms subject reclamation when the remote session is already absent", async () => {
+    const database = createConversationSessionDatabase("cattle");
+    await insertConversationSession(database, { status: "active" });
+    database.execute("UPDATE sandbox SET inactive_deadline_at = NULL");
+    const sandboxSessionId = "01J00000000000000000000001";
+    const sandbox = createSandbox({
+      deleteSessionError: new Error(`Session '${sandboxSessionId}' not found`),
+    });
+    const startedAt = Date.now();
+
+    await expect(
+      closeIdleCattleConversationSession(createBindings(database, sandbox), {
+        idleSinceLte: 1,
+        sandboxId: "01J0000000000000000000000D",
+        sessionId: "session-1",
+      }),
+    ).rejects.toThrow(`Session '${sandboxSessionId}' not found`);
+
+    await expect(readConversationSession(database)).resolves.toMatchObject({ status: "closed" });
+    const deadline = await readInactiveDeadline(database);
+    expect(deadline).toBeGreaterThanOrEqual(startedAt + 5 * 60_000);
+    expect(deadline).toBeLessThanOrEqual(Date.now() + 5 * 60_000);
   });
 });


### PR DESCRIPTION
## What changed

- Always converge the local conversation lifecycle and arm subject reclamation even when remote Sandbox session deletion fails.
- Repair historical active Cattle subjects with no inactive deadline when they have neither an active conversation nor a run lease.
- Add regression coverage for the observed remote `session not found` failure and stranded-subject repair.

## Root cause

The idle close path marked the conversation closed before remote deletion, then aborted when Cloudflare reported that the remote session was already absent. The local subject never received an inactive deadline, so stale active Cattle sandboxes permanently consumed the account concurrency limit.

## Impact

Existing stranded subjects self-heal through maintenance with the normal five-minute reclamation grace. New cleanup errors remain observable but can no longer strand capacity.

## Verification

- `TMPDIR="$PWD/.tmp/host-temp" just check` — 1214 tests passed
- Focused conversation close, recycle, and idle sweep tests — 15 passed
- `just commit-check` — passed

Generated files: none.
GraphQL codegen changes: none.
DB migrations: none.
Lockfile changes: none.
