### PR TITLE
docs(product): align durable Session scope and acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Your application remains yours. Its backend owns product behavior and end-user a
 
 ## Target Direction
 
-mosoo v1 targets research, data analysis, file processing, and report generation through `Project key + Agent + Input + optional files -> durable Session`. Agent configuration is optional and publishing is removed from first use. The reference acceptance flow is CSV analysis with reports, charts, and result data, followed by durable modification turns. This transition is not complete; see [SPEC](./docs/SPEC.md) and [remaining execution slices](./docs/prd/managed-agent-v1.md).
+mosoo v1 targets research, data analysis, file processing, and report generation through `Project key + Agent + Input + optional files -> durable Session`. Agent configuration is optional and publishing is removed from first use. Acceptance covers a single-turn ghFind repository evaluation and CSV analysis with durable follow-up, including recovery after runtime reclamation. Both use the same Session API and checkpoint gate. Project keys have shipped; the Session transition is not complete. See [SPEC](./docs/SPEC.md) and [remaining execution slices](./docs/prd/managed-agent-v1.md).
 
 ## How It Works Today
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,6 +1,6 @@
 # Mosoo Product Spec
 
-Status: canonical target product contract, updated after the product review on September 8, 2026. This document describes intended behavior; source, acceptance checks, and release evidence establish what is actually shipped.
+Status: canonical target product contract, updated after the product review on September 9, 2026. Single-turn tasks and multi-turn continuation share one durable Session contract. This document describes intended behavior; source, acceptance checks, and release evidence establish what is actually shipped.
 
 ## 1. Product Thesis
 
@@ -14,8 +14,10 @@ The core workflow is:
 Project API key + Agent + Input + optional files
   -> create a durable Session and execute work
   -> inspect status, read or stream events, download artifacts
-  -> send follow-up Input to the same Session
+  -> optionally send follow-up Input to the same Session
 ```
+
+One admitted input starts one turn, which may include multiple model requests and tool calls. An application may complete its task in one turn or continue across several turns using the same Session API.
 
 ## 2. First Request And Ownership
 
@@ -23,10 +25,10 @@ Project API key + Agent + Input + optional files
 - Managed Codex and Claude Code Agents are immediately callable. Already integrated runtimes use a shared lifecycle; developer-supplied runtime integration is outside v1.
 - Each managed Agent has a visible default model. Model overrides are supported, but first use does not require choosing a model. The actual model is recorded and fixed within the Session, with no silent model or runtime fallback.
 - The hosted platform supplies default model access. Bring your own key (BYOK) remains optional where already supported. Default access does not promise free or unlimited inference.
-- Project is the tenant and resource-ownership boundary. A key grants access only to its Project, including when the same account owns other Projects.
+- Project is the tenant and resource-ownership boundary. An account may own multiple Projects, each with multiple API keys. A key grants access only to its Project, including when the same account owns other Projects.
 - Project keys serve trusted application backends. They may configure Agents, execute Sessions, and access files only within their Project, without fine-grained scopes. They cannot manage accounts, delete Projects, or manage API keys.
 - Account owners use the console or CLI login for account management and cross-Project operations. CLI login credentials are distinct from application keys and may execute work in an explicitly selected owned Project.
-- The authentication cutover intentionally rejects old manually created account tokens and old CLI credentials. Users create new Project keys for integrations and log in again for CLI access; no default-Project reassignment is performed.
+- The completed #581 authentication cutover rejects old manually created account tokens and old CLI credentials. Users create new Project keys for integrations and log in again for CLI access; no default-Project reassignment is performed.
 - Revoking a Project key rejects subsequent requests but does not cancel work already admitted. The owner or another active key in the same Project can inspect and cancel that work.
 
 ## 3. Optional Private Agents
@@ -39,11 +41,28 @@ Project API key + Agent + Input + optional files
 
 ## 4. Session Lifecycle And Durability
 
+### Execution And Continuation
+
 - `session_id` is the single primary public execution handle. Callers do not need to manage internal Run or retry Attempt IDs.
 - Only one turn executes at a time in a Session. Busy Sessions reject new input, without input queuing or mid-execution steering.
 - The active turn can be cancelled. Another input is accepted only after that turn ends; cancellation cannot undo completed external side effects.
 - Completing a turn returns the Session to a state that accepts follow-up input; it does not terminate the conversation.
-- Follow-up continues the same working directory and runtime-native conversation, including after sandbox reclamation. Restore failure is explicit and never silently starts an empty conversation.
+- Follow-up continues the same working directory and runtime-native conversation, including after sandbox reclamation.
+
+### Checkpoint Gate
+
+A checkpoint represents committed state that can be restored. It is the durability and safe-reclamation gate for each turn.
+
+- After execution ends, persist artifacts, events, and usage, and commit a restorable checkpoint.
+- Model or tool execution ending alone does not establish successful turn completion. Required artifacts and a ready checkpoint must be committed before reporting success or reclaiming the uncommitted workspace.
+- Follow-up admission must continue from the preceding turn's committed state.
+- Checkpoint failure is explicit; it must not fabricate success or silently discard uncommitted output.
+- Failure, cancellation, and budget exhaustion retain their truthful outcomes and saved artifacts. A successful checkpoint does not turn those outcomes into successful execution.
+- The same gate applies to single-turn tasks and multi-turn Sessions. Applications do not need to send a second input to obtain durable results.
+
+### Reclamation, Recovery, And Expiry
+
+- After sandbox reclamation, continuation restores the working directory and runtime-native conversation. Restore failure is explicit and never silently starts an empty conversation.
 - Recovery state remains available for at least 30 days after the last successfully completed turn. Each successful follow-up restarts the period, and expiry is visible to users. Live processes, network connections, and machine-wide temporary state are excluded.
 - After recovery expiry, the old Session rejects continuation. History and saved artifacts remain viewable and are not automatically deleted by recovery expiry. This is not an indefinite retention promise or an exception to explicit deletion.
 - Users may explicitly create a new Session with selected historical summary and saved artifacts. It receives a new ID and does not claim restoration of the old workspace or native conversation. Automatic rollover is not required.
@@ -66,15 +85,40 @@ Project API key + Agent + Input + optional files
 - Prefer reusing existing mechanisms for follow-up idempotency instead of building a separate orchestration system. Deduplication details and key retention are implementation decisions; creation idempotency does not guarantee exactly-once external side effects.
 - Support input file upload and artifact download. Users request modifications through Agent instructions; v1 does not require an online file editor or file-manager UI.
 - Console onboarding prioritizes key creation and a minimal API example. After first use, Session records, status, artifacts, and usage are the primary surfaces. Private Agent configuration is secondary.
+- Builder is a console client of the same Agent configuration and Session APIs. Any retained Preview/Test action uses an ordinary Session and appears in the same operational Session records.
 
-## 7. Reference Acceptance: CSV Analysis And Follow-Up
+## 7. Acceptance: Single-Turn Tasks And Multi-Turn Continuation
+
+### Single-Turn Scenario: ghFind Repository Evaluation
+
+1. ghFind uses a Project key to create or select a private evaluator Agent that is callable immediately after saving.
+2. Submit one evaluation input and fixed-revision repository material, receiving one Session ID.
+3. Require no Agent Publish, Environment setup, App Deployment, or additional public Run ID.
+4. Execute real tools and produce analysis JSON, evidence JSON, and a Markdown report.
+5. Follow Session status and events, download the three artifacts, and validate their structure, content, and correspondence to the input material.
+6. Repeating an idempotent create request returns the same Session without duplicate execution. Internal retries use the same fixed input material.
+7. Successful completion satisfies the artifact-persistence and checkpoint gate. After runtime reclamation, status, historical events, and saved artifacts remain readable.
+8. Complete this business acceptance in one turn without requiring follow-up input. ghFind retains its own analysis ID, queue, rubric, validation, storage, and UI.
+
+**Open decision: repository input delivery.** Acceptance must record the fixed commit and material actually used. Prefer caller-prepared material from that commit through existing file input capabilities; #582 must settle the concrete input contract. Typed Git Resource mounting, private-repository authorization, and branch/PR workflows remain deferred extensions rather than implicit requirements of this acceptance case.
+
+### Multi-Turn Scenario: CSV Analysis And Follow-Up
 
 1. Create a Project API key and upload a CSV.
 2. Invoke a managed Agent with analysis instructions without configuring a provider, publishing an Agent, or selecting an Environment. Both Codex and Claude Code must execute real tools.
 3. Read status and events, then download an analysis report, chart, and result data. Verify calculations against a known fixture and check artifact formats.
 4. Request modifications in the same Session and verify existing files and native conversation continuity. Repeat after forced runtime reclamation.
 5. Create a private Agent with reusable analysis instructions through the API and repeat the flow. After updating the Agent, new Sessions use the new configuration while existing Sessions retain their original configuration.
-6. Run targeted checks for duplicate creation, input submitted while busy, cancellation, budget exhaustion, cross-Project denial, and recovery expiry.
+
+### Shared Failure And Boundary Checks
+
+- Duplicate creation and reuse of an idempotency key with a changed request.
+- Input submitted while a Session is busy.
+- Cancellation, budget exhaustion, and truthful outcome reporting.
+- Checkpoint failure preventing false success and unsafe reclamation.
+- Cross-Project denial and credential isolation.
+- Recovery after reclamation, with explicit failure instead of an empty-conversation fallback.
+- Recovery expiry rejecting continuation while history and saved artifacts remain readable.
 
 ## 8. Scope Boundaries
 
@@ -96,10 +140,35 @@ These are not a backlog to restore automatically after v1. Internal configuratio
 
 These boundaries do not prohibit an Agent from using existing authorized tools for an individual task.
 
-## 9. Implementation Status And Migration
+## 9. Implementation Status And Execution Slices
 
-Existing code provides runtime adapters, sandboxes, Thread/Run history, checkpoint recovery, files, MCP, events, and usage. Project keys, the new Session contract, and remaining product cleanup still need implementation and real acceptance evidence. This document does not establish production reliability, adoption, willingness to pay, or task economics.
+Existing code provides runtime adapters, sandboxes, Thread/Run history, checkpoint recovery, files, MCP, events, and usage. Project keys and separate CLI login shipped in #581. The new Session contract and remaining product cleanup still need implementation and real acceptance evidence. This document does not establish production reliability, adoption, willingness to pay, or task economics.
 
-#579 and #580 are closed. Remaining work follows #581 -> #582 -> #583 -> #584; see the [execution scope mapping](./prd/managed-agent-v1.md). #546 and its children still need reconciliation with this document, especially replacing ghfind/Git acceptance with CSV analysis and removing public version selection and interactive approval requirements.
+| Issue | Status And Responsibility                                                                                                                                       |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #546  | Overall Vision: an API-first managed Agent runtime.                                                                                                             |
+| #579  | Closed: remove Channels from Mosoo main.                                                                                                                        |
+| #580  | Closed: remove App Deployment and bound-capability coupling.                                                                                                    |
+| #581  | Shipped: multiple Projects, Project keys, separate CLI login, authentication cutover, and user notification.                                                    |
+| #582  | Remaining: managed Agents and one durable Session API, single-turn and multi-turn acceptance, checkpoint and recovery, and removal of the Pet/Cattle dual type. |
+| #583  | Remaining: remove Package, Manifest, and Fork product lifecycles while preserving necessary configuration and history.                                          |
+| #584  | Remaining: optional private Agent configuration and testing, without publishing or public version selection.                                                    |
+
+Remaining work follows #582 -> #583 -> #584, with a working acceptance path and a migration rollback point for each slice; see the [execution scope mapping](./prd/managed-agent-v1.md). #581 has [release evidence](https://github.com/langgenius/mosoo/issues/581#issuecomment-5582765337). Reconcile #546 and its children with this contract: retain ghFind alongside multi-turn acceptance, defer typed Git infrastructure and interactive approvals, and remove public historical-version selection.
+
+## 10. Migration And Breaking-Change Notification
 
 Migration preserves existing resource identities, ownership, and promised history, without redesigning Organization governance. Production D1 is append-only. Inventory active state before cutover and follow CONTRIBUTING.md. Destructive or data-rewrite migrations require explicit approval, backups, verification, and rollback plans. This document does not authorize destructive production operations.
+
+Intentional breaking changes are accepted with a defined cutover, treatment of admitted work, compatible clients, migration instructions, and a rollback point. Prepare the affected audience and notice before release. Notices must state the effective time, actual changes, preserved data, and required user actions.
+
+Use Cloudflare Email Service and retain sending outcomes plus sample inbox/content verification under the [breaking-change notification runbook](./production-deploy-verification.md#breaking-change-notification). Distinguish provider acceptance from inbox delivery; unattempted recipients or unknown outcomes cannot count as completed notification. Documentation synchronization alone does not trigger a release notice. A notice claiming the replacement is available follows deployment and verification of the API, console, and applicable CLI.
+
+The completed #581 key notice does not cover later Session or Builder changes. Future notices describe the actual changes and migration steps of their release.
+
+## 11. Open Decisions
+
+1. **Default model access and cost controls:** concrete default models, hosted provider supply, default turn budgets, allowed caps, and operational limits.
+2. **ghFind repository input contract:** the smallest way to supply fixed-commit material and record its identity for retries and validation.
+
+Resolve these before accepting and shipping the corresponding capabilities.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,6 +1,6 @@
 # Mosoo Product Spec
 
-Status: canonical target product contract, updated after the product review on September 9, 2026. Single-turn tasks and multi-turn continuation share one durable Session contract. This document describes intended behavior; source, acceptance checks, and release evidence establish what is actually shipped.
+Status: canonical target product contract, updated after the product review on September 10, 2026. Single-turn tasks and multi-turn continuation share one durable Session contract. This document describes intended behavior; source, acceptance checks, and release evidence establish what is actually shipped.
 
 ## 1. Product Thesis
 
@@ -43,6 +43,8 @@ One admitted input starts one turn, which may include multiple model requests an
 
 ### Execution And Continuation
 
+Within the recovery period, a user returning seconds or days later to the same Session must be able to continue the same work. The Session preserves its conversation context, working files, and admitted execution configuration across idle time and sandbox reclamation. Users do not need to restate prior work, upload the same material again, or create a replacement Session to continue. Recovery may take longer than warm continuation; continuity does not promise identical model wording or preservation of live processes.
+
 - `session_id` is the single primary public execution handle. Callers do not need to manage internal Run or retry Attempt IDs.
 - Only one turn executes at a time in a Session. Busy Sessions reject new input, without input queuing or mid-execution steering.
 - The active turn can be cancelled. Another input is accepted only after that turn ends; cancellation cannot undo completed external side effects.
@@ -51,7 +53,7 @@ One admitted input starts one turn, which may include multiple model requests an
 
 ### Checkpoint Gate
 
-A checkpoint represents committed state that can be restored. It is the durability and safe-reclamation gate for each turn.
+A checkpoint represents committed state that can be restored. It is the durability and safe-reclamation gate for each turn. Actual continuation from that state establishes acceptance of the design; a successful backup operation alone does not prove the Session continuity promise.
 
 - After execution ends, persist artifacts, events, and usage, and commit a restorable checkpoint.
 - Model or tool execution ending alone does not establish successful turn completion. Required artifacts and a ready checkpoint must be committed before reporting success or reclaiming the uncommitted workspace.
@@ -107,8 +109,9 @@ A checkpoint represents committed state that can be restored. It is the durabili
 1. Create a Project API key and upload a CSV.
 2. Invoke a managed Agent with analysis instructions without configuring a provider, publishing an Agent, or selecting an Environment. Both Codex and Claude Code must execute real tools.
 3. Read status and events, then download an analysis report, chart, and result data. Verify calculations against a known fixture and check artifact formats.
-4. Request modifications in the same Session and verify existing files and native conversation continuity. Repeat after forced runtime reclamation.
-5. Create a private Agent with reusable analysis instructions through the API and repeat the flow. After updating the Agent, new Sessions use the new configuration while existing Sessions retain their original configuration.
+4. Request modifications seconds later in the same Session and verify that the Agent uses prior conversation context and existing working files, including files outside the published artifacts, without being given that state again.
+5. Repeat continuation after a multi-day idle interval within the recovery period and after forced runtime reclamation. Verify the same Session ID, admitted configuration, context-dependent task result, and prior file contents. Use controlled time and persisted fixtures for deterministic retention checks; record actual elapsed time separately in live delayed-continuation evidence. A clock-advanced test is not evidence that a live Session survived several days.
+6. Create a private Agent with reusable analysis instructions through the API and repeat the flow. After updating the Agent, new Sessions use the new configuration while existing Sessions retain their original configuration.
 
 ### Shared Failure And Boundary Checks
 
@@ -154,7 +157,7 @@ Existing code provides runtime adapters, sandboxes, Thread/Run history, checkpoi
 | #583  | Remaining: remove Package, Manifest, and Fork product lifecycles while preserving necessary configuration and history.                                          |
 | #584  | Remaining: optional private Agent configuration and testing, without publishing or public version selection.                                                    |
 
-Remaining work follows #582 -> #583 -> #584, with a working acceptance path and a migration rollback point for each slice; see the [execution scope mapping](./prd/managed-agent-v1.md). #581 has [release evidence](https://github.com/langgenius/mosoo/issues/581#issuecomment-5582765337). Reconcile #546 and its children with this contract: retain ghFind alongside multi-turn acceptance, defer typed Git infrastructure and interactive approvals, and remove public historical-version selection.
+Remaining work follows #582 -> #583 -> #584, with a working acceptance path and a migration rollback point for each slice; see the [execution scope mapping](./prd/managed-agent-v1.md). #581 has [release evidence](https://github.com/langgenius/mosoo/issues/581#issuecomment-5582765337). The issue scope follows this contract: retain ghFind alongside multi-turn acceptance, defer typed Git infrastructure and interactive approvals, and remove public historical-version selection.
 
 ## 10. Migration And Breaking-Change Notification
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,9 +2,11 @@
 
 ## 1. Vision And Principles
 
-Target direction (2026-09-09): [SPEC](./SPEC.md) defines a Project-scoped managed runtime for general application-backend tasks. A Project key, Agent, input, and optional files create a durable Session. Single-turn ghFind evaluation and multi-turn CSV analysis share this contract. New Sessions resolve the latest Agent configuration and retain internal immutable snapshots; callers neither select historical versions nor deploy Workers per configuration.
+Target direction (2026-09-10): [SPEC](./SPEC.md) defines a Project-scoped managed runtime for general application-backend tasks. A Project key, Agent, input, and optional files create a durable Session. Single-turn ghFind evaluation and multi-turn CSV analysis share this contract. New Sessions resolve the latest Agent configuration and retain internal immutable snapshots; callers neither select historical versions nor deploy Workers per configuration.
 
 Existing checkpoint and runtime primitives must support native continuation without Pet/Cattle product semantics. Persist required artifacts, events, usage, and a ready checkpoint before reporting a successful turn or reclaiming its uncommitted workspace. Follow-up uses committed state; cold continuation restores the workspace and native conversation or fails explicitly. Recovery remains available for at least 30 days after the last successful turn, renewed by successful follow-up. Completing a turn leaves the Session available for continuation.
+
+The user-visible invariant is continuity of the same Session across seconds or days of idle time and runtime reclamation. Verify continuation against prior conversation context, working files, and the admitted configuration; successful backup creation is only an intermediate check. Live delayed-continuation evidence records actual elapsed time separately from deterministic tests that advance the clock.
 
 Full-access execution retains isolation and authorization. Interactive approvals and typed Git resource infrastructure remain deferred; ghFind's fixed-commit material delivery is an explicit open decision. See [remaining slices](./prd/managed-agent-v1.md). The topology and flows below describe current implementation until those slices land, including its existing checkpoint retention policy.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,11 @@
 
 ## 1. Vision And Principles
 
-Target direction (2026-09-08): [SPEC](./SPEC.md) defines a Project-scoped managed runtime for general application-backend tasks. A Project key, Agent, input, and optional files create a durable Session. New Sessions resolve the latest Agent configuration and retain internal immutable snapshots; callers neither select versions nor deploy Workers per configuration. Existing checkpoint and runtime primitives must support native continuation without Pet/Cattle product semantics. Full-access execution retains isolation and authorization; interactive approvals and Git resource onboarding are deferred. See [remaining slices](./prd/managed-agent-v1.md). The topology and flows below describe current implementation until those slices land.
+Target direction (2026-09-09): [SPEC](./SPEC.md) defines a Project-scoped managed runtime for general application-backend tasks. A Project key, Agent, input, and optional files create a durable Session. Single-turn ghFind evaluation and multi-turn CSV analysis share this contract. New Sessions resolve the latest Agent configuration and retain internal immutable snapshots; callers neither select historical versions nor deploy Workers per configuration.
+
+Existing checkpoint and runtime primitives must support native continuation without Pet/Cattle product semantics. Persist required artifacts, events, usage, and a ready checkpoint before reporting a successful turn or reclaiming its uncommitted workspace. Follow-up uses committed state; cold continuation restores the workspace and native conversation or fails explicitly. Recovery remains available for at least 30 days after the last successful turn, renewed by successful follow-up. Completing a turn leaves the Session available for continuation.
+
+Full-access execution retains isolation and authorization. Interactive approvals and typed Git resource infrastructure remain deferred; ghFind's fixed-commit material delivery is an explicit open decision. See [remaining slices](./prd/managed-agent-v1.md). The topology and flows below describe current implementation until those slices land, including its existing checkpoint retention policy.
 
 mosoo provides a Project-scoped control plane for configuring, publishing, running, and observing coding Agents through the console and Public Thread API.
 

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -11,7 +11,7 @@ their machine-readable contracts, code, or [Architecture](../architecture.md).
 
 ## Runtime and API
 
-- [Managed Agent v1 target and remaining slices](./managed-agent-v1.md) — agreed target, not shipped behavior.
+- [Managed Agent v1 target and remaining slices](./managed-agent-v1.md) — shipped Project keys, remaining Session and configuration work, with single-turn and multi-turn acceptance.
 - [Agent API Endpoint](./agent-endpoint-mvp.md)
 - [Public Thread API](./public-thread-api-surface.md)
 - [Runtime Sessions](./runtime-session-kernel.md)

--- a/docs/prd/managed-agent-v1.md
+++ b/docs/prd/managed-agent-v1.md
@@ -1,20 +1,33 @@
 # Managed Agent v1: Remaining Execution Slices
 
-Status: target scope from the 2026-09-08 owner interview. Implementation and remote issue reconciliation are pending. [SPEC](../SPEC.md) is the target contract.
+Status: target scope from the September 9, 2026 product review. Single-turn tasks and multi-turn continuation share the same durable Session contract. [SPEC](../SPEC.md) is the target contract; the remaining slices require implementation and release evidence.
+
+## #546 — API-First Managed Agent Runtime
+
+An application supplies a Project key, Agent, input, and optional files. Mosoo owns execution, sandboxing, durable continuation, events, artifacts, usage, and cleanup. The application keeps its business logic, end-user identity, queue, validation, storage, and UI. Managed Codex and Claude Code are directly callable; saved private Agent configuration is optional and never requires publishing.
+
+Both ghFind's single-turn evaluation and CSV analysis with follow-up are required acceptance paths. A single-turn integration does not restrict Session continuation. Reconcile the parent and child issue descriptions with this mapping, including removal of public historical-version selection and interactive approvals and deferral of typed Git infrastructure.
 
 ## Completed Prerequisites
 
-#579 (Channels) and #580 (App Deployment / bound capabilities) are closed with release evidence. Do not restore their product surfaces because inert historical storage remains.
+#579 (Channels), #580 (App Deployment / bound capabilities), and #581 (Project keys and separate CLI login) are closed. Do not restore removed product surfaces because inert historical storage remains.
 
-## #581 — Project And Keys
+## #581 — Project And Keys: Shipped
 
-Retain Project as the resource boundary: one account owns multiple Projects and each Project has multiple keys. Deliver key creation/revocation in Project settings and strict cross-Project denial for Agent configuration, execution, and files. Account control-plane and cross-Project access use console or CLI login, with a distinct account credential. The cutover rejects old account tokens and requires CLI re-login; it does not assign existing keys to a default Project. Preserve resources and history and verify the matching CLI release.
+Project is the shipped resource boundary: one account owns multiple Projects and each Project has multiple keys. Project settings provide key creation/revocation, with cross-Project denial for Agent configuration, execution, and files. Account control-plane and cross-Project access use console or CLI login with a distinct account credential. The completed cutover rejects old account tokens and requires CLI re-login; it does not assign existing keys to a default Project. Resources and history were preserved and the compatible CLI was released. Cloudflare accepted 153 user notices with sample inbox verification; see [#581 release evidence](https://github.com/langgenius/mosoo/issues/581#issuecomment-5582765337).
 
 ## #582 — Managed Agents And Durable Sessions
 
 Deliver the default-model, platform-funded first request and one public Session handle. Reuse runtime, files, events, usage, and checkpoints. Remove Pet/Cattle without removing native continuation.
 
-Revise prior acceptance: replace typed Git resources and ghfind with CSV analysis and multi-turn modification; add renewable 30-day recovery and explicit expiry; use full access while retaining isolation; defer interactive approvals. Include per-turn budget protection, creation idempotency, status/history/SSE, cancellation, and busy rejection. No input queue, steering, or Webhooks.
+Require both acceptance paths:
+
+- **ghFind:** one evaluation input and fixed-commit repository material produce validated analysis JSON, evidence JSON, and a Markdown report through one Session. Repeated idempotent creation does not duplicate work. History and saved artifacts remain readable after runtime reclamation, without requiring a follow-up turn. The concrete material delivery contract remains open; prefer existing file input capabilities with caller-prepared material. Typed Git mounting, private-repository authorization, and branch/PR workflows remain deferred.
+- **CSV analysis:** managed Codex and Claude Code execute real tools to produce verified reports, charts, and result data; follow-up retains the workspace and native conversation, including after forced reclamation. Recovery remains available for at least 30 days after the last successful turn, renewed by successful follow-up, with explicit expiry and preserved history/artifacts.
+
+Keep checkpoint as the turn durability and safe-reclamation gate. Required artifacts, events, usage, and a ready checkpoint precede successful completion and reclamation of an uncommitted workspace. Follow-up uses committed state; restore or checkpoint failure is explicit. Failure, cancellation, and budget exhaustion retain their actual outcomes and saved artifacts.
+
+Use full access while retaining isolation and defer interactive approvals. Include per-turn budgets, creation idempotency, status/history/SSE, cancellation, and busy rejection. No input queue, steering, or Webhooks.
 
 Private Agents are invoked by ID at their latest configuration, with immutable Session snapshots internally and no public version selector. That callable path belongs here even if remaining Builder cleanup lands in #584. Hosted provider funding and budget defaults need operational resolution before quickstart acceptance.
 
@@ -22,14 +35,18 @@ Private Agents are invoked by ID at their latest configuration, with immutable S
 
 Remove packages, manifest-as-public-lifecycle, and Fork. Preserve reusable instructions, Skills, MCP references, configuration snapshots, and promised user history. Existing destructive migration guardrails remain in force.
 
+Retained private Agents are immediately callable by ID at their latest configuration. Internal immutable Session snapshots preserve admitted configuration; this slice does not introduce explicit historical-version invocation, package compatibility parsers, or a replacement distribution format.
+
 ## #584 — Optional Configuration And Console
 
-Expose private Agent creation/update entirely through API and console, immediately callable after saving. Remove Publish/Unpublish and Draft/Live/version-selection experiences. Retain existing MCP and Skills capabilities.
+Expose private Agent creation/update entirely through API and console, immediately callable after saving. Remove Publish/Unpublish and Draft/Live/version-selection experiences. Retain existing MCP and Skills capabilities. A new Session uses the latest saved configuration; existing Sessions retain their initial snapshots. Any retained Preview/Test action executes through the ordinary Session API and appears in the same Session records.
 
 Prioritize keys, API examples, Session records, artifacts, and usage in the console; Agent configuration is secondary. Input upload and output download suffice. New file-manager and online-editor work are deferred; this is not authorization to delete stored files.
 
 ## Delivery Boundaries
 
-Preserve dependency order #581 -> #582 -> #583 -> #584, with a working, verifiable path and data-preservation/rollback obligations for each slice. Favor reuse and the smallest implementation meeting SPEC. Remote GitHub issues have not been edited by this documentation change.
+With #581 shipped, preserve dependency order #582 -> #583 -> #584, with a working, verifiable path and data-preservation/rollback obligations for each slice. Favor reuse and the smallest implementation meeting SPEC. Remote GitHub issues have not been edited by this documentation change; their descriptions must be reconciled with this mapping when the specification lands.
+
+Intentional breaking changes require a defined cutover, compatible client instructions, and Cloudflare user notification under the [release runbook](../production-deploy-verification.md#breaking-change-notification). The completed #581 key notice does not cover a later Session or Builder release. Resolve default model supply/budgets and the ghFind material input contract before accepting their corresponding capabilities.
 
 Current-state PRDs still describe Project/Thread, publishing, Agent Type, and package behavior. Update those notes as their implementation slices land; do not describe targets as shipped capabilities.

--- a/docs/prd/managed-agent-v1.md
+++ b/docs/prd/managed-agent-v1.md
@@ -1,12 +1,12 @@
 # Managed Agent v1: Remaining Execution Slices
 
-Status: target scope from the September 9, 2026 product review. Single-turn tasks and multi-turn continuation share the same durable Session contract. [SPEC](../SPEC.md) is the target contract; the remaining slices require implementation and release evidence.
+Status: target scope from the September 10, 2026 product review. Single-turn tasks and multi-turn continuation share the same durable Session contract. [SPEC](../SPEC.md) is the target contract; the remaining slices require implementation and release evidence.
 
 ## #546 — API-First Managed Agent Runtime
 
 An application supplies a Project key, Agent, input, and optional files. Mosoo owns execution, sandboxing, durable continuation, events, artifacts, usage, and cleanup. The application keeps its business logic, end-user identity, queue, validation, storage, and UI. Managed Codex and Claude Code are directly callable; saved private Agent configuration is optional and never requires publishing.
 
-Both ghFind's single-turn evaluation and CSV analysis with follow-up are required acceptance paths. A single-turn integration does not restrict Session continuation. Reconcile the parent and child issue descriptions with this mapping, including removal of public historical-version selection and interactive approvals and deferral of typed Git infrastructure.
+Both ghFind's single-turn evaluation and CSV analysis with follow-up are required acceptance paths. A single-turn integration does not restrict Session continuation. The parent and child issue descriptions follow this mapping, including removal of public historical-version selection and interactive approvals and deferral of typed Git infrastructure.
 
 ## Completed Prerequisites
 
@@ -23,9 +23,9 @@ Deliver the default-model, platform-funded first request and one public Session 
 Require both acceptance paths:
 
 - **ghFind:** one evaluation input and fixed-commit repository material produce validated analysis JSON, evidence JSON, and a Markdown report through one Session. Repeated idempotent creation does not duplicate work. History and saved artifacts remain readable after runtime reclamation, without requiring a follow-up turn. The concrete material delivery contract remains open; prefer existing file input capabilities with caller-prepared material. Typed Git mounting, private-repository authorization, and branch/PR workflows remain deferred.
-- **CSV analysis:** managed Codex and Claude Code execute real tools to produce verified reports, charts, and result data; follow-up retains the workspace and native conversation, including after forced reclamation. Recovery remains available for at least 30 days after the last successful turn, renewed by successful follow-up, with explicit expiry and preserved history/artifacts.
+- **CSV analysis:** managed Codex and Claude Code execute real tools to produce verified reports, charts, and result data. Follow-up seconds or days later retains the same Session, workspace, native conversation, and admitted configuration, including after forced reclamation. Verify a context-dependent modification using prior files without re-supplying them, including workspace files outside published artifacts. Recovery remains available for at least 30 days after the last successful turn, renewed by successful follow-up, with explicit expiry and preserved history/artifacts. Distinguish controlled-clock retention tests from actual elapsed-time evidence for delayed live continuation.
 
-Keep checkpoint as the turn durability and safe-reclamation gate. Required artifacts, events, usage, and a ready checkpoint precede successful completion and reclamation of an uncommitted workspace. Follow-up uses committed state; restore or checkpoint failure is explicit. Failure, cancellation, and budget exhaustion retain their actual outcomes and saved artifacts.
+Keep checkpoint as the turn durability and safe-reclamation gate. Required artifacts, events, usage, and a ready checkpoint precede successful completion and reclamation of an uncommitted workspace. Follow-up uses committed state; restore or checkpoint failure is explicit. Acceptance must prove actual continuation, not just backup creation. Failure, cancellation, and budget exhaustion retain their actual outcomes and saved artifacts.
 
 Use full access while retaining isolation and defer interactive approvals. Include per-turn budgets, creation idempotency, status/history/SSE, cancellation, and busy rejection. No input queue, steering, or Webhooks.
 
@@ -45,7 +45,7 @@ Prioritize keys, API examples, Session records, artifacts, and usage in the cons
 
 ## Delivery Boundaries
 
-With #581 shipped, preserve dependency order #582 -> #583 -> #584, with a working, verifiable path and data-preservation/rollback obligations for each slice. Favor reuse and the smallest implementation meeting SPEC. Remote GitHub issues have not been edited by this documentation change; their descriptions must be reconciled with this mapping when the specification lands.
+With #581 shipped, preserve dependency order #582 -> #583 -> #584, with a working, verifiable path and data-preservation/rollback obligations for each slice. Favor reuse and the smallest implementation meeting SPEC. The GitHub issue descriptions were aligned with this reviewed scope on September 10; implementation and release evidence are still required before closing them.
 
 Intentional breaking changes require a defined cutover, compatible client instructions, and Cloudflare user notification under the [release runbook](../production-deploy-verification.md#breaking-change-notification). The completed #581 key notice does not cover a later Session or Builder release. Resolve default model supply/budgets and the ghFind material input contract before accepting their corresponding capabilities.
 

--- a/docs/prd/project-boundary.md
+++ b/docs/prd/project-boundary.md
@@ -4,6 +4,10 @@ Status: shipped resource and ownership boundary. [mosoo Spec](../SPEC.md) define
 
 Project API keys belong to exactly one Project. Accounts may own multiple Projects, each with multiple keys. Resources and history retain their identities. Console and CLI login supply account-level access; application keys cannot cross Projects or manage accounts, Projects, or keys.
 
+## Managed Session Target
+
+The remaining [managed Agent slices](./managed-agent-v1.md) use Project as the ownership boundary for private Agent configuration, durable Sessions, files, and usage. A Session supports both a single-turn task and later input in the same workspace and native conversation. Console entry prioritizes keys, API examples, Session records, artifacts, and usage; private Agent configuration is optional. This target does not establish that the new Session API has shipped.
+
 ## Problem
 
 Builders previously had to understand mosoo through separate Agents and scattered resources. The Project boundary gives them one place to see and operate the product they are building.
@@ -34,6 +38,8 @@ The baseline is single-owner and does not offer organization-wide catalogs or co
 
 ## API Key Cutover
 
+The #581 cutover is complete; see its [release and notification evidence](https://github.com/langgenius/mosoo/issues/581#issuecomment-5582765337).
+
 Owners create and revoke keys in Project settings. A key is shown once and only its hash is stored. All Project keys support Agent configuration, Sessions, and files without configurable scopes. Revocation rejects future requests but leaves admitted work running; another active key in the Project or its owner can operate the existing Session.
 
-Old account tokens and CLI credentials must be replaced. Existing integrations create a new key in each target Project and update their configuration; CLI users run `mosoo login` again. Existing keys are not reassigned to a default Project.
+Old account tokens and CLI credentials must be replaced. Existing integrations create a new key in each target Project and update their configuration; CLI users run `mosoo auth login` again. Existing keys are not reassigned to a default Project.

--- a/docs/production-deploy-verification.md
+++ b/docs/production-deploy-verification.md
@@ -335,7 +335,12 @@ release's actual changes; require key rotation only if it changes valid keys.
 
 The target #582 acceptance covers both ghFind single-turn evaluation and
 multi-turn continuation, including checkpoint failure and recovery after
-runtime reclamation. Update the existing Thread smoke for the implemented
+runtime reclamation. Verify that replies seconds or days later use the same
+Session, prior conversation context, working files, and admitted configuration
+without re-supplying that state. Include working files outside published
+artifacts. Record actual elapsed time for delayed live continuation separately
+from controlled-clock retention checks; backup creation alone is insufficient
+acceptance evidence. Update the existing Thread smoke for the implemented
 Session contract and verify both paths in non-production before cutover.
 
 ## Stop Conditions

--- a/docs/production-deploy-verification.md
+++ b/docs/production-deploy-verification.md
@@ -302,6 +302,42 @@ Acceptance:
 - If local HTTPS probes resolve through the local TUN/fake-IP path, keep
   `--interface en0` and `--resolve` in the smoke commands.
 
+## Breaking-Change Notification
+
+Intentional breaking changes to the managed Agent API and configuration
+lifecycle require accurate migration instructions for affected users. Preserve
+the existing data, backup, rollback, and destructive-migration approval rules.
+
+1. Before cutover, inventory affected integrations and active tasks. Record
+   the exact contract change, treatment of admitted work, preserved history
+   and artifacts, compatible API/console/CLI versions, and rollback point.
+   Prepare the affected recipient snapshot and notice before deploying.
+2. State the effective time, actual changes, preserved data, and concrete
+   user migration steps and links. Advance notices describe upcoming behavior.
+   A notice claiming the replacement is available follows deployment and
+   verification of the API, console, and applicable CLI. Documentation-only
+   synchronization does not trigger a rollout notice.
+3. Send through Cloudflare Email Service using the configured Mosoo sender.
+   Verify sample inbox delivery and actual content, send individually, and
+   retain private per-recipient attempts, outcomes, and provider message IDs.
+   Resolve uncertain outcomes before retrying to avoid duplicate notices.
+4. Reconcile the recipient snapshot with accepted, failed, suppressed,
+   unknown, and unattempted outcomes before declaring notification complete.
+   Resolve unknown outcomes and unattempted recipients; investigate known
+   failures and record their disposition or outstanding follow-up. Publish
+   only aggregate counts and sample verification. Provider acceptance is not
+   proof of delivery to every inbox.
+
+One coordinated notice may cover slices shipped together when it describes
+all affected workflows and client actions. The completed #581 key-rotation
+notice does not cover a future Session or Builder change. Describe that
+release's actual changes; require key rotation only if it changes valid keys.
+
+The target #582 acceptance covers both ghFind single-turn evaluation and
+multi-turn continuation, including checkpoint failure and recovery after
+runtime reclamation. Update the existing Thread smoke for the implemented
+Session contract and verify both paths in non-production before cutover.
+
 ## Stop Conditions
 
 Stop before any real deploy when any item below is true:


### PR DESCRIPTION
## Summary

Require both single-turn ghFind evaluation and CSV analysis with multi-turn follow-up through one durable Session API. A user returning seconds or days later must continue from the prior conversation, working files, and admitted configuration, including after runtime reclamation. Retain the checkpoint gate for truthful success and safe reclamation, with renewable recovery for at least 30 days.

Keep Agent invocation at the latest saved configuration with internal Session snapshots, full access within isolation boundaries, and immediately callable managed Agents. Record #581 as shipped, align the README/architecture/PRD anchors, and document Cloudflare notification requirements for future breaking releases. The #546/#582–#584 issue descriptions were reconciled with this reviewed scope on September 10.

## Acceptance clarity

Actual continuation establishes acceptance; backup creation alone is insufficient. Verify modifications using prior context and working files outside published artifacts without re-supplying them. Separate controlled-clock retention tests from actual elapsed-time evidence for delayed live continuation. ghFind may complete its business task in one turn while its Session retains the same continuation guarantee.

## Verification

- All seven original changed Markdown files passed focused formatting checks; the four September 10 follow-up files passed again after editing.
- `just docs-check` passed for 56 Markdown/MDX files; `git diff --check` passed.
- The previous PR head passed the Repository check and metadata/CodeQL gates in CI. Checks for the new head run on this update.
- The earlier local `just check` failed in unchanged Driver process-supervision tests on macOS (1,226 passed, 61 skipped, 11 failed, one unhandled error); the full local gate was not repeated for this documentation-only follow-up.
- The commit-msg filename hook again incorrectly rejected the worktree COMMIT_EDITMSG path as an illegal Windows filename. Only `check-illegal-windows-names` was skipped for the retry; other hooks and commit metadata validation passed.
- Issue bodies were read back and matched the prepared scope; all four implementation issues remain open.

## Impact and review

This PR changes target documentation only. No runtime behavior, generated contracts, database schema/migrations, lockfile, environment configuration, production deployment, or email send changes. The local CLI provider smoke is not evidence of delayed continuation, and this PR does not claim implementation acceptance.

Default models/provider supply, budget values, and the smallest fixed-commit ghFind material contract still need resolution before their corresponding capabilities ship. Typed Git infrastructure, interactive approvals, and public historical-version invocation remain outside v1. Rollback is a documentation revert.

Refs #546, #581, #582, #583, #584.
