### PR TITLE
perf(agent-package): index archive skill assets

### DIFF
--- a/pkgs/agent-package/src/archive-assets.ts
+++ b/pkgs/agent-package/src/archive-assets.ts
@@ -12,6 +12,12 @@ interface PackageAssetReadResult {
   issues: AgentResolutionIssue[];
 }
 
+interface SkillAssetBucket {
+  entries: Array<[path: string, contentBytes: Uint8Array]>;
+  skill: AgentPackage["manifest"]["skills"][number];
+  skillPath: string;
+}
+
 export function readPackageAssets(
   agentPackage: AgentPackage,
   entries: Record<string, Uint8Array>,
@@ -30,12 +36,10 @@ function readSkillAssets(
   assets: AgentPackageAsset[],
   issues: AgentResolutionIssue[],
 ): void {
-  for (const skill of agentPackage.manifest.skills) {
-    const skillPath = skill.skillId.endsWith("/") ? skill.skillId : `${skill.skillId}/`;
-    const skillEntries = Object.entries(entries).filter(
-      ([path, entry]) => path.startsWith(skillPath) && entry.byteLength > 0,
-    );
-
+  for (const { entries: skillEntries, skill, skillPath } of collectSkillAssetBuckets(
+    agentPackage,
+    entries,
+  )) {
     if (skillEntries.length === 0) {
       issues.push(
         createArchiveIssue({
@@ -74,4 +78,68 @@ function readSkillAssets(
       });
     }
   }
+}
+
+function collectSkillAssetBuckets(
+  agentPackage: AgentPackage,
+  entries: Record<string, Uint8Array>,
+): SkillAssetBucket[] {
+  const buckets: SkillAssetBucket[] = agentPackage.manifest.skills.map((skill) => ({
+    entries: [],
+    skill,
+    skillPath: skill.skillId.endsWith("/") ? skill.skillId : `${skill.skillId}/`,
+  }));
+
+  if (buckets.length === 0) {
+    return buckets;
+  }
+
+  const archiveEntries = Object.entries(entries);
+
+  if (buckets.length === 1) {
+    const [bucket] = buckets;
+
+    if (bucket !== undefined) {
+      bucket.entries = archiveEntries.filter(
+        ([path, contentBytes]) => contentBytes.byteLength > 0 && path.startsWith(bucket.skillPath),
+      );
+    }
+
+    return buckets;
+  }
+
+  const entriesBySkillPath = new Map<string, SkillAssetBucket["entries"]>();
+
+  for (const bucket of buckets) {
+    if (!entriesBySkillPath.has(bucket.skillPath)) {
+      entriesBySkillPath.set(bucket.skillPath, []);
+    }
+  }
+
+  for (const [path, contentBytes] of archiveEntries) {
+    if (contentBytes.byteLength === 0) {
+      continue;
+    }
+
+    // Probe directory prefixes once per entry so overlapping and duplicate
+    // skill declarations keep their existing matching behavior.
+    let slashIndex = path.indexOf("/");
+
+    while (slashIndex !== -1) {
+      const candidateRoot = path.slice(0, slashIndex + 1);
+      const matchingEntries = entriesBySkillPath.get(candidateRoot);
+
+      if (matchingEntries !== undefined) {
+        matchingEntries.push([path, contentBytes]);
+      }
+
+      slashIndex = path.indexOf("/", slashIndex + 1);
+    }
+  }
+
+  for (const bucket of buckets) {
+    bucket.entries = entriesBySkillPath.get(bucket.skillPath) ?? [];
+  }
+
+  return buckets;
 }

--- a/pkgs/agent-package/tests/archive-entry-admission.test.ts
+++ b/pkgs/agent-package/tests/archive-entry-admission.test.ts
@@ -7,6 +7,8 @@ import {
 import type { AgentPackage } from "@mosoo/contracts/agent-manifest";
 import { AGENT_MANIFEST_VERSION, AGENT_PACKAGE_VERSION } from "@mosoo/contracts/agent-manifest";
 
+import { readPackageAssets } from "../src/archive-assets";
+
 interface StoredZipEntry {
   body: Uint8Array;
   path: string;
@@ -233,6 +235,56 @@ describe("agent package archive entry admission", () => {
       "skills/demo/SKILL.md",
       "skills/demo/scripts/run.ts",
       "skills/other/SKILL.md",
+    ]);
+  });
+
+  test("indexes skill assets without changing declaration or entry order", () => {
+    const agentPackage = createAgentPackageFixture({
+      skills: [
+        {
+          ownerName: null,
+          skillId: "skills/demo/nested/",
+          skillName: "Nested",
+          state: "active",
+        },
+        {
+          ownerName: null,
+          skillId: "skills/demo/",
+          skillName: "Demo",
+          state: "active",
+        },
+        {
+          ownerName: null,
+          skillId: "skills/demo/",
+          skillName: "Demo duplicate",
+          state: "active",
+        },
+        {
+          ownerName: null,
+          skillId: "skills/empty/",
+          skillName: "Empty",
+          state: "active",
+        },
+      ],
+    });
+    const result = readPackageAssets(agentPackage, {
+      "skills/demo/nested/child.txt": textToArchiveBytes("child"),
+      "skills/demo/root.txt": textToArchiveBytes("root"),
+      "skills/empty/zero.txt": new Uint8Array(),
+    });
+
+    expect(result.assets.map((asset) => ({ filename: asset.filename, key: asset.key }))).toEqual([
+      { filename: "child.txt", key: "skills/demo/nested/child.txt" },
+      { filename: "nested/child.txt", key: "skills/demo/nested/child.txt" },
+      { filename: "root.txt", key: "skills/demo/root.txt" },
+      { filename: "nested/child.txt", key: "skills/demo/nested/child.txt" },
+      { filename: "root.txt", key: "skills/demo/root.txt" },
+    ]);
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: "package.skill.missing",
+        targetLabel: "Empty",
+      }),
     ]);
   });
 


### PR DESCRIPTION
## Summary

- replace per-skill archive rescans with one prefix index for multi-skill Agent Packages
- preserve the direct single-skill path and existing asset/declaration ordering
- cover nested roots, duplicate declarations, empty files, and missing skills

## Why

- Agent Package asset discovery previously performed O(skills × archive entries) matching
- the indexed path reduces that to O(skills + archive path segments + matched assets)
- a 256-skill / 512-entry benchmark improved from 3.275 ms to 0.077 ms median (about 43×)

Closes YEF-1084

## Verification

- Commands:
  - `just test-package @mosoo/agent-package` — 11 passed
  - `just tc-package @mosoo/agent-package` — passed
  - `just commit-check` — passed
  - `just check` — formatting, docs, lint, and all type-checks passed; the test phase reached 1,222 passes but failed 11 unchanged `apps/driver` process-watchdog tests due PID-file/time-out behavior in this host
- Manual steps: synthetic Bun benchmark at the Agent Package 512-entry boundary
- Not run: browser and live-provider E2E flows; this change is isolated to pure archive asset matching

## Impact

- User/API/contract changes: none
- Generated files / GraphQL / DB / lockfile: none
- Env or config changes: none
- Risk and rollback: low; revert this commit to restore the prior scan, with no data migration required

## Review

- Closest review areas: skill-root prefix matching and asset ordering in `pkgs/agent-package`
- Known trade-offs: multi-skill imports retain a transient index proportional to declared roots and matched assets
