### PR TITLE
fix(web): let the agent list scroll inside the app shell

### DIFF
--- a/apps/web/src/routes/agent/agent-list.route.tsx
+++ b/apps/web/src/routes/agent/agent-list.route.tsx
@@ -89,7 +89,7 @@ export function AgentListPage() {
   const filteredAgents = filterAgents(agents, search);
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden">
+    <div className="flex h-full flex-col overflow-hidden">
       <PageHeader title={t("agent.title")} description={t("agent.description")}>
         <Button
           disabled={appId === null}

--- a/apps/web/tests/agent-list-scroll-boundary.test.ts
+++ b/apps/web/tests/agent-list-scroll-boundary.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+function readSource(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+describe("Agent list scroll boundaries", () => {
+  test("agent list page fills the shell content box so the list can scroll", () => {
+    const appShellSource = readSource("../src/app/app-shell.tsx");
+    const agentListSource = readSource("../src/routes/agent/agent-list.route.tsx");
+    const listPageSource = readSource("../src/shared/ui/list-page.tsx");
+
+    // The App shell mounts every route inside a block-level, height-bounded box.
+    // A page root only inherits that bound through an explicit height; `flex-1`
+    // alone lets it grow with its rows, so `overflow-hidden` clipped the tail of
+    // the Agents table instead of `ListPageContent` scrolling it.
+    expect(appShellSource).toContain(
+      '<div className="min-h-0 flex-1 overflow-hidden">{children}</div>',
+    );
+    expect(agentListSource).toContain('<div className="flex h-full flex-col overflow-hidden">');
+    expect(agentListSource).not.toContain('<div className="flex flex-1 flex-col overflow-hidden">');
+    expect(listPageSource).toContain("flex min-h-0 flex-1 flex-col overflow-y-auto");
+  });
+});


### PR DESCRIPTION
Fill what changed. Use N/A for irrelevant or maintainer-only items. See `CONTRIBUTING.md` for branch, CLA, generated file, and CI rules.

## Summary

Closes YEF-1045

- Give the Agents list page root an explicit `h-full` (was `flex-1` only) so the page is bounded by the App shell content box and `ListPageContent` becomes the scroll container again — the table (and grid view) now scroll instead of being clipped below the viewport.
- Add `apps/web/tests/agent-list-scroll-boundary.test.ts` pinning the shell wrapper / page root / list content layout contract.

## Why

- Since #353 the App shell mounts every route inside `<div className="min-h-0 flex-1 overflow-hidden">` — a block-level, height-bounded box. Under a block parent `flex-1` is a no-op, so the Agents page root grew with its rows and the wrapper's `overflow-hidden` clipped the tail of the list; nothing on the page was scrollable (no scrollbar, wheel did nothing).
- Every other console page (Threads, Files, Environments, Providers, Settings, deploy surface, …) already uses `h-full` on its root; the Agents list was the one page still relying on being a direct flex child of `<main>`.

## Verification

- Commands: `just check` (fmt, docs links, lint, tc, tests, GraphQL codegen freshness, Public API contract) — everything green except one pre-existing macOS-only failure in the untouched `apps/driver` submodule (`acp-file-system.test.ts` compares `/tmp` vs `/private/tmp`); `just test-package @mosoo/web` (235 pass, incl. the new boundary test), `just tc-package @mosoo/web`, `bun run --filter @mosoo/api test` (1214 pass), `just commit-check`.
- Manual steps: local stack (`wrangler dev` + `vp dev`), backdoor login, 14 agents in an App, 1280×800 headless Chrome. Before: `ListPageContent` client height 858px == scroll height (not scrollable), zero scrollable ancestors, last row bottom at 980px, wheel left `scrollTop = 0`. After: client 645px / scroll 858px, wheel scrolls to the last row (`scrollTop = 213`, last row fully visible); grid view scrolls too (`scrollTop = 360`); 390×780 mobile viewport scrolls under the mobile header. Screenshots attached to the tracking issue.
- Not run: nothing else.

## Impact

- User/API/contract changes: Agents list page (list + grid view) scrolls again when it overflows the viewport; header, search and toolbar stay pinned like other list pages. No API or contract change.
- Generated files / GraphQL / DB / lockfile: none.
- Env or config changes: none.
- Risk and rollback: one class-name change on a single page root; revert the commit to roll back.

## Review

- Closest review areas: `apps/web/src/routes/agent/agent-list.route.tsx` root wrapper vs `apps/web/src/app/app-shell.tsx` `ConsoleShell` content box; `apps/web/src/shared/ui/list-page.tsx` `ListPageContent`.
- Known trade-offs: fixes the page rather than turning the shell wrapper into a flex container — smaller blast radius and consistent with the `h-full` convention every other route root already follows.
