### PR TITLE
fix(deploy): switch driver protocol atomically

### DIFF
--- a/apps/api/bin/deploy-prod.ts
+++ b/apps/api/bin/deploy-prod.ts
@@ -194,6 +194,6 @@ writeStdout("▶ Building driver");
 runVp(["run", "--filter", "agent-driver", "build"]);
 
 writeStdout("▶ Deploying worker");
-run(["deploy", "--env", ENV, "--minify"]);
+run(["deploy", "--env", ENV, "--minify", "--containers-rollout", "immediate"]);
 
 writeStdout("✓ deploy complete");

--- a/apps/api/tests/production-deploy-safety.test.ts
+++ b/apps/api/tests/production-deploy-safety.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test";
+
+test("switches the production Worker and Driver image without a gradual protocol split", async () => {
+  const source = await Bun.file(new URL("../bin/deploy-prod.ts", import.meta.url)).text();
+
+  expect(source).toContain(
+    'run(["deploy", "--env", ENV, "--minify", "--containers-rollout", "immediate"]);',
+  );
+});

--- a/docs/production-deploy-verification.md
+++ b/docs/production-deploy-verification.md
@@ -183,7 +183,9 @@ Acceptance:
   latest local Drizzle snapshot, apply pending remote D1 migrations (its first
   remote mutation), verify every expected table exists in prod (the
   DEPLOY-D1-001 missing-table guard), ensure the required artifact and
-  channel-delivery queues, build the Driver, then deploy the API Worker.
+  channel-delivery queues, build the Driver, then deploy the API Worker with an
+  immediate Container rollout so the API and Driver protocol cannot split
+  across a gradual image rollout.
 - The guard does not compare columns, indexes, constraints, or extra live
   tables. The script performs no clean-worktree check and no dry-run of its own;
   Steps 0-7 of this runbook are the only preflight.


### PR DESCRIPTION
## Why

A protocol-changing release exposed Wrangler’s default gradual Container rollout: the V2 Worker accepted traffic while the Container application still served the V1 Driver image (and the reverse during rollback). New sandboxes then exited before ready because API and Driver protocol versions differed.

## Change

- force the production Worker/Container deployment to use `--containers-rollout immediate`
- document the protocol-split invariant in the production runbook
- add a focused regression test for the deploy command

This does not change the public `/api/v1` contract or runtime behavior. Production rollout still requires zero active Runs/Drivers before deployment.

## Verification

- `bun test apps/api/tests/production-deploy-safety.test.ts`
- `bun run --cwd apps/driver build`
- `bun run --filter @mosoo/api tc`
- `git diff --check`

## Production evidence

The first V2 rollout used the default gradual strategy and was rolled back before customer validation. Production is restored to V1 and a V1 smoke Run completed. The same V2 build passed the 京维为 staging replay, including a full GHFind task, three artifacts, and `artifacts valid`.