### PR TITLE
perf(contracts): optimize agent config change comparisons

### DIFF
--- a/apps/api/tests/agent-versioned-config-plan.test.ts
+++ b/apps/api/tests/agent-versioned-config-plan.test.ts
@@ -134,6 +134,48 @@ describe("agent versioned config plan", () => {
     );
   });
 
+  test("keeps MCP binding order changes visible", () => {
+    const plan = planVersionedAgentConfigChange({
+      agentStatus: "published",
+      current: createAgentConfigChangeSnapshot({
+        agent,
+        environment,
+        mcpServerIds: ["mcp_linear", "mcp_github"],
+        skillIds: [],
+      }),
+      next: createAgentConfigChangeSnapshot({
+        agent,
+        environment,
+        mcpServerIds: ["mcp_github", "mcp_linear"],
+        skillIds: [],
+      }),
+    });
+
+    expect(plan.action).toBe("patch-and-restart");
+    expect(plan.fieldLabels).toEqual(["MCP Servers"]);
+  });
+
+  test("keeps skill order changes visible", () => {
+    const plan = planVersionedAgentConfigChange({
+      agentStatus: "published",
+      current: createAgentConfigChangeSnapshot({
+        agent,
+        environment,
+        mcpServerIds: [],
+        skillIds: ["skill_browser", "skill_shell"],
+      }),
+      next: createAgentConfigChangeSnapshot({
+        agent,
+        environment,
+        mcpServerIds: [],
+        skillIds: ["skill_shell", "skill_browser"],
+      }),
+    });
+
+    expect(plan.action).toBe("patch-and-restart");
+    expect(plan.fieldLabels).toEqual(["Skills"]);
+  });
+
   test("classifies advanced provider option edits as patch-and-restart", () => {
     const plan = planVersionedAgentConfigChange({
       agentStatus: "published",

--- a/pkgs/contracts/src/agent/agent-config-change-plan.contract.ts
+++ b/pkgs/contracts/src/agent/agent-config-change-plan.contract.ts
@@ -73,6 +73,27 @@ function changed(left: unknown, right: unknown): boolean {
   return stableStringify(left) !== stableStringify(right);
 }
 
+function orderedStringArraysChanged(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) {
+    return true;
+  }
+
+  return left.some((value, index) => value !== right[index]);
+}
+
+function skillsChanged(
+  left: readonly AgentConfigChangeSkill[],
+  right: readonly AgentConfigChangeSkill[],
+): boolean {
+  if (left.length !== right.length) {
+    return true;
+  }
+
+  return left.some(
+    (skill, index) => skill.id !== right[index]?.id || skill.state !== right[index]?.state,
+  );
+}
+
 function pushIfChanged(plans: FieldPlan[], input: FieldPlan & { changed: boolean }): void {
   if (!input.changed) {
     return;
@@ -126,7 +147,7 @@ export function classifyAgentConfigChanges(input: {
   });
   pushIfChanged(fieldPlans, {
     action: "patch-and-restart",
-    changed: changed(input.current.mcpServerIds, input.saved.mcpServerIds),
+    changed: orderedStringArraysChanged(input.current.mcpServerIds, input.saved.mcpServerIds),
     label: "MCP Servers",
     rank: 2,
   });
@@ -156,7 +177,7 @@ export function classifyAgentConfigChanges(input: {
   });
   pushIfChanged(fieldPlans, {
     action: "patch-and-restart",
-    changed: changed(input.current.skills, input.saved.skills),
+    changed: skillsChanged(input.current.skills, input.saved.skills),
     label: "Skills",
     rank: 2,
   });


### PR DESCRIPTION
## Summary

- Optimize agent config change classification by comparing ordered MCP server and skill arrays directly.
- Add regression coverage that order changes remain visible for MCP bindings and skills.

## Why

- The complexity scan flagged repeated nested work in config change classification.
- These arrays have stable ordered string fields, so linear comparison avoids full stable JSON serialization while preserving existing order-sensitive behavior.

## Verification

- Commands:
  - `vp exec bun test apps/api/tests/agent-versioned-config-plan.test.ts`
  - `vp fmt --check pkgs/contracts/src/agent/agent-config-change-plan.contract.ts apps/api/tests/agent-versioned-config-plan.test.ts`
  - `vp run --filter @mosoo/contracts tc`
  - `vp run --filter @mosoo/contracts test`
- Manual steps: N/A
- Not run: Full workspace `vp run -w check`

## Impact

- User/API/contract changes: No public contract shape changes; internal classification remains order-sensitive.
- Generated files / GraphQL / DB / lockfile: N/A
- Env or config changes: N/A
- Risk and rollback: Low; rollback is reverting the single commit.

## Review

- Closest review areas: `pkgs/contracts/src/agent/agent-config-change-plan.contract.ts`, `apps/api/tests/agent-versioned-config-plan.test.ts`
- Known trade-offs: Provider options and built-in tools still use stable serialization because nested object key order must remain normalized.
