### PR TITLE
chore(deployment): freeze App Deployment creation

### DIFF
--- a/apps/api/src/modules/apps/graphql/app-graphql.ts
+++ b/apps/api/src/modules/apps/graphql/app-graphql.ts
@@ -1,3 +1,4 @@
+import type { DeployAppInput } from "@mosoo/contracts/app";
 import { parsePlatformId } from "@mosoo/id";
 import type { OrganizationId, AppId } from "@mosoo/id";
 
@@ -5,7 +6,6 @@ import type { GraphQLModule } from "../../../adapters/graphql/graphql-module";
 import { appGraphQLSpec } from "../../../adapters/graphql/graphql-module-specs";
 import {
   deleteAppDeployment,
-  deployApp,
   getAppDeploymentStatus,
   listAppDeploymentRuns,
 } from "../application/app-deployment.service";
@@ -42,7 +42,7 @@ interface CreateAppArgs {
 }
 
 interface DeployAppArgs {
-  input: Parameters<typeof deployApp>[2];
+  input: DeployAppInput;
 }
 
 interface DeleteAppDeploymentArgs {
@@ -64,8 +64,9 @@ export const appGraphQLModule = {
       createApp(context.bindings, context.viewer, args.input),
     deleteAppDeployment: async (_parent, args: DeleteAppDeploymentArgs, context) =>
       deleteAppDeployment(context.bindings, context.viewer, args.input),
-    deployApp: async (_parent, args: DeployAppArgs, context) =>
-      deployApp(context.bindings, context.viewer, args.input),
+    deployApp: async (_parent, _args: DeployAppArgs, _context) => {
+      throw new Error("App deployment creation is frozen for product retirement.");
+    },
     renameApp: async (_parent, args: RenameAppArgs, context) =>
       renameApp(context.bindings.DB, context.viewer, args.input),
   },


### PR DESCRIPTION
## Summary

- freeze the `deployApp` mutation before the App Deployment retirement cleanup
- keep status, inventory, delete compensation, and command processing live while production resources drain
- this is the required first rollout for #580; the final removal PR will delete this temporary resolver together with the entire feature

## Why two phases

Existing cleanup must remain executable until all tenant deployments, deployment sandboxes, external Workers/routes/domains, and deployment command claims are settled. Removing the processor first would strand those resources.

## Verification

- `just graphql-codegen`
- `just tc-package @mosoo/api`
- `just test-file apps/api/tests/graphql-module-coverage.test.ts`
- `git diff --check`