### PR TITLE
perf(agent-package): index archive entries by skill path

### DIFF
--- a/pkgs/agent-package/src/archive-assets.ts
+++ b/pkgs/agent-package/src/archive-assets.ts
@@ -12,6 +12,12 @@ interface PackageAssetReadResult {
   issues: AgentResolutionIssue[];
 }
 
+type ArchiveEntry = [path: string, contentBytes: Uint8Array];
+
+function toSkillPath(skillId: string): string {
+  return skillId.endsWith("/") ? skillId : `${skillId}/`;
+}
+
 export function readPackageAssets(
   agentPackage: AgentPackage,
   entries: Record<string, Uint8Array>,
@@ -30,11 +36,11 @@ function readSkillAssets(
   assets: AgentPackageAsset[],
   issues: AgentResolutionIssue[],
 ): void {
+  const skillEntriesByPath = indexSkillEntries(agentPackage, entries);
+
   for (const skill of agentPackage.manifest.skills) {
-    const skillPath = skill.skillId.endsWith("/") ? skill.skillId : `${skill.skillId}/`;
-    const skillEntries = Object.entries(entries).filter(
-      ([path, entry]) => path.startsWith(skillPath) && entry.byteLength > 0,
-    );
+    const skillPath = toSkillPath(skill.skillId);
+    const skillEntries = skillEntriesByPath.get(skillPath) ?? [];
 
     if (skillEntries.length === 0) {
       issues.push(
@@ -74,4 +80,41 @@ function readSkillAssets(
       });
     }
   }
+}
+
+function indexSkillEntries(
+  agentPackage: AgentPackage,
+  entries: Record<string, Uint8Array>,
+): ReadonlyMap<string, readonly ArchiveEntry[]> {
+  const entriesBySkillPath = new Map<string, ArchiveEntry[]>();
+
+  for (const skill of agentPackage.manifest.skills) {
+    entriesBySkillPath.set(toSkillPath(skill.skillId), []);
+  }
+
+  if (entriesBySkillPath.size === 0) {
+    return entriesBySkillPath;
+  }
+
+  for (const entry of Object.entries(entries)) {
+    const [path, contentBytes] = entry;
+
+    if (contentBytes.byteLength === 0) {
+      continue;
+    }
+
+    let slashIndex = path.indexOf("/");
+
+    while (slashIndex !== -1) {
+      const matchingEntries = entriesBySkillPath.get(path.slice(0, slashIndex + 1));
+
+      if (matchingEntries !== undefined) {
+        matchingEntries.push(entry);
+      }
+
+      slashIndex = path.indexOf("/", slashIndex + 1);
+    }
+  }
+
+  return entriesBySkillPath;
 }

--- a/pkgs/agent-package/tests/archive-entry-admission.test.ts
+++ b/pkgs/agent-package/tests/archive-entry-admission.test.ts
@@ -236,6 +236,43 @@ describe("agent package archive entry admission", () => {
     ]);
   });
 
+  test("preserves archive order when declared skill roots overlap", () => {
+    const parsed = parseAgentPackageArchiveBytes(
+      createStoredZipArchive([
+        {
+          body: textToArchiveBytes(
+            createPackageManifestJson({
+              skills: [
+                { name: "Nested", path: "skills/demo/nested/" },
+                { name: "Demo", path: "skills/demo/" },
+              ],
+            }),
+          ),
+          path: "manifest.json",
+        },
+        {
+          body: textToArchiveBytes('{"secretNames":[],"setupScript":""}'),
+          path: "environment/definition.json",
+        },
+        {
+          body: textToArchiveBytes("nested"),
+          path: "skills/demo/nested/file.txt",
+        },
+        {
+          body: textToArchiveBytes("root"),
+          path: "skills/demo/root.txt",
+        },
+      ]),
+    );
+
+    expect(parsed.package).not.toBeNull();
+    expect(parsed.package?.assets.map((asset) => [asset.key, asset.filename])).toEqual([
+      ["skills/demo/nested/file.txt", "file.txt"],
+      ["skills/demo/nested/file.txt", "nested/file.txt"],
+      ["skills/demo/root.txt", "root.txt"],
+    ]);
+  });
+
   test("rejects package assets that point at a declared skill root", () => {
     const parsed = parseAgentPackageArchiveBytes(
       createStoredZipArchive([


### PR DESCRIPTION
## Summary

- Index non-empty package archive entries by declared skill path in one pass.
- Preserve manifest order, archive-entry order, missing-skill behavior, and overlapping skill-root projection.

## Why

- Package import previously filtered every archive entry once per declared skill, for O(skills × entries) matching work.
- The new prefix index reduces matching to O(skills + entries × path depth + matched assets).
- A synthetic 300-skill, 6,000-entry archive improved from 41.83 ms to 0.86 ms per import (about 49×) on the same runner.

Closes YEF-1078

## Verification

- Commands:
  - `just test-file pkgs/agent-package/tests/archive-entry-admission.test.ts`
  - `just test-package @mosoo/agent-package`
  - `just tc-package @mosoo/agent-package`
  - `bun run --filter @mosoo/agent-package lint`
  - `just fmt-check-path pkgs/agent-package/src/archive-assets.ts`
  - `just fmt-check-path pkgs/agent-package/tests/archive-entry-admission.test.ts`
  - `just commit-check`
  - `just check` (format, docs, lint, and typecheck passed; test phase stopped on 11 unmodified Driver process-watchdog/PID timing failures on macOS)
- Manual steps: N/A
- Not run: N/A

## Impact

- User/API/contract changes: None; package import output and issue behavior are preserved.
- Generated files / GraphQL / DB / lockfile: None.
- Env or config changes: None.
- Risk and rollback: Low; rollback by reverting the single commit.

## Review

- Closest review areas: archive path-prefix matching and overlapping declared skill roots.
- Known trade-offs: The index adds memory proportional to declared skill paths and matched assets, while avoiding repeated full archive scans.
