### PR TITLE
fix(runtime): preserve namespaced OpenCode model routing

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-vendor-proxy-env.builder.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-vendor-proxy-env.builder.ts
@@ -195,8 +195,8 @@ function resolveOpenCodeProviderId(vendor: RuntimeCatalogVendor): string {
 function resolveOpenCodeModelId(vendor: RuntimeCatalogVendor, model: string): string {
   const openCodeProviderId = resolveOpenCodeProviderId(vendor);
 
-  if (!model.includes("/")) {
-    return `${openCodeProviderId}/${model}`;
+  if (model.startsWith(`${openCodeProviderId}/`)) {
+    return model;
   }
 
   const vendorPrefix = `${vendor.vendorId}/`;
@@ -205,7 +205,10 @@ function resolveOpenCodeModelId(vendor: RuntimeCatalogVendor, model: string): st
     return `${openCodeProviderId}/${model.slice(vendorPrefix.length)}`;
   }
 
-  return model;
+  // A slash can belong to the upstream model ID (for example an OpenRouter
+  // model), rather than naming the OpenCode provider. Keep it on the provider
+  // whose credential and proxy grant were selected for this Run.
+  return `${openCodeProviderId}/${model}`;
 }
 
 function resolveOpenCodeProviderModelId(vendor: RuntimeCatalogVendor, model: string): string {

--- a/apps/api/tests/runtime-vendor-env-vars.test.ts
+++ b/apps/api/tests/runtime-vendor-env-vars.test.ts
@@ -554,6 +554,43 @@ describe("runtime vendor proxy env vars", () => {
     });
   });
 
+  test.each(["deepseek/deepseek-v4-flash", "openai-compatible/deepseek/deepseek-v4-flash"])(
+    "keeps namespaced custom model %s on its credential provider",
+    async (model) => {
+      const envVars = await buildVendorProxyEnvVars({
+        bindings: BINDINGS,
+        driverGeneration: DRIVER_GENERATION,
+        driverInstanceId: DRIVER_INSTANCE_ID,
+        profile: {
+          model,
+          runtimeId: "acp-fallback",
+          vendorCredential: vendorCredential({
+            apiBase: "https://models.example.com/v1",
+            vendorId: "openai-compatible",
+          }),
+        },
+        requestUrl: REQUEST_URL,
+      });
+
+      await expectLlmProxyGrant(envVars["OPENAI_COMPATIBLE_API_KEY"], {
+        modelId: "deepseek/deepseek-v4-flash",
+        modelProtocol: "openai-chat-completions",
+      });
+      expect(parseOpenCodeConfig(envVars)).toMatchObject({
+        enabled_providers: ["openai-compatible"],
+        model: "openai-compatible/deepseek/deepseek-v4-flash",
+        small_model: "openai-compatible/deepseek/deepseek-v4-flash",
+        provider: {
+          "openai-compatible": {
+            models: {
+              "deepseek/deepseek-v4-flash": { name: "deepseek/deepseek-v4-flash" },
+            },
+          },
+        },
+      });
+    },
+  );
+
   test("declares the selected custom OpenCode model for an unrestricted credential", async () => {
     const envVars = await buildVendorProxyEnvVars({
       bindings: BINDINGS,

--- a/docs/operations/reliability.md
+++ b/docs/operations/reliability.md
@@ -31,6 +31,10 @@ expired)` for real `ui` Runs. Preview Runs and cancellations
   Tail event. A runtime becomes `unknown` after 24 hours without a real Run;
   the page does not manufacture traffic to keep it green.
 
+Overall health is `degraded` when any fresh component reports degradation;
+otherwise it is `unknown` when the platform or any runtime lacks a fresh
+observation. API liveness alone must not imply that all runtimes have recovered.
+
 A failed API invocation is shown immediately. A runtime becomes `degraded`
 after three consecutive observed Run failures; earlier failures remain visible
 in its completion rate and latest error code. Three consecutive failures also


### PR DESCRIPTION
Custom OpenAI-compatible model IDs containing a slash were interpreted as another OpenCode provider. For example, `deepseek/deepseek-v4-flash` selected the native DeepSeek provider while the configured credential and model grant belonged to `openai-compatible`. Always qualify upstream model IDs with the selected provider and preserve the full upstream namespace. Keep existing provider-prefixed and Zhipu/Z.ai mappings intact.

Refs #606. Production Cloudflare logs confirm Chat Completions requests returned 403 and both incidents ran Worker version `96beb829-95ea-4c81-abc0-78f6d8af6c5c`; the already-merged model-declaration fix #596 has not been deployed. This patch fixes a reproduced configuration defect; production recovery still requires verification. The reliability document also clarifies the matching website status fix: missing runtime observations cannot imply overall health.

Validation:
- Regression failed before the fix; 31 vendor environment tests pass after it.
- Driver LLM proxy route tests pass, including model capability rejection.
- API typecheck and focused formatting checks pass.
- Real installed OpenCode 1.18.4 against a local deterministic model fixture: custom namespaced DeepSeek and Qwen both complete a real bash call and assistant response. The old custom-model configuration fails before inference. This is not live-provider or production acceptance.
- `just check` attempted locally; macOS process-tree/watchdog tests in the unchanged Driver fail. Linux CI must pass before release.

No generated files, GraphQL codegen, migrations, or lockfile changes. Preserve the model-scoped proxy authorization; do not weaken admission to mask routing errors.
