### PR TITLE
fix(sessions): exclude idle gaps from process durations

### DIFF
--- a/apps/api/src/modules/sessions/application/session-process-events.service.ts
+++ b/apps/api/src/modules/sessions/application/session-process-events.service.ts
@@ -29,11 +29,14 @@ export interface SessionEventProcessRow {
 
 const DEFAULT_PROCESS_EVENT_LIMIT = 500;
 const MAX_PROCESS_EVENT_LIMIT = 1000;
+// Longer gaps may be permission or user waits, not continuous execution.
+const MAX_INFERRED_PROCESS_EVENT_DURATION_MS = 5 * 60 * 1000;
 
 interface ProcessEventProjection {
   event: SessionProcessEvent;
   endMs: number;
   order: number;
+  runId: SessionRunId | null;
   startMs: number;
 }
 
@@ -63,12 +66,18 @@ function finalizeProcessEventDurations(
 
   return sortedProjections.map((projection, index) => {
     const next = sortedProjections[index + 1] ?? null;
+    const inferredDurationMs = next === null ? 0 : next.startMs - projection.startMs;
+    const canInferDuration =
+      projection.runId !== null &&
+      next?.runId === projection.runId &&
+      inferredDurationMs >= 0 &&
+      inferredDurationMs <= MAX_INFERRED_PROCESS_EVENT_DURATION_MS;
     const durationMs =
       projection.endMs > projection.startMs
         ? projection.endMs - projection.startMs
-        : next === null
-          ? 0
-          : Math.max(0, next.startMs - projection.startMs);
+        : canInferDuration
+          ? inferredDurationMs
+          : 0;
 
     return {
       content: projection.event.content,
@@ -97,6 +106,7 @@ function toProcessEventProjectionFromSessionEventRow(
       type: row.process_type,
     },
     order: row.seq,
+    runId: row.run_id,
     startMs: row.occurred_at,
   };
 }

--- a/apps/api/tests/session-process-events.test.ts
+++ b/apps/api/tests/session-process-events.test.ts
@@ -284,6 +284,139 @@ describe("session process event projection", () => {
     expect(events.map((event) => event.type)).toEqual(["run.started"]);
   });
 
+  test("keeps valid explicit durations authoritative", async () => {
+    const database = createProcessEventQueryDatabase();
+    await insertSessionProcessEvent(database, {
+      endedAt: 901_000,
+      id: "event-1",
+      occurredAt: 1_000,
+      runId: "run-1",
+      seq: 1,
+    });
+    await insertSessionProcessEvent(database, {
+      id: "event-2",
+      occurredAt: 2_000,
+      runId: "run-2",
+      seq: 2,
+    });
+
+    const events = await getThreadSessionProcessEvents(database, VIEWER, {
+      appId: APP_ID,
+      sessionId: SESSION_ID,
+    });
+
+    expect(events[0]?.durationMs).toBe(900_000);
+  });
+
+  test("infers adjacent event durations within the same run", async () => {
+    const database = createProcessEventQueryDatabase();
+    await insertSessionProcessEvent(database, {
+      id: "event-1",
+      occurredAt: 1_000,
+      runId: "run-1",
+      seq: 1,
+    });
+    await insertSessionProcessEvent(database, {
+      id: "event-2",
+      occurredAt: 2_500,
+      runId: "run-1",
+      seq: 2,
+    });
+
+    const events = await getThreadSessionProcessEvents(database, VIEWER, {
+      appId: APP_ID,
+      sessionId: SESSION_ID,
+    });
+
+    expect(events.map((event) => event.durationMs)).toEqual([1_500, 0]);
+  });
+
+  test("does not infer durations without an identified shared run", async () => {
+    const database = createProcessEventQueryDatabase();
+    await insertSessionProcessEvent(database, {
+      id: "event-1",
+      occurredAt: 1_000,
+      runId: null,
+      seq: 1,
+    });
+    await insertSessionProcessEvent(database, {
+      id: "event-2",
+      occurredAt: 2_000,
+      runId: "run-1",
+      seq: 2,
+    });
+
+    const events = await getThreadSessionProcessEvents(database, VIEWER, {
+      appId: APP_ID,
+      sessionId: SESSION_ID,
+    });
+
+    expect(events.map((event) => event.durationMs)).toEqual([0, 0]);
+  });
+
+  test("does not infer same-run durations across waits longer than five minutes", async () => {
+    const database = createProcessEventQueryDatabase();
+    await insertSessionProcessEvent(database, {
+      id: "event-1",
+      occurredAt: 1_000,
+      runId: "run-1",
+      seq: 1,
+    });
+    await insertSessionProcessEvent(database, {
+      id: "event-2",
+      occurredAt: 301_001,
+      runId: "run-1",
+      seq: 2,
+    });
+
+    const events = await getThreadSessionProcessEvents(database, VIEWER, {
+      appId: APP_ID,
+      sessionId: SESSION_ID,
+    });
+
+    expect(events.map((event) => event.durationMs)).toEqual([0, 0]);
+  });
+
+  test("excludes a twelve-day idle gap between runs from total duration", async () => {
+    const database = createProcessEventQueryDatabase();
+    const runBStartMs = 12 * 24 * 60 * 60 * 1000;
+    await insertSessionProcessEvent(database, {
+      endedAt: 1_000,
+      id: "run-a-started",
+      occurredAt: 0,
+      runId: "run-a",
+      seq: 1,
+    });
+    await insertSessionProcessEvent(database, {
+      id: "run-a-files-updated",
+      occurredAt: 2_000,
+      processType: "session.files.updated",
+      runId: "run-a",
+      seq: 2,
+    });
+    await insertSessionProcessEvent(database, {
+      id: "run-b-started",
+      occurredAt: runBStartMs,
+      runId: "run-b",
+      seq: 3,
+    });
+    await insertSessionProcessEvent(database, {
+      id: "run-b-completed",
+      occurredAt: runBStartMs + 2_000,
+      processType: "run.completed",
+      runId: "run-b",
+      seq: 4,
+    });
+
+    const events = await getThreadSessionProcessEvents(database, VIEWER, {
+      appId: APP_ID,
+      sessionId: SESSION_ID,
+    });
+
+    expect(events.map((event) => event.durationMs)).toEqual([1_000, 0, 2_000, 0]);
+    expect(events.reduce((total, event) => total + (event.durationMs ?? 0), 0)).toBe(3_000);
+  });
+
   test("folds persisted assistant message fragments into one process event", async () => {
     const database = createProcessEventQueryDatabase();
     await insertSessionProcessEvent(database, {


### PR DESCRIPTION
## Summary

- restrict missing-duration inference to adjacent events with the same non-null Run ID
- cap inferred same-Run continuity at five minutes while preserving valid explicit end timestamps
- cover the 12-day cross-Run idle-gap regression and duration boundary rules

## Why

Session process timelines treated the calendar gap before the next Run as active execution time, inflating event durations, timeline offsets, and total duration.

Closes YEF-1055

## Verification

- Commands: `just test-file apps/api/tests/session-process-events.test.ts`; `just tc-package @mosoo/api`; `just check`; `just commit-check`
- Manual steps: N/A
- Not run: Browser acceptance; the Web timeline already derives totals, segments, and offsets from the corrected API `durationMs` projection.

## Impact

- User/API/contract changes: Process-event durations no longer absorb cross-Run gaps or same-Run waits longer than five minutes.
- Generated files / GraphQL / DB / lockfile: None.
- Env or config changes: None.
- Risk and rollback: Low; revert commit `5d45e028` to restore the previous projection behavior.

## Review

- Closest review areas: `session-process-events.service.ts` inference boundary and regression fixtures.
- Known trade-offs: Missing explicit durations separated by more than five minutes report zero, even if the underlying operation was continuously active.
