### PR TITLE
docs(incident): record August runtime recoveries

### DIFF
--- a/docs/operations/incidents/2026-08-13-acp-tool-call-identity-conflict.md
+++ b/docs/operations/incidents/2026-08-13-acp-tool-call-identity-conflict.md
@@ -1,0 +1,70 @@
+# 2026-08-13 — ACP Tool Calls Failed On Streamed Identity Conflict
+
+- Status: Resolved
+- Severity: SEV-2
+- Window: 2026-08-13 16:24–18:47 UTC
+- Affected surface: OpenCode (ACP) runtime through UI and Public API Runs
+- Public status update: https://mosoo.ai/status
+- Tracking PR: [#534](https://github.com/langgenius/mosoo/pull/534)
+
+## Summary And Impact
+
+ACP Runs that used tools could fail before the tool completed. Users saw a
+generic `acp.turn_failed` internal server error instead of an assistant result.
+
+Production records show eight matching user-facing Run failures across two
+accounts and three Agents. The account count does not identify the number of
+individual users. Separate provider `insufficient balance` failures that shared
+the top-level `acp.turn_failed` code are excluded from this incident.
+
+## Timeline
+
+- 16:24 — The first matching user-facing ACP Run failed.
+- 17:22 — The last matching pre-fix Run failure was recorded.
+- 18:24 — The hotfix was committed after reproducing the reported Skill and
+  tool path in a production-shaped staging environment.
+- 18:32 — [#534](https://github.com/langgenius/mosoo/pull/534) merged.
+- 18:40 — The API hotfix reached production.
+- 18:47 — The first post-deploy user-facing ACP Run completed. No later
+  matching identity-conflict failure was recorded through 2026-08-17.
+
+## Root Cause
+
+Migration `0008_public-thread-tool-call-identity.sql` correctly rejected reuse
+of a durable tool-call identity with different immutable data. ACP providers,
+however, stream tool arguments as evolving snapshots, including incomplete JSON
+objects. The API persisted every running snapshot as if its tool input were
+already immutable. A later snapshot for the same Tool Call ID then looked like
+identity reuse, so D1 raised a `session_event tool identity conflict` and the
+Run surfaced `acp.turn_failed`.
+
+The test and release path had verified stable terminal tool events, but had not
+exercised evolving ACP argument snapshots against the production D1 identity
+constraint.
+
+## Detection And Response
+
+A user report on a Skill-loading path initiated the investigation. The public
+Run error exposed only `acp.turn_failed`, so production-shaped staging and the
+session-event write path were needed to isolate the D1 identity conflict. The
+hotfix kept the stable tool name while a call was running and delayed canonical
+tool input persistence until the terminal snapshot was authoritative.
+
+## Corrective Actions
+
+- [x] Runtime team — persist canonical ACP tool input only at terminal state —
+      2026-08-13
+- [x] Runtime team — keep terminal display titles out of durable tool identity —
+      2026-08-13
+- [x] Runtime team — add regression coverage for evolving tool arguments and
+      the durable identity constraint — 2026-08-13
+- [x] Runtime team — verify the reported Skill and tool path on isolated,
+      production-shaped staging — 2026-08-13
+
+## Lessons
+
+A streamed snapshot is mutable until the protocol marks it terminal. Durable
+identity checks must use fields that are stable for the whole Tool Call, while
+canonical input belongs to the terminal event. A generic runtime error is not
+enough to distinguish a storage-contract failure from an upstream provider
+failure, so incident analysis must preserve the lower-level cause.

--- a/docs/operations/incidents/2026-08-15-stranded-cattle-account-capacity.md
+++ b/docs/operations/incidents/2026-08-15-stranded-cattle-account-capacity.md
@@ -1,0 +1,85 @@
+# 2026-08-15 — Stranded Cattle Sandboxes Exhausted Account Capacity
+
+- Status: Resolved
+- Severity: SEV-3
+- Window: 2026-08-13 10:57–2026-08-15 10:58 UTC
+- Affected surface: OpenCode (ACP) runtime provisioning for one account
+- Public status update: https://mosoo.ai/status
+- Tracking PRs:
+  [#538](https://github.com/langgenius/mosoo/pull/538) and
+  [#539](https://github.com/langgenius/mosoo/pull/539)
+
+## Summary And Impact
+
+New Runs for one account could not acquire runtime capacity even though earlier
+Cattle conversations were no longer active. Users saw
+`runtime.provision_failed` with "Runtime subject is busy with lifecycle
+maintenance" instead of a started Run.
+
+The observed failure cluster contained 54 user-facing Runs across one account
+and four Agents. Other accounts were not confirmed affected. Successful Runs
+were still possible when capacity was available, so the incident appeared as
+intermittent provisioning failure rather than a platform-wide outage.
+
+## Timeline
+
+- 2026-08-13 10:57 — The first matching user-facing provisioning failure was
+  recorded.
+- 2026-08-15 09:49 — The last matching pre-fix failure was recorded.
+- 10:17 — The lifecycle convergence and historical repair hotfix was committed.
+- 10:22 — [#538](https://github.com/langgenius/mosoo/pull/538) merged.
+- 10:28 — The API hotfix reached production.
+- 10:31 — The deployment workflow reported failure after healthy Workers
+  returned Cloudflare's zone-level HTTP 301 redirect instead of the expected
+  Worker fallback HTTP 308.
+- 10:36 — [#539](https://github.com/langgenius/mosoo/pull/539) aligned final
+  verification with the production redirect and merged.
+- 10:43 — The repeated deployment and final endpoint verification completed.
+- 10:54 — The first post-repair user-facing ACP Run completed.
+- 10:58 — A second consecutive user-facing Run completed; recovery was
+  confirmed. No later matching provisioning failure was recorded through
+  2026-08-17.
+
+## Root Cause
+
+The idle conversation close path treated remote Sandbox session deletion as a
+prerequisite for local lifecycle convergence. When Cloudflare reported that a
+remote session was already absent, the delete call failed and local finalization
+did not arm the Cattle subject's inactive deadline.
+
+Those active subjects had no conversation or Run lease but continued to count
+against the account's concurrent sandbox limit. Admission then rejected new
+subjects with the same generic lifecycle-busy error used for real maintenance
+contention. No maintenance repair existed for already-stranded subjects.
+
+## Detection And Response
+
+Run telemetry exposed repeated `runtime.provision_failed` results, while
+lifecycle logs and database state connected them to remote `session not found`
+cleanup errors and active Cattle subjects without inactive deadlines. The
+hotfix made local close finalization unconditional and added a maintenance
+repair for historical stranded records.
+
+The first release workflow failure was a verification false alarm, not a second
+user outage: the API and Web Workers had deployed, but the final probe expected
+HTTP 308 while Cloudflare redirected plaintext traffic with HTTP 301 before
+either Worker ran.
+
+## Corrective Actions
+
+- [x] Runtime team — converge the local conversation lifecycle even when remote
+      Sandbox deletion fails — 2026-08-15
+- [x] Runtime team — repair active Cattle subjects that have no conversation,
+      Run lease, or inactive deadline — 2026-08-15
+- [x] Runtime team — cover remote `session not found` and stranded-subject
+      repair with regression tests — 2026-08-15
+- [x] Release team — verify Cloudflare's zone-level HTTP 301 while preserving
+      exact HTTPS redirect-target checks — 2026-08-15
+
+## Lessons
+
+Remote cleanup is best-effort; local capacity accounting must still converge in
+a `finally` path. Every lifecycle fix also needs a repair path for records that
+were stranded before the fix. Release verification must model the edge layer
+that answers first, otherwise a healthy deployment can be mistaken for a
+failed recovery.


### PR DESCRIPTION
## What

- Add the 2026-08-13 ACP streamed Tool Call identity-conflict postmortem.
- Add the 2026-08-15 stranded Cattle account-capacity postmortem.
- Record verified impact, recovery windows, root causes, and corrective actions.

## Why

The public status page needs durable recovery reports for the two August hotfix incidents. These reports separate the Tool Call ID failure from the account concurrency-capacity failure and preserve the production evidence behind each recovery claim.

## Impact

Documentation only. No runtime or database behavior changes.

## Verification

- `just docs-check`
- `just fmt-check-path docs/operations/incidents/2026-08-13-acp-tool-call-identity-conflict.md`
- `just fmt-check-path docs/operations/incidents/2026-08-15-stranded-cattle-account-capacity.md`
- Local `prek` file hygiene, commit metadata, and pre-push checks

Full `just check` was not run because this PR adds Markdown-only incident records; the focused documentation and formatting gates cover the changed surface.

## Change inventory

- Generated files: none
- GraphQL codegen: none
- New DB migration files: none
- Lockfile changes: none
