### PR TITLE
fix(runtime): restore production OpenCode provider configuration

### DIFF
--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-vendor-proxy-env.builder.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-vendor-proxy-env.builder.ts
@@ -208,6 +208,16 @@ function resolveOpenCodeModelId(vendor: RuntimeCatalogVendor, model: string): st
   return model;
 }
 
+function resolveOpenCodeProviderModelId(vendor: RuntimeCatalogVendor, model: string): string {
+  const openCodeProviderId = resolveOpenCodeProviderId(vendor);
+  const openCodeModel = resolveOpenCodeModelId(vendor, model);
+  const providerPrefix = `${openCodeProviderId}/`;
+
+  return openCodeModel.startsWith(providerPrefix)
+    ? openCodeModel.slice(providerPrefix.length)
+    : openCodeModel;
+}
+
 function resolveOpenCodeProxyBaseUrl(vendor: RuntimeCatalogVendor, proxyUrl: string): string {
   // OpenCode's native providers resolve request paths against a base that
   // already contains the SDK path prefix. @ai-sdk/anthropic defaults to
@@ -225,17 +235,20 @@ function buildOpenCodeProviderConfig(input: OpenCodeProviderConfigInput): OpenCo
   const options: Record<string, string> = {
     apiKey: `{env:${input.vendor.apiKeyEnvVar}}`,
   };
-  const models =
-    input.credential.models === null
-      ? undefined
-      : Object.fromEntries(input.credential.models.map((modelId) => [modelId, { name: modelId }]));
+  // OpenCode removes configured providers that have no models. An unrestricted
+  // Mosoo credential still needs the active model rendered for ACP startup.
+  const declaredModelIds = new Set(input.credential.models ?? []);
+  declaredModelIds.add(resolveOpenCodeProviderModelId(input.vendor, input.model));
+  const models = Object.fromEntries(
+    [...declaredModelIds].map((modelId) => [modelId, { name: modelId }]),
+  );
   const provider = input.vendor.openCodeProvider;
 
   if (provider === undefined) {
     options["baseURL"] = resolveOpenCodeProxyBaseUrl(input.vendor, input.proxyUrl);
 
     return {
-      ...(models === undefined ? {} : { models }),
+      models,
       options,
     };
   }
@@ -246,7 +259,7 @@ function buildOpenCodeProviderConfig(input: OpenCodeProviderConfigInput): OpenCo
   );
 
   return {
-    ...(models === undefined ? {} : { models }),
+    models,
     name: provider.name,
     npm: provider.npmPackage,
     options,

--- a/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-vendor-proxy-env.builder.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-sandbox-provisioning/runtime-vendor-proxy-env.builder.ts
@@ -195,8 +195,8 @@ function resolveOpenCodeProviderId(vendor: RuntimeCatalogVendor): string {
 function resolveOpenCodeModelId(vendor: RuntimeCatalogVendor, model: string): string {
   const openCodeProviderId = resolveOpenCodeProviderId(vendor);
 
-  if (!model.includes("/")) {
-    return `${openCodeProviderId}/${model}`;
+  if (model.startsWith(`${openCodeProviderId}/`)) {
+    return model;
   }
 
   const vendorPrefix = `${vendor.vendorId}/`;
@@ -205,7 +205,10 @@ function resolveOpenCodeModelId(vendor: RuntimeCatalogVendor, model: string): st
     return `${openCodeProviderId}/${model.slice(vendorPrefix.length)}`;
   }
 
-  return model;
+  // A slash can belong to the upstream model ID (for example an OpenRouter
+  // model), rather than naming the OpenCode provider. Keep it on the provider
+  // whose credential and proxy grant were selected for this Run.
+  return `${openCodeProviderId}/${model}`;
 }
 
 function resolveOpenCodeProviderModelId(vendor: RuntimeCatalogVendor, model: string): string {

--- a/apps/api/tests/runtime-vendor-env-vars.test.ts
+++ b/apps/api/tests/runtime-vendor-env-vars.test.ts
@@ -516,6 +516,43 @@ describe("runtime vendor proxy env vars", () => {
     });
   });
 
+  test.each(["deepseek/deepseek-v4-flash", "openai-compatible/deepseek/deepseek-v4-flash"])(
+    "keeps namespaced custom model %s on its credential provider",
+    async (model) => {
+      const envVars = await buildVendorProxyEnvVars({
+        bindings: BINDINGS,
+        driverGeneration: DRIVER_GENERATION,
+        driverInstanceId: DRIVER_INSTANCE_ID,
+        profile: {
+          model,
+          runtimeId: "acp-fallback",
+          vendorCredential: vendorCredential({
+            apiBase: "https://models.example.com/v1",
+            vendorId: "openai-compatible",
+          }),
+        },
+        requestUrl: REQUEST_URL,
+      });
+
+      await expectLlmProxyGrant(envVars["OPENAI_COMPATIBLE_API_KEY"], {
+        modelId: "deepseek/deepseek-v4-flash",
+        modelProtocol: "openai-chat-completions",
+      });
+      expect(parseOpenCodeConfig(envVars)).toMatchObject({
+        enabled_providers: ["openai-compatible"],
+        model: "openai-compatible/deepseek/deepseek-v4-flash",
+        small_model: "openai-compatible/deepseek/deepseek-v4-flash",
+        provider: {
+          "openai-compatible": {
+            models: {
+              "deepseek/deepseek-v4-flash": { name: "deepseek/deepseek-v4-flash" },
+            },
+          },
+        },
+      });
+    },
+  );
+
   test("declares the selected custom OpenCode model for an unrestricted credential", async () => {
     const envVars = await buildVendorProxyEnvVars({
       bindings: BINDINGS,

--- a/apps/api/tests/runtime-vendor-env-vars.test.ts
+++ b/apps/api/tests/runtime-vendor-env-vars.test.ts
@@ -431,6 +431,11 @@ describe("runtime vendor proxy env vars", () => {
         small_model: `${providerId}/${model}`,
         provider: {
           [providerId]: {
+            models: {
+              [model]: {
+                name: model,
+              },
+            },
             name,
             npm,
             options: {
@@ -505,6 +510,37 @@ describe("runtime vendor proxy env vars", () => {
           options: {
             apiKey: "{env:OPENAI_COMPATIBLE_API_KEY}",
             baseURL: PROXY_URL,
+          },
+        },
+      },
+    });
+  });
+
+  test("declares the selected custom OpenCode model for an unrestricted credential", async () => {
+    const envVars = await buildVendorProxyEnvVars({
+      bindings: BINDINGS,
+      driverGeneration: DRIVER_GENERATION,
+      driverInstanceId: DRIVER_INSTANCE_ID,
+      profile: {
+        model: "deepseek-v4-flash",
+        runtimeId: "acp-fallback",
+        vendorCredential: vendorCredential({
+          apiBase: "https://api.deepseek.com",
+          vendorId: "openai-compatible",
+        }),
+      },
+      requestUrl: REQUEST_URL,
+    });
+
+    expect(parseOpenCodeConfig(envVars)).toMatchObject({
+      enabled_providers: ["openai-compatible"],
+      model: "openai-compatible/deepseek-v4-flash",
+      provider: {
+        "openai-compatible": {
+          models: {
+            "deepseek-v4-flash": {
+              name: "deepseek-v4-flash",
+            },
           },
         },
       },

--- a/docs/operations/reliability.md
+++ b/docs/operations/reliability.md
@@ -31,6 +31,10 @@ expired)` for real `ui` Runs. Preview Runs and cancellations
   Tail event. A runtime becomes `unknown` after 24 hours without a real Run;
   the page does not manufacture traffic to keep it green.
 
+Overall health is `degraded` when any fresh component reports degradation;
+otherwise it is `unknown` when the platform or any runtime lacks a fresh
+observation. API liveness alone must not imply that all runtimes have recovered.
+
 A failed API invocation is shown immediately. A runtime becomes `degraded`
 after three consecutive observed Run failures; earlier failures remain visible
 in its completion rate and latest error code. Three consecutive failures also


### PR DESCRIPTION
Backport the reviewed OpenCode provider-model declaration fix #596 and namespaced model routing fix #607 onto the currently deployed source commit `dd0bf6e08c80450587a328a74d820171fb71b4cb`. This restores provider registration for Qwen and keeps custom namespaced models on their configured credential provider. Refs #606.

This release deliberately contains no schema migration: production's latest D1 ledger entry is `0011_cattle-terminal-checkpoints.sql`; main's unrelated App→Project migration has not been applied. The release branch retains the production App contract, Driver submodule and image configuration, and immutable migration chain. The only changed files are the provider config builder, its regression tests, and the status reliability documentation.

Evidence and verification:
- Cloudflare history confirms both incidents ran API version `96beb829-95ea-4c81-abc0-78f6d8af6c5c`; the active version is unchanged since September 1.
- Qwen's missing model declaration reproduces the exact `Internal error: OpenCode service failure` via real OpenCode 1.18.4 ACP, before any inference request. Declaring the model produces a completed bash tool call and `end_turn` with a local deterministic inference fixture.
- The fixed custom `deepseek/deepseek-v4-flash` config sends that complete upstream model ID through Chat Completions; real OpenCode ACP executes bash and reaches `end_turn` against the same fixture. Production logs show 403 on the expected Chat Completions path; the historical request body is not recorded, so the exact historical mismatch remains unobserved.
- Focused provider-env tests, model proxy authorization tests, and API typecheck pass on the main patch. Require this release branch's Linux repository check and deployment preflight before production.
- macOS full repository check hits unchanged Driver process-tree/watchdog failures; do not claim that local gate passed.

Deployment sequence: merge this backport PR into the release branch after CI passes, run the repository non-production Public API smoke, verify no pending production migrations and a clean release tree, then use the repository release flow and verify real production runs. Roll back API and Driver together to the recorded pre-release version/image if acceptance fails; do not reset or rewrite D1.
