### PR TITLE
fix(deploy): fetch main for public API contract check

### DIFF
--- a/.github/workflows/deploy-try.yml
+++ b/.github/workflows/deploy-try.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           submodules: true
           persist-credentials: false
 

--- a/config/public-api-compatibility.test.ts
+++ b/config/public-api-compatibility.test.ts
@@ -53,6 +53,12 @@ function document(input: {
 }
 
 describe("public API compatibility", () => {
+  test("keeps the production check supplied with main history", async () => {
+    const workflow = await Bun.file(".github/workflows/deploy-try.yml").text();
+
+    expect(workflow).toMatch(/actions\/checkout@[^\n]*\n\s+with:\n\s+fetch-depth: 0\n/);
+  });
+
   test("reports request tightening, field removal, enum narrowing, and response removal", () => {
     const before = document({});
     const after = document({


### PR DESCRIPTION
## Summary

- fetch full Git history in the production workflow so the Public API compatibility gate can resolve `origin/main`
- add a regression test for the workflow checkout contract

## Production impact

The failed deploy run stopped at `just check`; migration, dry-run, deploy, and verification steps never started. This change only repairs the pre-deploy gate and does not change runtime behavior or D1.

## Verification

- `just test-file config/public-api-compatibility.test.ts`
- `TMPDIR=/private/tmp just check`
- `just commit-check`
- repository-managed pre-push hooks