### PR TITLE
docs(readme): add contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ The public landing page and blog live in the private `langgenius/mosoo-website` 
 
 Contributions are welcome. Read [CONTRIBUTING.md](./CONTRIBUTING.md) for the development workflow, commit policy, and verification expectations. Contributions are covered by the [Contributor License Agreement](./CLA.md); CLA Assistant will prompt you on your first pull request.
 
+## Contributors
+
+<a href="https://github.com/langgenius/mosoo/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=langgenius/mosoo" alt="mosoo contributors" />
+</a>
+
 ## License
 
 mosoo is licensed under the [Apache License 2.0](./LICENSE).


### PR DESCRIPTION
## Summary

- add a Contributors section to the README
- render the repository contributor avatars dynamically via contrib.rocks
- link the avatar wall to GitHub’s full contributor graph

## Impact

Contributors are visible from the project README without maintaining a manual list.

## Verification

- `just fmt-check-path README.md`
- `just docs-check`
- `git diff --check`
- `just commit-check`
- `just check` (1089 passed, 42 skipped, 1 unrelated existing macOS path failure in `apps/driver/tests/acp-file-system.test.ts`: `/var` vs `/private/var`; focused rerun reproduced it)

Generated files: none. GraphQL codegen: not applicable. DB migrations: none. Lockfile changes: none.