### PR TITLE
fix(deploy): match Cloudflare HTTPS redirect status

### DIFF
--- a/.github/workflows/deploy-try.yml
+++ b/.github/workflows/deploy-try.yml
@@ -127,11 +127,12 @@ jobs:
           wait_for_redirect \
             'https://try.mosoo.ai/' \
             '308 https://cloud.mosoo.ai/'
+          # Cloudflare's zone-level HTTPS redirect runs before either Worker.
           wait_for_redirect \
             'http://cloud.mosoo.ai/' \
-            '308 https://cloud.mosoo.ai/'
+            '301 https://cloud.mosoo.ai/'
           wait_for_redirect \
             'http://cloud.mosoo.ai/api/health' \
-            '308 https://cloud.mosoo.ai/api/health'
+            '301 https://cloud.mosoo.ai/api/health'
           curl "${curl_args[@]}" https://try.mosoo.ai/api/health \
             | jq -e '.name == "mosoo" and .ok == true'


### PR DESCRIPTION
## What changed

- Match production verification to Cloudflare's zone-level HTTP-to-HTTPS response.
- Keep exact redirect-target checks for both the console root and API health endpoint.

## Root cause

Cloudflare redirects plaintext requests before either Worker runs and returns HTTP 301. The workflow expected the Workers' internal 308 fallback, so releases deployed successfully but were reported as failed during final verification.

## Impact

Production releases now remain green when the deployed endpoints and redirect targets are healthy.

## Verification

- `CI=1 TMPDIR="$PWD/.tmp/host-temp" just check` — 1214 tests passed
- Live probes returned the expected 301 status and exact HTTPS targets
- `just commit-check` — passed

Generated files: none.
GraphQL codegen changes: none.
DB migrations: none.
Lockfile changes: none.
