### PR TITLE
fix(runtime): stop preview reconnect wakes and repair idle state

### DIFF
--- a/apps/api/src/adapters/http/routes/root-route.ts
+++ b/apps/api/src/adapters/http/routes/root-route.ts
@@ -26,7 +26,6 @@ export function registerRootRoute(app: Hono<ApiGatewayEnvironment>) {
 
     try {
       return await connectAuthenticatedSessionViewerWebSocket(c.env, {
-        executionContext: c.executionCtx,
         projectId: projectId ?? "",
         request: c.req.raw,
         sessionId,

--- a/apps/api/src/modules/runtime/application/session-runs/schedule-session-prewarm.service.ts
+++ b/apps/api/src/modules/runtime/application/session-runs/schedule-session-prewarm.service.ts
@@ -25,12 +25,8 @@ export interface SessionRuntimePrewarmAck {
 /**
  * Re-schedules the prewarm pipeline for an existing session.
  *
- * The viewer-socket entry point already prewarms once on initial connect, but
- * Durable Object hibernation after a few minutes of idle clears the warm
- * driver state with no automatic re-trigger. This service is the cheap path
- * that lets the client request another prewarm — e.g. when the user resumes
- * typing in the follow-up composer — without having to actually send a
- * message to discover that the runtime went cold.
+ * Viewer sockets only subscribe to events. Explicit composer activity can
+ * request prewarm here before a user sends another message.
  *
  * Authorization piggy-backs on participant access (same gate that lets a
  * viewer read messages). The underlying scheduler is fire-and-forget through

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-conversation-session-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-conversation-session-store.ts
@@ -22,6 +22,7 @@ import {
 } from "../session-runs/session-run-admission.repository";
 import {
   activeConversationSessionQuery,
+  activeSessionRunQueryForListedSubject,
   mapReadyRuntimeSubjectBackup,
   readyConversationBackupTable,
   runLeaseQuery,
@@ -169,6 +170,56 @@ export async function listIdleSessionScopedConversationSessions(
         ),
       ),
     )
+    .limit(input.limit)
+    .all();
+}
+
+// Older releases could publish success before the terminal checkpoint. A follow-up
+// is blocked by the admission gate until this exact completed turn is durable.
+export async function listPendingIdleConversationCheckpoints(
+  database: D1Database,
+  input: { readonly idleSinceLte: number; readonly limit: number },
+) {
+  const appDb = getAppDatabase(database);
+  return appDb
+    .select({
+      sandboxId: sandboxSessionsTable.sandboxId,
+      sessionId: sandboxSessionsTable.sessionId,
+      sessionRunId: sessionRunsTable.id,
+    })
+    .from(sandboxSessionsTable)
+    .innerJoin(sandboxesTable, eq(sandboxesTable.id, sandboxSessionsTable.sandboxId))
+    .innerJoin(sessionsTable, eq(sessionsTable.id, sandboxSessionsTable.sessionId))
+    .innerJoin(sessionRunsTable, eq(sessionRunsTable.id, sessionsTable.lastRunId))
+    .where(
+      and(
+        eq(sandboxSessionsTable.status, "active"),
+        eq(sandboxesTable.status, "active"),
+        eq(sandboxesTable.kind, "cattle"),
+        eq(sessionsTable.status, "IDLE"),
+        eq(sessionsTable.workspaceCheckpointRequired, true),
+        eq(sessionRunsTable.status, "completed"),
+        lte(sandboxSessionsTable.updatedAt, input.idleSinceLte),
+        isNull(sandboxesTable.claimOwner),
+        notExists(activeSessionRunQueryForListedSubject(appDb)),
+        notExists(runLeaseQueryForListedSubject(appDb)),
+        completedRunHistoryPredicate(appDb, sessionsTable.lastRunId),
+        notExists(
+          appDb
+            .select({ id: sandboxBackupsTable.id })
+            .from(sandboxBackupsTable)
+            .where(
+              and(
+                eq(sandboxBackupsTable.sandboxId, sandboxSessionsTable.sandboxId),
+                eq(sandboxBackupsTable.dir, sandboxSessionsTable.cwd),
+                eq(sandboxBackupsTable.sessionRunId, sessionRunsTable.id),
+                eq(sandboxBackupsTable.status, "ready"),
+              ),
+            ),
+        ),
+      ),
+    )
+    .orderBy(sandboxSessionsTable.sessionId)
     .limit(input.limit)
     .all();
 }

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-maintenance.service.ts
@@ -16,14 +16,19 @@ import { reconcileStaleActiveSessionRuns } from "../../application/session-runs/
 import { reconcileTerminalSessionRuns } from "../../application/session-runs/terminal-run-reconciliation.service";
 import { getRuntimeKindPolicy } from "../../domain/runtime-kind-policy";
 import { cleanupDriverInstances } from "../driver-instance/maintenance";
+import { createSandboxCheckpoints } from "../sandbox-backup.service";
 import { repairRuntimeCommandRecords } from "../session-runs/runtime-command-store.repository";
 import { createSessionStatusTransitionPatch } from "../session-runs/session-lifecycle-projection.repository";
 import { setSessionRunStatus } from "../session-runs/session-run-store.repository";
 import type { SessionRunTransitionOutcome } from "../session-runs/session-run-store.repository";
-import { listIdleSessionScopedConversationSessions } from "./runtime-conversation-session-store";
+import {
+  listPendingIdleConversationCheckpoints,
+  listIdleSessionScopedConversationSessions,
+} from "./runtime-conversation-session-store";
 import { repairStrandedRuntimeSubjectDeadlines } from "./runtime-subject-maintenance-store";
 import {
   claimInactiveRuntimeSubject,
+  claimExpiredRuntimeSubjectActivations,
   listInactiveRuntimeSubjects,
   listStaleRuntimeSubjectOperations,
 } from "./runtime-subject-store";
@@ -286,6 +291,33 @@ async function closeIdleSessionScopedConversationSessions(
   }
 }
 
+export async function repairIdleConversationCheckpoints(
+  bindings: ApiBindings,
+  now: number,
+): Promise<void> {
+  const policy = getRuntimeKindPolicy("cattle");
+  const pending = await listPendingIdleConversationCheckpoints(bindings.DB, {
+    idleSinceLte: now - policy.subject.idleReleaseDelayMs,
+    limit: MAINTENANCE_BATCH_SIZE,
+  });
+  for (const candidate of pending) {
+    try {
+      await createSandboxCheckpoints(bindings, {
+        requiredSessionId: candidate.sessionId,
+        rules: policy.checkpoint.createOnTerminal,
+        sandboxId: candidate.sandboxId,
+        sessionRunId: candidate.sessionRunId,
+      });
+    } catch (error) {
+      // Preserve the resident workspace and retry on the next sweep.
+      logWarn("runtime.conversation.checkpoint_repair_failed", {
+        ...createErrorLogContext(error),
+        ...candidate,
+      });
+    }
+  }
+}
+
 export async function runSandboxMaintenance(bindings: ApiBindings): Promise<void> {
   const now = Date.now();
 
@@ -312,6 +344,7 @@ export async function runSandboxMaintenance(bindings: ApiBindings): Promise<void
     limit: MAINTENANCE_BATCH_SIZE,
     staleUpdatedAtLte: now - MAINTENANCE_OPERATION_REPAIR_AFTER_MS,
   });
+  await repairIdleConversationCheckpoints(bindings, now);
   await closeIdleSessionScopedConversationSessions(bindings, now);
   const repairedDeadlines = await repairStrandedRuntimeSubjectDeadlines(bindings.DB, { now });
 
@@ -325,7 +358,7 @@ export async function runSandboxMaintenance(bindings: ApiBindings): Promise<void
     logWarn("runtime.subject.orphan_pet_deadline_repaired", { count: repairedDeadlines.pet });
   }
 
-  const [candidates, repairCandidates] = await Promise.all([
+  const [candidates, staleOperations, expiredActivations] = await Promise.all([
     listInactiveRuntimeSubjects(bindings.DB, {
       limit: MAINTENANCE_BATCH_SIZE,
       now,
@@ -334,7 +367,13 @@ export async function runSandboxMaintenance(bindings: ApiBindings): Promise<void
       limit: MAINTENANCE_BATCH_SIZE,
       staleChangedAtLte: now - MAINTENANCE_OPERATION_REPAIR_AFTER_MS,
     }),
+    claimExpiredRuntimeSubjectActivations(bindings.DB, {
+      limit: MAINTENANCE_BATCH_SIZE,
+      now,
+      staleChangedAtLte: now - MAINTENANCE_OPERATION_REPAIR_AFTER_MS,
+    }),
   ]);
+  const repairCandidates = [...staleOperations, ...expiredActivations];
 
   if (candidates.length === 0 && repairCandidates.length === 0) {
     return;

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-record-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-record-store.ts
@@ -11,7 +11,7 @@ import type {
   SandboxBackupId,
   SandboxId,
 } from "@mosoo/id";
-import { and, eq, inArray, isNull, lte, notExists, or, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, lte, notExists, or, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
 import { getAppDatabase, getD1ChangeCount } from "../../../../platform/db/drizzle";
@@ -28,13 +28,16 @@ import type { RuntimeSubjectOperationStatus } from "../../domain/runtime-subject
 import {
   activeSessionRunQueryForListedSubject,
   lastBackupTable,
+  liveDriverInstanceQueryForListedSubject,
   mapRuntimeSubjectBackup,
   mapReadyRuntimeSubjectBackup,
   readyLastBackupTable,
   runLeaseQuery,
+  runLeaseQueryForListedSubject,
 } from "./runtime-subject-store-queries";
 import type {
   RuntimeSubjectActivationRecord,
+  RuntimeSubjectOperationRepairCandidate,
   RuntimeSubjectRecord,
   RuntimeSubjectStatus,
 } from "./runtime-subject-store.types";
@@ -455,6 +458,65 @@ export async function markRuntimeSubjectActive(
     .run();
 
   return getD1ChangeCount(result) > 0;
+}
+
+/** Fence abandoned restores into the existing retryable teardown path. */
+export async function claimExpiredRuntimeSubjectActivations(
+  database: D1Database,
+  input: {
+    readonly limit: number;
+    readonly now: number;
+    readonly staleChangedAtLte: number;
+  },
+): Promise<RuntimeSubjectOperationRepairCandidate[]> {
+  const appDb = getAppDatabase(database);
+  const eligible = and(
+    eq(sandboxesTable.status, "restoring"),
+    lte(sandboxesTable.statusChangedAt, input.staleChangedAtLte),
+    or(isNull(sandboxesTable.claimExpiresAt), lte(sandboxesTable.claimExpiresAt, input.now)),
+    notExists(liveDriverInstanceQueryForListedSubject(appDb)),
+    notExists(activeSessionRunQueryForListedSubject(appDb)),
+    notExists(runLeaseQueryForListedSubject(appDb)),
+  );
+  const candidates = await appDb
+    .select({ id: sandboxesTable.id, kind: sandboxesTable.kind, seq: sandboxesTable.statusSeq })
+    .from(sandboxesTable)
+    .where(eligible)
+    .orderBy(asc(sandboxesTable.id))
+    .limit(input.limit)
+    .all();
+  const claimed: RuntimeSubjectOperationRepairCandidate[] = [];
+  for (const candidate of candidates) {
+    const operationId = createPlatformId<RuntimeOperationId>();
+    // Recheck both the lease and live-work guards at the write boundary.
+    const result = await appDb
+      .update(sandboxesTable)
+      .set({
+        claimOwner: null,
+        claimExpiresAt: null,
+        inactiveDeadlineAt: null,
+        lastError: "Runtime subject activation expired before restore completed.",
+        lastErrorCode: "runtime.subject_activation_failed",
+        ...runtimeSubjectStatusPatch({
+          now: input.now,
+          operationId,
+          source: "maintenance",
+          status: "destroying",
+        }),
+      })
+      .where(
+        and(
+          eligible,
+          eq(sandboxesTable.id, candidate.id),
+          eq(sandboxesTable.statusSeq, candidate.seq),
+        ),
+      )
+      .run();
+    if (getD1ChangeCount(result) > 0) {
+      claimed.push({ id: candidate.id, kind: candidate.kind, operationId, status: "destroying" });
+    }
+  }
+  return claimed;
 }
 
 export async function markRuntimeSubjectActivationDestroying(

--- a/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store.ts
+++ b/apps/api/src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store.ts
@@ -19,6 +19,7 @@ export {
 export {
   advanceRuntimeSubjectOperationStatus,
   claimRuntimeSubjectActivation,
+  claimExpiredRuntimeSubjectActivations,
   ensureRuntimeSubjectId,
   getRuntimeSubject,
   getRuntimeSubjectActivationRecord,

--- a/apps/api/src/modules/sessions/application/session-viewer-socket.service.ts
+++ b/apps/api/src/modules/sessions/application/session-viewer-socket.service.ts
@@ -1,4 +1,3 @@
-import type { SessionType } from "@mosoo/contracts/session";
 import { parsePlatformId } from "@mosoo/id";
 import type { ProjectId, SessionId } from "@mosoo/id";
 
@@ -6,27 +5,6 @@ import type { ApiBindings } from "../../../platform/cloudflare/worker-types";
 import type { AuthenticatedViewer } from "../../auth/application/viewer-auth.service";
 import { getActiveProjectSessionParticipantAccess } from "../domain/session-access.policy";
 import { connectSessionViewerWebSocket } from "../infrastructure/session/client";
-
-interface ActiveViewerSocketSession {
-  id: SessionId;
-  projectId: ProjectId;
-  type: SessionType;
-}
-
-export interface SessionViewerSocketRuntimePrewarmRequest {
-  bindings: ApiBindings;
-  executionContext: Pick<ExecutionContext, "waitUntil"> | null;
-  requestUrl: string;
-  session: {
-    id: SessionId;
-    projectId: ProjectId;
-  };
-  viewer: AuthenticatedViewer;
-}
-
-export type SessionViewerSocketRuntimePrewarmScheduler = (
-  request: SessionViewerSocketRuntimePrewarmRequest,
-) => void;
 
 export type SessionViewerSocketConnector = (
   bindings: ApiBindings,
@@ -38,74 +16,11 @@ export type SessionViewerSocketConnector = (
   },
 ) => Promise<Response>;
 
-export function shouldSchedulePreviewRuntimePrewarmForViewerSocket(input: {
-  responseStatus: number;
-  sessionType: SessionType;
-}): boolean {
-  return input.sessionType === "preview" && input.responseStatus === 101;
-}
-
-function scheduleSessionViewerSocketRuntimePrewarm(
-  request: SessionViewerSocketRuntimePrewarmRequest,
-): void {
-  if (!request.executionContext) {
-    return;
-  }
-
-  request.executionContext.waitUntil(
-    import("../../runtime/application/session-runs/prewarm-agent-session-runtime.service").then(
-      ({ prewarmAgentSessionRuntime }) =>
-        prewarmAgentSessionRuntime({
-          bindings: request.bindings,
-          failureMode: "best_effort",
-          requestUrl: request.requestUrl,
-          session: request.session,
-          viewer: request.viewer,
-        }),
-    ),
-  );
-}
-
-function schedulePreviewRuntimePrewarmForViewerSocket(input: {
-  bindings: ApiBindings;
-  executionContext: Pick<ExecutionContext, "waitUntil"> | null;
-  requestUrl: string;
-  responseStatus: number;
-  runtimePrewarmScheduler?: SessionViewerSocketRuntimePrewarmScheduler | null;
-  session: ActiveViewerSocketSession;
-  viewer: AuthenticatedViewer;
-}): void {
-  if (
-    !shouldSchedulePreviewRuntimePrewarmForViewerSocket({
-      responseStatus: input.responseStatus,
-      sessionType: input.session.type,
-    })
-  ) {
-    return;
-  }
-
-  const runtimePrewarmScheduler =
-    input.runtimePrewarmScheduler ?? scheduleSessionViewerSocketRuntimePrewarm;
-
-  runtimePrewarmScheduler({
-    bindings: input.bindings,
-    executionContext: input.executionContext,
-    requestUrl: input.requestUrl,
-    session: {
-      id: input.session.id,
-      projectId: input.session.projectId,
-    },
-    viewer: input.viewer,
-  });
-}
-
 export async function connectAuthenticatedSessionViewerWebSocket(
   bindings: ApiBindings,
   input: {
-    executionContext?: Pick<ExecutionContext, "waitUntil"> | null;
     projectId: string;
     request: Request;
-    runtimePrewarmScheduler?: SessionViewerSocketRuntimePrewarmScheduler | null;
     sessionViewerSocketConnector?: SessionViewerSocketConnector | null;
     sessionId: string;
     viewer: AuthenticatedViewer;
@@ -115,7 +30,7 @@ export async function connectAuthenticatedSessionViewerWebSocket(
   const projectId = parsePlatformId<ProjectId>(input.projectId, "Session viewer socket project ID");
   const viewer = input.viewer;
   const viewerId = viewer.id;
-  const access = await getActiveProjectSessionParticipantAccess(bindings.DB, viewerId, {
+  await getActiveProjectSessionParticipantAccess(bindings.DB, viewerId, {
     projectId,
     sessionId,
   });
@@ -128,19 +43,6 @@ export async function connectAuthenticatedSessionViewerWebSocket(
     viewer,
   });
 
-  schedulePreviewRuntimePrewarmForViewerSocket({
-    bindings,
-    executionContext: input.executionContext ?? null,
-    requestUrl: input.request.url,
-    responseStatus: response.status,
-    runtimePrewarmScheduler: input.runtimePrewarmScheduler ?? null,
-    session: {
-      id: sessionId,
-      projectId: access.project_id,
-      type: access.type,
-    },
-    viewer,
-  });
-
+  // Viewer reconnects only subscribe to durable events; they must not wake compute.
   return response;
 }

--- a/apps/api/tests/runtime-conversation-idle-sweep.test.ts
+++ b/apps/api/tests/runtime-conversation-idle-sweep.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   claimIdleSessionScopedConversationForClose,
   listIdleSessionScopedConversationSessions,
+  listPendingIdleConversationCheckpoints,
 } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-conversation-session-store";
 import { SqliteD1Database } from "./helpers/sqlite-d1";
 
@@ -26,6 +27,10 @@ function createDatabase(): SqliteD1Database {
 
     CREATE TABLE sandbox (
       id text PRIMARY KEY NOT NULL,
+      status text DEFAULT 'active',
+      claim_owner text,
+      subject_kind text DEFAULT 'session',
+      subject_id text,
       kind text NOT NULL
     );
 
@@ -36,6 +41,8 @@ function createDatabase(): SqliteD1Database {
 
     CREATE TABLE session_run (
       created_by_key_id text,
+      session_id text,
+      agent_id text,
       id text PRIMARY KEY NOT NULL,
       driver_instance_id text,
       status text NOT NULL
@@ -43,6 +50,7 @@ function createDatabase(): SqliteD1Database {
 
     CREATE TABLE session (
       id text PRIMARY KEY NOT NULL,
+      status text DEFAULT 'IDLE',
       kind text NOT NULL,
       last_run_id text,
       workspace_checkpoint_required integer DEFAULT 0 NOT NULL
@@ -181,6 +189,46 @@ describe("idle session-scoped conversation sweep", () => {
         limit: 10,
       }),
     ).resolves.toEqual([{ sandboxId: "sb-checkpoint", sessionId: "session-checkpoint" }]);
+  });
+
+  test("repairs only an idle completed workspace without a ready checkpoint or live lease", async () => {
+    const database = createDatabase();
+    await insertConversation(database, {
+      kind: "cattle",
+      sandboxId: "sb-repair",
+      sessionId: "session-repair",
+      status: "active",
+      updatedAt: NOW - GRACE_MS - 1,
+    });
+    database.execute(`
+      UPDATE sandbox SET subject_id = 'session-repair';
+      INSERT INTO session_run (id, session_id, status) VALUES ('run-repair', 'session-repair', 'completed');
+      UPDATE session SET last_run_id = 'run-repair', workspace_checkpoint_required = 1;
+    `);
+    const list = () =>
+      listPendingIdleConversationCheckpoints(database, {
+        idleSinceLte: NOW - GRACE_MS,
+        limit: 10,
+      });
+    expect(await list()).toEqual([]);
+    database.execute("INSERT INTO session_event VALUES ('event', 'run-repair', 'run.completed')");
+    expect(await list()).toEqual([
+      {
+        sandboxId: "sb-repair",
+        sessionId: "session-repair",
+        sessionRunId: "run-repair",
+      },
+    ]);
+    database.execute("UPDATE sandbox SET claim_owner = 'activation'");
+    expect(await list()).toEqual([]);
+    database.execute("UPDATE sandbox SET claim_owner = NULL");
+    await insertActiveRunLease(database, { runId: "other-run", sandboxId: "sb-repair" });
+    expect(await list()).toEqual([]);
+    database.execute("UPDATE session_run SET status = 'failed' WHERE id = 'other-run'");
+    database.execute(
+      "INSERT INTO sandbox_backup VALUES ('cwd', 'backup', 'sb-repair', 'run-repair', 'ready')",
+    );
+    expect(await list()).toEqual([]);
   });
 
   test("lets the idle sweep recycle a pre-rollout cattle conversation", async () => {

--- a/apps/api/tests/runtime-subject-recycle.test.ts
+++ b/apps/api/tests/runtime-subject-recycle.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   listInactiveRuntimeSubjects,
   listStaleRuntimeSubjectOperations,
+  claimExpiredRuntimeSubjectActivations,
 } from "../src/modules/runtime/infrastructure/runtime-subject-lifecycle/runtime-subject-store";
 import { encodeSandboxBackupIdForStorage } from "../src/modules/runtime/infrastructure/sandbox-backup-id";
 import type { SandboxHandle } from "../src/modules/runtime/infrastructure/sandbox-handles";
@@ -646,5 +647,82 @@ describe("runtime subject recycle", () => {
         status: "destroying",
       },
     ]);
+  });
+
+  test("repairs an expired restore without an operation id and preserves its backup", async () => {
+    const database = createRuntimeSubjectRecycleDatabase();
+    await database
+      .prepare(
+        "UPDATE sandbox SET status = 'restoring', status_changed_at = 10, claim_expires_at = 20, status_operation_id = NULL, last_backup_id = ? WHERE id = ?",
+      )
+      .bind(BACKUP_ID, SANDBOX_ID)
+      .run();
+    const [candidate] = await claimExpiredRuntimeSubjectActivations(database, {
+      limit: 20,
+      now: 30,
+      staleChangedAtLte: 10,
+    });
+    expect(candidate).toMatchObject({ id: SANDBOX_ID, status: "destroying" });
+    if (!candidate) throw new Error("Expected an expired activation repair.");
+    expect(isPlatformId(candidate.operationId)).toBe(true);
+    await expect(
+      claimExpiredRuntimeSubjectActivations(database, {
+        limit: 20,
+        now: 30,
+        staleChangedAtLte: 10,
+      }),
+    ).resolves.toEqual([]);
+    currentSandbox = {
+      ...createSandboxHandle(),
+      destroy: async () => {
+        throw new Error("temporary teardown failure");
+      },
+    };
+    const repair = {
+      kind: candidate.kind,
+      operationId: candidate.operationId,
+      reason: "test.expired_activation",
+      runtimeSubjectId: candidate.id,
+      status: candidate.status,
+    };
+    await expect(
+      resumeRuntimeSubjectRecycleOperation(createBindings(database), repair),
+    ).rejects.toThrow("temporary teardown failure");
+    await expect(readRuntimeSubjectRecycleRow(database)).resolves.toMatchObject({
+      status: "destroying",
+      status_operation_id: candidate.operationId,
+      last_backup_id: BACKUP_ID,
+    });
+    currentSandbox = { ...createSandboxHandle(), destroy: async () => {} };
+    await resumeRuntimeSubjectRecycleOperation(createBindings(database), repair);
+    await expect(readRuntimeSubjectRecycleRow(database)).resolves.toMatchObject({
+      status: "cold",
+      last_backup_id: BACKUP_ID,
+    });
+  });
+
+  test.each([
+    "UPDATE sandbox SET claim_expires_at = 31",
+    "INSERT INTO driver_instance (id, sandbox_id, status) SELECT 'leased', id, 'stopped' FROM sandbox; INSERT INTO session_run (id, driver_instance_id, status) VALUES ('lease', 'leased', 'running')",
+    "UPDATE sandbox SET status_changed_at = 11",
+    "INSERT INTO driver_instance (id, sandbox_id, status) SELECT 'live', id, 'ready' FROM sandbox",
+    "INSERT INTO session_run (id, session_id, status) SELECT 'run', subject_id, 'running' FROM sandbox",
+    "UPDATE sandbox SET subject_kind = 'agent'; INSERT INTO session_run (id, agent_id, status) SELECT 'run', subject_id, 'queued' FROM sandbox",
+  ])("does not reclaim a restore with live work or a fresh lease: %s", async (protection) => {
+    const database = createRuntimeSubjectRecycleDatabase();
+    database.execute(
+      "UPDATE sandbox SET status = 'restoring', status_changed_at = 10, claim_expires_at = 20, status_operation_id = NULL",
+    );
+    database.execute(protection);
+    await expect(
+      claimExpiredRuntimeSubjectActivations(database, {
+        limit: 20,
+        now: 30,
+        staleChangedAtLte: 10,
+      }),
+    ).resolves.toEqual([]);
+    await expect(readRuntimeSubjectRecycleRow(database)).resolves.toMatchObject({
+      status: "restoring",
+    });
   });
 });

--- a/apps/api/tests/session-viewer-socket-prewarm.test.ts
+++ b/apps/api/tests/session-viewer-socket-prewarm.test.ts
@@ -1,18 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import type { AuthenticatedViewer } from "../src/modules/auth/application/viewer-auth.service";
-import {
-  connectAuthenticatedSessionViewerWebSocket,
-  shouldSchedulePreviewRuntimePrewarmForViewerSocket,
-} from "../src/modules/sessions/application/session-viewer-socket.service";
-import type {
-  SessionViewerSocketConnector,
-  SessionViewerSocketRuntimePrewarmRequest,
-} from "../src/modules/sessions/application/session-viewer-socket.service";
+import { connectAuthenticatedSessionViewerWebSocket } from "../src/modules/sessions/application/session-viewer-socket.service";
+import type { SessionViewerSocketConnector } from "../src/modules/sessions/application/session-viewer-socket.service";
 import type { ApiBindings } from "../src/platform/cloudflare/worker-types";
 import {
   createPublicHttpTestBindings,
-  createTestExecutionContext,
   SqliteD1Database,
 } from "./helpers/public-api-http-test-fixture";
 
@@ -128,22 +121,15 @@ async function connectForTest(input: {
 }): Promise<{
   connectorCallCount: number;
   response: Response;
-  scheduledRequest: SessionViewerSocketRuntimePrewarmRequest | null;
 }> {
-  const executionContext = createTestExecutionContext();
   let connectorCallCount = 0;
-  let scheduledRequest: SessionViewerSocketRuntimePrewarmRequest | null = null;
   const sessionViewerSocketConnector: SessionViewerSocketConnector = async () => {
     connectorCallCount += 1;
     return createSocketResponse(input.responseStatus);
   };
 
   const response = await connectAuthenticatedSessionViewerWebSocket(createBindings(input), {
-    executionContext,
     request: new Request(SESSION_VIEWER_SOCKET_URL),
-    runtimePrewarmScheduler: (request) => {
-      scheduledRequest = request;
-    },
     projectId: PROJECT_ID,
     sessionId: SESSION_ID,
     sessionViewerSocketConnector,
@@ -153,89 +139,44 @@ async function connectForTest(input: {
   return {
     connectorCallCount,
     response,
-    scheduledRequest,
   };
 }
 
-describe("session viewer socket runtime prewarm", () => {
-  test("schedules prewarm only after an active preview viewer socket is accepted", async () => {
-    const { connectorCallCount, response, scheduledRequest } = await connectForTest({
-      responseStatus: 101,
-      type: "preview",
-    });
+describe("session viewer socket subscriptions", () => {
+  test.each(["preview", "ui"] as const)(
+    "accepts repeated %s subscriptions without runtime bindings",
+    async (type) => {
+      // The fixture has no Sandbox/Driver runtime. Every reconnect must remain read-only.
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const { connectorCallCount, response } = await connectForTest({
+          responseStatus: 101,
+          type,
+        });
+        expect(connectorCallCount).toBe(1);
+        expect(response.status).toBe(101);
+      }
+    },
+  );
 
-    expect(connectorCallCount).toBe(1);
-    expect(response.status).toBe(101);
-    expect(scheduledRequest).not.toBeNull();
-    if (!scheduledRequest) {
-      throw new Error("Expected accepted preview viewer socket to schedule runtime prewarm.");
-    }
-
-    expect(scheduledRequest.requestUrl).toBe(SESSION_VIEWER_SOCKET_URL);
-    expect(scheduledRequest.session).toEqual({
-      id: SESSION_ID,
-      projectId: PROJECT_ID,
-    });
-    expect(scheduledRequest.viewer).toBe(VIEWER);
-  });
-
-  test("does not schedule prewarm when the preview viewer socket is rejected", async () => {
-    const { connectorCallCount, response, scheduledRequest } = await connectForTest({
-      responseStatus: 426,
-      type: "preview",
-    });
-
-    expect(connectorCallCount).toBe(1);
+  test("preserves a rejected socket response", async () => {
+    const { response } = await connectForTest({ responseStatus: 426, type: "preview" });
     expect(response.status).toBe(426);
-    expect(scheduledRequest).toBeNull();
-    expect(
-      shouldSchedulePreviewRuntimePrewarmForViewerSocket({
-        responseStatus: 426,
-        sessionType: "preview",
-      }),
-    ).toBe(false);
   });
 
-  test("does not schedule prewarm for an accepted UI viewer socket", async () => {
-    const { connectorCallCount, response, scheduledRequest } = await connectForTest({
-      responseStatus: 101,
-      type: "ui",
-    });
-
-    expect(connectorCallCount).toBe(1);
-    expect(response.status).toBe(101);
-    expect(scheduledRequest).toBeNull();
-    expect(
-      shouldSchedulePreviewRuntimePrewarmForViewerSocket({
-        responseStatus: 101,
-        sessionType: "ui",
-      }),
-    ).toBe(false);
-  });
-
-  test("does not connect or prewarm when the viewer cannot access the session", async () => {
-    let scheduledRequest: SessionViewerSocketRuntimePrewarmRequest | null = null;
+  test("does not connect when the viewer cannot access the session", async () => {
     let connectorCallCount = 0;
-    const sessionViewerSocketConnector: SessionViewerSocketConnector = async () => {
-      connectorCallCount += 1;
-      return createSocketResponse(101);
-    };
-
     await expect(
       connectAuthenticatedSessionViewerWebSocket(createBindings({ type: "preview" }), {
-        executionContext: createTestExecutionContext(),
         request: new Request(SESSION_VIEWER_SOCKET_URL),
-        runtimePrewarmScheduler: (request) => {
-          scheduledRequest = request;
-        },
         projectId: PROJECT_ID,
         sessionId: SESSION_ID,
-        sessionViewerSocketConnector,
+        sessionViewerSocketConnector: async () => {
+          connectorCallCount += 1;
+          return createSocketResponse(101);
+        },
         viewer: OUTSIDER_VIEWER,
       }),
     ).rejects.toThrow();
-
     expect(connectorCallCount).toBe(0);
-    expect(scheduledRequest).toBeNull();
   });
 });

--- a/docs/prd/session-lifecycle.md
+++ b/docs/prd/session-lifecycle.md
@@ -13,6 +13,11 @@ they create or continue work for an end user.
 
 ## User flow
 
+Viewing history or reconnecting its event stream does not wake the Sandbox. Explicit
+composer activity may prewarm it; sending a task activates it when needed.
+Maintenance retries missing checkpoints for idle completed turns before reclamation;
+a failed backup keeps the resident workspace available for another attempt.
+
 1. A user starts a Thread and sends a task. While the Agent is working, output appears in the
    conversation.
 2. In Preview or live chat, **Stop generating** ends the current attempt. The Thread remains


### PR DESCRIPTION
Preview event-stream reconnects currently start Sandbox/Driver prewarm on every accepted WebSocket, so an idle preview can repeatedly wake compute without a new Run. Remove that passive trigger while retaining explicit prewarm and Run activation.

Maintenance also repairs two stranded states: expired restoring claims with no live Driver/Run/lease are fenced by status sequence into the retryable destroy-to-cold path with backups retained; idle completed Cattle turns missing their checkpoint retry the existing terminal backup flow before idle reclamation. Backup failure continues to block recycling.

Validation: focused socket/recycle/idle-sweep tests and API typecheck pass. Local `just check` reached Driver tests but fails on Linux-specific process-tree tests using `/usr/bin/setsid` and `/proc` on macOS; the required Linux CI full gate must pass before merge. Linux CI full repository gate passed (34460036510), and non-production Public API smoke passed (34459899871). API package suite: 987 passed, 0 failed. Production deployment succeeded: https://github.com/langgenius/mosoo/actions/runs/34460458970 (API abdade22-3f8f-4710-af18-d89b0a826e39). Both audited Sandbox records reached cold with their ready backups preserved. The isolated real OpenAI Run executed Shell, saved a marker, automatically recycled to cold, then a second real Run read the original file with a matching SHA-256; both Runs completed with ready checkpoints. During approximately 15 minutes of observation the target preview created zero new Drivers. Two missing-platform-session cleanup warnings did not block reclamation; this is not a claim of zero warnings or a 24-hour cost reduction. The test Session was archived after acceptance.

No generated files, GraphQL changes, migrations, or lockfile changes.
