### PR TITLE
fix(runtime): preserve custom model identity in OpenCode config

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-vendor-proxy-env.builder.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-vendor-proxy-env.builder.ts
@@ -31,7 +31,7 @@ export interface VendorProxyEnvironmentInput {
 
 interface OpenCodeProviderConfigInput {
   credential: DriverVendorCredentialProfile;
-  model: string;
+  modelId: string;
   proxyUrl: string;
   vendor: RuntimeCatalogVendor;
 }
@@ -51,6 +51,11 @@ function getRuntimeLlmProxyUrl(requestUrl: string, credentialId: VendorCredentia
 }
 
 function resolveVendorModelId(vendorId: string, model: string): string {
+  // Custom endpoint model IDs are opaque, including any provider-like prefix.
+  if (vendorId === "openai-compatible") {
+    return model;
+  }
+
   const vendorPrefix = `${vendorId}/`;
   return model.startsWith(vendorPrefix) ? model.slice(vendorPrefix.length) : model;
 }
@@ -163,7 +168,7 @@ export async function buildVendorProxyEnvVars(
   if (input.profile.runtimeId === "acp-fallback") {
     envVars[OPENCODE_CONFIG_CONTENT_ENV] = buildOpenCodeConfig({
       credential,
-      model: input.profile.model,
+      modelId: modelBinding.modelId,
       proxyUrl,
       vendor,
     });
@@ -174,7 +179,8 @@ export async function buildVendorProxyEnvVars(
 
 function buildOpenCodeConfig(input: OpenCodeProviderConfigInput): string {
   const openCodeProviderId = resolveOpenCodeProviderId(input.vendor);
-  const model = resolveOpenCodeModelId(input.vendor, input.model);
+  // OpenCode owns the first segment; the remaining model ID must match the grant.
+  const model = `${openCodeProviderId}/${input.modelId}`;
   const providerConfig = buildOpenCodeProviderConfig(input);
 
   return JSON.stringify({
@@ -190,32 +196,6 @@ function buildOpenCodeConfig(input: OpenCodeProviderConfigInput): string {
 
 function resolveOpenCodeProviderId(vendor: RuntimeCatalogVendor): string {
   return vendor.openCodeProvider?.providerId ?? vendor.vendorId;
-}
-
-function resolveOpenCodeModelId(vendor: RuntimeCatalogVendor, model: string): string {
-  const openCodeProviderId = resolveOpenCodeProviderId(vendor);
-
-  if (!model.includes("/")) {
-    return `${openCodeProviderId}/${model}`;
-  }
-
-  const vendorPrefix = `${vendor.vendorId}/`;
-
-  if (openCodeProviderId !== vendor.vendorId && model.startsWith(vendorPrefix)) {
-    return `${openCodeProviderId}/${model.slice(vendorPrefix.length)}`;
-  }
-
-  return model;
-}
-
-function resolveOpenCodeProviderModelId(vendor: RuntimeCatalogVendor, model: string): string {
-  const openCodeProviderId = resolveOpenCodeProviderId(vendor);
-  const openCodeModel = resolveOpenCodeModelId(vendor, model);
-  const providerPrefix = `${openCodeProviderId}/`;
-
-  return openCodeModel.startsWith(providerPrefix)
-    ? openCodeModel.slice(providerPrefix.length)
-    : openCodeModel;
 }
 
 function resolveOpenCodeProxyBaseUrl(vendor: RuntimeCatalogVendor, proxyUrl: string): string {
@@ -238,7 +218,7 @@ function buildOpenCodeProviderConfig(input: OpenCodeProviderConfigInput): OpenCo
   // OpenCode removes configured providers that have no models. An unrestricted
   // Mosoo credential still needs the active model rendered for ACP startup.
   const declaredModelIds = new Set(input.credential.models ?? []);
-  declaredModelIds.add(resolveOpenCodeProviderModelId(input.vendor, input.model));
+  declaredModelIds.add(input.modelId);
   const models = Object.fromEntries(
     [...declaredModelIds].map((modelId) => [modelId, { name: modelId }]),
   );

--- a/apps/api/tests/driver-llm-proxy-route.test.ts
+++ b/apps/api/tests/driver-llm-proxy-route.test.ts
@@ -10,6 +10,7 @@ import { registerDriverRoute } from "../src/adapters/http/routes/driver-route";
 import { getRuntimeDriverLlmProxyPath } from "../src/modules/runtime/domain/runtime-driver-routes";
 import { createRuntimeActionToken } from "../src/modules/runtime/infrastructure/runtime-boot-token";
 import type { RuntimeActionTokenPayload } from "../src/modules/runtime/infrastructure/runtime-boot-token";
+import { buildVendorProxyEnvVars } from "../src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-vendor-proxy-env.builder";
 import { storeVendorCredentialSecret } from "../src/modules/vendor-credentials/application/vendor-credential.secret-resolution";
 import type { ApiBindings, ApiGatewayEnvironment } from "../src/platform/cloudflare/worker-types";
 import {
@@ -234,6 +235,54 @@ async function dispatch(bindings: ApiBindings, request: Request): Promise<Respon
 }
 
 describe("driver LLM proxy route", () => {
+  test("admits the provisioned custom model while rejecting a different model or protocol", async () => {
+    const apiBase = "https://gateway.example.com/v1";
+    const modelId = "deepseek/deepseek-v4-flash";
+    const { bindings } = await setupFixture({ apiBase, vendorId: "openai-compatible" });
+    const envVars = await buildVendorProxyEnvVars({
+      bindings,
+      driverGeneration: 0,
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      profile: {
+        model: modelId,
+        runtimeId: "acp-fallback",
+        vendorCredential: {
+          apiBase,
+          credentialId: CREDENTIAL_ID,
+          models: null,
+          projectId: PROJECT_ID,
+          vendorId: "openai-compatible",
+        },
+      },
+      requestUrl: "https://api.example.com",
+    });
+    const captured = captureUpstreamFetch();
+
+    for (const [path, model, status] of [
+      ["/chat/completions", modelId, 200],
+      ["/chat/completions", "deepseek-v4-flash", 403],
+      ["/responses", modelId, 403],
+    ] as const) {
+      const response = await dispatch(
+        bindings,
+        llmProxyRequest(path, {
+          body: JSON.stringify({ model }),
+          headers: {
+            Authorization: `Bearer ${envVars["OPENAI_COMPATIBLE_API_KEY"]}`,
+            "Content-Type": "application/json",
+          },
+          method: "POST",
+        }),
+      );
+      expect(response.status).toBe(status);
+    }
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.url).toBe(`${apiBase}/chat/completions`);
+    expect(captured[0]?.body).toBe(JSON.stringify({ model: modelId }));
+    expect(captured[0]?.headers.get("authorization")).toBe(`Bearer ${UPSTREAM_API_KEY}`);
+  });
+
   test("forwards api-key style requests with the vault credential injected", async () => {
     const { bindings } = await setupFixture();
     const captured = captureUpstreamFetch();

--- a/apps/api/tests/runtime-vendor-env-vars.test.ts
+++ b/apps/api/tests/runtime-vendor-env-vars.test.ts
@@ -554,6 +554,44 @@ describe("runtime vendor proxy env vars", () => {
     });
   });
 
+  test.each([
+    "deepseek-v4-flash",
+    "deepseek/deepseek-v4-flash",
+    "team/deepseek/deepseek-v4-flash",
+    "openai-compatible/deepseek-v4-flash",
+  ])("preserves custom model %s in both OpenCode and its proxy grant", async (modelId) => {
+    const envVars = await buildVendorProxyEnvVars({
+      bindings: BINDINGS,
+      driverGeneration: DRIVER_GENERATION,
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      profile: {
+        model: modelId,
+        runtimeId: "acp-fallback",
+        vendorCredential: vendorCredential({
+          apiBase: "https://gateway.example.com/v1",
+          models: ["gpt-5", modelId],
+          vendorId: "openai-compatible",
+        }),
+      },
+      requestUrl: REQUEST_URL,
+    });
+
+    expect(parseOpenCodeConfig(envVars)).toMatchObject({
+      enabled_providers: ["openai-compatible"],
+      model: `openai-compatible/${modelId}`,
+      small_model: `openai-compatible/${modelId}`,
+      provider: {
+        "openai-compatible": {
+          models: { [modelId]: { name: modelId } },
+        },
+      },
+    });
+    await expectLlmProxyGrant(envVars["OPENAI_COMPATIBLE_API_KEY"], {
+      modelId,
+      modelProtocol: "openai-chat-completions",
+    });
+  });
+
   test("declares the selected custom OpenCode model for an unrestricted credential", async () => {
     const envVars = await buildVendorProxyEnvVars({
       bindings: BINDINGS,


### PR DESCRIPTION
## Summary

- Preserve custom endpoint model IDs, including slashes, and use the same resolved model ID for the LLM proxy grant and OpenCode configuration.
- Render OpenCode's provider prefix only at the adapter boundary; remove the duplicate model parsing helpers.

## Why

Selecting `deepseek/deepseek-v4-flash` through an `openai-compatible` credential previously produced an OpenCode selection of `deepseek/deepseek-v4-flash`, although only `openai-compatible` was enabled. OpenCode can then fall back to another declared model and receive a 403 because its request differs from the model authorized by the proxy.

The selection is now `openai-compatible/deepseek/deepseek-v4-flash`, while both the upstream model ID and grant retain `deepseek/deepseek-v4-flash`. Existing preset vendor-prefix normalization remains supported.

## Verification

- `just test-file apps/api/tests/runtime-vendor-env-vars.test.ts`: 33 passed; slash-containing regression cases failed before the fix and passed afterward.
- `just test-file apps/api/tests/driver-llm-proxy-route.test.ts`: 34 passed, including admission of the provisioned model and rejection of altered models/protocols.
- `just tc-package @mosoo/api`, `just lint`, changed-file formatting checks, and `git diff --check`: passed.
- Manual: ran the pinned OpenCode 1.18.4 ACP process against a local controlled Chat Completions endpoint, with both `gpt-5` and `deepseek/deepseek-v4-flash` declared. The old selection requested GPT and received a model-capability 403. The fixed selection requested DeepSeek throughout, executed a real bash tool writing `pi-byok-ok` to a temporary file, and completed the turn.
- Full gate: `just check` was attempted on macOS; existing driver process-supervision tests require Linux `/usr/bin/setsid` and fail locally. See Linux CI for the complete gate.
- Not run: production Sandbox / live upstream acceptance. The local reproduction proves this failure mechanism, but the original production request body was unavailable.

## Impact

- User/API/contract changes: custom model IDs remain intact, avoiding unintended model fallback and proxy denial. No public schema or UI changes.
- Generated files / GraphQL / DB / lockfile: none.
- Env or config changes: corrected generated OpenCode model selection; no new environment variables or secrets. No Pi dependency or runtime migration.
- Risk and rollback: custom model IDs beginning with `openai-compatible/` are now treated literally. Revert this commit to restore prior behavior. Deployment verification should use a new session/driver so it receives the new configuration and grant; existing generated session configuration is not rewritten.

## Review

- Closest review areas: OpenCode provider selection, opaque custom model IDs, and exact model/protocol proxy authorization.
- Known trade-offs: retains the existing protocol selection and preset compatibility rules; this is a focused model-identity fix.
